### PR TITLE
fix: update Discord invite links to current server

### DIFF
--- a/compute-js/src/index.js
+++ b/compute-js/src/index.js
@@ -21,7 +21,7 @@ const EXTERNAL_REDIRECTS = {
   '/news': { url: 'https://about.divine.video/news/', status: 301 },
   '/media-resources': { url: 'https://about.divine.video/media-resources/', status: 301 },
   '/news/vine-revisited': { url: 'https://about.divine.video/vine-revisited-a-return-to-the-halcyon-days-of-the-internet/', status: 301 },
-  '/discord': { url: 'https://discord.gg/RZVbzuQ5qM', status: 302 },
+  '/discord': { url: 'https://discord.gg/d6HpB6XnHp', status: 302 },
 };
 
 // eslint-disable-next-line no-restricted-globals

--- a/src/components/AppFooter.tsx
+++ b/src/components/AppFooter.tsx
@@ -122,7 +122,7 @@ export function AppFooter() {
                   />
                 </a>
                 <a
-                  href="https://discord.gg/2J5JcUKrPw"
+                  href="https://discord.gg/d6HpB6XnHp"
                   target="_blank"
                   rel="noopener noreferrer"
                   aria-label="Join us on Discord"


### PR DESCRIPTION
## Summary
- Update Discord invite link in AppFooter from expired `2J5JcUKrPw` to `d6HpB6XnHp`
- Update Discord redirect in Fastly edge worker from `RZVbzuQ5qM` to `d6HpB6XnHp`

## Test plan
- [ ] Verify footer Discord icon links to correct server
- [ ] Verify `/discord` redirect works after Fastly deploy