### PR TITLE
Update HubSpot form text to diVine Inspiration branding

### DIFF
--- a/src/components/AppFooter.tsx
+++ b/src/components/AppFooter.tsx
@@ -9,8 +9,11 @@ export function AppFooter() {
           {/* Main Footer Content - Side by side on desktop */}
           <div className="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-6 mb-6">
             {/* Left side - Email signup */}
-            <div className="flex flex-col gap-4 lg:max-w-md">
-              <div className="text-sm font-medium text-foreground">Stay Updated</div>
+            <div className="flex flex-col gap-2 lg:max-w-md">
+              <div className="text-sm font-semibold text-primary">diVine Inspiration</div>
+              <p className="text-sm text-foreground mb-2">
+                The diVine beta is currently full. If you'd like to hear our news and be amongst the first to hear when the diVine app goes live, sign up here.
+              </p>
               <HubSpotSignup />
             </div>
 

--- a/src/components/HubSpotSignup.tsx
+++ b/src/components/HubSpotSignup.tsx
@@ -1,9 +1,9 @@
 import { useEffect } from 'react';
 
-// Only load HubSpot on production
+// Only load HubSpot on production and localhost
 function isHubSpotAllowed(): boolean {
   const hostname = window.location.hostname;
-  return hostname === 'divine.video' || hostname === 'about.divine.video';
+  return hostname === 'divine.video' || hostname === 'about.divine.video' || hostname === 'localhost';
 }
 
 export function HubSpotSignup() {

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -120,11 +120,11 @@ export function LandingPage() {
             {/* Mailing List Signup */}
             <div className="pt-4">
               <div className="hs-form-landing bg-card border border-border rounded-lg p-6 shadow-sm max-w-[600px] w-full mx-auto">
-                <h4 className="text-base font-normal text-foreground text-center mb-2">
-                  Join the diVine mobile app waitlist
+                <h4 className="text-base font-semibold text-primary text-center mb-2">
+                  diVine Inspiration
                 </h4>
                 <p className="text-sm text-foreground text-center mb-6 leading-5">
-                  Our beta test is full and we can't let more folks on the apps until Apple and Google do their thing. If you want to be the first to know when that happens, join our mailing list.
+                  The diVine beta is currently full. If you'd like to hear our news and be amongst the first to hear when the diVine app goes live, sign up here.
                 </p>
                 <HubSpotSignup />
               </div>


### PR DESCRIPTION
## Summary
- Update landing page and footer form text to match diVine Inspiration branding
- Title: "diVine Inspiration"
- Description: "The diVine beta is currently full. If you'd like to hear our news and be amongst the first to hear when the diVine app goes live, sign up here."
- Allow HubSpot to load on localhost for local development

## Test plan
- [ ] Verify form appears on localhost
- [ ] Verify form text matches on landing page
- [ ] Verify form text matches in footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)