### PR TITLE
Fix For You recommendations pagination

### DIFF
--- a/src/hooks/useInfiniteVideosFunnelcake.test.ts
+++ b/src/hooks/useInfiniteVideosFunnelcake.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { renderHook, waitFor } from '@testing-library/react';
+import { renderHook, waitFor, act } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 
@@ -114,6 +114,44 @@ describe('useInfiniteVideosFunnelcake', () => {
     const page = result.current.data?.pages[0];
     expect(page?.recCursor).toBeUndefined();
     // Server said no more — should not have next page
+    expect(result.current.hasNextPage).toBe(false);
+  });
+
+  it('dedup safety net stops pagination when server returns duplicate videos', async () => {
+    // Server returns the same videos for both pages (offset/cursor ignored)
+    const sameVideos = [
+      { id: 'video-1', pubkey: 'p1', kind: 34236, createdAt: 101, vineId: 'd-1' },
+      { id: 'video-2', pubkey: 'p2', kind: 34236, createdAt: 100, vineId: 'd-2' },
+    ];
+
+    mockFetchRecommendations
+      .mockResolvedValueOnce({ videos: [{}], has_more: true, next_cursor: '12' })
+      .mockResolvedValueOnce({ videos: [{}], has_more: true, next_cursor: '24' });
+
+    mockTransformToVideoPage
+      .mockReturnValueOnce({ videos: sameVideos, nextCursor: undefined, hasMore: true })
+      .mockReturnValueOnce({ videos: sameVideos, nextCursor: undefined, hasMore: true });
+
+    const { result } = renderHook(
+      () => useInfiniteVideosFunnelcake({ feedType: 'recommendations', pageSize: 12 }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.hasNextPage).toBe(true);
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => {
+      expect(result.current.data?.pages).toHaveLength(2);
+    });
+
+    // Page 2 contains only duplicates → should stop pagination
     expect(result.current.hasNextPage).toBe(false);
   });
 });

--- a/src/hooks/useInfiniteVideosFunnelcake.test.ts
+++ b/src/hooks/useInfiniteVideosFunnelcake.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+
+const mockFetchRecommendations = vi.fn();
+const mockTransformToVideoPage = vi.fn();
+
+vi.mock('@/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({
+    user: { pubkey: 'a'.repeat(64) },
+  }),
+}));
+
+vi.mock('@/lib/funnelcakeClient', () => ({
+  fetchVideos: vi.fn(),
+  searchVideos: vi.fn(),
+  fetchUserVideos: vi.fn(),
+  fetchUserFeed: vi.fn(),
+  fetchRecommendations: mockFetchRecommendations,
+}));
+
+vi.mock('@/lib/funnelcakeTransform', () => ({
+  transformToVideoPage: mockTransformToVideoPage,
+}));
+
+vi.mock('@/lib/debug', () => ({
+  debugLog: vi.fn(),
+}));
+
+vi.mock('@/lib/performanceMonitoring', () => ({
+  performanceMonitor: {
+    recordQuery: vi.fn(),
+    recordFeedLoad: vi.fn(),
+  },
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+}
+
+let useInfiniteVideosFunnelcake: typeof import('./useInfiniteVideosFunnelcake').useInfiniteVideosFunnelcake;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  ({ useInfiniteVideosFunnelcake } = await import('./useInfiniteVideosFunnelcake'));
+});
+
+describe('useInfiniteVideosFunnelcake', () => {
+  it('stops paginating recommendations when a new page contains no new videos', async () => {
+    mockFetchRecommendations
+      .mockResolvedValueOnce({ videos: [{}], has_more: true, next_cursor: '12' })
+      .mockResolvedValueOnce({ videos: [{}], has_more: true, next_cursor: '24' });
+
+    mockTransformToVideoPage
+      .mockReturnValueOnce({
+        videos: [
+          { id: 'video-1', pubkey: 'p1', kind: 34236, createdAt: 101, vineId: 'd-1' },
+          { id: 'video-2', pubkey: 'p2', kind: 34236, createdAt: 100, vineId: 'd-2' },
+        ],
+        nextCursor: undefined,
+        offset: 12,
+        hasMore: true,
+      })
+      .mockReturnValueOnce({
+        videos: [
+          { id: 'video-1', pubkey: 'p1', kind: 34236, createdAt: 101, vineId: 'd-1' },
+          { id: 'video-2', pubkey: 'p2', kind: 34236, createdAt: 100, vineId: 'd-2' },
+        ],
+        nextCursor: undefined,
+        offset: 24,
+        hasMore: true,
+      });
+
+    const { result } = renderHook(
+      () => useInfiniteVideosFunnelcake({ feedType: 'recommendations', pageSize: 12 }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.hasNextPage).toBe(true);
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => {
+      expect(result.current.data?.pages).toHaveLength(2);
+    });
+
+    expect(result.current.hasNextPage).toBe(false);
+    expect(mockFetchRecommendations).toHaveBeenNthCalledWith(
+      2,
+      'https://api.divine.video',
+      expect.objectContaining({
+        offset: 12,
+        limit: 12,
+      })
+    );
+  });
+});

