### PR TITLE
Remove support for kind 21 and 22 videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ OpenVine-compatible Nostr client for short-form looping videos. Built with React
 
 ## Features
 
-- **6-second looping videos** (Kind 34236 - NIP-71)
+- **6-second looping videos** (Kind 34236)
 - **MP4 and GIF support** with auto-loop playback
 - **Blurhash placeholders** for smooth progressive loading
 - **Social features**: Likes, reposts, follows, hashtag discovery

--- a/src/components/AddToListDialog.tsx
+++ b/src/components/AddToListDialog.tsx
@@ -22,12 +22,11 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Plus, List, Check, Loader2 } from 'lucide-react';
 import { useToast } from '@/hooks/useToast';
-import { SHORT_VIDEO_KIND, HORIZONTAL_VIDEO_KIND, LEGACY_VIDEO_KIND } from '@/types/video';
+import { VIDEO_KIND } from '@/types/video';
 
 interface AddToListDialogProps {
   videoId: string;
   videoPubkey: string;
-  videoKind?: typeof SHORT_VIDEO_KIND | typeof HORIZONTAL_VIDEO_KIND | typeof LEGACY_VIDEO_KIND; // Default to SHORT_VIDEO_KIND if not specified
   open: boolean;
   onClose: () => void;
 }
