### PR TITLE
Deduplicate UserInteraction type

### DIFF
--- a/src/hooks/useOptimisticLike.ts
+++ b/src/hooks/useOptimisticLike.ts
@@ -2,6 +2,7 @@
 // ABOUTME: Updates UI immediately before server confirms the action
 
 import { useQueryClient } from '@tanstack/react-query';
+import { UserInteractions } from '@/types/video';
 import { useNostrPublish } from '@/hooks/useNostrPublish';
 import { useToast } from '@/hooks/useToast';
 import { debugLog } from '@/lib/debug';
@@ -14,13 +15,6 @@ interface OptimisticLikeParams {
   userPubkey: string;
   isCurrentlyLiked: boolean;
   currentLikeEventId: string | null;
-}
-
-interface UserInteractions {
-  hasLiked: boolean;
-  hasReposted: boolean;
-  likeEventId: string | null;
-  repostEventId: string | null;
 }
 
 export function useOptimisticLike() {

--- a/src/hooks/useVideoSocialMetrics.ts
+++ b/src/hooks/useVideoSocialMetrics.ts
@@ -1,6 +1,7 @@
 // ABOUTME: Hook for fetching video social interaction metrics (likes, reposts, views)
 // ABOUTME: Provides efficient batched queries to minimize relay requests
 
+import { UserInteractions } from '@/types/video';
 import { useQuery } from '@tanstack/react-query';
 import { useNostr } from '@nostrify/react';
 
@@ -157,10 +158,12 @@ export function useVideoUserInteractions(
           }
         ], { signal });
 
-        let hasLiked = false;
-        let hasReposted = false;
-        let likeEventId: string | null = null;
-        let repostEventId: string | null = null;
+        const userInteractions: UserInteractions = {
+          hasLiked: false,
+          hasReposted: false,
+          likeEventId: null,
+          repostEventId: null
+        };
 
         // Filter out deleted events by checking for delete events (kind 5)
         const deleteEvents = await nostr.query([
@@ -186,16 +189,16 @@ export function useVideoUserInteractions(
           if (deletedEventIds.has(event.id)) continue; // Skip deleted events
 
           if (event.kind === 7 && (event.content === '+' || event.content === '❤️' || event.content === '👍')) {
-            hasLiked = true;
-            likeEventId = event.id;
+            userInteractions.hasLiked = true;
+            userInteractions.likeEventId = event.id;
           }
           if (event.kind === 16) {
-            hasReposted = true;
-            repostEventId = event.id;
+            userInteractions.hasReposted = true;
+            userInteractions.repostEventId = event.id;
           }
         }
 
-        return { hasLiked, hasReposted, likeEventId, repostEventId };
+        return userInteractions;
       } catch (error) {
         console.error('Failed to fetch user video interactions:', error);
         return { hasLiked: false, hasReposted: false, likeEventId: null, repostEventId: null };

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -100,3 +100,10 @@ export interface ParsedVideoData {
   // - getTotalReposts(video): number - Total number of reposts
   // - getUniqueReposters(video): RepostMetadata[] - Deduplicated list of reposters
 }
+
+export interface UserInteractions {
+  hasLiked: boolean;
+  hasReposted: boolean;
+  likeEventId: string | null;
+  repostEventId: string | null;
+}


### PR DESCRIPTION
- Keep a single declaration of UserInteraction
- Use UserInteraction rather than raw types representing the same structure

Please note that the inability to remove likes and reposts is already present in `main` and is not introduced by this commit.