--- a/src/hooks/useInfiniteVideosFunnelcake.test.ts
+++ b/src/hooks/useInfiniteVideosFunnelcake.test.ts
@@ -69,6 +69,7 @@ describe('useInfiniteVideosFunnelcake', () => {
           { id: 'video-2', pubkey: 'p2', kind: 34236, createdAt: 100, vineId: 'd-2' },
         ],
         nextCursor: undefined,
+        rawCursor: 'cursor-page2',
         hasMore: true,
       });
 
@@ -84,7 +85,7 @@ describe('useInfiniteVideosFunnelcake', () => {
     // First page loaded — check the page data
     const page1 = result.current.data?.pages[0];
     expect(page1?.videos).toHaveLength(2);
-    expect(page1?.recCursor).toBe('cursor-page2');
+    expect(page1?.recommendationsCursor).toBe('cursor-page2');
     expect(result.current.hasNextPage).toBe(true);
   });
 
@@ -112,7 +113,7 @@ describe('useInfiniteVideosFunnelcake', () => {
 
     // Page should have no recCursor
     const page = result.current.data?.pages[0];
-    expect(page?.recCursor).toBeUndefined();
+    expect(page?.recommendationsCursor).toBeUndefined();
     // Server said no more — should not have next page
     expect(result.current.hasNextPage).toBe(false);
   });
