### PR TITLE
Fix home feed to use reverse chron order rather than top sort

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -21,7 +21,7 @@ const SORT_MODES = [
 export function HomePage() {
   const { user } = useCurrentUser();
   const { data: followList, isLoading, isFetching, dataUpdatedAt } = useFollowList();
-  const [sortMode, setSortMode] = useState<SortMode | undefined>('hot');
+  const [sortMode, setSortMode] = useState<SortMode | undefined>(undefined);
 
   // Check if data is from cache (not currently fetching but has data)
   const isShowingCachedData = !isLoading && !isFetching && !!followList && followList.length > 0;


### PR DESCRIPTION
It was using the "hot" sort rather than just showing in reverse chron order. 

Try it here: https://divine-web-32.shakespeare.wtf/