### PR TITLE
fix: persist JWT login across subdomains

### DIFF
--- a/src/hooks/useDivineSession.ts
+++ b/src/hooks/useDivineSession.ts
@@ -4,6 +4,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useLocalStorage } from '@/hooks/useLocalStorage';
 import { getJWTExpiration } from '@/lib/jwtDecode';
+import { setJwtCookie, clearJwtCookie } from '@/lib/crossSubdomainAuth';
 
 // Legacy key names stay in place so existing hosted-login sessions survive this rename.
 const TOKEN_KEY = 'keycast_jwt_token';
@@ -124,6 +125,15 @@ export function useDivineSession() {
       setSessionStart(now);
       setEmail(userEmail);
       setRememberMe(shouldRememberMe);
+
+      // Share JWT session across subdomains via cookie
+      setJwtCookie({
+        token: newToken,
+        expiration: expiresAt,
+        sessionStart: now,
+        rememberMe: shouldRememberMe,
+        email: userEmail || undefined,
+      });
     },
     [setToken, setExpiration, setSessionStart, setEmail, setRememberMe]
   );
@@ -150,8 +160,20 @@ export function useDivineSession() {
       setToken(newToken);
       setExpiration(expiresAt);
       // Keep original sessionStart to track 1-week limit
+
+      // Update JWT cookie with refreshed token
+      if (sessionStart) {
+        setJwtCookie({
+          token: newToken,
+          expiration: expiresAt,
+          sessionStart,
+          rememberMe,
+          email: email || undefined,
+          bunkerUrl: bunkerUrl || undefined,
+        });
+      }
     },
-    [setToken, setExpiration]
+    [setToken, setExpiration, sessionStart, rememberMe, email, bunkerUrl]
   );
 
   /**
@@ -161,8 +183,20 @@ export function useDivineSession() {
     (url: string) => {
       console.log('[useDivineSession] Saving bunker URL for persistent reconnection');
       setBunkerUrl(url);
+
+      // Update JWT cookie with bunker URL
+      if (token && expiration && sessionStart) {
+        setJwtCookie({
+          token,
+          expiration,
+          sessionStart,
+          rememberMe,
+          email: email || undefined,
+          bunkerUrl: url,
+        });
+      }
     },
-    [setBunkerUrl]
+    [setBunkerUrl, token, expiration, sessionStart, rememberMe, email]
   );
 
   /**
@@ -182,6 +216,7 @@ export function useDivineSession() {
     setEmail(null);
     setRememberMe(false);
     setBunkerUrl(null);
+    clearJwtCookie();
   }, [setToken, setExpiration, setSessionStart, setEmail, setRememberMe, setBunkerUrl]);
 
   /**

--- a/src/lib/crossSubdomainAuth.test.ts
+++ b/src/lib/crossSubdomainAuth.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { getCookieDomain, getLoginCookie, setLoginCookie, clearLoginCookie, hydrateLoginFromCookie } from './crossSubdomainAuth';
+import { getCookieDomain, getLoginCookie, setLoginCookie, clearLoginCookie, hydrateLoginFromCookie, setJwtCookie, getJwtCookie, clearJwtCookie } from './crossSubdomainAuth';
 
 // Mock localStorage for Node.js environment
 const localStorageMock = (() => {
@@ -207,6 +207,96 @@ describe('hydrateLoginFromCookie', () => {
     hydrateLoginFromCookie();
 
     expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+    expect(cookieJar).toBe('');
+  });
+
+  // --- JWT cross-subdomain hydration ---
+
+  it('when localStorage has JWT, syncs TO jwt cookie', () => {
+    const token = 'eyJ0eXAiOiJKV1QifQ.test-token';
+    const expiration = Date.now() + 86400000;
+    localStorage.setItem('keycast_jwt_token', JSON.stringify(token));
+    localStorage.setItem('keycast_jwt_expiration', JSON.stringify(expiration));
+    localStorage.setItem('keycast_session_start', JSON.stringify(Date.now()));
+    localStorage.setItem('keycast_remember_me', JSON.stringify(false));
+
+    hydrateLoginFromCookie();
+
+    const jwtCookie = getJwtCookie();
+    expect(jwtCookie).not.toBeNull();
+    expect(jwtCookie!.token).toBe(token);
+    expect(jwtCookie!.expiration).toBe(expiration);
+  });
+
+  it('when localStorage has no JWT but jwt cookie exists, hydrates localStorage', () => {
+    const expiration = Date.now() + 86400000;
+    const sessionStart = Date.now();
+    const jwtData = {
+      token: 'eyJ0eXAiOiJKV1QifQ.hydrate-test',
+      expiration,
+      sessionStart,
+      rememberMe: true,
+      email: 'test@divine.video',
+    };
+    cookieJar = `divine_jwt=${btoa(JSON.stringify(jwtData))}`;
+
+    hydrateLoginFromCookie();
+
+    expect(JSON.parse(localStorage.getItem('keycast_jwt_token')!)).toBe(jwtData.token);
+    expect(JSON.parse(localStorage.getItem('keycast_jwt_expiration')!)).toBe(expiration);
+    expect(JSON.parse(localStorage.getItem('keycast_session_start')!)).toBe(sessionStart);
+    expect(JSON.parse(localStorage.getItem('keycast_remember_me')!)).toBe(true);
+    expect(JSON.parse(localStorage.getItem('keycast_email')!)).toBe('test@divine.video');
+  });
+
+  it('does NOT hydrate JWT from cookie if token is expired', () => {
+    const jwtData = {
+      token: 'eyJ0eXAiOiJKV1QifQ.expired',
+      expiration: Date.now() - 1000, // expired
+      sessionStart: Date.now() - 86400000,
+      rememberMe: false,
+    };
+    cookieJar = `divine_jwt=${btoa(JSON.stringify(jwtData))}`;
+
+    hydrateLoginFromCookie();
+
+    expect(localStorage.getItem('keycast_jwt_token')).toBeNull();
+  });
+});
+
+describe('JWT cookie functions', () => {
+  it('setJwtCookie sets and getJwtCookie reads', () => {
+    const data = {
+      token: 'test-jwt-token',
+      expiration: Date.now() + 86400000,
+      sessionStart: Date.now(),
+      rememberMe: false,
+    };
+    setJwtCookie(data);
+    const result = getJwtCookie();
+    expect(result).toEqual(data);
+  });
+
+  it('clearJwtCookie removes the cookie', () => {
+    setJwtCookie({
+      token: 'test',
+      expiration: Date.now() + 86400000,
+      sessionStart: Date.now(),
+      rememberMe: false,
+    });
+    expect(getJwtCookie()).not.toBeNull();
+    clearJwtCookie();
+    expect(getJwtCookie()).toBeNull();
+  });
+
+  it('does not set cookie on localhost', () => {
+    setHostname('localhost');
+    setJwtCookie({
+      token: 'test',
+      expiration: Date.now() + 86400000,
+      sessionStart: Date.now(),
+      rememberMe: false,
+    });
     expect(cookieJar).toBe('');
   });
 });

--- a/src/lib/crossSubdomainAuth.ts
+++ b/src/lib/crossSubdomainAuth.ts
@@ -8,11 +8,21 @@
  */
 
 const COOKIE_NAME = 'nostr_login';
