### PR TITLE
Comment out video count display in hashtag explorer grid

### DIFF
--- a/src/components/HashtagExplorer.tsx
+++ b/src/components/HashtagExplorer.tsx
@@ -80,7 +80,7 @@ function HashtagCard({ stat }: { stat: HashtagStats }) {
           {thumbnailUrl ? (
             <>
               {thumbnailUrl.endsWith('.mp4') || thumbnailUrl.endsWith('.webm') || thumbnailUrl.endsWith('.mov') ? (
-                <video 
+                <video
                   src={thumbnailUrl}
                   className="w-full h-full object-cover"
                   muted
@@ -88,8 +88,8 @@ function HashtagCard({ stat }: { stat: HashtagStats }) {
                   preload="metadata"
                 />
               ) : (
-                <img 
-                  src={thumbnailUrl} 
+                <img
+                  src={thumbnailUrl}
                   alt={`#${stat.tag}`}
                   className="w-full h-full object-cover"
                   loading="lazy"
@@ -102,7 +102,7 @@ function HashtagCard({ stat }: { stat: HashtagStats }) {
               <Hash className="h-12 w-12 text-primary/30" />
             </div>
           )}
-          
+
           {/* Overlay info */}
           <div className="absolute bottom-0 left-0 right-0 p-3 text-white">
             <div className="flex items-end justify-between">
@@ -111,9 +111,9 @@ function HashtagCard({ stat }: { stat: HashtagStats }) {
                   <Hash className="h-4 w-4" />
                   {stat.tag}
                 </h3>
-                <p className="text-sm opacity-90">
+                {/* <p className="text-sm opacity-90">
                   {stat.count.toLocaleString()} videos
-                </p>
+                </p> */}
               </div>
               <Badge variant="secondary" className="bg-white/20 text-white border-white/30">
                 #{stat.rank}
@@ -147,7 +147,7 @@ export function HashtagExplorer() {
     // Apply search filter
     if (searchTerm) {
       const search = searchTerm.toLowerCase();
-      filtered = filtered.filter(stat => 
+      filtered = filtered.filter(stat =>
         stat.tag.includes(search)
       );
     }


### PR DESCRIPTION
Many of these videos arent in the relay yet, so it feels "broken" when the user expects 1,000 videos and gets 0. 

Temp solution: Hide the video count from hashtag cards while keeping the component for potential future use

<img width="1250" height="890" alt="Screenshot from 2025-11-18 17-20-50" src="https://github.com/user-attachments/assets/1785bae5-9e42-4737-a14a-d98dd32035ef" />
