### PR TITLE
fix: add requester name to Zendesk report ticket creation

### DIFF
--- a/compute-js/src/index.js
+++ b/compute-js/src/index.js
@@ -447,7 +447,7 @@ async function handleReport(req) {
       });
     }
 
-    const { contentType, reason, timestamp, eventId, pubkey, reporterPubkey, reporterEmail, details, contentUrl } = body;
+    const { contentType, reason, timestamp, eventId, pubkey, reporterPubkey, reporterName, reporterEmail, details, contentUrl } = body;
 
     // Validate required fields
     if (!contentType || !reason || !timestamp) {
@@ -517,7 +517,7 @@ async function handleReport(req) {
       ticket: {
         subject,
         comment: { body: bodyParts.join('\n') },
-        requester: { email: requesterEmail },
+        requester: { email: requesterEmail, name: reporterName || reporterPubkey || reporterEmail },
         tags,
         priority,
       },

--- a/src/components/ReportContentDialog.tsx
+++ b/src/components/ReportContentDialog.tsx
@@ -4,6 +4,7 @@
 import { useState } from 'react';
 import { useReportContent } from '@/hooks/useModeration';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
+import { useAuthor } from '@/hooks/useAuthor';
 import { useLoginDialog } from '@/contexts/LoginDialogContext';
 import {
   Dialog,
@@ -37,6 +38,7 @@ export function ReportContentDialog({
 }: ReportContentDialogProps) {
   const { toast } = useToast();
   const { user } = useCurrentUser();
+  const { data: authorData } = useAuthor(user?.pubkey);
   const { openLoginDialog } = useLoginDialog();
   const reportContent = useReportContent();
   const isLoggedIn = !!user;
@@ -63,6 +65,7 @@ export function ReportContentDialog({
         reason,
         details: details.trim() || undefined,
         contentType,
+        reporterName: authorData?.metadata?.display_name || authorData?.metadata?.name,
       });
 
       toast({

--- a/src/hooks/useModeration.ts
+++ b/src/hooks/useModeration.ts
@@ -238,13 +238,15 @@ export function useReportContent() {
       pubkey,
       reason,
       details,
-      contentType = 'video'
+      contentType = 'video',
+      reporterName,
     }: {
       eventId?: string;
       pubkey?: string;
       reason: ContentFilterReason;
       details?: string;
       contentType?: 'video' | 'user' | 'comment';
+      reporterName?: string;
     }) => {
       if (!user) throw new Error('Must be logged in to report content');
 
@@ -274,6 +276,7 @@ export function useReportContent() {
       // Fire-and-forget Zendesk ticket creation
       submitReportToZendesk({
         reporterPubkey: user.pubkey,
+        reporterName,
         eventId,
         pubkey,
         contentType,

--- a/src/lib/reportApi.ts
+++ b/src/lib/reportApi.ts
@@ -3,6 +3,7 @@
 
 export interface ReportPayload {
   reporterPubkey?: string;
+  reporterName?: string;
   reporterEmail?: string;
   eventId?: string;
   pubkey?: string;


### PR DESCRIPTION
## Summary

- Zendesk API rejects ticket creation with 422 when the requester has no name field, causing all divine-web content reports to return 502 instead of creating tickets
- Reports continued to reach the relay and relay-manager queue via kind 1984 events unaffected
- Passes the reporter's Nostr display name through to the Zendesk requester name field, falling back to pubkey if no profile is available

## Changes

- `compute-js/src/index.js`: read `reporterName` from payload, use as requester name with pubkey/email fallback
- `src/lib/reportApi.ts`: add `reporterName` to `ReportPayload`
- `src/hooks/useModeration.ts`: accept and forward `reporterName` param
- `src/components/ReportContentDialog.tsx`: resolve reporter's display name via `useAuthor` and pass to report submission

## Test plan

- [ ] `tsc --noEmit` clean, `eslint` clean, 467 vitest tests pass
- [ ] Deploy to Fastly Compute and verify `POST /api/report` returns 200 instead of 502
- [ ] Confirm Zendesk ticket is created with reporter's display name as requester
- [ ] Verify fallback: reporter with no Nostr profile gets pubkey as requester name