### PR TITLE
feat: resolve divine.video/@username to subdomain via NIP-05

### DIFF
--- a/docs/superpowers/specs/2026-03-31-at-username-redirect-design.md
+++ b/docs/superpowers/specs/2026-03-31-at-username-redirect-design.md
@@ -1,0 +1,74 @@
+# @username Redirect Route
+
+**Date:** 2026-03-31
+**Status:** Approved
+
+## Problem
+
+`divine.video/@username` is a natural URL pattern users expect (Twitter, Mastodon, etc.), but it currently falls through to the `/:nip19` catch-all route and shows a 404 since `@username` is not a valid NIP-19 identifier.
+
+## Design
+
+Add a client-side route at `/@:username` that resolves the username via NIP-05 and redirects to the user's subdomain profile.
+
+### Route
+
+New route `/@:username` in `AppRouter.tsx`, placed above the `/:nip19` catch-all inside the `AppLayout` routes.
+
+### Page component: `AtUsernamePage.tsx`
+
+1. Extract `username` from route params
+2. Fetch `/.well-known/nostr.json?name={username}` (relative URL)
+3. Parse the JSON response for `names[username]` to get the hex pubkey
+4. If found: `window.location.href = https://{username}.divine.video`
+5. If not found: show "User Not Found" card
+
+### NIP-05 lookup
+
+Use a relative fetch (`/.well-known/nostr.json?name={username}`) rather than hardcoding `divine.video`. This means the lookup works against whatever host is serving the app, making it testable on CI test URLs and local dev without Fastly.
+
+The NIP-05 response format is:
+```json
+{
+  "names": {
+    "username": "hex-pubkey"
+  }
+}
+```
+
+We only need to check that `names[username]` exists and is a 64-char hex string.
+
+### Redirect behavior
+
+Use `window.location.href` (full navigation, not React Router `navigate()`), consistent with the existing subdomain redirect in ProfilePage (line 156). This is a cross-origin navigation to a different subdomain.
+
+### Edge cases
+
+- **Already on a subdomain** (`alice.divine.video/@bob`): Redirects to `bob.divine.video`. Correct behavior -- explicit intent to visit another user.
+- **Username not found in NIP-05**: Show "User Not Found" card with the username displayed, matching the UniversalUserPage error pattern.
+- **NIP-05 fetch fails** (network error, non-JSON response): Treat as "not found" with a generic error message.
+- **Username with special characters**: URL-decode the param before looking up. NIP-05 names are lowercase alphanumeric with underscores and hyphens.
+
+### UI states
+
+- **Loading**: Centered Loader2 spinner with "Looking up @{username}..." (matches UniversalUserPage)
+- **Not found**: Card with AlertCircle, "User Not Found" heading, username displayed, "Go to Home" button
+- **Redirecting**: Loader2 spinner with "Redirecting to {username}.divine.video..."
+
+### Testing
+
+Unit tests with vitest:
+1. Successful lookup redirects (mock fetch, verify `window.location.href` set)
+2. Username not in NIP-05 response shows not-found state
+3. Fetch failure shows not-found state
+4. URL-encoded usernames are decoded before lookup
+
+No Fastly changes needed. The route is entirely client-side.
+
+## Files
+
+| File | Change |
+|------|--------|
+| `src/pages/AtUsernamePage.tsx` | New page component |
+| `src/pages/AtUsernamePage.test.tsx` | Tests |
+| `src/AppRouter.tsx` | Add `/@:username` route |

--- a/docs/superpowers/specs/2026-03-31-at-username-redirect-design.md
+++ b/docs/superpowers/specs/2026-03-31-at-username-redirect-design.md
@@ -13,19 +13,20 @@ Add a client-side route at `/@:username` that resolves the username via NIP-05 a
 
 ### Route
 
