### PR TITLE
Add AtUsernamePage coverage and normalize lookups

### DIFF
--- a/docs/superpowers/plans/2026-04-02-at-username-coverage.md
+++ b/docs/superpowers/plans/2026-04-02-at-username-coverage.md
@@ -1,0 +1,57 @@
+# AtUsernamePage Coverage Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add direct regression coverage for the shipped `AtUsernamePage` behavior and fix mixed-case client-side username lookup normalization.
+
+**Architecture:** Keep the existing `AtUsernamePage` and worker flow intact. Add a page test file that mocks the current collaborators (`useParams`, `useNavigate`, `getSubdomainUser`, `ProfilePage`) and make the smallest possible production change so mixed-case usernames are normalized before the NIP-05 fetch.
+
+**Tech Stack:** React 18, TypeScript, Vitest, Testing Library, TanStack Query, Vite
+
+---
+
+### Task 1: Add the failing page coverage
+
+**Files:**
+- Create: `src/pages/AtUsernamePage.test.tsx`
+- Modify: `src/pages/AtUsernamePage.tsx`
+- Test: `src/pages/AtUsernamePage.test.tsx`
+
+- [ ] **Step 1: Write the failing test file**
+
+Add page-level tests for:
+- successful lookup navigates to `/profile/:npub`
+- mixed-case usernames are lowercased before fetch
+- failed lookup shows the not-found card
+- invalid pubkey shows the not-found card
+- pending fetch shows the loading copy
+- injected subdomain user skips fetch and renders `ProfilePage`
+
+- [ ] **Step 2: Run the targeted test to verify the intended failure**
+
+Run: `npx vitest run src/pages/AtUsernamePage.test.tsx`
+Expected: at least the lowercase lookup case fails against current production code.
+
+- [ ] **Step 3: Implement the minimal production fix**
+
+Normalize the username used by the fetch query in `src/pages/AtUsernamePage.tsx` before constructing the request URL and reading the response map.
+
+- [ ] **Step 4: Re-run the targeted test**
+
+Run: `npx vitest run src/pages/AtUsernamePage.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Run the full verification suite**
+
+Run: `npm test`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-04-02-at-username-coverage-design.md \
+  docs/superpowers/plans/2026-04-02-at-username-coverage.md \
+  src/pages/AtUsernamePage.test.tsx \
+  src/pages/AtUsernamePage.tsx
+git commit -m "Add AtUsernamePage coverage and normalize lookups"
+```

--- a/docs/superpowers/specs/2026-04-02-at-username-coverage-design.md
+++ b/docs/superpowers/specs/2026-04-02-at-username-coverage-design.md
@@ -1,0 +1,46 @@
+# AtUsernamePage Coverage Design
+
+**Date:** 2026-04-02
+**Status:** Approved
+
+## Goal
+
+Bring the shipped `AtUsernamePage` behavior on `main` under direct test coverage and close the remaining mixed-case lookup gap without changing the broader `@username` architecture that landed in PR #219.
+
+## Scope
+
+This follow-up stays intentionally narrow:
+
+1. Add page-level tests for the current `AtUsernamePage` flow.
+2. Normalize usernames to lowercase before the client-side NIP-05 lookup.
+3. Add coverage for the edge-injected `getSubdomainUser()` fast path so the page can safely skip fetches when the worker has already resolved the user.
+
+## Current Design Constraints
+
+- `AtUsernamePage` already shipped with a specific architecture:
+  - it accepts the route param via `useParams`
+  - it checks `getSubdomainUser()` first
+  - it falls back to a client-side fetch against `https://divine.video/.well-known/nostr.json`
+  - it navigates to `/profile/:npub` rather than forcing a full-page subdomain redirect
+- The worker already handles `divine.video/@username` at the edge. This change does not replace or re-argue that design.
+
+## Chosen Approach
+
+Keep the implementation in place and add missing regression coverage around it.
+
+The one behavior change is username normalization before fetch. Today the page queries with the raw route value and only lowercases when reading `data.names?.[username.toLowerCase()]`. That means a mixed-case route like `/@KingBach` can still ask the server for `name=KingBach`, which is less robust than querying lowercase directly.
+
+## Test Coverage To Add
+
+- Navigates to `/profile/:npub` after a successful lookup.
+- Lowercases the username before the fetch request.
+- Renders the not-found state when the lookup fails.
+- Renders the not-found state when the resolved pubkey is invalid.
+- Renders the loading state while the lookup is pending.
+- Skips the fetch and renders the profile path when `getSubdomainUser()` returns injected data.
+
+## Non-Goals
+
+- Reverting to the earlier client-side full-page redirect design from PR #218.
+- Reworking the edge worker route behavior.
+- Broad refactors of `AtUsernamePage`, `ProfilePage`, or router structure.

