### PR TITLE
Add timestamp tooltip to comment date

### DIFF
--- a/src/components/comments/Comment.tsx
+++ b/src/components/comments/Comment.tsx
@@ -62,7 +62,10 @@ export function Comment({ root, comment, depth = 0, maxDepth = 3, limit }: Comme
                   >
                     {displayName}
                   </Link>
-                  <p className="text-xs text-muted-foreground">{timeAgo}</p>
+                  <p className="text-xs text-muted-foreground"
+                    title={new Date(comment.created_at * 1000).toLocaleString()}>
+                    {timeAgo}
+                  </p>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Adds a tooltip to comment post date that displays the exact timestamp.