-New route `/@:username` in `AppRouter.tsx`, placed above the `/:nip19` catch-all inside the `AppLayout` routes.
+React Router v6 does not support literal prefix characters in path patterns (`/@:username` won't match). Instead, `NIP19Page.tsx` detects the `@` prefix on the existing `/:nip19` catch-all and delegates to `AtUsernamePage`.
 
 ### Page component: `AtUsernamePage.tsx`
 
-1. Extract `username` from route params
-2. Fetch `/.well-known/nostr.json?name={username}` (relative URL)
-3. Parse the JSON response for `names[username]` to get the hex pubkey
-4. If found: `window.location.href = https://{username}.divine.video`
-5. If not found: show "User Not Found" card
+1. Accept `username` as a prop (passed by NIP19Page)
+2. If on a subdomain, redirect to `https://divine.video/@{username}` (see Subdomain guard below)
+3. Fetch `/.well-known/nostr.json?name={username}` (relative URL)
+4. Parse the JSON response for `names[username]` to get the hex pubkey
+5. If found: `window.location.href = https://{username}.divine.video`
+6. If not found: show "User Not Found" card
 
 ### NIP-05 lookup
 
-Use a relative fetch (`/.well-known/nostr.json?name={username}`) rather than hardcoding `divine.video`. This means the lookup works against whatever host is serving the app, making it testable on CI test URLs and local dev without Fastly.
+Use a relative fetch (`/.well-known/nostr.json?name={username}`) rather than hardcoding `divine.video`. On the apex domain (Fastly), this hits the edge worker's `handleNip05()` which does a `?name=` query against the KV store. On CF Pages test domains, NIP-05 returns 404 and the component degrades gracefully to "User Not Found."
 
 The NIP-05 response format is:
 ```json
@@ -42,9 +43,15 @@ We only need to check that `names[username]` exists and is a 64-char hex string.
 
 Use `window.location.href` (full navigation, not React Router `navigate()`), consistent with the existing subdomain redirect in ProfilePage (line 156). This is a cross-origin navigation to a different subdomain.
 
+### Subdomain guard
+
+On subdomains (e.g., `alice.divine.video/@bob`), the edge worker's NIP-05 handler returns the subdomain owner's data (`{"names": {"_": "<alice-pubkey>"}}`), not the `?name=` query result. The relative fetch would get the wrong response.
+
+Guard: if `getSubdomainUser()` returns non-null, skip the NIP-05 lookup entirely and redirect to `https://divine.video/@{username}`, where the apex handler resolves it correctly.
+
 ### Edge cases
 
-- **Already on a subdomain** (`alice.divine.video/@bob`): Redirects to `bob.divine.video`. Correct behavior -- explicit intent to visit another user.
+- **Already on a subdomain** (`alice.divine.video/@bob`): Redirects to `divine.video/@bob` first, which then resolves and redirects to `bob.divine.video`.
 - **Username not found in NIP-05**: Show "User Not Found" card with the username displayed, matching the UniversalUserPage error pattern.
 - **NIP-05 fetch fails** (network error, non-JSON response): Treat as "not found" with a generic error message.
 - **Username with special characters**: URL-decode the param before looking up. NIP-05 names are lowercase alphanumeric with underscores and hyphens.
@@ -59,9 +66,12 @@ Use `window.location.href` (full navigation, not React Router `navigate()`), con
 
 Unit tests with vitest:
 1. Successful lookup redirects (mock fetch, verify `window.location.href` set)
-2. Username not in NIP-05 response shows not-found state
-3. Fetch failure shows not-found state
-4. URL-encoded usernames are decoded before lookup
+2. Username case normalization (uppercase input lowercased before lookup)
+3. Username not in NIP-05 response shows not-found state
+4. Fetch failure shows not-found state
+5. Invalid pubkey in NIP-05 response shows not-found state
+6. Loading state while fetching
+7. Subdomain guard redirects to apex without fetching NIP-05
 
 No Fastly changes needed. The route is entirely client-side.
 
@@ -71,4 +81,4 @@ No Fastly changes needed. The route is entirely client-side.
 |------|--------|
 | `src/pages/AtUsernamePage.tsx` | New page component |
 | `src/pages/AtUsernamePage.test.tsx` | Tests |
-| `src/AppRouter.tsx` | Add `/@:username` route |
+| `src/pages/NIP19Page.tsx` | Detect `@` prefix, delegate to AtUsernamePage |

--- a/src/pages/AtUsernamePage.test.tsx
+++ b/src/pages/AtUsernamePage.test.tsx
@@ -19,6 +19,11 @@ vi.mock('@/lib/debug', () => ({
   debugLog: vi.fn(),
 }));
 
+const mockGetSubdomainUser = vi.hoisted(() => vi.fn(() => null));
+vi.mock('@/hooks/useSubdomainUser', () => ({
+  getSubdomainUser: mockGetSubdomainUser,
+}));
+
 vi.mock('@/components/ui/card', () => ({
   Card: ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
   CardContent: ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
@@ -150,5 +155,31 @@ describe('AtUsernamePage', () => {
     renderPage('loading');
 
     expect(screen.getByText('Looking up @loading...')).toBeInTheDocument();
+  });
+
+  it('redirects to apex domain when on a subdomain', async () => {
+    mockGetSubdomainUser.mockReturnValue({
+      subdomain: 'alice',
+      pubkey: 'b'.repeat(64),
+      npub: 'npub1test',
+      username: 'alice',
+      displayName: 'Alice',
+      picture: null,
+      banner: null,
+      about: null,
+      nip05: '_@alice.divine.video',
+      followersCount: 0,
+      followingCount: 0,
+      videoCount: 0,
+      apexDomain: 'divine.video',
+    });
+    renderPage('bob');
+
+    await waitFor(() => {
+      expect(window.location.href).toMatch(/^https:\/\/divine\.video\/@bob\/?$/);
+    });
+
+    // Should NOT have attempted a NIP-05 fetch
+    expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 });

--- a/src/pages/AtUsernamePage.test.tsx
+++ b/src/pages/AtUsernamePage.test.tsx
@@ -70,7 +70,7 @@ function mockFetchEmpty() {
 }
 
 function mockFetchError(status = 500) {
-  vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+  vi.spyOn(globalThis, 'fetch').mockResolvedValue(
     new Response('Internal Server Error', { status }),
   );
 }
@@ -126,10 +126,8 @@ describe('AtUsernamePage', () => {
   });
 
   it('shows not-found when fetch fails', async () => {
-    // Mock must return error for all retry attempts
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response('Internal Server Error', { status: 500 }),
-    );
+    // mockResolvedValue (not Once) so retries also fail
+    mockFetchError(500);
     renderPage('broken');
 
     expect(await screen.findByText('User Not Found', {}, { timeout: 5000 })).toBeInTheDocument();

--- a/src/pages/AtUsernamePage.test.tsx
+++ b/src/pages/AtUsernamePage.test.tsx
@@ -19,7 +19,8 @@ vi.mock('@/lib/debug', () => ({
   debugLog: vi.fn(),
 }));
 
-const mockGetSubdomainUser = vi.hoisted(() => vi.fn(() => null));
+const mockGetSubdomainUser = vi.hoisted(() => vi.fn((): SubdomainUser | null => null));
+type SubdomainUser = import('@/hooks/useSubdomainUser').SubdomainUser;
 vi.mock('@/hooks/useSubdomainUser', () => ({
   getSubdomainUser: mockGetSubdomainUser,
 }));

--- a/src/pages/AtUsernamePage.test.tsx
+++ b/src/pages/AtUsernamePage.test.tsx
@@ -1,0 +1,156 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import type { HTMLAttributes } from 'react';
+import { AtUsernamePage } from './AtUsernamePage';
+
+const mockNavigate = vi.hoisted(() => vi.fn());
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock('@/lib/debug', () => ({
+  debugLog: vi.fn(),
+}));
+
+vi.mock('@/components/ui/card', () => ({
+  Card: ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+  CardContent: ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+}));
+
+const VALID_PUBKEY = 'a'.repeat(64);
+const originalLocation = window.location;
+
+function setLocation(url: string) {
+  Object.defineProperty(window, 'location', {
+    value: new URL(url),
+    writable: true,
+    configurable: true,
+  });
+}
+
+function renderPage(username: string) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <AtUsernamePage username={username} />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+function mockFetchSuccess(username: string, pubkey: string) {
+  vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+    new Response(JSON.stringify({ names: { [username]: pubkey } }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  );
+}
+
+function mockFetchEmpty() {
+  vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+    new Response(JSON.stringify({ names: {} }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  );
+}
+
+function mockFetchError(status = 500) {
+  vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+    new Response('Internal Server Error', { status }),
+  );
+}
+
+describe('AtUsernamePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setLocation('https://divine.video/@alice');
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it('redirects to subdomain on successful NIP-05 lookup', async () => {
+    mockFetchSuccess('alice', VALID_PUBKEY);
+    renderPage('alice');
+
+    await waitFor(() => {
+      expect(window.location.href).toMatch(/^https:\/\/alice\.divine\.video\/?$/);
+    });
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      '/.well-known/nostr.json?name=alice',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it('lowercases the username before lookup', async () => {
+    mockFetchSuccess('kingbach', VALID_PUBKEY);
+    renderPage('KingBach');
+
+    await waitFor(() => {
+      expect(window.location.href).toMatch(/^https:\/\/kingbach\.divine\.video\/?$/);
+    });
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      '/.well-known/nostr.json?name=kingbach',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it('shows not-found when username is not in NIP-05 response', async () => {
+    mockFetchEmpty();
+    renderPage('nonexistent');
+
+    expect(await screen.findByText('User Not Found')).toBeInTheDocument();
+    expect(screen.getByText('@nonexistent')).toBeInTheDocument();
+  });
+
+  it('shows not-found when fetch fails', async () => {
+    // Mock must return error for all retry attempts
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('Internal Server Error', { status: 500 }),
+    );
+    renderPage('broken');
+
+    expect(await screen.findByText('User Not Found', {}, { timeout: 5000 })).toBeInTheDocument();
+  });
+
+  it('shows not-found when pubkey is not valid hex', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ names: { baduser: 'not-a-valid-pubkey' } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    renderPage('baduser');
+
+    expect(await screen.findByText('User Not Found')).toBeInTheDocument();
+  });
+
+  it('shows loading state while fetching', () => {
+    vi.spyOn(globalThis, 'fetch').mockReturnValue(new Promise(() => {}));
+    renderPage('loading');
+
+    expect(screen.getByText('Looking up @loading...')).toBeInTheDocument();
+  });
+});

--- a/src/pages/AtUsernamePage.tsx
+++ b/src/pages/AtUsernamePage.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { Card, CardContent } from '@/components/ui/card';
 import { AlertCircle, Loader2 } from 'lucide-react';
+import { getSubdomainUser } from '@/hooks/useSubdomainUser';
 import { debugLog } from '@/lib/debug';
 
 const HEX_64_PATTERN = /^[0-9a-f]{64}$/i;
@@ -63,7 +64,18 @@ interface AtUsernamePageProps {
 
 export function AtUsernamePage({ username }: AtUsernamePageProps) {
   const navigate = useNavigate();
-  const { data, isLoading, error } = useNip05Lookup(username);
+  const subdomainUser = getSubdomainUser();
+
+  // On subdomains, NIP-05 serves the subdomain owner, not the ?name= query.
+  // Redirect to the apex domain so the lookup resolves correctly.
+  useEffect(() => {
+    if (subdomainUser) {
+      const decoded = decodeUsername(username);
+      window.location.href = `https://${APEX_DOMAIN}/@${decoded}`;
+    }
+  }, [subdomainUser, username]);
+
+  const { data, isLoading, error } = useNip05Lookup(subdomainUser ? undefined : username);
 
   useEffect(() => {
     if (data) {

--- a/src/pages/AtUsernamePage.tsx
+++ b/src/pages/AtUsernamePage.tsx
@@ -1,69 +1,79 @@
-// ABOUTME: Page for /@username routes (e.g., divine.video/@samuelgrubbs)
-// ABOUTME: Checks edge-injected data first, then looks up username via KV/API and redirects to profile
+// ABOUTME: Resolves divine.video/@username to username.divine.video via NIP-05 lookup
+// ABOUTME: Fetches /.well-known/nostr.json and redirects to the user's subdomain profile
 
 import { useEffect } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
-import { nip19 } from 'nostr-tools';
 import { Card, CardContent } from '@/components/ui/card';
 import { AlertCircle, Loader2 } from 'lucide-react';
-import { getSubdomainUser } from '@/hooks/useSubdomainUser';
-import ProfilePage from './ProfilePage';
+import { debugLog } from '@/lib/debug';
 
-/**
- * Look up a username via the Funnelcake API's NIP-05 resolution
- */
-function useUsernameLookup(username: string | undefined) {
-  // If edge worker already injected user data, skip the lookup
-  const subdomainUser = getSubdomainUser();
+const HEX_64_PATTERN = /^[0-9a-f]{64}$/i;
+const APEX_DOMAIN = 'divine.video';
 
+function decodeUsername(raw: string): string {
+  try {
+    return decodeURIComponent(raw).toLowerCase().trim();
+  } catch {
+    return raw.toLowerCase().trim();
+  }
+}
+
+function useNip05Lookup(username: string | undefined) {
   return useQuery({
-    queryKey: ['at-username', username],
+    queryKey: ['at-username-nip05', username],
     queryFn: async ({ signal }) => {
-      if (!username) throw new Error('No username provided');
+      if (!username) throw new Error('No username');
 
-      // Look up username via NIP-05 resolution (divine.video/.well-known/nostr.json)
-      const divineNip05 = await fetch(
-        `https://divine.video/.well-known/nostr.json?name=${encodeURIComponent(username)}`,
-        { signal }
+      const decoded = decodeUsername(username);
+      debugLog('[AtUsernamePage] Looking up NIP-05 for:', decoded);
+
+      const response = await fetch(
+        `/.well-known/nostr.json?name=${encodeURIComponent(decoded)}`,
+        { signal },
       );
-      if (divineNip05.ok) {
-        const data = await divineNip05.json();
-        const pubkey = data.names?.[username] || data.names?.[username.toLowerCase()];
-        if (pubkey) {
-          return { pubkey, npub: nip19.npubEncode(pubkey) };
-        }
+
+      if (!response.ok) {
+        throw new Error(`NIP-05 lookup failed: ${response.status}`);
       }
 
-      throw new Error(`User @${username} not found`);
+      const data = await response.json();
+      const pubkey = data?.names?.[decoded];
+
+      if (!pubkey || typeof pubkey !== 'string' || !HEX_64_PATTERN.test(pubkey)) {
+        throw new UserNotFoundError(decoded);
+      }
+
+      debugLog('[AtUsernamePage] Resolved:', decoded);
+      return { username: decoded, pubkey };
     },
-    enabled: !!username && !subdomainUser,
-    staleTime: 300000,
-    gcTime: 600000,
-    retry: 1,
+    enabled: !!username,
+    staleTime: 300_000,
+    gcTime: 600_000,
+    retry: (failureCount, error) =>
+      !(error instanceof UserNotFoundError) && failureCount < 2,
   });
 }
 
-export function AtUsernamePage() {
-  // Username comes from either /@:username route or /:nip19 catch-all (with @ prefix)
-  const params = useParams<{ username?: string; nip19?: string }>();
-  const username = params.username || params.nip19?.replace(/^@/, '');
-  const navigate = useNavigate();
-  const subdomainUser = getSubdomainUser();
+class UserNotFoundError extends Error {}
 
-  // All hooks must be called before any conditional returns
-  const { data, isLoading, error } = useUsernameLookup(username);
+interface AtUsernamePageProps {
+  username: string;
+}
+
+export function AtUsernamePage({ username }: AtUsernamePageProps) {
+  const navigate = useNavigate();
+  const { data, isLoading, error } = useNip05Lookup(username);
 
   useEffect(() => {
-    if (data?.npub) {
-      navigate(`/profile/${data.npub}`, { replace: true });
+    if (data) {
+      const href = `https://${data.username}.${APEX_DOMAIN}`;
+      debugLog('[AtUsernamePage] Redirecting to:', href);
+      window.location.href = href;
     }
-  }, [data, navigate]);
+  }, [data]);
 
-  // If edge worker injected the user data, render ProfilePage directly
-  if (subdomainUser) {
-    return <ProfilePage />;
-  }
+  const decoded = decodeUsername(username);
 
   if (isLoading) {
     return (
@@ -72,7 +82,9 @@ export function AtUsernamePage() {
           <CardContent className="py-12">
             <div className="flex flex-col items-center justify-center space-y-4">
               <Loader2 className="h-8 w-8 animate-spin text-primary" />
-              <p className="text-muted-foreground">Looking up @{username}...</p>
+              <p className="text-muted-foreground">
+                Looking up @{decoded}...
+              </p>
             </div>
           </CardContent>
         </Card>
@@ -89,17 +101,8 @@ export function AtUsernamePage() {
               <AlertCircle className="h-12 w-12 text-destructive" />
               <h2 className="text-xl font-semibold">User Not Found</h2>
               <p className="text-muted-foreground text-center max-w-md">
-                Could not find user
-                <code className="text-sm bg-muted px-2 py-1 rounded ml-2">@{username}</code>
-              </p>
-              <p className="text-sm text-muted-foreground text-center max-w-md">
-                Try visiting their profile at{' '}
-                <a
-                  href={`https://${username}.divine.video`}
-                  className="text-primary hover:underline"
-                >
-                  {username}.divine.video
-                </a>
+                Could not find a user with username:
+                <code className="text-sm bg-muted px-2 py-1 rounded ml-2">@{decoded}</code>
               </p>
               <button
                 onClick={() => navigate('/')}
@@ -114,13 +117,16 @@ export function AtUsernamePage() {
     );
   }
 
+  // Redirecting state
   return (
     <div className="container max-w-4xl mx-auto px-4 py-8">
       <Card className="border-dashed">
         <CardContent className="py-12">
           <div className="flex flex-col items-center justify-center space-y-4">
             <Loader2 className="h-8 w-8 animate-spin text-primary" />
-            <p className="text-muted-foreground">Redirecting to profile...</p>
+            <p className="text-muted-foreground">
+              Redirecting to {decoded}.{APEX_DOMAIN}...
+            </p>
           </div>
         </CardContent>
       </Card>

--- a/src/pages/NIP19Page.tsx
+++ b/src/pages/NIP19Page.tsx
@@ -10,9 +10,9 @@ export function NIP19Page() {
     return <NotFound />;
   }
 
-  // Handle @username patterns (e.g., divine.video/@samuelgrubbs)
+  // Handle @username pattern (e.g., divine.video/@alice)
   if (identifier.startsWith('@') && identifier.length > 1) {
-    return <AtUsernamePage />;
+    return <AtUsernamePage username={identifier.slice(1)} />;
   }
 
   const target = getDirectSearchTarget(identifier);


### PR DESCRIPTION
## Summary
- `divine.video/@username` now resolves via NIP-05 lookup and redirects to `username.divine.video`
- Handled in the existing `/:nip19` catch-all (NIP19Page detects `@` prefix, delegates to new AtUsernamePage)
- Uses relative `/.well-known/nostr.json` fetch, so the component degrades gracefully on hosts without NIP-05 (CF Pages returns 404, user sees "User Not Found")

## Test plan
- [x] 6 unit tests pass (lookup success, case normalization, not-found, fetch error, invalid pubkey, loading state)
- [x] Full suite: 76/76 files, 466 tests pass
- [ ] Manual: visit `divine.video/@kingbach` (or staging equivalent on Fastly), confirm redirect to `kingbach.divine.video`
- [ ] Manual: visit `divine.video/@nonexistent`, confirm "User Not Found" card