### PR TITLE
fix: include pubkey in unsigned events for JWT signer

### DIFF
--- a/src/hooks/useNostrPublish.ts
+++ b/src/hooks/useNostrPublish.ts
@@ -19,11 +19,15 @@ export function useNostrPublish(): UseMutationResult<NostrEvent> {
           tags.push(["client", location.hostname]);
         }
 
+        // Include pubkey in the unsigned event for signers (like DivineJWTSigner)
+        // that forward to an API expecting pubkey to already be set.
+        const pubkey = user.pubkey;
         const event = await signer.signEvent({
           kind: t.kind,
           content: t.content ?? "",
           tags,
           created_at: t.created_at ?? Math.floor(Date.now() / 1000),
+          pubkey,
         });
 
         await nostr.event(event, { signal: AbortSignal.timeout(5000) });

--- a/src/hooks/useNostrPublish.ts
+++ b/src/hooks/useNostrPublish.ts
@@ -19,16 +19,17 @@ export function useNostrPublish(): UseMutationResult<NostrEvent> {
           tags.push(["client", location.hostname]);
         }
 
-        // Include pubkey in the unsigned event for signers (like DivineJWTSigner)
-        // that forward to an API expecting pubkey to already be set.
-        const pubkey = user.pubkey;
-        const event = await signer.signEvent({
+        // Build the unsigned event. We include pubkey for signers (like
+        // DivineJWTSigner) that forward to an API expecting it, even though
+        // the NostrSigner type omits it. NIP-07/nsec signers ignore extra fields.
+        const unsigned = {
           kind: t.kind,
           content: t.content ?? "",
           tags,
           created_at: t.created_at ?? Math.floor(Date.now() / 1000),
-          pubkey,
-        });
+          pubkey: user.pubkey,
+        };
+        const event = await signer.signEvent(unsigned as Parameters<typeof signer.signEvent>[0]);
 
         await nostr.event(event, { signal: AbortSignal.timeout(5000) });
         return event;


### PR DESCRIPTION
## Summary
- Fixes `login.divine.video/api/nostr` returning 400 "Invalid event format: missing field pubkey" for every signEvent call
- The DivineJWTSigner sends events to the login API which expects pubkey to be pre-filled, but `useNostrPublish` wasn't including it
- This caused **hundreds of failed publish attempts** (view count events, Kind 22236) which spammed the console and likely blocked feed pagination

## Root cause
`signer.signEvent()` receives `{ kind, content, tags, created_at }` without `pubkey`. NIP-07/nsec signers fill this in automatically, but the JWT REST signer forwards the event as-is to the API.

## Fix
Set `pubkey: user.pubkey` on the unsigned event before calling `signer.signEvent()`.

## Also needs fixing in @divinevideo/login SDK (separate issue)
1. `signEvent()` should set pubkey from cached `getPublicKey()` result before sending to API
2. `getPublicKey()` should cache its result — currently hits the server on every call (hundreds of times per session)

## Test plan
- [x] TypeScript clean
- [ ] Log in with invite code, scroll feed, verify no more "missing field pubkey" 400 errors
- [ ] Verify view count events publish successfully
- [ ] Verify feed pagination works past first page

🤖 Generated with [Claude Code](https://claude.com/claude-code)