### PR TITLE
chore: align divine web login origin

### DIFF
--- a/src/lib/DivineJWTSigner.test.ts
+++ b/src/lib/DivineJWTSigner.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { DivineJWTSigner } from './DivineJWTSigner';
+import { DIVINE_LOGIN_ORIGIN } from './divineLoginOrigin';
 
 const mockFetch = vi.fn();
 global.fetch = mockFetch as unknown as typeof fetch;
@@ -28,7 +29,7 @@ describe('DivineJWTSigner', () => {
 
     expect(pubkey).toBe(mockPubkey);
     expect(mockFetch).toHaveBeenCalledWith(
-      'https://login.divine.video/api/nostr',
+      `${DIVINE_LOGIN_ORIGIN}/api/nostr`,
       expect.objectContaining({
         method: 'POST',
         headers: {
@@ -100,7 +101,7 @@ describe('DivineJWTSigner', () => {
     await expect(signer.signEvent(unsignedEvent)).resolves.toEqual(signedEvent);
     expect(mockFetch).toHaveBeenNthCalledWith(
       1,
-      'https://login.divine.video/api/nostr',
+      `${DIVINE_LOGIN_ORIGIN}/api/nostr`,
       expect.objectContaining({
         method: 'POST',
         headers: {
@@ -115,7 +116,7 @@ describe('DivineJWTSigner', () => {
     );
     expect(mockFetch).toHaveBeenNthCalledWith(
       2,
-      'https://login.divine.video/api/nostr',
+      `${DIVINE_LOGIN_ORIGIN}/api/nostr`,
       expect.objectContaining({
         method: 'POST',
         headers: {
@@ -146,7 +147,7 @@ describe('DivineJWTSigner', () => {
 
     expect(mockFetch).toHaveBeenNthCalledWith(
       1,
-      'https://login.divine.video/api/nostr',
+      `${DIVINE_LOGIN_ORIGIN}/api/nostr`,
       expect.objectContaining({
         body: JSON.stringify({
           method: 'nip04_encrypt',
@@ -156,7 +157,7 @@ describe('DivineJWTSigner', () => {
     );
     expect(mockFetch).toHaveBeenNthCalledWith(
       2,
-      'https://login.divine.video/api/nostr',
+      `${DIVINE_LOGIN_ORIGIN}/api/nostr`,
       expect.objectContaining({
         body: JSON.stringify({
           method: 'nip44_encrypt',

--- a/src/lib/DivineJWTSigner.ts
+++ b/src/lib/DivineJWTSigner.ts
@@ -1,10 +1,11 @@
 // ABOUTME: JWT-based Nostr signer backed by the hosted Divine login RPC API
-// ABOUTME: Implements the NostrSigner interface on top of login.divine.video/api/nostr
+// ABOUTME: Implements the NostrSigner interface on top of the Divine login RPC API
 
 import { DivineRpc } from '@divinevideo/login';
 import type { NostrEvent, NostrSigner } from '@nostrify/nostrify';
 
-const DIVINE_LOGIN_SERVER_URL = import.meta.env.VITE_DIVINE_LOGIN_URL || 'https://login.divine.video';
+import { DIVINE_LOGIN_ORIGIN } from './divineLoginOrigin';
+
 type DivineRpcUnsignedEvent = Parameters<DivineRpc['signEvent']>[0];
 
 export interface DivineJWTSignerOptions {
@@ -26,7 +27,7 @@ export class DivineJWTSigner implements NostrSigner {
 
   constructor(options: DivineJWTSignerOptions) {
     this.token = options.token;
-    this.serverUrl = options.serverUrl || DIVINE_LOGIN_SERVER_URL;
+    this.serverUrl = options.serverUrl || DIVINE_LOGIN_ORIGIN;
     this.timeout = options.timeout || 10000;
   }
 

--- a/src/lib/divineLogin.test.ts
+++ b/src/lib/divineLogin.test.ts
@@ -8,6 +8,7 @@ import {
   exchangeDivineLoginCallback,
   parseDivineLoginCallback,
 } from './divineLogin';
+import { DIVINE_LOGIN_ORIGIN } from './divineLoginOrigin';
 
 const fetchMock = vi.fn<typeof fetch>();
 const originalLocation = window.location;
@@ -64,7 +65,7 @@ describe('divineLogin', () => {
     const redirect = await buildSignupRedirect({ returnPath: '/messages' });
     const url = new URL(redirect.url);
 
-    expect(`${url.origin}${url.pathname}`).toBe('https://login.divine.video/api/oauth/authorize');
+    expect(`${url.origin}${url.pathname}`).toBe(`${DIVINE_LOGIN_ORIGIN}/api/oauth/authorize`);
     expect(url.searchParams.get('client_id')).toBe('divine-web');
     expect(url.searchParams.get('redirect_uri')).toBe('https://divine.video/auth/callback');
     expect(url.searchParams.get('default_register')).toBe('true');
@@ -76,7 +77,7 @@ describe('divineLogin', () => {
     const redirect = await buildLoginRedirect({ returnPath: '/messages' });
     const url = new URL(redirect.url);
 
-    expect(`${url.origin}${url.pathname}`).toBe('https://login.divine.video/api/oauth/authorize');
+    expect(`${url.origin}${url.pathname}`).toBe(`${DIVINE_LOGIN_ORIGIN}/api/oauth/authorize`);
     expect(url.searchParams.get('client_id')).toBe('divine-web');
     expect(url.searchParams.get('redirect_uri')).toBe('https://divine.video/auth/callback');
     expect(url.searchParams.get('default_register')).toBeNull();
@@ -94,7 +95,7 @@ describe('divineLogin', () => {
     const redirect = await buildSecureAccountRedirect(nsec, { returnPath: '/settings/linked-accounts' });
     const url = new URL(redirect.url);
 
-    expect(`${url.origin}${url.pathname}`).toBe('https://login.divine.video/api/oauth/authorize');
+    expect(`${url.origin}${url.pathname}`).toBe(`${DIVINE_LOGIN_ORIGIN}/api/oauth/authorize`);
     expect(url.searchParams.get('byok_pubkey')).toBe(getPublicKey(decoded.data));
     expect(url.searchParams.get('default_register')).toBe('true');
     expect(redirect.url).not.toContain(nsec);
@@ -174,7 +175,7 @@ describe('divineLogin', () => {
     });
 
     expect(fetchMock).toHaveBeenCalledWith(
-      'https://login.divine.video/api/oauth/token',
+      `${DIVINE_LOGIN_ORIGIN}/api/oauth/token`,
       expect.objectContaining({
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/src/lib/divineLogin.ts
+++ b/src/lib/divineLogin.ts
@@ -1,7 +1,8 @@
 import { createDivineClient } from '@divinevideo/login';
 import { getPublicKey, nip19 } from 'nostr-tools';
 
-const DIVINE_LOGIN_BASE_URL = import.meta.env.VITE_DIVINE_LOGIN_URL || 'https://login.divine.video';
+import { DIVINE_LOGIN_ORIGIN } from './divineLoginOrigin';
+
 const DIVINE_LOGIN_CLIENT_ID = 'divine-web';
 const RETURN_PATH_PREFIX = 'divine:return-path:';
 
@@ -37,7 +38,7 @@ function buildCallbackUrl(): string {
 
 function createClient(fetchImpl?: typeof fetch) {
   return createDivineClient({
-    serverUrl: DIVINE_LOGIN_BASE_URL,
+    serverUrl: DIVINE_LOGIN_ORIGIN,
     clientId: DIVINE_LOGIN_CLIENT_ID,
     redirectUri: buildCallbackUrl(),
     ...(fetchImpl ? {

--- a/src/lib/divineLoginOrigin.ts
+++ b/src/lib/divineLoginOrigin.ts
@@ -1,0 +1,1 @@
+export const DIVINE_LOGIN_ORIGIN = import.meta.env.VITE_DIVINE_LOGIN_URL || 'https://login.divine.video';


### PR DESCRIPTION
## Summary
- centralize the canonical production login origin
- update the login helpers to use login.divine.video consistently
- keep the web auth surface aligned with the phase 1 rollout host contract

## Test Plan
- [x] npm ci
- [x] npx vitest run src/lib/divineLogin.test.ts src/lib/DivineJWTSigner.test.ts