### PR TITLE
Add exact timestamp tooltip to video upload date

### DIFF
--- a/src/components/VideoCard.tsx
+++ b/src/components/VideoCard.tsx
@@ -297,7 +297,10 @@ export function VideoCard({
         {/* Original badge and timestamp - aligned with author */}
         <div className="flex items-center gap-2 text-sm text-muted-foreground shrink-0">
           {isMigratedVine && <VineBadge />}
-          <span>{timeAgo}</span>
+          <span
+            title={new Date(timestamp * 1000).toLocaleString()}>
+            {timeAgo}
+          </span>
         </div>
       </div>
 


### PR DESCRIPTION
- Adds a tooltip for when you hover over the video upload date, displaying the exact timestamp of the video.
<img width="235" height="76" alt="image" src="https://github.com/user-attachments/assets/a55630ac-d50f-4fa5-b762-f7337d6ddc22" />