### PR TITLE
Fix count display by summing original and social metric values

### DIFF
--- a/src/components/VideoFeed.tsx
+++ b/src/components/VideoFeed.tsx
@@ -418,10 +418,10 @@ export function VideoFeed({
         onCloseComments={handleCloseComments}
         isLiked={userInteractions.data?.hasLiked || false}
         isReposted={userInteractions.data?.hasReposted || false}
-        likeCount={video.likeCount ?? socialMetrics.data?.likeCount ?? 0}
-        repostCount={video.repostCount ?? socialMetrics.data?.repostCount ?? 0}
-        commentCount={video.commentCount ?? socialMetrics.data?.commentCount ?? 0}
-        viewCount={socialMetrics.data?.viewCount || video.loopCount}
+        likeCount={(video.likeCount ?? 0) + (socialMetrics.data?.likeCount ?? 0)}
+        repostCount={(video.repostCount ?? 0) + (socialMetrics.data?.repostCount ?? 0)}
+        commentCount={(video.commentCount ?? 0) + (socialMetrics.data?.commentCount ?? 0)}
+        viewCount={(socialMetrics.data?.viewCount ?? 0) + (video.loopCount ?? 0)}
         showComments={showCommentsForVideo === video.id}
         navigationContext={{
           source: feedType,

--- a/src/pages/VideoPage.tsx
+++ b/src/pages/VideoPage.tsx
@@ -308,10 +308,10 @@ export function VideoPage() {
         onCloseComments={handleCloseComments}
         isLiked={userInteractions?.hasLiked || false}
         isReposted={userInteractions?.hasReposted || false}
-        likeCount={video.likeCount ?? socialMetrics?.likeCount ?? 0}
-        repostCount={video.repostCount ?? socialMetrics?.repostCount ?? 0}
-        commentCount={video.commentCount ?? socialMetrics?.commentCount ?? 0}
-        viewCount={socialMetrics?.viewCount || video.loopCount}
+        likeCount={(video.likeCount ?? 0) + (socialMetrics?.likeCount ?? 0)}
+        repostCount={(video.repostCount ?? 0) + (socialMetrics?.repostCount ?? 0)}
+        commentCount={(video.commentCount ?? 0) + (socialMetrics?.commentCount ?? 0)}
+        viewCount={(socialMetrics?.viewCount ?? 0) + (video.loopCount ?? 0)}
         showComments={showCommentsForVideo === video.id}
         navigationContext={context || undefined}
       />


### PR DESCRIPTION
This PR updates the logic for `likeCount`, `repostCount`, `commentCount`, and `viewCount` so that the displayed value is now the sum of `originalXXXCount` and the corresponding socialMetrics count, instead of choosing one or the other.