--- a/src/pages/AtUsernamePage.test.tsx
+++ b/src/pages/AtUsernamePage.test.tsx
@@ -1,0 +1,160 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { HTMLAttributes } from 'react';
+import { nip19 } from 'nostr-tools';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AtUsernamePage } from './AtUsernamePage';
+
+const { mockNavigate, mockUseParams, mockGetSubdomainUser } = vi.hoisted(() => ({
+  mockNavigate: vi.fn(),
+  mockUseParams: vi.fn<() => { username?: string; nip19?: string }>(),
+  mockGetSubdomainUser: vi.fn(),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useParams: () => mockUseParams(),
+  };
+});
+
+vi.mock('@/hooks/useSubdomainUser', () => ({
+  getSubdomainUser: () => mockGetSubdomainUser(),
+}));
+
+vi.mock('./ProfilePage', () => ({
+  default: () => <div data-testid="profile-page">Profile Page</div>,
+}));
+
+vi.mock('@/components/ui/card', () => ({
+  Card: ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+  CardContent: ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+}));
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        retryDelay: 0,
+      },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AtUsernamePage />
+    </QueryClientProvider>,
+  );
+}
+
+describe('AtUsernamePage', () => {
+  const validPubkey = 'a'.repeat(64);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseParams.mockReturnValue({ username: 'alice' });
+    mockGetSubdomainUser.mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('navigates to the resolved profile after a successful lookup', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ names: { alice: validPubkey } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(
+        `/profile/${nip19.npubEncode(validPubkey)}`,
+        { replace: true },
+      );
+    });
+  });
+
+  it('lowercases the username before the client-side NIP-05 lookup', async () => {
+    mockUseParams.mockReturnValue({ username: 'KingBach' });
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ names: { kingbach: validPubkey } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        'https://divine.video/.well-known/nostr.json?name=kingbach',
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    });
+  });
+
+  it('shows the not-found state when the lookup fails', async () => {
+    mockUseParams.mockReturnValue({ nip19: '@missing' });
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('Not Found', { status: 404 }),
+    );
+
+    renderPage();
+
+    expect(await screen.findByRole('heading', { name: 'User Not Found' })).toBeInTheDocument();
+    expect(screen.getByText('@missing')).toBeInTheDocument();
+  });
+
+  it('shows the not-found state when the resolved pubkey is invalid', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ names: { alice: 'not-a-pubkey' } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    renderPage();
+
+    expect(await screen.findByRole('heading', { name: 'User Not Found' })).toBeInTheDocument();
+  });
+
+  it('shows the loading state while the lookup is pending', () => {
+    vi.spyOn(globalThis, 'fetch').mockReturnValue(new Promise(() => {}));
+
+    renderPage();
+
+    expect(screen.getByText('Looking up @alice...')).toBeInTheDocument();
+  });
+
+  it('skips the fetch and renders the profile page when subdomain data is already injected', () => {
+    mockGetSubdomainUser.mockReturnValue({
+      subdomain: 'alice',
+      pubkey: validPubkey,
+      npub: nip19.npubEncode(validPubkey),
+      username: 'alice',
+      displayName: 'Alice',
+      picture: null,
+      banner: null,
+      about: null,
+      nip05: '_@alice.divine.video',
+      followersCount: 0,
+      followingCount: 0,
+      videoCount: 0,
+      apexDomain: 'divine.video',
+    });
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    renderPage();
+
+    expect(screen.getByTestId('profile-page')).toBeInTheDocument();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/AtUsernamePage.tsx
+++ b/src/pages/AtUsernamePage.tsx
@@ -18,18 +18,19 @@ function useUsernameLookup(username: string | undefined) {
   const subdomainUser = getSubdomainUser();
 
   return useQuery({
-    queryKey: ['at-username', username],
+    queryKey: ['at-username', username?.toLowerCase()],
     queryFn: async ({ signal }) => {
       if (!username) throw new Error('No username provided');
+      const normalizedUsername = username.toLowerCase();
 
       // Look up username via NIP-05 resolution (divine.video/.well-known/nostr.json)
       const divineNip05 = await fetch(
-        `https://divine.video/.well-known/nostr.json?name=${encodeURIComponent(username)}`,
+        `https://divine.video/.well-known/nostr.json?name=${encodeURIComponent(normalizedUsername)}`,
         { signal }
       );
       if (divineNip05.ok) {
         const data = await divineNip05.json();
-        const pubkey = data.names?.[username] || data.names?.[username.toLowerCase()];
+        const pubkey = data.names?.[normalizedUsername];
         if (pubkey) {
           return { pubkey, npub: nip19.npubEncode(pubkey) };
         }


### PR DESCRIPTION
## Summary
- add direct page-level coverage for the shipped `AtUsernamePage` flow, including loading, not-found, invalid-pubkey, and injected-subdomain cases
- normalize `@username` lookups to lowercase before the client-side NIP-05 request so mixed-case routes use a stable query key and request URL
- capture the scope in a matching design doc and implementation plan for the follow-up to PR #219

## Test Plan
- [x] `npx vitest run src/pages/AtUsernamePage.test.tsx`
- [x] `npm test`
