### PR TITLE
Temporarily disable Zendesk widget

### DIFF
--- a/src/components/ZendeskWidget.tsx
+++ b/src/components/ZendeskWidget.tsx
@@ -7,13 +7,14 @@ interface ZendeskWidgetProps {
   hideOnMobile?: boolean;
 }
 
-export function ZendeskWidget({ hideOnMobile = true }: ZendeskWidgetProps) {
-  // TEMPORARILY DISABLED (Jan 24, 2026)
-  // Widget went live before support team was ready. Re-enable when prepared.
-  // To restore: remove this return and the early return in Support.tsx useEffect
-  return null;
+// TEMPORARILY DISABLED (Jan 24, 2026)
+// Widget went live before support team was ready. Re-enable when prepared.
+// To restore: set ZENDESK_ENABLED to true (and in Support.tsx)
+const ZENDESK_ENABLED = false;
 
+export function ZendeskWidget({ hideOnMobile = true }: ZendeskWidgetProps) {
   useEffect(() => {
+    if (!ZENDESK_ENABLED) return;
     // Check if script already exists
     const existingScript = document.getElementById('ze-snippet');
 

--- a/src/pages/Support.tsx
+++ b/src/pages/Support.tsx
@@ -8,11 +8,13 @@ import { Button } from '@/components/ui/button';
 import { MarketingLayout } from '@/components/MarketingLayout';
 
 export function Support() {
+  // TEMPORARILY DISABLED (Jan 24, 2026)
+  // Widget went live before support team was ready. Re-enable when prepared.
+  // To restore: set ZENDESK_ENABLED to true and remove return null in ZendeskWidget.tsx
+  const ZENDESK_ENABLED = false;
+
   useEffect(() => {
-    // TEMPORARILY DISABLED (Jan 24, 2026)
-    // Widget went live before support team was ready. Re-enable when prepared.
-    // To restore: remove this return and the return null in ZendeskWidget.tsx
-    return;
+    if (!ZENDESK_ENABLED) return;
 
     // Load Zendesk widget script if not already loaded
     const existingScript = document.getElementById('ze-snippet');


### PR DESCRIPTION
Adds early return in `ZendeskWidget.tsx` and `Support.tsx` to disable widget loading.

To re-enable: remove the early returns and comments in both files.