### PR TITLE
feat: use video dimensions from imeta tag for proper aspect ratios

### DIFF
--- a/src/components/VideoCard.tsx
+++ b/src/components/VideoCard.tsx
@@ -103,10 +103,19 @@ export function VideoCard({
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [showViewSourceDialog, setShowViewSourceDialog] = useState(false);
   const [showReactionsModal, setShowReactionsModal] = useState<'likes' | 'reposts' | null>(null);
-  // Default aspect ratio: Vine videos (have loopCount) were square, others are likely 9:16 vertical
-  const [videoAspectRatio, setVideoAspectRatio] = useState<number>(
-    video.loopCount ? 1 : 9 / 16
-  );
+  // Calculate initial aspect ratio from video dimensions, or use sensible defaults
+  const getInitialAspectRatio = (): number => {
+    // Try to parse dimensions from video data (format: "WIDTHxHEIGHT", e.g., "1080x1920")
+    if (video.dimensions) {
+      const [width, height] = video.dimensions.split('x').map(Number);
+      if (width && height && !isNaN(width) && !isNaN(height)) {
+        return width / height;
+      }
+    }
+    // Fallback: Vine videos (have loopCount) were square, others are likely 9:16 vertical
+    return video.loopCount ? 1 : 9 / 16;
+  };
+  const [videoAspectRatio, setVideoAspectRatio] = useState<number>(getInitialAspectRatio);
   const _isMobile = useIsMobile();
   // Determine layout: use prop if provided, otherwise always vertical (text below video)
   const effectiveLayout = layout ?? 'vertical';

--- a/src/lib/funnelcakeTransform.ts
+++ b/src/lib/funnelcakeTransform.ts
@@ -58,6 +58,7 @@ export function transformFunnelcakeVideo(raw: FunnelcakeVideoRaw): ParsedVideoDa
     thumbnailUrl: raw.thumbnail,
     blurhash: raw.blurhash,
     title: raw.title,
+    dimensions: raw.dim, // Video dimensions from API (e.g., "1080x1920")
     hashtags,
 
     // Vine-specific fields

--- a/src/lib/videoParser.ts
+++ b/src/lib/videoParser.ts
@@ -698,6 +698,7 @@ export function parseVideoEvents(events: NostrEvent[]): ParsedVideoData[] {
       blurhash: videoEvent.videoMetadata?.blurhash,
       title: videoEvent.title,
       duration: videoEvent.videoMetadata?.duration,
+      dimensions: videoEvent.videoMetadata?.dimensions,
       hashtags: videoEvent.hashtags || [],
       vineId,
       loopCount: getLoopCount(event),

--- a/src/types/funnelcake.ts
+++ b/src/types/funnelcake.ts
@@ -20,6 +20,7 @@ export interface FunnelcakeVideoRaw {
   thumbnail?: string;     // Thumbnail URL
   video_url: string;      // Primary video URL
   blurhash?: string;      // Progressive loading placeholder
+  dim?: string;           // Video dimensions (e.g., "1080x1920")
   author_name?: string;   // Cached author display name
   author_avatar?: string; // Cached author avatar URL
 

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -80,6 +80,7 @@ export interface ParsedVideoData {
   blurhash?: string; // Blurhash for progressive loading placeholder
   title?: string;
   duration?: number;
+  dimensions?: string; // Video dimensions from imeta dim tag (e.g., "1080x1920")
   hashtags: string[];
   vineId: string | null;
   loopCount?: number;


### PR DESCRIPTION
## Summary
- Add `dimensions` field to video data types to capture the `dim` tag from Nostr imeta
- Pass dimensions through both WebSocket (videoParser) and REST (funnelcakeTransform) paths
- Use dimensions in VideoCard to calculate correct initial aspect ratio before video loads
- Prevents video containers from collapsing to wrong heights when videos fail to load

## Changes
- `src/types/video.ts`: Add `dimensions?: string` to `ParsedVideoData`
- `src/types/funnelcake.ts`: Add `dim?: string` to `FunnelcakeVideoRaw`
- `src/lib/videoParser.ts`: Pass `dimensions` from `videoMetadata`
- `src/lib/funnelcakeTransform.ts`: Pass `dim` from API response
- `src/components/VideoCard.tsx`: Calculate initial aspect ratio from dimensions (e.g., "1080x1920" → 0.5625)

## Test plan
- [ ] Verify videos with `dim` tags display with correct aspect ratio on initial render
- [ ] Verify videos without `dim` tags fall back to loopCount-based aspect ratio
- [ ] Verify error state containers maintain proper height when video fails to load

🤖 Generated with [Claude Code](https://claude.com/claude-code)