### PR TITLE
Add Press Release link to Media Resources page

### DIFF
--- a/src/pages/MediaResourcesPage.tsx
+++ b/src/pages/MediaResourcesPage.tsx
@@ -76,11 +76,17 @@ export function MediaResourcesPage() {
                 </ul>
               </div>
             </div>
-            <div className="pt-4">
+            <div className="pt-4 flex flex-wrap gap-3">
               <Button asChild variant="outline">
                 <Link to="/about" className="inline-flex items-center gap-2">
                   Learn More About diVine
                   <ExternalLink className="h-4 w-4" />
+                </Link>
+              </Button>
+              <Button asChild variant="outline">
+                <Link to="/press-release" className="inline-flex items-center gap-2">
+                  <FileText className="h-4 w-4" />
+                  Read Press Release
                 </Link>
               </Button>
             </div>


### PR DESCRIPTION
Just added the link to the Press Release here on the media Resources page. 

<img width="755" height="507" alt="Screenshot from 2025-11-19 17-16-39" src="https://github.com/user-attachments/assets/cb6b9db2-06c7-4f13-ae38-ca46ff62f881" />
