### PR TITLE
feat: support divine.video/@username profile URLs

### DIFF
--- a/compute-js/src/index.js
+++ b/compute-js/src/index.js
@@ -96,6 +96,19 @@ async function handleRequest(event) {
     return Response.redirect(redirect.url, redirect.status);
   }
 
+  // 3b. Handle /@username paths on apex domain (e.g., divine.video/@samuelgrubbs)
+  const atUsernameMatch = url.pathname.match(/^\/@([a-zA-Z0-9_-]+)$/);
+  if (atUsernameMatch) {
+    const username = atUsernameMatch[1].toLowerCase();
+    console.log('Handling @username profile for:', username);
+    try {
+      return await handleSubdomainProfile(username, url, request, hostnameToUse);
+    } catch (err) {
+      console.error('@username profile error:', err.message, err.stack);
+      // Fall through to SPA handler which will render the client-side @username route
+    }
+  }
+
   // 4. Handle .well-known requests
   if (url.pathname.startsWith('/.well-known/')) {
     // 4a. NIP-05 from KV store

--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -29,7 +29,6 @@ import ModerationSettingsPage from "./pages/ModerationSettingsPage";
 import LinkedAccountsSettingsPage from "./pages/LinkedAccountsSettingsPage";
 // import { NIP05ProfilePage } from "./pages/NIP05ProfilePage";
 import { UniversalUserPage } from "./pages/UniversalUserPage";
-import { AtUsernamePage } from "./pages/AtUsernamePage";
 import EventPage from "./pages/EventPage";
 
 import PrivacyPage from "./pages/PrivacyPage";
@@ -107,7 +106,6 @@ export function AppRouter() {
           <Route path="/search" element={<SearchPage />} />
           <Route path="/leaderboard" element={<LeaderboardPage />} />
           <Route path="/u/:userId" element={<UniversalUserPage />} />
-          <Route path="/@:username" element={<AtUsernamePage />} />
           <Route path="/list/:pubkey/:listId" element={<ListDetailPage />} />
           <Route path="/event/:eventId" element={<EventPage />} />
           <Route path="/event/a/:kind/:pubkey/:identifier" element={<EventPage />} />

--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -29,6 +29,7 @@ import ModerationSettingsPage from "./pages/ModerationSettingsPage";
 import LinkedAccountsSettingsPage from "./pages/LinkedAccountsSettingsPage";
 // import { NIP05ProfilePage } from "./pages/NIP05ProfilePage";
 import { UniversalUserPage } from "./pages/UniversalUserPage";
+import { AtUsernamePage } from "./pages/AtUsernamePage";
 import EventPage from "./pages/EventPage";
 
 import PrivacyPage from "./pages/PrivacyPage";
@@ -106,6 +107,7 @@ export function AppRouter() {
           <Route path="/search" element={<SearchPage />} />
           <Route path="/leaderboard" element={<LeaderboardPage />} />
           <Route path="/u/:userId" element={<UniversalUserPage />} />
+          <Route path="/@:username" element={<AtUsernamePage />} />
           <Route path="/list/:pubkey/:listId" element={<ListDetailPage />} />
           <Route path="/event/:eventId" element={<EventPage />} />
           <Route path="/event/a/:kind/:pubkey/:identifier" element={<EventPage />} />

--- a/src/pages/AtUsernamePage.tsx
+++ b/src/pages/AtUsernamePage.tsx
@@ -1,0 +1,127 @@
+// ABOUTME: Page for /@username routes (e.g., divine.video/@samuelgrubbs)
+// ABOUTME: Checks edge-injected data first, then looks up username via KV/API and redirects to profile
+
+import { useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { nip19 } from 'nostr-tools';
+import { Card, CardContent } from '@/components/ui/card';
+import { AlertCircle, Loader2 } from 'lucide-react';
+import { getSubdomainUser } from '@/hooks/useSubdomainUser';
+import ProfilePage from './ProfilePage';
+
+/**
+ * Look up a username via the Funnelcake API's NIP-05 resolution
+ */
+function useUsernameLookup(username: string | undefined) {
+  // If edge worker already injected user data, skip the lookup
+  const subdomainUser = getSubdomainUser();
+
+  return useQuery({
+    queryKey: ['at-username', username],
+    queryFn: async ({ signal }) => {
+      if (!username) throw new Error('No username provided');
+
+      // Look up username via NIP-05 resolution (divine.video/.well-known/nostr.json)
+      const divineNip05 = await fetch(
+        `https://divine.video/.well-known/nostr.json?name=${encodeURIComponent(username)}`,
+        { signal }
+      );
+      if (divineNip05.ok) {
+        const data = await divineNip05.json();
+        const pubkey = data.names?.[username] || data.names?.[username.toLowerCase()];
+        if (pubkey) {
+          return { pubkey, npub: nip19.npubEncode(pubkey) };
+        }
+      }
+
+      throw new Error(`User @${username} not found`);
+    },
+    enabled: !!username && !subdomainUser,
+    staleTime: 300000,
+    gcTime: 600000,
+    retry: 1,
+  });
+}
+
+export function AtUsernamePage() {
+  const { username } = useParams<{ username: string }>();
+  const navigate = useNavigate();
+
+  // If edge worker injected the user data, render ProfilePage directly
+  const subdomainUser = getSubdomainUser();
+  if (subdomainUser) {
+    return <ProfilePage />;
+  }
+
+  // Client-side navigation: look up username and redirect
+  const { data, isLoading, error } = useUsernameLookup(username);
+
+  useEffect(() => {
+    if (data?.npub) {
+      navigate(`/profile/${data.npub}`, { replace: true });
+    }
+  }, [data, navigate]);
+
+  if (isLoading) {
+    return (
+      <div className="container max-w-4xl mx-auto px-4 py-8">
+        <Card className="border-dashed">
+          <CardContent className="py-12">
+            <div className="flex flex-col items-center justify-center space-y-4">
+              <Loader2 className="h-8 w-8 animate-spin text-primary" />
+              <p className="text-muted-foreground">Looking up @{username}...</p>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="container max-w-4xl mx-auto px-4 py-8">
+        <Card className="border-destructive">
+          <CardContent className="py-12">
+            <div className="flex flex-col items-center justify-center space-y-4">
+              <AlertCircle className="h-12 w-12 text-destructive" />
+              <h2 className="text-xl font-semibold">User Not Found</h2>
+              <p className="text-muted-foreground text-center max-w-md">
+                Could not find user
+                <code className="text-sm bg-muted px-2 py-1 rounded ml-2">@{username}</code>
+              </p>
+              <p className="text-sm text-muted-foreground text-center max-w-md">
+                Try visiting their profile at{' '}
+                <a
+                  href={`https://${username}.divine.video`}
+                  className="text-primary hover:underline"
+                >
+                  {username}.divine.video
+                </a>
+              </p>
+              <button
+                onClick={() => navigate('/')}
+                className="px-4 py-2 bg-primary text-primary-foreground rounded-md hover:brightness-110 transition-colors"
+              >
+                Go to Home
+              </button>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container max-w-4xl mx-auto px-4 py-8">
+      <Card className="border-dashed">
+        <CardContent className="py-12">
+          <div className="flex flex-col items-center justify-center space-y-4">
+            <Loader2 className="h-8 w-8 animate-spin text-primary" />
+            <p className="text-muted-foreground">Redirecting to profile...</p>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/pages/AtUsernamePage.tsx
+++ b/src/pages/AtUsernamePage.tsx
@@ -49,14 +49,9 @@ export function AtUsernamePage() {
   const params = useParams<{ username?: string; nip19?: string }>();
   const username = params.username || params.nip19?.replace(/^@/, '');
   const navigate = useNavigate();
-
-  // If edge worker injected the user data, render ProfilePage directly
   const subdomainUser = getSubdomainUser();
-  if (subdomainUser) {
-    return <ProfilePage />;
-  }
 
-  // Client-side navigation: look up username and redirect
+  // All hooks must be called before any conditional returns
   const { data, isLoading, error } = useUsernameLookup(username);
 
   useEffect(() => {
@@ -64,6 +59,11 @@ export function AtUsernamePage() {
       navigate(`/profile/${data.npub}`, { replace: true });
     }
   }, [data, navigate]);
+
+  // If edge worker injected the user data, render ProfilePage directly
+  if (subdomainUser) {
+    return <ProfilePage />;
+  }
 
   if (isLoading) {
     return (

--- a/src/pages/AtUsernamePage.tsx
+++ b/src/pages/AtUsernamePage.tsx
@@ -45,7 +45,9 @@ function useUsernameLookup(username: string | undefined) {
 }
 
 export function AtUsernamePage() {
-  const { username } = useParams<{ username: string }>();
+  // Username comes from either /@:username route or /:nip19 catch-all (with @ prefix)
+  const params = useParams<{ username?: string; nip19?: string }>();
+  const username = params.username || params.nip19?.replace(/^@/, '');
   const navigate = useNavigate();
 
   // If edge worker injected the user data, render ProfilePage directly

--- a/src/pages/NIP19Page.tsx
+++ b/src/pages/NIP19Page.tsx
@@ -1,5 +1,6 @@
 import { useParams, Navigate } from 'react-router-dom';
 import { getDirectSearchTarget } from '@/lib/directSearch';
+import { AtUsernamePage } from './AtUsernamePage';
 import NotFound from './NotFound';
 
 export function NIP19Page() {
@@ -7,6 +8,11 @@ export function NIP19Page() {
 
   if (!identifier) {
     return <NotFound />;
+  }
+
+  // Handle @username patterns (e.g., divine.video/@samuelgrubbs)
+  if (identifier.startsWith('@') && identifier.length > 1) {
+    return <AtUsernamePage />;
   }
 
   const target = getDirectSearchTarget(identifier);


### PR DESCRIPTION
## Summary
- Adds `divine.video/@username` as an alternate URL to `username.divine.video` for user profiles
- Edge worker detects `/@username` paths and reuses existing subdomain profile logic (KV lookup, OG tag injection, `window.__DIVINE_USER__` injection)
- New `AtUsernamePage` client component handles client-side navigation with NIP-05 fallback
- Fixes 404 when users visit `https://divine.video/@samuelgrubbs`

## Test plan
- [ ] Visit `divine.video/@samuelgrubbs` — should show profile (not 404)
- [ ] Social media crawlers get proper OG tags for `/@username` URLs
- [ ] Client-side navigation to `/@username` resolves via NIP-05 and redirects to profile
- [ ] Unknown usernames show "User Not Found" with link to try subdomain
- [ ] Existing subdomain profiles (`samuelgrubbs.divine.video`) still work
- [ ] Static assets (JS/CSS) still load correctly on `/@username` pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)