### PR TITLE
fix: rebrand remaining diVine → Divine in OG meta tags

### DIFF
--- a/compute-js/src/index.js
+++ b/compute-js/src/index.js
@@ -771,8 +771,8 @@ async function handleSubdomainProfile(subdomain, url, request, originalHostname)
   const userScript = `<script>window.__DIVINE_USER__ = ${JSON.stringify(divineUser)};</script>`;
 
   // Update OG tags for the profile
-  const ogTitle = divineUser.displayName + ' on diVine';
-  const ogDescription = divineUser.about || `Watch ${divineUser.displayName}'s videos on diVine`;
+  const ogTitle = divineUser.displayName + ' on Divine';
+  const ogDescription = divineUser.about || `Watch ${divineUser.displayName}'s videos on Divine`;
   const ogImage = divineUser.picture || 'https://divine.video/og.png';
   const ogUrl = `https://${subdomain}.${apexDomain}/`;
 
@@ -982,15 +982,15 @@ async function fetchVideoMetadata(videoId) {
       description = content.trim();
     } else if (statsList.length > 0) {
       // Show engagement stats
-      description = `${statsList.join(' • ')} on diVine`;
+      description = `${statsList.join(' • ')} on Divine`;
     } else {
-      description = 'Watch this short video on diVine';
+      description = 'Watch this short video on Divine';
     }
 
     console.log('Fetched video metadata - title:', title, 'thumbnail:', thumbnail);
 
     return {
-      title: title || 'Video on diVine',
+      title: title || 'Video on Divine',
       description: description,
       thumbnail: thumbnail || 'https://divine.video/og.avif',
       authorName: getTag('author') || '',
@@ -1018,8 +1018,8 @@ async function handleVideoOgTags(request, videoId, url) {
     }
 
     // Default meta values if video not found
-    const title = videoMeta?.title || 'Video on diVine';
-    const description = videoMeta?.description || 'Watch this video on diVine - Short-form looping videos on Nostr';
+    const title = videoMeta?.title || 'Video on Divine';
+    const description = videoMeta?.description || 'Watch this video on Divine - Short-form looping videos on Nostr';
     const thumbnail = videoMeta?.thumbnail || 'https://divine.video/og.avif';
     const authorName = videoMeta?.authorName || '';
     const videoUrl = `https://divine.video/video/${videoId}`;
@@ -1033,7 +1033,7 @@ async function handleVideoOgTags(request, videoId, url) {
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>${escapeHtml(title)} - diVine</title>
+  <title>${escapeHtml(title)} - Divine</title>
 
   <!-- Open Graph Meta Tags -->
   <meta property="og:type" content="video.other" />
@@ -1043,7 +1043,7 @@ async function handleVideoOgTags(request, videoId, url) {
   <meta property="og:image:width" content="480" />
   <meta property="og:image:height" content="480" />
   <meta property="og:url" content="${escapeHtml(videoUrl)}" />
-  <meta property="og:site_name" content="diVine" />
+  <meta property="og:site_name" content="Divine" />
 
   <!-- Twitter Card Meta Tags -->
   <meta name="twitter:card" content="summary_large_image" />

--- a/functions/[[path]].test.ts
+++ b/functions/[[path]].test.ts
@@ -5,16 +5,16 @@ import { onRequest } from './[[path]]';
 const INDEX_HTML = `<!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>diVine Web - Short-form Looping Videos on Nostr</title>
+    <title>Divine Web - Short-form Looping Videos on Nostr</title>
     <meta name="description" content="Watch and share 6-second looping videos on the decentralized Nostr network." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://divine.video/" />
-    <meta property="og:title" content="diVine Web - Short-form Looping Videos on Nostr" />
+    <meta property="og:title" content="Divine Web - Short-form Looping Videos on Nostr" />
     <meta property="og:description" content="Watch and share 6-second looping videos on the decentralized Nostr network." />
     <meta property="og:image" content="https://divine.video/og.png" />
-    <meta property="og:image:alt" content="diVine Web - Short-form looping videos on the Nostr network" />
+    <meta property="og:image:alt" content="Divine Web - Short-form looping videos on the Nostr network" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="diVine Web - Short-form Looping Videos on Nostr" />
+    <meta name="twitter:title" content="Divine Web - Short-form Looping Videos on Nostr" />
     <meta name="twitter:description" content="Watch and share 6-second looping videos on the decentralized Nostr network." />
     <meta name="twitter:image" content="https://divine.video/og.png" />
   </head>
@@ -98,7 +98,7 @@ describe('functions/[[path]]', () => {
     const html = await response.text();
 
     expect(response.status).toBe(200);
-    expect(html).toContain(`<title>${'diVine Web - Short-form Looping Videos on Nostr'}</title>`);
+    expect(html).toContain(`<title>${'Divine Web - Short-form Looping Videos on Nostr'}</title>`);
     expect(html).not.toContain('property="og:video"');
   });
 });

--- a/functions/[[path]].ts
+++ b/functions/[[path]].ts
@@ -156,13 +156,13 @@ async function fetchVideoMeta(url: URL): Promise<PageMeta | null> {
 
     const title = getTagValue(payload.event.tags, 'title')
       || getTagValue(payload.event.tags, 'alt')
-      || 'Video on diVine';
+      || 'Video on Divine';
     const authorName = payload.stats?.author_name;
     const description = truncateText(
       getTagValue(payload.event.tags, 'summary')
         || payload.event.content
         || getTagValue(payload.event.tags, 'alt')
-        || (authorName ? `Watch this video by ${authorName} on diVine` : 'Watch this video on diVine'),
+        || (authorName ? `Watch this video by ${authorName} on Divine` : 'Watch this video on Divine'),
       200
     );
     const media = parseImeta(payload.event.tags);


### PR DESCRIPTION
## Summary

- Noticed "Video on diVine" appearing in iMessage link previews for videos without titles
- Updates Fastly Compute (`compute-js/src/index.js`) — 9 occurrences across video + profile OG tags
- Updates CF Pages function (`functions/[[path]].ts`) — 3 occurrences in video fallbacks
- Updates CF Pages test fixture to match

## Test plan

- [ ] Share an untitled video link and verify preview shows "Video on Divine" not "diVine"
- [ ] Share a profile subdomain link and verify "{name} on Divine" casing
- [ ] Run `npx vitest run functions` to verify CF Pages tests pass