### PR TITLE
fix/profile-video-stat-state

### DIFF
--- a/src/hooks/useProfileStats.ts
+++ b/src/hooks/useProfileStats.ts
@@ -5,32 +5,26 @@
 import { useQuery } from '@tanstack/react-query';
 import { useNostr } from '@nostrify/react';
 import type { ProfileStats } from '@/components/ProfileHeader';
-import { VIDEO_KINDS } from '@/types/video';
 import { debugLog } from '@/lib/debug';
+import type { ParsedVideoData } from '@/types/video';
 
 /**
  * Fetch comprehensive profile statistics for a user
  * Includes video count, total views, follower/following counts, and joined date
  */
-export function useProfileStats(pubkey: string) {
+export function useProfileStats(pubkey: string, videos?: ParsedVideoData[]) {
   const { nostr } = useNostr();
 
   return useQuery({
-    queryKey: ['profile-stats', pubkey],
+    queryKey: ['profile-stats', pubkey, videos?.length],
     queryFn: async (context) => {
       if (!pubkey) throw new Error('No pubkey provided');
 
       const signal = AbortSignal.any([context.signal, AbortSignal.timeout(10000)]);
 
       try {
-        // Query all videos (no limit) and contact list
+        // Query contact list for social metrics
         const allEvents = await nostr.query([
-          // 1. User's videos (kind 34236 - NIP-71) - NO LIMIT
-          {
-            kinds: VIDEO_KINDS,
-            authors: [pubkey],
-          },
-          // 2. User's own contact list (people they follow)
           {
             kinds: [3],
             authors: [pubkey],
@@ -38,15 +32,13 @@ export function useProfileStats(pubkey: string) {
           }
         ], { signal });
 
-        // Separate events by type
-        const videoEvents = allEvents.filter(e => VIDEO_KINDS.includes(e.kind));
         const userContactList = allEvents.filter(e => e.kind === 3 && e.pubkey === pubkey);
 
-        // Calculate video count
-        const videosCount = videoEvents.length;
+        // Calculate video count from provided videos
+        const videosCount = videos?.length || 0;
 
         // Get video IDs for social metrics calculation
-        const videoIds = videoEvents.map(event => event.id);
+        const videoIds = videos?.map(v => v.id) || [];
 
         // Fetch social interactions for all videos
         let totalViews = 0;
@@ -93,9 +85,8 @@ export function useProfileStats(pubkey: string) {
 
         // Calculate joined date (earliest video or contact list)
         let joinedDate: Date | null = null;
-        const allUserEvents = [...videoEvents, ...userContactList];
-        if (allUserEvents.length > 0) {
-          const earliestTimestamp = Math.min(...allUserEvents.map(event => event.created_at));
+        if (userContactList.length > 0) {
+          const earliestTimestamp = Math.min(...userContactList.map(event => event.created_at));
           joinedDate = new Date(earliestTimestamp * 1000);
         }
 
@@ -112,7 +103,7 @@ export function useProfileStats(pubkey: string) {
         console.error('Failed to fetch profile stats:', error);
         // Return default stats on error
         return {
-          videosCount: 0,
+          videosCount: videos?.length || 0,
           totalViews: 0,
           joinedDate: null,
           followersCount: 0,

--- a/src/hooks/useVideoEvents.ts
+++ b/src/hooks/useVideoEvents.ts
@@ -319,9 +319,14 @@ export function useVideoEvents(options: UseVideoEventsOptions = {}) {
       ]);
 
       // Build base filter with NIP-50 support
+      // Profile feeds: no limit (get all videos for accurate stats)
+      // Other feeds: cap at 50 per query (they use pagination/infinite scroll)
       const baseFilter: NIP50Filter = {
         kinds: VIDEO_KINDS,
-        limit: Math.min(limit, 50),
+        ...(feedType === 'profile' 
+          ? {} // No limit for profiles
+          : { limit: Math.min(limit, 50) } // Cap at 50 for other feeds
+        ),
         ...filter
       };
 

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -64,15 +64,14 @@ export function ProfilePage() {
   const author = pubkey ? enhanceAuthorData(authorData, pubkey) : null;
   const metadata = author?.metadata;
 
-  // Fetch profile statistics
-  const { data: stats, isLoading: statsLoading } = useProfileStats(pubkey || '');
-
-  // Fetch videos
+  // Fetch ALL videos for profile (no limit)
   const { data: videos, isLoading: videosLoading, error: videosError } = useVideoEvents({
     feedType: 'profile',
     pubkey: pubkey || '',
-    limit: 50,
   });
+
+  // Fetch profile statistics - pass videos to calculate totalViews
+  const { data: stats, isLoading: statsLoading } = useProfileStats(pubkey || '', videos);
 
   // Follow relationship data
   const { data: followData, isLoading: followLoading } = useFollowRelationship(pubkey || '');


### PR DESCRIPTION
This PR addresses two issues present on the profile page.
- we used different data coming from different queries for the two video counts we displayed. These had different limits and caching, so resulted in out of sync data AND incorrect data past a certain scale (count of videos).
- we made more queries than necessary, now the two necessary hooks are refactored to work together and reduce relay load
- correctly count video interactions (ie without limits)