### PR TITLE
fix: skip URL-like queries in search to prevent Funnelcake 500 errors

### DIFF
--- a/src/hooks/useInfiniteSearchVideos.test.ts
+++ b/src/hooks/useInfiniteSearchVideos.test.ts
@@ -116,6 +116,21 @@ describe('useInfiniteSearchVideos', () => {
     expect(result.current.data?.pages[0].videos).toEqual([]);
   });
 
+  it('returns empty results for scheme-less Vine URLs without calling the API', async () => {
+    const { result } = renderHook(
+      () => useInfiniteSearchVideos({ query: 'vine.co/v/hAgW0mP5zKL', sortMode: 'relevance', pageSize: 20 }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockSearchVideos).not.toHaveBeenCalled();
+    expect(mockNostrQuery).not.toHaveBeenCalled();
+    expect(result.current.data?.pages[0].videos).toEqual([]);
+  });
+
   it('falls back to relay search when Funnelcake search throws', async () => {
     const relayVideos = [
       { id: 'video-2', pubkey: 'pubkey-2', createdAt: 456 } as const,

--- a/src/hooks/useInfiniteSearchVideos.test.ts
+++ b/src/hooks/useInfiniteSearchVideos.test.ts
@@ -101,6 +101,21 @@ describe('useInfiniteSearchVideos', () => {
     expect(result.current.data?.pages[0].videos).toEqual(expectedVideos);
   });
 
+  it('returns empty results for URL-like queries without calling the API', async () => {
+    const { result } = renderHook(
+      () => useInfiniteSearchVideos({ query: 'https://vine.co/v/hAgW0mP5zKL//', sortMode: 'relevance', pageSize: 20 }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockSearchVideos).not.toHaveBeenCalled();
+    expect(mockNostrQuery).not.toHaveBeenCalled();
+    expect(result.current.data?.pages[0].videos).toEqual([]);
+  });
+
   it('falls back to relay search when Funnelcake search throws', async () => {
     const relayVideos = [
       { id: 'video-2', pubkey: 'pubkey-2', createdAt: 456 } as const,

--- a/src/hooks/useInfiniteSearchVideos.ts
+++ b/src/hooks/useInfiniteSearchVideos.ts
@@ -13,6 +13,7 @@ import { isFunnelcakeAvailable } from '@/lib/funnelcakeHealth';
 import { debugLog } from '@/lib/debug';
 import { transformToVideoPage } from '@/lib/funnelcakeTransform';
 import { reportFunnelcakeFallback } from '@/lib/funnelcakeFallbackReporting';
+import { isUrlLikeQuery } from '@/lib/searchUtils';
 
 interface UseInfiniteSearchVideosOptions {
   query: string;
@@ -100,7 +101,7 @@ export function useInfiniteSearchVideos({
       }
 
       // Skip URL-like queries that cause Funnelcake 500 errors (#166)
-      if (/^https?:\/\//i.test(debouncedQuery.trim())) {
+      if (isUrlLikeQuery(debouncedQuery)) {
         return { videos: [], nextCursor: undefined };
       }
 

--- a/src/hooks/useInfiniteSearchVideos.ts
+++ b/src/hooks/useInfiniteSearchVideos.ts
@@ -99,6 +99,11 @@ export function useInfiniteSearchVideos({
         return { videos: [], nextCursor: undefined };
       }
 
+      // Skip URL-like queries that cause Funnelcake 500 errors (#166)
+      if (/^https?:\/\//i.test(debouncedQuery.trim())) {
+        return { videos: [], nextCursor: undefined };
+      }
+
       const requestStartedAt = performance.now();
       const cursor = pageParam as number | undefined;
       const searchParams = parseSearchQuery(debouncedQuery, searchType);

--- a/src/hooks/useSearchUsers.test.ts
+++ b/src/hooks/useSearchUsers.test.ts
@@ -153,6 +153,21 @@ describe('useSearchUsers', () => {
     expect(result.current.data).toEqual([]);
   });
 
+  it('returns empty results for scheme-less Vine URLs without calling the API', async () => {
+    const { result } = renderHook(
+      () => useSearchUsers({ query: 'vine.co/v/hAgW0mP5zKL', limit: 20 }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockSearchProfiles).not.toHaveBeenCalled();
+    expect(mockNostrQuery).not.toHaveBeenCalled();
+    expect(result.current.data).toEqual([]);
+  });
+
   it('skips Funnelcake entirely when the circuit breaker marks it unavailable', async () => {
     mockIsFunnelcakeAvailable.mockReturnValue(false);
     mockNostrQuery.mockResolvedValue([

--- a/src/hooks/useSearchUsers.test.ts
+++ b/src/hooks/useSearchUsers.test.ts
@@ -138,6 +138,21 @@ describe('useSearchUsers', () => {
     ]);
   });
 
+  it('returns empty results for URL-like queries without calling the API', async () => {
+    const { result } = renderHook(
+      () => useSearchUsers({ query: 'https://vine.co/v/hAgW0mP5zKL//', limit: 20 }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockSearchProfiles).not.toHaveBeenCalled();
+    expect(mockNostrQuery).not.toHaveBeenCalled();
+    expect(result.current.data).toEqual([]);
+  });
+
   it('skips Funnelcake entirely when the circuit breaker marks it unavailable', async () => {
     mockIsFunnelcakeAvailable.mockReturnValue(false);
     mockNostrQuery.mockResolvedValue([

--- a/src/hooks/useSearchUsers.ts
+++ b/src/hooks/useSearchUsers.ts
@@ -9,6 +9,7 @@ import { API_CONFIG } from '@/config/api';
 import { debugLog } from '@/lib/debug';
 import { reportFunnelcakeFallback } from '@/lib/funnelcakeFallbackReporting';
 import { isFunnelcakeAvailable } from '@/lib/funnelcakeHealth';
+import { isUrlLikeQuery } from '@/lib/searchUtils';
 import type { NostrMetadata, NostrEvent } from '@nostrify/nostrify';
 
 interface UseSearchUsersOptions {
@@ -91,7 +92,7 @@ export function useSearchUsers(options: UseSearchUsersOptions) {
       }
 
       // Skip URL-like queries that cause Funnelcake 500 errors (#166)
-      if (/^https?:\/\//i.test(debouncedQuery.trim())) {
+      if (isUrlLikeQuery(debouncedQuery)) {
         return [];
       }
 

--- a/src/hooks/useSearchUsers.ts
+++ b/src/hooks/useSearchUsers.ts
@@ -90,6 +90,11 @@ export function useSearchUsers(options: UseSearchUsersOptions) {
         return [];
       }
 
+      // Skip URL-like queries that cause Funnelcake 500 errors (#166)
+      if (/^https?:\/\//i.test(debouncedQuery.trim())) {
+        return [];
+      }
+
       const requestStartedAt = performance.now();
       const requestContext = {
         query: debouncedQuery,

--- a/src/lib/searchUtils.test.ts
+++ b/src/lib/searchUtils.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { isUrlLikeQuery } from './searchUtils';
+
+describe('isUrlLikeQuery', () => {
+  it('detects http URLs', () => {
+    expect(isUrlLikeQuery('http://example.com')).toBe(true);
+  });
+
+  it('detects https URLs', () => {
+    expect(isUrlLikeQuery('https://vine.co/v/hAgW0mP5zKL//')).toBe(true);
+  });
+
+  it('is case-insensitive', () => {
+    expect(isUrlLikeQuery('HTTPS://VINE.CO')).toBe(true);
+    expect(isUrlLikeQuery('Http://Example.com')).toBe(true);
+  });
+
+  it('handles leading/trailing whitespace', () => {
+    expect(isUrlLikeQuery('  https://vine.co  ')).toBe(true);
+  });
+
+  it('rejects normal search terms', () => {
+    expect(isUrlLikeQuery('funny cats')).toBe(false);
+  });
+
+  it('rejects hashtags', () => {
+    expect(isUrlLikeQuery('#divine')).toBe(false);
+  });
+
+  it('rejects empty string', () => {
+    expect(isUrlLikeQuery('')).toBe(false);
+  });
+
+  it('rejects strings that contain URLs but do not start with them', () => {
+    expect(isUrlLikeQuery('check out https://vine.co')).toBe(false);
+  });
+});

--- a/src/lib/searchUtils.test.ts
+++ b/src/lib/searchUtils.test.ts
@@ -34,4 +34,24 @@ describe('isUrlLikeQuery', () => {
   it('rejects strings that contain URLs but do not start with them', () => {
     expect(isUrlLikeQuery('check out https://vine.co')).toBe(false);
   });
+
+  it('detects bare hostname with path (scheme-less Vine URL)', () => {
+    expect(isUrlLikeQuery('vine.co/v/hAgW0mP5zKL')).toBe(true);
+    expect(isUrlLikeQuery('vine.co/v/hAgW0mP5zKL//')).toBe(true);
+  });
+
+  it('detects other bare hostname URLs with paths', () => {
+    expect(isUrlLikeQuery('example.com/page')).toBe(true);
+    expect(isUrlLikeQuery('sub.domain.co.uk/path')).toBe(true);
+  });
+
+  it('rejects bare hostnames without a path', () => {
+    expect(isUrlLikeQuery('vine.co')).toBe(false);
+    expect(isUrlLikeQuery('example.com')).toBe(false);
+  });
+
+  it('rejects dotted words that are not URLs', () => {
+    expect(isUrlLikeQuery('funny.cats')).toBe(false);
+    expect(isUrlLikeQuery('music.video')).toBe(false);
+  });
 });

--- a/src/lib/searchUtils.ts
+++ b/src/lib/searchUtils.ts
@@ -1,0 +1,10 @@
+// ABOUTME: Shared search query utilities
+// ABOUTME: Guards and sanitizers reused across search hooks
+
+/**
+ * Detect URL-like input that causes Funnelcake 500 errors.
+ * See: https://github.com/divinevideo/divine-web/issues/166
+ */
+export function isUrlLikeQuery(query: string): boolean {
+  return /^https?:\/\//i.test(query.trim());
+}

--- a/src/lib/searchUtils.ts
+++ b/src/lib/searchUtils.ts
@@ -3,8 +3,23 @@
 
 /**
  * Detect URL-like input that causes Funnelcake 500 errors.
+ * Catches both explicit URLs (https://vine.co/v/abc) and bare hostnames
+ * with paths (vine.co/v/abc), aligned with parseHttpUrl() in directSearch.
  * See: https://github.com/divinevideo/divine-web/issues/166
  */
 export function isUrlLikeQuery(query: string): boolean {
-  return /^https?:\/\//i.test(query.trim());
+  const trimmed = query.trim();
+  if (/^https?:\/\//i.test(trimmed)) return true;
+
+  // Bare hostname with path (e.g. vine.co/v/abc):
+  // prepend https:// and try to parse — same approach as parseHttpUrl().
+  // Require pathname beyond "/" to avoid false positives on "funny.cats".
+  try {
+    const url = new URL(`https://${trimmed}`);
+    if (url.hostname.includes('.') && url.pathname.length > 1) return true;
+  } catch {
+    // not parseable — not a URL
+  }
+
+  return false;
 }


### PR DESCRIPTION
  ## Description
  Skip URL-like queries in search hooks to prevent Funnelcake 500 errors.

  When users paste URLs like `https://vine.co/v/hAgW0mP5zKL//` into the search bar, the query goes directly to the Funnelcake API which returns HTTP 500. This generates Sentry noise (FUNNELCAKE-F: 227 events, FUNNELCAKE-1: 395 events).

  Added client-side URL detection in both video search and profile search hooks. URL-like queries now return empty results immediately instead of hitting the API.

  ## Related Issue
  Fixes #166

  ## Changes Made
  - `useInfiniteSearchVideos.ts`: return empty results for `http://` / `https://` queries
  - `useSearchUsers.ts`: same guard for profile search

  ## Checklist
  - [x] Linter passes
  - [x] Both search hooks protected