### PR TITLE
Add posted date on hover to video grid

### DIFF
--- a/src/components/VideoGrid.tsx
+++ b/src/components/VideoGrid.tsx
@@ -9,6 +9,7 @@ import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
 import type { ParsedVideoData } from '@/types/video';
 import { buildVideoNavigationUrl, type VideoNavigationContext } from '@/hooks/useVideoNavigation';
+import { formatDistanceToNow } from 'date-fns';
 
 interface VideoGridProps {
   videos: ParsedVideoData[];
@@ -239,6 +240,31 @@ export function VideoGrid({ videos, loading = false, className, navigationContex
                   )}
                 </div>
               )}
+              {/* Posted Date */}
+              {(() => {
+                const timestamp = video.originalVineTimestamp || video.createdAt;
+                const date = new Date(timestamp * 1000);
+                const now = new Date();
+
+                const yearsDiff = now.getFullYear() - date.getFullYear();
+                let timeAgo;
+
+                if (yearsDiff > 1 || (yearsDiff === 1 && now.getTime() < new Date(date).setFullYear(date.getFullYear() + 1))) {
+                  timeAgo = date.toLocaleDateString('en-US', {
+                    month: 'short',
+                    day: 'numeric',
+                    year: 'numeric'
+                  });
+                } else {
+                  timeAgo = formatDistanceToNow(date, { addSuffix: true });
+                }
+
+                return (
+                  <div className="absolute top-2 left-2 bg-black/40 text-white text-xs px-2 py-1 rounded opacity-0 group-hover:opacity-100">
+                    {timeAgo}
+                  </div>
+                );
+              })()}
             </div>
           </Card>
         );


### PR DESCRIPTION
- Adds a posted date overlay in the top left corner of thumbnail when video is hovered over.
- It uses the same formatting logic as the video card timestamp. For example, it will say "about 9 hours ago" if it was a recent video.
<img width="338" height="403" alt="image" src="https://github.com/user-attachments/assets/9e0d7a30-9776-472b-84d1-1ea0bdacf714" />
<img width="355" height="405" alt="image" src="https://github.com/user-attachments/assets/7cb10f4a-e40e-44c2-9e7d-54ffbe454595" />