+const JWT_COOKIE_NAME = 'divine_jwt';
 
 interface LoginCookieData {
   type: 'extension' | 'bunker' | 'nsec';
   pubkey: string;
   bunkerUri?: string; // only for bunker logins
+}
+
+interface JwtCookieData {
+  token: string;
+  expiration: number;
+  sessionStart: number;
+  rememberMe: boolean;
+  email?: string;
+  bunkerUrl?: string;
 }
 
 export function getCookieDomain(): string | null {
@@ -63,6 +73,46 @@ export function getLoginCookie(): LoginCookieData | null {
   }
 }
 
+// --- JWT cross-subdomain cookie (for hosted Divine login sessions) ---
+
+export function setJwtCookie(data: JwtCookieData): void {
+  const domain = getCookieDomain();
+  if (!domain) return;
+
+  try {
+    const value = btoa(JSON.stringify(data));
+    const parts = [
+      `${JWT_COOKIE_NAME}=${value}`,
+      `domain=${domain}`,
+      `path=/`,
+      `max-age=${60 * 60 * 24 * 7}`, // 1 week (matches session max)
+      `SameSite=Lax`,
+      `Secure`,
+    ];
+    document.cookie = parts.join('; ');
+  } catch {
+    // silently fail - cookie is best-effort
+  }
+}
+
+export function getJwtCookie(): JwtCookieData | null {
+  try {
+    const match = document.cookie.match(new RegExp(`(?:^|; )${JWT_COOKIE_NAME}=([^;]+)`));
+    if (!match) return null;
+    return JSON.parse(atob(match[1]));
+  } catch {
+    return null;
+  }
+}
+
+export function clearJwtCookie(): void {
+  const domain = getCookieDomain();
+  if (!domain) return;
+
+  document.cookie = `${JWT_COOKIE_NAME}=; domain=${domain}; path=/; max-age=0; Secure`;
+  document.cookie = `${JWT_COOKIE_NAME}=; path=/; max-age=0; Secure`;
+}
+
 /**
  * Called on app startup (before React renders).
  * If localStorage has no login state but a cross-subdomain cookie exists,
@@ -70,6 +120,51 @@ export function getLoginCookie(): LoginCookieData | null {
  */
 export function hydrateLoginFromCookie(): void {
   const STORAGE_KEY = 'nostr:login';
+
+  // --- JWT session hydration ---
+  // JWT keys used by useDivineSession (must match those constants)
+  const JWT_TOKEN_KEY = 'keycast_jwt_token';
+  const JWT_EXPIRATION_KEY = 'keycast_jwt_expiration';
+  const JWT_SESSION_START_KEY = 'keycast_session_start';
+  const JWT_REMEMBER_ME_KEY = 'keycast_remember_me';
+  const JWT_EMAIL_KEY = 'keycast_email';
+  const JWT_BUNKER_URL_KEY = 'keycast_bunker_url';
+
+  // useLocalStorage wraps values with JSON.stringify, so we parse them back
+  const rawJwt = localStorage.getItem(JWT_TOKEN_KEY);
+  const existingJwt = rawJwt ? JSON.parse(rawJwt) : null;
+  if (existingJwt) {
+    // Already have JWT on this origin — keep cookie in sync
+    const expiration = localStorage.getItem(JWT_EXPIRATION_KEY);
+    const sessionStart = localStorage.getItem(JWT_SESSION_START_KEY);
+    if (expiration && sessionStart) {
+      setJwtCookie({
+        token: existingJwt,
+        expiration: JSON.parse(expiration),
+        sessionStart: JSON.parse(sessionStart),
+        rememberMe: JSON.parse(localStorage.getItem(JWT_REMEMBER_ME_KEY) || 'false'),
+        email: JSON.parse(localStorage.getItem(JWT_EMAIL_KEY) || 'null') || undefined,
+        bunkerUrl: JSON.parse(localStorage.getItem(JWT_BUNKER_URL_KEY) || 'null') || undefined,
+      });
+    }
+  } else {
+    // No JWT on this origin — check cookie
+    const jwtCookie = getJwtCookie();
+    if (jwtCookie && jwtCookie.token && jwtCookie.expiration > Date.now()) {
+      localStorage.setItem(JWT_TOKEN_KEY, JSON.stringify(jwtCookie.token));
+      localStorage.setItem(JWT_EXPIRATION_KEY, JSON.stringify(jwtCookie.expiration));
+      localStorage.setItem(JWT_SESSION_START_KEY, JSON.stringify(jwtCookie.sessionStart));
+      localStorage.setItem(JWT_REMEMBER_ME_KEY, JSON.stringify(jwtCookie.rememberMe));
+      if (jwtCookie.email) {
+        localStorage.setItem(JWT_EMAIL_KEY, JSON.stringify(jwtCookie.email));
+      }
+      if (jwtCookie.bunkerUrl) {
+        localStorage.setItem(JWT_BUNKER_URL_KEY, JSON.stringify(jwtCookie.bunkerUrl));
+      }
+    }
+  }
+
+  // --- Nostr login hydration (extension/bunker/nsec) ---
 
   // Already logged in on this origin - sync cookie FROM localStorage instead
   const stored = localStorage.getItem(STORAGE_KEY);


### PR DESCRIPTION
## Summary

- Users logging in via `login.divine.video` were losing their session when redirected to `username.divine.video` because JWT data lived only in localStorage (per-origin isolation)
- The existing cross-subdomain cookie (`nostr_login`) only handled extension/bunker/nsec logins, not the JWT path which is the primary login flow
- Adds a `divine_jwt` cookie scoped to `.divine.video` that carries the JWT session across all subdomains, with automatic hydration on app startup and expiration checking

## Test plan

- [ ] Log in via `login.divine.video` on `divine.video`
- [ ] Navigate to your profile → verify redirect to `username.divine.video` keeps you logged in
- [ ] Manually visit `username.divine.video` directly → verify JWT is hydrated from cookie
- [ ] Log out on any subdomain → verify JWT cookie is cleared across all subdomains
- [ ] Verify expired JWT cookies are not hydrated
- [ ] Run `npx vitest run src/lib/crossSubdomainAuth.test.ts` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)