### PR TITLE
fix: enable deep link verification files to be served correctly

### DIFF
--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -6,7 +6,9 @@
         "appID": "GZCZBKH7MY.co.openvine.app",
         "paths": [
           "/video/*",
-          "/profile/*"
+          "/profile/*",
+          "/hashtag/*",
+          "/search/*"
         ]
       }
     ]

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,2 +1,8 @@
 /discord https://discord.gg/sHb4HMSF 302
+
+# Deep link verification files - must be served as-is (before catch-all)
+/.well-known/apple-app-site-association /.well-known/apple-app-site-association 200
+/.well-known/assetlinks.json /.well-known/assetlinks.json 200
+
+# SPA catch-all - serves index.html for all other routes
 /* /index.html 200


### PR DESCRIPTION
The SPA catch-all redirect was preventing .well-known files from being served. Added explicit redirect rules before the catch-all to ensure apple-app-site-association and assetlinks.json are served as static files.

Also added hashtag and search paths to iOS universal links config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)