### PR TITLE
Add timestamp tooltip to profile join date

### DIFF
--- a/src/components/ProfileHeader.tsx
+++ b/src/components/ProfileHeader.tsx
@@ -244,7 +244,12 @@ export function ProfileHeader({
         <div className="text-center col-span-2 sm:col-span-1">
           {stats ? (
             <>
-              <div className="text-xs sm:text-sm text-muted-foreground">
+              <div className="text-xs sm:text-sm text-muted-foreground"
+              title={
+                stats.joinedDate
+                  ? stats.joinedDate.toLocaleString()
+                  : undefined
+              }>
                 {formatJoinedDate(stats.joinedDate)}
               </div>
             </>


### PR DESCRIPTION
- Adds a tooltip to user profile join date that displays the exact timestamp.
- If there is not a date and it is shown as "Recently joined", then the tooltip while be blank and not rendered.
<img width="242" height="82" alt="image" src="https://github.com/user-attachments/assets/fecd1456-94ee-4581-9224-167019220f9b" />