### PR TITLE
feat: implement fullscreen TikTok-style video mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import { AppProvider } from '@/components/AppProvider';
 import { NWCProvider } from '@/contexts/NWCContext';
 import { AppConfig } from '@/contexts/AppContext';
 import { VideoPlaybackProvider } from '@/contexts/VideoPlaybackContext';
+import { FullscreenFeedProvider } from '@/contexts/FullscreenFeedContext';
 import AppRouter from './AppRouter';
 import { PRIMARY_RELAY, PRESET_RELAYS, toLegacyFormat } from '@/config/relays';
 
@@ -60,13 +61,15 @@ export function App() {
               <KeycastJWTWindowNostr />
               <NWCProvider>
                 <VideoPlaybackProvider>
-                  <TooltipProvider>
-                    <Toaster />
-                    <Sonner />
-                    <Suspense>
-                      <AppRouter />
-                    </Suspense>
-                  </TooltipProvider>
+                  <FullscreenFeedProvider>
+                    <TooltipProvider>
+                      <Toaster />
+                      <Sonner />
+                      <Suspense>
+                        <AppRouter />
+                      </Suspense>
+                    </TooltipProvider>
+                  </FullscreenFeedProvider>
                 </VideoPlaybackProvider>
               </NWCProvider>
             </NostrProvider>

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -3,13 +3,16 @@ import { AppHeader } from '@/components/AppHeader';
 import { AppFooter } from '@/components/AppFooter';
 import { BottomNav } from '@/components/BottomNav';
 import { PWAInstallPrompt } from '@/components/PWAInstallPrompt';
+import { FullscreenFeed } from '@/components/FullscreenFeed';
 import { useNostrLogin } from '@nostrify/react/login';
 import { useAppContext } from '@/hooks/useAppContext';
+import { useFullscreenFeed } from '@/contexts/FullscreenFeedContext';
 
 export function AppLayout() {
   const location = useLocation();
   const { logins } = useNostrLogin();
   const { isRecording } = useAppContext();
+  const { state: fullscreenState, exitFullscreen, onLoadMore, hasMore } = useFullscreenFeed();
 
   // Only consider user logged in if they have active logins, not just a token
   const isLoggedIn = logins.length > 0;
@@ -26,6 +29,17 @@ export function AppLayout() {
       <AppFooter />
       {!isLandingPage && !isRecording && <BottomNav />}
       <PWAInstallPrompt />
+
+      {/* Fullscreen video feed overlay */}
+      {fullscreenState.isOpen && (
+        <FullscreenFeed
+          videos={fullscreenState.videos}
+          startIndex={fullscreenState.startIndex}
+          onClose={exitFullscreen}
+          onLoadMore={onLoadMore}
+          hasMore={hasMore}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/FullscreenFeed.tsx
+++ b/src/components/FullscreenFeed.tsx
@@ -170,6 +170,7 @@ function FullscreenVideoWithMetrics({
       likeCount={(video.likeCount ?? 0) + (socialMetrics.data?.likeCount ?? 0)}
       repostCount={(video.repostCount ?? 0) + (socialMetrics.data?.repostCount ?? 0)}
       commentCount={(video.commentCount ?? 0) + (socialMetrics.data?.commentCount ?? 0)}
+      viewCount={(socialMetrics.data?.viewCount ?? 0) + (video.loopCount ?? 0)}
     />
   );
 }

--- a/src/components/VideoCard.tsx
+++ b/src/components/VideoCard.tsx
@@ -3,7 +3,7 @@
 
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { Heart, Repeat2, MessageCircle, Share, Eye, MoreVertical, Flag, UserX, Trash2, Volume2, VolumeX, Code, Users, ListPlus, Download } from 'lucide-react';
+import { Heart, Repeat2, MessageCircle, Share, Eye, MoreVertical, Flag, UserX, Trash2, Volume2, VolumeX, Code, Users, ListPlus, Download, Maximize2 } from 'lucide-react';
 import { nip19 } from 'nostr-tools';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -49,6 +49,7 @@ interface VideoCardProps {
   onCloseComments?: () => void;
   onPlay?: () => void;
   onLoadedData?: () => void;
+  onEnterFullscreen?: () => void;
   isLiked?: boolean;
   isReposted?: boolean;
   likeCount?: number;
@@ -72,6 +73,7 @@ export function VideoCard({
   onCloseComments,
   onPlay,
   onLoadedData,
+  onEnterFullscreen,
   isLiked = false,
   isReposted = false,
   likeCount = 0,
@@ -456,6 +458,35 @@ export function VideoCard({
                   ) : (
                     <Volume2 className="h-5 w-5" />
                   )}
+                </Button>
+              )}
+
+              {/* Fullscreen button overlay - bottom left corner */}
+              {isPlaying && !videoError && onEnterFullscreen && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className={cn(
+                    "absolute bottom-3 left-3 z-30",
+                    "bg-black/50 hover:bg-black/70 text-white",
+                    "backdrop-blur-sm rounded-full",
+                    "w-10 h-10 p-0 flex items-center justify-center",
+                    "transition-all duration-200"
+                  )}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    onEnterFullscreen();
+                  }}
+                  onTouchStart={(e) => {
+                    e.stopPropagation();
+                  }}
+                  onTouchEnd={(e) => {
+                    e.stopPropagation();
+                  }}
+                  aria-label="Enter fullscreen"
+                >
+                  <Maximize2 className="h-5 w-5" />
                 </Button>
               )}
             </div>

--- a/src/components/VideoCardWithMetrics.tsx
+++ b/src/components/VideoCardWithMetrics.tsx
@@ -20,6 +20,7 @@ interface VideoCardWithMetricsProps {
   showComments: boolean;
   onOpenComments: () => void;
   onCloseComments: () => void;
+  onEnterFullscreen?: () => void;
   navigationContext?: VideoNavigationContext;
 }
 
@@ -33,6 +34,7 @@ function VideoCardWithMetricsInner({
   showComments,
   onOpenComments,
   onCloseComments,
+  onEnterFullscreen,
   navigationContext,
 }: VideoCardWithMetricsProps) {
   const { user } = useCurrentUser();
@@ -106,6 +108,7 @@ function VideoCardWithMetricsInner({
       onRepost={handleVideoRepost}
       onOpenComments={onOpenComments}
       onCloseComments={onCloseComments}
+      onEnterFullscreen={onEnterFullscreen}
       isLiked={userInteractions.data?.hasLiked || false}
       isReposted={userInteractions.data?.hasReposted || false}
       likeCount={(video.likeCount ?? 0) + (socialMetrics.data?.likeCount ?? 0)}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -19,7 +19,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-[200] bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg max-h-[90vh] overflow-y-auto",
+        "fixed left-[50%] top-[50%] z-[200] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg max-h-[90vh] overflow-y-auto",
         className
       )}
       {...props}

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -45,7 +45,7 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "z-[200] min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
       className
     )}
     {...props}
@@ -63,7 +63,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-[200] min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className
       )}
       {...props}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -19,7 +19,7 @@ const SheetOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Overlay
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-[200] bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}
@@ -29,7 +29,7 @@ const SheetOverlay = React.forwardRef<
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
 
 const sheetVariants = cva(
-  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+  "fixed z-[200] gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
   {
     variants: {
       side: {


### PR DESCRIPTION
## Summary

- Wire up existing fullscreen video infrastructure for app-like vertical swipe experience
- Add fullscreen button to VideoCard (bottom-left expand icon)
- Implement full feature parity with VideoCard in fullscreen mode
- Fix z-index issues so modals appear above fullscreen overlay
- Add infinite scroll support in fullscreen mode

## Changes

### Infrastructure
- Add `FullscreenFeedProvider` to `App.tsx`
- Render `FullscreenFeed` overlay in `AppLayout` when activated
- Extend context to support `onLoadMore` and `hasMore` for pagination

### Entry Points
- Add fullscreen button to `VideoCard` (visible when video is playing)
- Register videos from `VideoFeed` to fullscreen context
- Wire up handlers through `VideoCardWithMetrics`

### Touch Gestures
- Remove `pointer-events-none` that was blocking touch
- Add double-tap to like with heart animation
- Swipe right to close already working

### Feature Parity (FullscreenVideoItem)
- View count with Eye icon
- VineBadge for migrated Vines
- ProofModeBadge for verified videos
- VideoReactionsModal (click like/repost count)
- Lists button (add to list)
- More menu (delete, report video/user, mute, view source)
- NoteContent parsing for mentions/links

### Z-Index Fixes
- Dialog: z-50 → z-[200]
- DropdownMenu: z-50 → z-[200]
- Sheet: z-50 → z-[200]

## Test plan

- [ ] Click fullscreen button on VideoCard → overlay appears
- [ ] Swipe up/down changes videos
- [ ] Double-tap to like shows heart animation
- [ ] Press Escape or X to close
- [ ] Like, repost, share, download buttons work
- [ ] Comment button opens modal
- [ ] Lists button opens dialog
- [ ] More menu opens with all options
- [ ] Scroll to end loads more videos

🤖 Generated with [Claude Code](https://claude.com/claude-code)