### PR TITLE
Add `a` tag to reaction events

### DIFF
--- a/src/hooks/useOptimisticLike.ts
+++ b/src/hooks/useOptimisticLike.ts
@@ -7,6 +7,7 @@ import { useNostrPublish } from '@/hooks/useNostrPublish';
 import { useToast } from '@/hooks/useToast';
 import { debugLog } from '@/lib/debug';
 import type { VideoSocialMetrics } from '@/hooks/useVideoSocialMetrics';
+import { VIDEO_KIND } from '@/types/video';
 
 interface OptimisticLikeParams {
   videoId: string;
@@ -85,6 +86,7 @@ export function useOptimisticLike() {
           content: '+',
           tags: [
             ['e', videoId],
+            ['a', `${VIDEO_KIND}:${videoPubkey}:${vineId}`],
             ['p', videoPubkey],
           ],
         });


### PR DESCRIPTION
## Summary

This PR adds an `a` tag to reaction events.

## Why

Video events are replaceable, so relying only on the `e` tag means that when a video is edited, all previous reactions become detached and effectively lost.
Adding the `a` tag ensures reactions stay correctly linked even after the video event is updated.