### PR TITLE
fix: disable broken keycast login UI and fix profile page bugs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,6 @@ import { InferSeoMetaPlugin } from '@unhead/addons';
 import { Suspense } from 'react';
 import NostrProvider from '@/components/NostrProvider';
 import { EventCachePreloader } from '@/components/EventCachePreloader';
-import { KeycastJWTWindowNostr } from '@/components/KeycastJWTWindowNostr';
 import { SentryUserSync } from '@/components/SentryUserSync';
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
@@ -59,7 +58,6 @@ export function App() {
           <NostrLoginProvider storageKey='nostr:login'>
             <NostrProvider>
               <EventCachePreloader />
-              <KeycastJWTWindowNostr />
               <SentryUserSync />
               <NWCProvider>
                 <VideoPlaybackProvider>

--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -42,11 +42,7 @@ import { AppLayout } from "@/components/AppLayout";
 import { DebugVideoPage } from "./pages/DebugVideoPage";
 import LeaderboardPage from "./pages/LeaderboardPage";
 // import { UploadPage } from "./pages/UploadPage"; // DISABLED: Upload route is commented out
-import { KeycastAutoConnect } from "@/components/KeycastAutoConnect";
-
 export function AppRouter() {
-  // Auto-connect Keycast bunker if user has a session
-  KeycastAutoConnect();
   const { logins } = useNostrLogin();
 
   // Check if user is logged in

--- a/src/components/auth/LoginArea.tsx
+++ b/src/components/auth/LoginArea.tsx
@@ -6,7 +6,6 @@ import { User, UserPlus } from 'lucide-react';
 import { Button } from '@/components/ui/button.tsx';
 import LoginDialog from './LoginDialog';
 import SignupDialog from './SignupDialog';
-import { KeycastSignupDialog } from './KeycastSignupDialog';
 import { useLoggedInAccounts } from '@/hooks/useLoggedInAccounts';
 import { AccountSwitcher } from './AccountSwitcher';
 import { cn } from '@/lib/utils';
@@ -21,7 +20,6 @@ export function LoginArea({ className }: LoginAreaProps) {
   const { isOpen: globalLoginDialogOpen, closeLoginDialog } = useLoginDialog();
   const [localLoginDialogOpen, setLocalLoginDialogOpen] = useState(false);
   const [signupDialogOpen, setSignupDialogOpen] = useState(false);
-  const [keycastSignupDialogOpen, setKeycastSignupDialogOpen] = useState(false);
 
   // Combine global and local dialog open states
   const loginDialogOpen = globalLoginDialogOpen || localLoginDialogOpen;
@@ -35,7 +33,6 @@ export function LoginArea({ className }: LoginAreaProps) {
   const handleLogin = () => {
     handleCloseLoginDialog();
     setSignupDialogOpen(false);
-    setKeycastSignupDialogOpen(false);
   };
 
   return (
@@ -80,12 +77,6 @@ export function LoginArea({ className }: LoginAreaProps) {
         }}
       />
 
-      <KeycastSignupDialog
-        isOpen={keycastSignupDialogOpen}
-        onClose={() => setKeycastSignupDialogOpen(false)}
-        onComplete={handleLogin}
-        onSwitchToLogin={() => setLocalLoginDialogOpen(true)}
-      />
     </div>
   );
 }

--- a/src/components/auth/LoginDialog.tsx
+++ b/src/components/auth/LoginDialog.tsx
@@ -2,14 +2,13 @@
 // It is important that all functionality in this file is preserved, and should only be modified if explicitly requested.
 
 import React, { useRef, useState, useEffect } from 'react';
-import { Shield, Upload, AlertTriangle, KeyRound, Cloud, Mail } from 'lucide-react';
+import { Shield, Upload, AlertTriangle, KeyRound, Cloud } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Dialog, DialogContent, DialogHeader, DialogDescription } from "@/components/ui/dialog";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { useLoginActions } from '@/hooks/useLoginActions';
-import { KeycastLoginForm } from '@/components/auth/KeycastLoginForm';
 import { cn } from '@/lib/utils';
 
 interface LoginDialogProps {
@@ -187,15 +186,11 @@ const LoginDialog: React.FC<LoginDialogProps> = ({ isOpen, onClose, onLogin, onS
 
           {/* Login Methods */}
           <Tabs defaultValue={defaultTab} className="w-full">
-            <TabsList className="grid w-full grid-cols-4 bg-muted rounded-lg mb-4">
+            <TabsList className="grid w-full grid-cols-3 bg-muted rounded-lg mb-4">
               <TabsTrigger value="extension" className="flex items-center gap-2">
                 <Shield className="w-4 h-4" />
                 <span className="hidden sm:inline">Extension</span>
                 <span className="sm:hidden">Ext</span>
-              </TabsTrigger>
-              <TabsTrigger value="email" className="flex items-center gap-2">
-                <Mail className="w-4 h-4" />
-                <span>Email</span>
               </TabsTrigger>
               <TabsTrigger value="key" className="flex items-center gap-2">
                 <KeyRound className="w-4 h-4" />
@@ -228,26 +223,6 @@ const LoginDialog: React.FC<LoginDialogProps> = ({ isOpen, onClose, onLogin, onS
                     {isLoading ? 'Logging in...' : 'Login with Extension'}
                   </Button>
                 </div>
-              </div>
-            </TabsContent>
-
-            <TabsContent value='email' className='space-y-3'>
-              <div className='p-4 rounded-lg bg-gray-50 dark:bg-gray-800'>
-                <Mail className='w-12 h-12 mx-auto mb-3 text-primary' />
-                <p className='text-sm text-gray-600 dark:text-gray-300 mb-4 text-center'>
-                  Login with your diVine account
-                </p>
-                <div className='p-4 mb-4 rounded-lg bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-800'>
-                  <p className='text-sm text-blue-800 dark:text-blue-200 text-center'>
-                    Note: Email signup is currently disabled. The beta is only open to existing Nostr users.
-                  </p>
-                </div>
-                <KeycastLoginForm
-                  onSuccess={() => {
-                    onLogin();
-                    onClose();
-                  }}
-                />
               </div>
             </TabsContent>
 

--- a/src/pages/FAQPage.tsx
+++ b/src/pages/FAQPage.tsx
@@ -388,7 +388,6 @@ export function FAQPage() {
                     <strong>Web app:</strong> You have several options:
                   </p>
                   <ul className="list-disc list-inside space-y-1 ml-4">
-                    <li><strong>Email signup:</strong> Sign up with email using Keycast, which manages your Nostr keys for you</li>
                     <li><strong>Browser extension:</strong> Use extensions like Alby, nos2x, or Flamingo</li>
                     <li><strong>Private key (advanced):</strong> Import your existing Nostr private key (nsec)</li>
                     <li><strong>Remote signer:</strong> Use a bunker URL for secure remote signing</li>
@@ -448,7 +447,7 @@ export function FAQPage() {
                     <li>Save your private key in a password manager</li>
                     <li>Write it down on paper and store it securely</li>
                     <li>Use a browser extension that securely stores your key</li>
-                    <li>Or use email signup with Keycast, which manages keys for you</li>
+                    <li>Or use a password manager to store your key securely</li>
                   </ul>
                 </div>
               </FAQQuestion>


### PR DESCRIPTION
## Summary
- Remove keycast email login tab from login dialog (4 tabs -> 3: Extension, Key, Bunker)
- Remove KeycastSignupDialog from signup flow
- Remove KeycastAutoConnect and KeycastJWTWindowNostr from app initialization
- Update FAQ to remove keycast/email signup references
- Keycast source files kept as dead code for re-enablement via #80

### Additional fixes on main
- **App crash:** Add missing `PROFILE_SORT_MODES` export to sortModes.ts
  (18f6be1 added the import to ProfilePage but not the export — deploying
  main without this fix renders a blank page)
- **Float display:** Round `total_loops` in profile stats formatter so
  values like `754.3333333333325` display as `754`

## Test plan
- [ ] Login dialog shows 3 tabs: Extension, Key, Bunker (no Email)
- [ ] Signup dialog shows direct "Create Account" flow (no Keycast)
- [ ] App loads without crashes on /discovery and /profile routes
- [ ] Profile page stats show integer loop counts, not floats
- [ ] FAQ page has no keycast/email references