### PR TITLE
Fix Cloudflare Pages deployment project name

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,4 +36,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy dist --project-name=divine-web --branch=main
+          command: pages deploy dist --project-name=divine-web-direct-deploy --branch=main

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy dist --project-name=divine-web --branch=${{ github.event.pull_request.head.ref }}
+          command: pages deploy dist --project-name=divine-web-direct-deploy --branch=${{ github.event.pull_request.head.ref }}
 
       - name: Comment preview URL on PR
         uses: actions/github-script@v7


### PR DESCRIPTION
## Summary
- Update GitHub Actions workflows to deploy to `divine-web-direct-deploy` Cloudflare Pages project
- This project has the `divine.video` custom domain configured

Previously CI was deploying to `divine-web` project which doesn't have the production domain.

## Test plan
- [ ] Merge and verify deployment reaches divine.video

🤖 Generated with [Claude Code](https://claude.com/claude-code)