### PR TITLE
fix: update remaining Divine branding literals

### DIFF
--- a/compute-js/fastly.toml
+++ b/compute-js/fastly.toml
@@ -2,7 +2,7 @@
 # https://www.fastly.com/documentation/reference/compute/fastly-toml
 
 authors = ["you@example.com"]
-description = "diVine video app for Nostr"
+description = "Divine video app for Nostr"
 language = "javascript"
 manifest_version = 3
 name = "divine-web"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -81,8 +81,8 @@ VitePWA({
         'browserconfig.xml'
       ],
       manifest: {
-        name: 'diVine Web - Short-form Looping Videos',
-        short_name: 'diVine',
+        name: 'Divine Web - Short-form Looping Videos',
+        short_name: 'Divine',
         description: 'Watch and share 6-second looping videos on the decentralized Nostr network.',
         theme_color: '#27C58B',
         background_color: '#09090b',


### PR DESCRIPTION
## Summary
- update the generated PWA manifest branding from `diVine` to `Divine` in `vite.config.ts`
- update the Fastly package description string in `compute-js/fastly.toml`

## Why separate
These are remaining low-risk branding literals outside the scope of #222, which is focused on edge-rendered OG/meta fallback text.

## Test plan
- [x] `npm install`
- [x] `./node_modules/.bin/vite build`
- [x] verified generated `dist/manifest.webmanifest` contains `name: "Divine Web - Short-form Looping Videos"` and `short_name: "Divine"`