### PR TITLE
Don't republish every author event

### DIFF
--- a/src/hooks/useAuthor.ts
+++ b/src/hooks/useAuthor.ts
@@ -37,12 +37,6 @@ export function useAuthor(pubkey: string | undefined) {
         return {};
       }
 
-      // Republish the profile to the main relay in the background
-      // This ensures profiles are cached on relay.divine.video even if they came from profile relays
-      nostr.event(event).catch(() => {
-        // Silently ignore republish errors - this is best-effort caching
-      });
-
       // Also add to event cache for future synchronous access
       eventCache.event(event).catch(() => {
         // Silently ignore cache errors


### PR DESCRIPTION
Every profile the user views is republished back to the same relay they viewed it from, as well as to all other relays known by the application. This is unnecessary and wasteful, wasting bandwidth and harming relay performance.