### PR TITLE
ui/clickable-previous-next

### DIFF
--- a/src/pages/VideoPage.tsx
+++ b/src/pages/VideoPage.tsx
@@ -444,8 +444,16 @@ export function VideoPage() {
       {(hasNext || hasPrevious) && (
         <div className="text-center mt-4">
           <div className="text-xs text-muted-foreground inline-flex items-center gap-3">
-            {hasPrevious && <span>← previous</span>}
-            {hasNext && <span>next →</span>}
+            {hasPrevious && (
+              <button onClick={goToPrevious} className="hover:underline">
+                ← previous
+              </button>
+            )}
+            {hasNext && (
+              <button onClick={goToNext} className="hover:underline">
+                next →
+              </button>
+            )}
           </div>
         </div>
       )}


### PR DESCRIPTION
<img width="634" height="119" alt="image" src="https://github.com/user-attachments/assets/49d62f21-2b86-40c7-a1db-e081f0125838" />

These are clickable now, not just indicators. This was unintuitive to me before.