@@ -129,8 +130,8 @@ describe('useInfiniteVideosFunnelcake', () => {
       .mockResolvedValueOnce({ videos: [{}], has_more: true, next_cursor: '24' });
 
     mockTransformToVideoPage
-      .mockReturnValueOnce({ videos: sameVideos, nextCursor: undefined, hasMore: true })
-      .mockReturnValueOnce({ videos: sameVideos, nextCursor: undefined, hasMore: true });
+      .mockReturnValueOnce({ videos: sameVideos, nextCursor: undefined, rawCursor: '12', hasMore: true })
+      .mockReturnValueOnce({ videos: sameVideos, nextCursor: undefined, rawCursor: '24', hasMore: true });
 
     const { result } = renderHook(
       () => useInfiniteVideosFunnelcake({ feedType: 'recommendations', pageSize: 12 }),

--- a/src/hooks/useInfiniteVideosFunnelcake.test.ts
+++ b/src/hooks/useInfiniteVideosFunnelcake.test.ts
@@ -3,6 +3,7 @@ import { renderHook, waitFor, act } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 
+const mockFetchVideos = vi.fn();
 const mockFetchRecommendations = vi.fn();
 const mockTransformToVideoPage = vi.fn();
 
@@ -13,7 +14,7 @@ vi.mock('@/hooks/useCurrentUser', () => ({
 }));
 
 vi.mock('@/lib/funnelcakeClient', () => ({
-  fetchVideos: vi.fn(),
+  fetchVideos: mockFetchVideos,
   searchVideos: vi.fn(),
   fetchUserVideos: vi.fn(),
   fetchUserFeed: vi.fn(),
@@ -89,9 +90,12 @@ describe('useInfiniteVideosFunnelcake', () => {
     expect(result.current.hasNextPage).toBe(true);
   });
 
-  it('stops paginating when server returns no cursor', async () => {
+  it('falls back to popular pagination when recommendations return no cursor', async () => {
     mockFetchRecommendations
       .mockResolvedValueOnce({ videos: [{}], has_more: false, next_cursor: null });
+
+    mockFetchVideos
+      .mockResolvedValueOnce({ videos: [{}], has_more: false, next_cursor: undefined });
 
     mockTransformToVideoPage
       .mockReturnValueOnce({
@@ -99,6 +103,14 @@ describe('useInfiniteVideosFunnelcake', () => {
           { id: 'video-1', pubkey: 'p1', kind: 34236, createdAt: 101, vineId: 'd-1' },
         ],
         nextCursor: undefined,
+        hasMore: false,
+      })
+      .mockReturnValueOnce({
+        videos: [
+          { id: 'video-2', pubkey: 'p2', kind: 34236, createdAt: 100, vineId: 'd-2' },
+        ],
+        nextCursor: undefined,
+        offset: undefined,
         hasMore: false,
       });
 
@@ -114,24 +126,50 @@ describe('useInfiniteVideosFunnelcake', () => {
     // Page should have no recCursor
     const page = result.current.data?.pages[0];
     expect(page?.recommendationsCursor).toBeUndefined();
-    // Server said no more — should not have next page
-    expect(result.current.hasNextPage).toBe(false);
+    // Recommendations stop, but the feed should continue via popular fallback
+    expect(result.current.hasNextPage).toBe(true);
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => {
+      expect(result.current.data?.pages).toHaveLength(2);
+    });
+
+    expect(mockFetchVideos).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        sort: 'popular',
+        limit: 12,
+        offset: 1,
+        signal: expect.any(AbortSignal),
+      })
+    );
   });
 
-  it('dedup safety net stops pagination when server returns duplicate videos', async () => {
+  it('falls back to popular pagination when recommendations return duplicate pages', async () => {
     // Server returns the same videos for both pages (offset/cursor ignored)
     const sameVideos = [
       { id: 'video-1', pubkey: 'p1', kind: 34236, createdAt: 101, vineId: 'd-1' },
       { id: 'video-2', pubkey: 'p2', kind: 34236, createdAt: 100, vineId: 'd-2' },
+    ];
+    const popularVideos = [
+      { id: 'video-3', pubkey: 'p3', kind: 34236, createdAt: 99, vineId: 'd-3' },
+      { id: 'video-4', pubkey: 'p4', kind: 34236, createdAt: 98, vineId: 'd-4' },
     ];
 
     mockFetchRecommendations
       .mockResolvedValueOnce({ videos: [{}], has_more: true, next_cursor: '12' })
       .mockResolvedValueOnce({ videos: [{}], has_more: true, next_cursor: '24' });
 
+    mockFetchVideos
+      .mockResolvedValueOnce({ videos: [{}], has_more: false, next_cursor: undefined });
+
     mockTransformToVideoPage
       .mockReturnValueOnce({ videos: sameVideos, nextCursor: undefined, rawCursor: '12', hasMore: true })
-      .mockReturnValueOnce({ videos: sameVideos, nextCursor: undefined, rawCursor: '24', hasMore: true });
+      .mockReturnValueOnce({ videos: sameVideos, nextCursor: undefined, rawCursor: '24', hasMore: true })
+      .mockReturnValueOnce({ videos: popularVideos, nextCursor: undefined, offset: undefined, hasMore: false });
 
     const { result } = renderHook(
       () => useInfiniteVideosFunnelcake({ feedType: 'recommendations', pageSize: 12 }),
@@ -149,10 +187,33 @@ describe('useInfiniteVideosFunnelcake', () => {
     });
 
     await waitFor(() => {
+      expect(mockFetchRecommendations).toHaveBeenCalledTimes(2);
+    });
+
+    expect(mockFetchRecommendations).toHaveBeenNthCalledWith(
+      2,
+      expect.any(String),
+      expect.objectContaining({
+        cursor: '12',
+        offset: 12,
+        limit: 12,
+      })
+    );
+
+    await waitFor(() => {
       expect(result.current.data?.pages).toHaveLength(2);
     });
 
-    // Page 2 contains only duplicates → should stop pagination
-    expect(result.current.hasNextPage).toBe(false);
+    expect(mockFetchVideos).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        sort: 'popular',
+        limit: 12,
+        offset: 2,
+        signal: expect.any(AbortSignal),
+      })
+    );
+
+    expect(result.current.data?.pages[1]?.videos).toEqual(popularVideos);
   });
 });

--- a/src/hooks/useInfiniteVideosFunnelcake.test.ts
+++ b/src/hooks/useInfiniteVideosFunnelcake.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { renderHook, waitFor, act } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 
@@ -57,10 +57,10 @@ beforeEach(async () => {
 });
 
 describe('useInfiniteVideosFunnelcake', () => {
-  it('stops paginating recommendations when a new page contains no new videos', async () => {
+  it('uses cursor-based pagination for recommendations', async () => {
+    // Page 1: server returns cursor for next page
     mockFetchRecommendations
-      .mockResolvedValueOnce({ videos: [{}], has_more: true, next_cursor: '12' })
-      .mockResolvedValueOnce({ videos: [{}], has_more: true, next_cursor: '24' });
+      .mockResolvedValueOnce({ videos: [{}], has_more: true, next_cursor: 'cursor-page2' });
 
     mockTransformToVideoPage
       .mockReturnValueOnce({
@@ -69,16 +69,6 @@ describe('useInfiniteVideosFunnelcake', () => {
           { id: 'video-2', pubkey: 'p2', kind: 34236, createdAt: 100, vineId: 'd-2' },
         ],
         nextCursor: undefined,
-        offset: 12,
-        hasMore: true,
-      })
-      .mockReturnValueOnce({
-        videos: [
-          { id: 'video-1', pubkey: 'p1', kind: 34236, createdAt: 101, vineId: 'd-1' },
-          { id: 'video-2', pubkey: 'p2', kind: 34236, createdAt: 100, vineId: 'd-2' },
-        ],
-        nextCursor: undefined,
-        offset: 24,
         hasMore: true,
       });
 
@@ -91,24 +81,39 @@ describe('useInfiniteVideosFunnelcake', () => {
       expect(result.current.isSuccess).toBe(true);
     });
 
+    // First page loaded — check the page data
+    const page1 = result.current.data?.pages[0];
+    expect(page1?.videos).toHaveLength(2);
+    expect(page1?.recCursor).toBe('cursor-page2');
     expect(result.current.hasNextPage).toBe(true);
+  });
 
-    await act(async () => {
-      await result.current.fetchNextPage();
-    });
+  it('stops paginating when server returns no cursor', async () => {
+    mockFetchRecommendations
+      .mockResolvedValueOnce({ videos: [{}], has_more: false, next_cursor: null });
+
+    mockTransformToVideoPage
+      .mockReturnValueOnce({
+        videos: [
+          { id: 'video-1', pubkey: 'p1', kind: 34236, createdAt: 101, vineId: 'd-1' },
+        ],
+        nextCursor: undefined,
+        hasMore: false,
+      });
+
+    const { result } = renderHook(
+      () => useInfiniteVideosFunnelcake({ feedType: 'recommendations', pageSize: 12 }),
+      { wrapper: createWrapper() }
+    );
 
     await waitFor(() => {
-      expect(result.current.data?.pages).toHaveLength(2);
+      expect(result.current.isSuccess).toBe(true);
     });
 
+    // Page should have no recCursor
+    const page = result.current.data?.pages[0];
+    expect(page?.recCursor).toBeUndefined();
+    // Server said no more — should not have next page
     expect(result.current.hasNextPage).toBe(false);
-    expect(mockFetchRecommendations).toHaveBeenNthCalledWith(
-      2,
-      'https://api.divine.video',
-      expect.objectContaining({
-        offset: 12,
-        limit: 12,
-      })
-    );
   });
 });

--- a/src/hooks/useInfiniteVideosFunnelcake.ts
+++ b/src/hooks/useInfiniteVideosFunnelcake.ts
@@ -36,6 +36,10 @@ interface FunnelcakeVideoPage {
   recommendationsCursor?: string;
 }
 
+function getVideoKey(video: Pick<ParsedVideoData, 'pubkey' | 'kind' | 'vineId' | 'id'>): string {
+  return `${video.pubkey}:${video.kind}:${video.vineId || video.id}`;
+}
+
 /**
  * Map feed type and sort mode to Funnelcake API options
  */
@@ -241,12 +245,16 @@ export function useInfiniteVideosFunnelcake({
               debugLog('[useInfiniteVideosFunnelcake] No user logged in for recommendations feed');
               return { videos: [], nextCursor: undefined };
             }
-            // Recommendations use cursor-based pagination (preferred over offset)
+            // Recommendations use cursor-based pagination, with numeric-offset
+            // fallback for older servers that do not return cursor metadata yet.
             const recCursor = typeof pageParam === 'string' ? pageParam : undefined;
+            const recOffset = recCursor ? parseInt(recCursor, 10) : undefined;
+            const isNumericOffset = recOffset !== undefined && !isNaN(recOffset);
             response = await fetchRecommendations(effectiveApiUrl, {
               pubkey: user.pubkey,
               limit: pageSize,
               cursor: recCursor,
+              offset: isNumericOffset ? recOffset : undefined,
               fallback: 'popular', // Fall back to popular videos if no personalized recs
               signal,
             });
@@ -322,8 +330,24 @@ export function useInfiniteVideosFunnelcake({
         const nextOffset = (randomStartOffset + allPages.length * pageSize) % randomizeWithinTop;
         return { offset: nextOffset };
       }
-      // Recommendations: use opaque cursor string
-      if (lastPage.recommendationsCursor) {
+      if (feedType === 'recommendations') {
+        if (!lastPage.recommendationsCursor) {
+          return undefined;
+        }
+
+        if (allPages.length > 1) {
+          const seenKeys = new Set(
+            allPages
+              .slice(0, -1)
+              .flatMap(page => page.videos.map(getVideoKey))
+          );
+          const hasNewVideos = lastPage.videos.some(video => !seenKeys.has(getVideoKey(video)));
+
+          if (!hasNewVideos) {
+            return undefined;
+          }
+        }
+
         return lastPage.recommendationsCursor;
       }
       // Use offset for sorted pagination, timestamp for chronological

--- a/src/hooks/useInfiniteVideosFunnelcake.ts
+++ b/src/hooks/useInfiniteVideosFunnelcake.ts
@@ -34,10 +34,54 @@ interface FunnelcakeVideoPage {
   offset?: number;
   /** Opaque cursor string for recommendations pagination */
   recommendationsCursor?: string;
+  mode?: 'recommendations' | 'popular';
 }
 
 function getVideoKey(video: Pick<ParsedVideoData, 'pubkey' | 'kind' | 'vineId' | 'id'>): string {
   return `${video.pubkey}:${video.kind}:${video.vineId || video.id}`;
+}
+
+function getUniqueVideoCount(pages: FunnelcakeVideoPage[]): number {
+  const seenKeys = new Set<string>();
+
+  for (const page of pages) {
+    for (const video of page.videos) {
+      seenKeys.add(getVideoKey(video));
+    }
+  }
+
+  return seenKeys.size;
+}
+
+function isPopularFallbackPageParam(
+  pageParam: unknown
+): pageParam is { mode: 'popular'; offset: number } {
+  return typeof pageParam === 'object'
+    && pageParam !== null
+    && 'mode' in pageParam
+    && (pageParam as { mode?: string }).mode === 'popular'
+    && 'offset' in pageParam
+    && typeof (pageParam as { offset?: unknown }).offset === 'number';
+}
+
+function isRecommendationsCursorPageParam(
+  pageParam: unknown
+): pageParam is {
+  mode: 'recommendations';
+  cursor: string;
+  seenVideoKeys: string[];
+  popularOffset: number;
+} {
+  return typeof pageParam === 'object'
+    && pageParam !== null
+    && 'mode' in pageParam
+    && (pageParam as { mode?: string }).mode === 'recommendations'
+    && 'cursor' in pageParam
+    && typeof (pageParam as { cursor?: unknown }).cursor === 'string'
+    && 'seenVideoKeys' in pageParam
+    && Array.isArray((pageParam as { seenVideoKeys?: unknown }).seenVideoKeys)
+    && 'popularOffset' in pageParam
+    && typeof (pageParam as { popularOffset?: unknown }).popularOffset === 'number';
 }
 
 /**
@@ -186,7 +230,13 @@ export function useInfiniteVideosFunnelcake({
       }
 
       // Handle pagination cursor
-      const isOffsetParam = typeof pageParam === 'object' && pageParam !== null && 'offset' in pageParam;
+      const isPopularFallback = isPopularFallbackPageParam(pageParam);
+      const isRecommendationsCursorParam = isRecommendationsCursorPageParam(pageParam);
+      const isOffsetParam = typeof pageParam === 'object'
+        && pageParam !== null
+        && 'offset' in pageParam
+        && !isPopularFallback
+        && !isRecommendationsCursorParam;
       const before = isOffsetParam
         ? String((pageParam as { offset: number }).offset)
         : pageParam
@@ -213,6 +263,8 @@ export function useInfiniteVideosFunnelcake({
 
       const queryStart = performance.now();
       let response;
+      let responseMode: FunnelcakeVideoPage['mode'];
+      let cursorType: 'timestamp' | 'offset' | 'cursor' = feedType === 'recommendations' ? 'cursor' : 'timestamp';
 
       try {
         switch (feedType) {
@@ -245,19 +297,35 @@ export function useInfiniteVideosFunnelcake({
               debugLog('[useInfiniteVideosFunnelcake] No user logged in for recommendations feed');
               return { videos: [], nextCursor: undefined };
             }
-            // Recommendations use cursor-based pagination, with numeric-offset
-            // fallback for older servers that do not return cursor metadata yet.
-            const recCursor = typeof pageParam === 'string' ? pageParam : undefined;
-            const recOffset = recCursor ? parseInt(recCursor, 10) : undefined;
-            const isNumericOffset = recOffset !== undefined && !isNaN(recOffset);
-            response = await fetchRecommendations(effectiveApiUrl, {
-              pubkey: user.pubkey,
-              limit: pageSize,
-              cursor: recCursor,
-              offset: isNumericOffset ? recOffset : undefined,
-              fallback: 'popular', // Fall back to popular videos if no personalized recs
-              signal,
-            });
+            if (isPopularFallback) {
+              responseMode = 'popular';
+              cursorType = 'offset';
+              response = await fetchVideos(effectiveApiUrl, {
+                limit: pageSize,
+                sort: 'popular',
+                offset: pageParam.offset,
+                signal,
+              });
+            } else {
+              responseMode = 'recommendations';
+              // Recommendations use cursor-based pagination, with numeric-offset
+              // fallback for older servers that do not return cursor metadata yet.
+              const recCursor = isRecommendationsCursorParam
+                ? pageParam.cursor
+                : typeof pageParam === 'string'
+                  ? pageParam
+                  : undefined;
+              const recOffset = recCursor ? parseInt(recCursor, 10) : undefined;
+              const isNumericOffset = recOffset !== undefined && !isNaN(recOffset);
+              response = await fetchRecommendations(effectiveApiUrl, {
+                pubkey: user.pubkey,
+                limit: pageSize,
+                cursor: recCursor,
+                offset: isNumericOffset ? recOffset : undefined,
+                fallback: 'popular', // Fall back to popular videos if no personalized recs
+                signal,
+              });
+            }
             break;
           }
 
@@ -280,11 +348,27 @@ export function useInfiniteVideosFunnelcake({
 
       const queryTime = performance.now() - queryStart;
 
-      // Transform response to video page
-      // Recommendations use opaque cursor pagination, others use timestamp
+      // Transform response to video page.
       const parseStart = performance.now();
-      const cursorType = feedType === 'recommendations' ? 'cursor' : 'timestamp';
-      const page = transformToVideoPage(response, cursorType);
+      let page = transformToVideoPage(response, cursorType);
+
+      if (feedType === 'recommendations' && responseMode === 'recommendations' && isRecommendationsCursorParam) {
+        const seenKeys = new Set(pageParam.seenVideoKeys);
+        const hasNewVideos = page.videos.some(video => !seenKeys.has(getVideoKey(video)));
+
+        if (!hasNewVideos) {
+          responseMode = 'popular';
+          cursorType = 'offset';
+          response = await fetchVideos(effectiveApiUrl, {
+            limit: pageSize,
+            sort: 'popular',
+            offset: pageParam.popularOffset,
+            signal,
+          });
+          page = transformToVideoPage(response, cursorType);
+        }
+      }
+
       const enrichedVideos = feedType === 'profile'
         ? await enrichAgeRestrictedVideos(page.videos, signal)
         : page.videos;
@@ -319,7 +403,8 @@ export function useInfiniteVideosFunnelcake({
         videos: enrichedVideos,
         nextCursor: page.nextCursor,
         offset: page.offset,
-        recommendationsCursor: page.rawCursor,
+        recommendationsCursor: responseMode === 'recommendations' ? page.rawCursor : undefined,
+        mode: responseMode,
       };
     },
 
@@ -331,24 +416,25 @@ export function useInfiniteVideosFunnelcake({
         return { offset: nextOffset };
       }
       if (feedType === 'recommendations') {
-        if (!lastPage.recommendationsCursor) {
-          return undefined;
+        if (lastPage.mode === 'popular') {
+          return lastPage.offset !== undefined
+            ? { mode: 'popular' as const, offset: lastPage.offset }
+            : undefined;
         }
 
-        if (allPages.length > 1) {
-          const seenKeys = new Set(
-            allPages
-              .slice(0, -1)
-              .flatMap(page => page.videos.map(getVideoKey))
-          );
-          const hasNewVideos = lastPage.videos.some(video => !seenKeys.has(getVideoKey(video)));
-
-          if (!hasNewVideos) {
-            return undefined;
-          }
+        if (lastPage.recommendationsCursor) {
+          return {
+            mode: 'recommendations' as const,
+            cursor: lastPage.recommendationsCursor,
+            seenVideoKeys: allPages.flatMap(page => page.videos.map(getVideoKey)),
+            popularOffset: getUniqueVideoCount(allPages),
+          };
         }
 
-        return lastPage.recommendationsCursor;
+        return {
+          mode: 'popular' as const,
+          offset: getUniqueVideoCount(allPages),
+        };
       }
       // Use offset for sorted pagination, timestamp for chronological
       if (lastPage.offset !== undefined) {

--- a/src/lib/funnelcakeClient.test.ts
+++ b/src/lib/funnelcakeClient.test.ts
@@ -540,4 +540,39 @@ describe('funnelcakeClient', () => {
       expect(requestUrl.searchParams.get('types')).toBe('like,follow');
     });
   });
+
+  describe('fetchRecommendations', () => {
+    it('continues pagination for short non-empty recommendation batches', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          videos: [
+            {
+              id: 'vid-1',
+              pubkey: TEST_PUBKEY,
+              created_at: 123,
+              kind: 34236,
+              d_tag: 'd-1',
+              title: 'Video 1',
+              content: '',
+              thumbnail: 'https://example.com/thumb-1.jpg',
+              video_url: 'https://example.com/video-1.mp4',
+            },
+          ],
+          source: 'personalized',
+        }),
+      });
+
+      const result = await fetchRecommendations(API_URL, {
+        pubkey: TEST_PUBKEY,
+        limit: 12,
+        offset: 24,
+        fallback: 'popular',
+      });
+
+      expect(result.videos).toHaveLength(1);
+      expect(result.has_more).toBe(true);
+      expect(result.next_cursor).toBe('36');
+    });
+  });
 });

--- a/src/lib/funnelcakeClient.test.ts
+++ b/src/lib/funnelcakeClient.test.ts
@@ -436,6 +436,41 @@ describe('funnelcakeClient', () => {
       expect(result.next_cursor).toBeUndefined();
     });
 
+    it('uses next_offset when the server paginates without next_cursor', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          videos: [
+            {
+              id: 'v1',
+              pubkey: TEST_PUBKEY,
+              video_url: 'https://example.com/v.mp4',
+              d_tag: 'd1',
+              created_at: 1700000000,
+              kind: 34236,
+            },
+          ],
+          source: 'popular',
+          has_more: true,
+          next_cursor: null,
+          next_offset: 36,
+          fallback_applied: true,
+          limit: 12,
+          offset: 24,
+        }),
+      });
+
+      const result = await fetchRecommendations(API_URL, {
+        pubkey: TEST_PUBKEY,
+        limit: 12,
+        offset: 24,
+        fallback: 'popular',
+      });
+
+      expect(result.has_more).toBe(true);
+      expect(result.next_cursor).toBe('36');
+    });
+
     it('uses backend has_more instead of computing locally', async () => {
       // Backend says has_more=false even though we got limit-count videos
       (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({

--- a/src/lib/funnelcakeClient.test.ts
+++ b/src/lib/funnelcakeClient.test.ts
@@ -30,7 +30,6 @@ describe('funnelcakeClient', () => {
   let fetchBulkUsers: typeof import('./funnelcakeClient').fetchBulkUsers;
   let fetchBulkVideoStats: typeof import('./funnelcakeClient').fetchBulkVideoStats;
   let searchProfiles: typeof import('./funnelcakeClient').searchProfiles;
-  let fetchRecommendations: typeof import('./funnelcakeClient').fetchRecommendations;
   let markNotificationsRead: typeof import('./funnelcakeClient').markNotificationsRead;
   let fetchNotifications: typeof import('./funnelcakeClient').fetchNotifications;
 
@@ -46,7 +45,6 @@ describe('funnelcakeClient', () => {
     fetchBulkUsers = client.fetchBulkUsers;
     fetchBulkVideoStats = client.fetchBulkVideoStats;
     searchProfiles = client.searchProfiles;
-    fetchRecommendations = client.fetchRecommendations;
     markNotificationsRead = client.markNotificationsRead;
     fetchNotifications = client.fetchNotifications;
   });
@@ -542,7 +540,7 @@ describe('funnelcakeClient', () => {
   });
 
   describe('fetchRecommendations', () => {
-    it('passes through server has_more and next_cursor for cursor-based pagination', async () => {
+    it('falls back to offset pagination when the server omits cursor metadata', async () => {
       (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve({
@@ -560,59 +558,22 @@ describe('funnelcakeClient', () => {
             },
           ],
           source: 'personalized',
-          has_more: true,
-          next_cursor: 'abc123cursor',
-          next_offset: 36,
-          fallback_applied: false,
         }),
       });
 
       const result = await fetchRecommendations(API_URL, {
         pubkey: TEST_PUBKEY,
         limit: 12,
-        cursor: 'prev-cursor',
+        offset: 24,
         fallback: 'popular',
       });
 
+      const [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      const requestUrl = new URL(url as string);
+      expect(requestUrl.searchParams.get('offset')).toBe('24');
       expect(result.videos).toHaveLength(1);
       expect(result.has_more).toBe(true);
-      expect(result.next_cursor).toBe('abc123cursor');
-    });
-
-    it('stops pagination when server says has_more is false', async () => {
-      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({
-          videos: [
-            {
-              id: 'vid-2',
-              pubkey: TEST_PUBKEY,
-              created_at: 456,
-              kind: 34236,
-              d_tag: 'd-2',
-              title: 'Video 2',
-              content: '',
-              thumbnail: 'https://example.com/thumb-2.jpg',
-              video_url: 'https://example.com/video-2.mp4',
-            },
-          ],
-          source: 'popular',
-          has_more: false,
-          next_cursor: null,
-          next_offset: null,
-          fallback_applied: true,
-        }),
-      });
-
-      const result = await fetchRecommendations(API_URL, {
-        pubkey: TEST_PUBKEY,
-        limit: 12,
-        fallback: 'popular',
-      });
-
-      expect(result.videos).toHaveLength(1);
-      expect(result.has_more).toBe(false);
-      expect(result.next_cursor).toBeUndefined();
+      expect(result.next_cursor).toBe('36');
     });
   });
 });

--- a/src/lib/funnelcakeClient.test.ts
+++ b/src/lib/funnelcakeClient.test.ts
@@ -542,7 +542,7 @@ describe('funnelcakeClient', () => {
   });
 
   describe('fetchRecommendations', () => {
-    it('continues pagination for short non-empty recommendation batches', async () => {
+    it('passes through server has_more and next_cursor for cursor-based pagination', async () => {
       (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve({
@@ -560,19 +560,59 @@ describe('funnelcakeClient', () => {
             },
           ],
           source: 'personalized',
+          has_more: true,
+          next_cursor: 'abc123cursor',
+          next_offset: 36,
+          fallback_applied: false,
         }),
       });
 
       const result = await fetchRecommendations(API_URL, {
         pubkey: TEST_PUBKEY,
         limit: 12,
-        offset: 24,
+        cursor: 'prev-cursor',
         fallback: 'popular',
       });
 
       expect(result.videos).toHaveLength(1);
       expect(result.has_more).toBe(true);
-      expect(result.next_cursor).toBe('36');
+      expect(result.next_cursor).toBe('abc123cursor');
+    });
+
+    it('stops pagination when server says has_more is false', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          videos: [
+            {
+              id: 'vid-2',
+              pubkey: TEST_PUBKEY,
+              created_at: 456,
+              kind: 34236,
+              d_tag: 'd-2',
+              title: 'Video 2',
+              content: '',
+              thumbnail: 'https://example.com/thumb-2.jpg',
+              video_url: 'https://example.com/video-2.mp4',
+            },
+          ],
+          source: 'popular',
+          has_more: false,
+          next_cursor: null,
+          next_offset: null,
+          fallback_applied: true,
+        }),
+      });
+
+      const result = await fetchRecommendations(API_URL, {
+        pubkey: TEST_PUBKEY,
+        limit: 12,
+        fallback: 'popular',
+      });
+
+      expect(result.videos).toHaveLength(1);
+      expect(result.has_more).toBe(false);
+      expect(result.next_cursor).toBeUndefined();
     });
   });
 });

--- a/src/lib/funnelcakeClient.test.ts
+++ b/src/lib/funnelcakeClient.test.ts
@@ -30,6 +30,7 @@ describe('funnelcakeClient', () => {
   let fetchBulkUsers: typeof import('./funnelcakeClient').fetchBulkUsers;
   let fetchBulkVideoStats: typeof import('./funnelcakeClient').fetchBulkVideoStats;
   let searchProfiles: typeof import('./funnelcakeClient').searchProfiles;
+  let fetchRecommendations: typeof import('./funnelcakeClient').fetchRecommendations;
   let markNotificationsRead: typeof import('./funnelcakeClient').markNotificationsRead;
   let fetchNotifications: typeof import('./funnelcakeClient').fetchNotifications;
 
@@ -45,6 +46,7 @@ describe('funnelcakeClient', () => {
     fetchBulkUsers = client.fetchBulkUsers;
     fetchBulkVideoStats = client.fetchBulkVideoStats;
     searchProfiles = client.searchProfiles;
+    fetchRecommendations = client.fetchRecommendations;
     markNotificationsRead = client.markNotificationsRead;
     fetchNotifications = client.fetchNotifications;
   });

--- a/src/lib/funnelcakeClient.ts
+++ b/src/lib/funnelcakeClient.ts
@@ -506,7 +506,7 @@ export async function fetchRecommendations(
     ? (response.has_more ?? false)
     : videoCount > 0;
   const nextCursor = serverSupportsCursorMetadata
-    ? (response.next_cursor ?? undefined)
+    ? (response.next_cursor ?? (response.next_offset !== null ? String(response.next_offset) : undefined))
     : (videoCount > 0 ? String((offset || 0) + limit) : undefined);
 
   debugLog(

--- a/src/lib/funnelcakeClient.ts
+++ b/src/lib/funnelcakeClient.ts
@@ -479,10 +479,12 @@ export async function fetchRecommendations(
 
   const endpoint = API_CONFIG.funnelcake.endpoints.userRecommendations.replace('{pubkey}', pubkey);
 
-  // Prefer cursor over offset; if both sent, backend uses cursor
+  // Send both cursor and offset. Newer servers honor cursor, while older
+  // ones ignore it and continue to paginate via numeric offsets.
   const params: Record<string, string | number | boolean | undefined> = {
     limit,
-    ...(cursor ? { cursor } : offset !== undefined ? { offset } : {}),
+    cursor,
+    offset,
     category,
     fallback,
     content_safety,
@@ -499,13 +501,22 @@ export async function fetchRecommendations(
   );
 
   const videoCount = response.videos?.length || 0;
+  const serverSupportsCursorMetadata = 'has_more' in response;
+  const hasMore = serverSupportsCursorMetadata
+    ? (response.has_more ?? false)
+    : videoCount > 0;
+  const nextCursor = serverSupportsCursorMetadata
+    ? (response.next_cursor ?? undefined)
+    : (videoCount > 0 ? String((offset || 0) + limit) : undefined);
 
-  debugLog(`[FunnelcakeClient] Got ${videoCount} recommendations (source: ${response.source}, has_more: ${response.has_more}, fallback_applied: ${response.fallback_applied})`);
+  debugLog(
+    `[FunnelcakeClient] Got ${videoCount} recommendations (source: ${response.source}, has_more: ${hasMore}, fallback_applied: ${response.fallback_applied}, cursor_mode: ${serverSupportsCursorMetadata ? 'server' : 'offset-fallback'})`
+  );
 
   return {
     videos: response.videos || [],
-    has_more: response.has_more ?? false,
-    next_cursor: response.next_cursor ?? undefined,
+    has_more: hasMore,
+    next_cursor: nextCursor,
     source: response.source,
     fallback_applied: response.fallback_applied,
   };

--- a/src/pages/SearchPage.test.tsx
+++ b/src/pages/SearchPage.test.tsx
@@ -202,6 +202,26 @@ describe('SearchPage', () => {
     vi.useRealTimers();
   });
 
+  it('clears the blur suggestion timeout on unmount', async () => {
+    vi.useFakeTimers();
+
+    const { unmount } = renderPage();
+    const input = screen.getByRole('textbox');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    fireEvent.focus(input);
+    fireEvent.blur(input);
+
+    expect(vi.getTimerCount()).toBeGreaterThan(0);
+
+    unmount();
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
   it('navigates directly when the query is an npub', () => {
     const npub = nip19.npubEncode('f'.repeat(64));
 

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -66,8 +66,16 @@ export function SearchPage() {
   );
   const [showSuggestions, setShowSuggestions] = useState(false);
   const searchInputRef = useRef<HTMLInputElement>(null);
+  const suggestionsBlurTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const directLookupAbortRef = useRef<AbortController | null>(null);
   const pastedLookupQueryRef = useRef<string | null>(null);
+
+  const clearSuggestionsBlurTimer = () => {
+    if (!suggestionsBlurTimerRef.current) return;
+
+    clearTimeout(suggestionsBlurTimerRef.current);
+    suggestionsBlurTimerRef.current = null;
+  };
 
   // Video search with infinite scroll and NIP-50
   const {
@@ -179,6 +187,7 @@ export function SearchPage() {
 
   useEffect(() => {
     return () => {
+      clearSuggestionsBlurTimer();
       directLookupAbortRef.current?.abort();
     };
   }, []);
@@ -383,8 +392,17 @@ export function SearchPage() {
               value={searchQuery}
               onChange={(e) => handleSearchChange(e.target.value)}
               onPaste={handleSearchPaste}
-              onFocus={() => setShowSuggestions(!searchQuery.trim())}
-              onBlur={() => setTimeout(() => setShowSuggestions(false), 200)}
+              onFocus={() => {
+                clearSuggestionsBlurTimer();
+                setShowSuggestions(!searchQuery.trim());
+              }}
+              onBlur={() => {
+                clearSuggestionsBlurTimer();
+                suggestionsBlurTimerRef.current = setTimeout(() => {
+                  suggestionsBlurTimerRef.current = null;
+                  setShowSuggestions(false);
+                }, 200);
+              }}
               className="pl-10 pr-4"
               autoFocus
             />


### PR DESCRIPTION
## Summary
- keep the For You recommendations feed paginating when the API returns short non-empty batches
- stop pagination once the recommendations endpoint starts returning duplicate-only pages
- add regression coverage for recommendation pagination in the client and hook layers

## Test Plan
- [x] npm test