@@ -35,7 +34,6 @@ interface AddToListDialogProps {
 export function AddToListDialog({
   videoId,
   videoPubkey,
-  videoKind = SHORT_VIDEO_KIND,
   open,
   onClose
 }: AddToListDialogProps) {
@@ -51,7 +49,7 @@ export function AddToListDialog({
   const [newListDescription, setNewListDescription] = useState('');
   const [isCreating, setIsCreating] = useState(false);
 
-  const videoCoordinate = `${videoKind}:${videoPubkey}:${videoId}`;
+  const videoCoordinate = `${VIDEO_KIND}:${videoPubkey}:${videoId}`;
 
   const handleAddToLists = async () => {
     if (selectedLists.size === 0) return;

--- a/src/hooks/useInfiniteVideos.ts
+++ b/src/hooks/useInfiniteVideos.ts
@@ -63,7 +63,7 @@ function parseVideoEvents(events: NostrEvent[]): ParsedVideoData[] {
     parsedVideos.push({
       id: event.id,
       pubkey: event.pubkey,
-      kind: event.kind as 21 | 22 | 34236,
+      kind: event.kind as 34236,
       createdAt: event.created_at,
       originalVineTimestamp: getOriginalVineTimestamp(event),
       content: event.content,

--- a/src/hooks/usePublishVideo.ts
+++ b/src/hooks/usePublishVideo.ts
@@ -1,9 +1,9 @@
-// ABOUTME: Hook for publishing NIP-71 video events (kinds 21, 22) to Nostr
+// ABOUTME: Hook for publishing video events (kind 34236) to Nostr
 // ABOUTME: Handles video metadata creation and event signing with proper tags
 
 import { useMutation } from '@tanstack/react-query';
 import { useNostrPublish } from '@/hooks/useNostrPublish';
-import { SHORT_VIDEO_KIND, HORIZONTAL_VIDEO_KIND, LEGACY_VIDEO_KIND } from '@/types/video';
+import { VIDEO_KIND } from '@/types/video';
 import type { VideoMetadata } from '@/types/video';
 
 interface PublishVideoOptions {
@@ -15,7 +15,6 @@ interface PublishVideoOptions {
   dimensions?: string;
   hashtags?: string[];
   vineId?: string; // Optional, will generate if not provided
-  kind?: typeof SHORT_VIDEO_KIND | typeof HORIZONTAL_VIDEO_KIND | typeof LEGACY_VIDEO_KIND; // Kind 22 (short/vertical), 21 (horizontal), or 34236 (legacy) - defaults to 22
 }
 
 /**
@@ -75,8 +74,7 @@ export function usePublishVideo() {
         duration = 6,
         dimensions = '480x480',
         hashtags = [],
-        vineId = generateVineId(),
-        kind = SHORT_VIDEO_KIND // Default to short vertical videos (kind 22)
+        vineId = generateVineId()
       } = options;
 
       // Build tags according to NIP-71
@@ -117,7 +115,7 @@ export function usePublishVideo() {
 
       // Publish the event
       const event = await publishEvent({
-        kind,
+        kind: VIDEO_KIND,
         content,
         tags
       });
@@ -136,15 +134,13 @@ export function useRepostVideo() {
   return useMutation({
     mutationFn: async ({
       originalPubkey,
-      vineId,
-      kind = SHORT_VIDEO_KIND
+      vineId
     }: {
       originalPubkey: string;
       vineId: string;
-      kind?: typeof SHORT_VIDEO_KIND | typeof HORIZONTAL_VIDEO_KIND;
     }) => {
       const tags: string[][] = [
-        ['a', `${kind}:${originalPubkey}:${vineId}`],
+        ['a', `${VIDEO_KIND}:${originalPubkey}:${vineId}`],
         ['p', originalPubkey],
         ['client', 'divine-web']
       ];

--- a/src/hooks/useVideoEvents.ts
+++ b/src/hooks/useVideoEvents.ts
@@ -1,5 +1,5 @@
 // ABOUTME: Hook for querying and managing video events from Nostr relays
-// ABOUTME: Handles NIP-71 videos (kinds 21, 22, 34236) and Kind 6 reposts with proper parsing
+// ABOUTME: Handles video events (kind 34236) and Kind 6 reposts with proper parsing
 // ABOUTME: Supports auto-refresh for home and recent feeds matching Flutter app behavior
 
 import { useNostr } from '@nostrify/react';
@@ -25,19 +25,16 @@ interface UseVideoEventsOptions {
 }
 
 /**
- * Validates that a NIP-71 video event (kinds 21, 22, or 34236) has required fields
+ * Validates that a video event (kind 34236) has required fields
  */
 function validateVideoEvent(event: NostrEvent): boolean {
   if (!VIDEO_KINDS.includes(event.kind)) return false;
 
   // Kind 34236 (addressable/replaceable event) MUST have d tag per NIP-33
-  // Kinds 21 and 22 are regular events and don't require d tag
-  if (event.kind === 34236) {
-    const vineId = getVineId(event);
-    if (!vineId) {
-      debugLog('[validateVideoEvent] Kind 34236 event missing required d tag:', event.id);
-      return false;
-    }
+  const vineId = getVineId(event);
+  if (!vineId) {
+    debugLog('[validateVideoEvent] Kind 34236 event missing required d tag:', event.id);
+    return false;
   }
 
   return true;
@@ -113,8 +110,8 @@ async function parseVideoEvents(
       continue;
     }
 
-    // Get vineId - for kind 34236 use d tag, for 21/22 use event id as fallback
-    const vineId = getVineId(event) || event.id;
+    // Get vineId from d tag (required for kind 34236)
+    const vineId = getVineId(event)!;
 
     const videoUrl = videoEvent.videoMetadata?.url;
     if (!videoUrl) {
@@ -137,7 +134,7 @@ async function parseVideoEvents(
     videoMap.set(uniqueKey, {
       id: event.id,
       pubkey: event.pubkey,
-      kind: event.kind as 21 | 22 | 34236,
+      kind: event.kind as 34236,
       createdAt: event.created_at,
       originalVineTimestamp: getOriginalVineTimestamp(event),
       content: event.content,

--- a/src/lib/videoParser.ts
+++ b/src/lib/videoParser.ts
@@ -147,10 +147,10 @@ function _convertHlsToMp4(hlsUrl: string): string | null {
 }
 
 /**
- * Extract video URL from NIP-71 compliant event following spec priority
+ * Extract video URL from event following spec priority
  */
 function extractVideoUrl(event: NostrEvent): string | null {
-  // NIP-71: Primary video URL should be in `imeta` tag with url field
+  // Primary video URL should be in `imeta` tag with url field
   for (const tag of event.tags) {
     if (tag[0] === 'imeta') {
       const metadata = parseImetaTag(tag);
@@ -193,7 +193,7 @@ function extractVideoUrl(event: NostrEvent): string | null {
 }
 
 /**
- * Extract limited fallback video URLs from event tags (NIP-71 compliant)
+ * Extract limited fallback video URLs from event tags
  */
 function extractAllVideoUrls(event: NostrEvent): string[] {
   const urls: string[] = [];
@@ -232,7 +232,7 @@ function extractAllVideoUrls(event: NostrEvent): string[] {
 }
 
 /**
- * Extract video metadata from NIP-71 compliant event
+ * Extract video metadata from video event
  */
 export function extractVideoMetadata(event: NostrEvent): VideoMetadata | null {
   const primaryUrl = extractVideoUrl(event);
@@ -299,7 +299,7 @@ export function parseVideoEvent(event: NostrEvent): VideoEvent | null {
   // Create VideoEvent
   const videoEvent: VideoEvent = {
     ...event,
-    kind: event.kind as 34236, // NIP-71 Addressable Short Videos
+    kind: event.kind as 34236, // Kind 34236 Addressable Short Videos
     videoMetadata,
     title,
     hashtags

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -1,20 +1,15 @@
 // ABOUTME: Core video event types and interfaces for OpenVine/Divine Web
-// ABOUTME: Defines the structure of NIP-71 video events (kinds 21, 22) and related metadata
+// ABOUTME: Defines the structure of video events (kind 34236) and related metadata
 
 import type { NostrEvent } from '@nostrify/nostrify';
 
-// NIP-71 Video Event Kinds
-export const HORIZONTAL_VIDEO_KIND = 21; // NIP-71 Normal (horizontal) videos
-export const SHORT_VIDEO_KIND = 22; // NIP-71 Short (vertical) videos
-export const LEGACY_VIDEO_KIND = 34236; // Legacy kind for backward compatibility
+// Video Event Kinds
+export const VIDEO_KIND = 34236; // Kind 34236 - Addressable short-form videos
 
 // Array of all supported video kinds
-export const VIDEO_KINDS = [HORIZONTAL_VIDEO_KIND, SHORT_VIDEO_KIND, LEGACY_VIDEO_KIND];
+export const VIDEO_KINDS = [VIDEO_KIND];
 
 export const REPOST_KIND = 6;
-
-// Deprecated: Use VIDEO_KINDS array instead
-export const VIDEO_KIND = SHORT_VIDEO_KIND;
 
 export interface VideoMetadata {
   url: string;
@@ -30,7 +25,7 @@ export interface VideoMetadata {
 }
 
 export interface VideoEvent extends NostrEvent {
-  kind: typeof HORIZONTAL_VIDEO_KIND | typeof SHORT_VIDEO_KIND | typeof LEGACY_VIDEO_KIND;
+  kind: typeof VIDEO_KIND;
   videoMetadata?: VideoMetadata;
   title?: string;
   hashtags?: string[];
@@ -72,7 +67,7 @@ export interface RepostMetadata {
 export interface ParsedVideoData {
   id: string;                // Original video event ID
   pubkey: string;            // Original author pubkey
-  kind: typeof HORIZONTAL_VIDEO_KIND | typeof SHORT_VIDEO_KIND | typeof LEGACY_VIDEO_KIND; // NIP-71 video kind
+  kind: typeof VIDEO_KIND;   // Video kind (34236)
   createdAt: number;
   originalVineTimestamp?: number; // Custom published_at timestamp (NIP-31 - can be set by any video)
   content: string;


### PR DESCRIPTION
- Remove HORIZONTAL_VIDEO_KIND (21) and SHORT_VIDEO_KIND (22) constants
- Keep only VIDEO_KIND (34236) as the supported video event kind
- Update all type definitions to use only kind 34236
- Update usePublishVideo to only publish kind 34236 events
- Update AddToListDialog to only handle kind 34236
- Update validation logic to require d tag for all videos (kind 34236)
- Remove videoKind parameter from components (always use 34236)
- Update comments to remove NIP-71 references
- All tests pass and project builds successfully