### PR TITLE
feat: switch For You feed to cursor-based pagination

### DIFF
--- a/src/hooks/useInfiniteVideosFunnelcake.ts
+++ b/src/hooks/useInfiniteVideosFunnelcake.ts
@@ -31,6 +31,8 @@ interface FunnelcakeVideoPage {
   videos: ParsedVideoData[];
   nextCursor: number | undefined;
   offset?: number;
+  /** Opaque cursor string for recommendations pagination */
+  recommendationsCursor?: string;
 }
 
 /**
@@ -238,12 +240,12 @@ export function useInfiniteVideosFunnelcake({
               debugLog('[useInfiniteVideosFunnelcake] No user logged in for recommendations feed');
               return { videos: [], nextCursor: undefined };
             }
-            // Recommendations use offset pagination
-            const recOffset = isOffsetParam ? (pageParam as { offset: number }).offset : 0;
+            // Recommendations use cursor-based pagination (preferred over offset)
+            const recCursor = typeof pageParam === 'string' ? pageParam : undefined;
             response = await fetchRecommendations(effectiveApiUrl, {
               pubkey: user.pubkey,
               limit: pageSize,
-              offset: recOffset,
+              cursor: recCursor,
               fallback: 'popular', // Fall back to popular videos if no personalized recs
               signal,
             });
@@ -270,9 +272,9 @@ export function useInfiniteVideosFunnelcake({
       const queryTime = performance.now() - queryStart;
 
       // Transform response to video page
-      // Recommendations use offset-based pagination, others use timestamp
+      // Recommendations use opaque cursor pagination, others use timestamp
       const parseStart = performance.now();
-      const cursorType = feedType === 'recommendations' ? 'offset' : 'timestamp';
+      const cursorType = feedType === 'recommendations' ? 'cursor' : 'timestamp';
       const page = transformToVideoPage(response, cursorType);
       const parseTime = performance.now() - parseStart;
 
@@ -305,6 +307,7 @@ export function useInfiniteVideosFunnelcake({
         videos: page.videos,
         nextCursor: page.nextCursor,
         offset: page.offset,
+        recommendationsCursor: page.rawCursor,
       };
     },
 
@@ -314,6 +317,10 @@ export function useInfiniteVideosFunnelcake({
         if (allPages.length >= totalPages) return undefined; // All pages fetched
         const nextOffset = (randomStartOffset + allPages.length * pageSize) % randomizeWithinTop;
         return { offset: nextOffset };
+      }
+      // Recommendations: use opaque cursor string
+      if (lastPage.recommendationsCursor) {
+        return lastPage.recommendationsCursor;
       }
       // Use offset for sorted pagination, timestamp for chronological
       if (lastPage.offset !== undefined) {

--- a/src/lib/funnelcakeClient.test.ts
+++ b/src/lib/funnelcakeClient.test.ts
@@ -23,6 +23,7 @@ describe('funnelcakeClient', () => {
   let fetchBulkUsers: typeof import('./funnelcakeClient').fetchBulkUsers;
   let fetchBulkVideoStats: typeof import('./funnelcakeClient').fetchBulkVideoStats;
   let searchProfiles: typeof import('./funnelcakeClient').searchProfiles;
+  let fetchRecommendations: typeof import('./funnelcakeClient').fetchRecommendations;
 
   beforeEach(async () => {
     vi.resetModules();
@@ -35,6 +36,7 @@ describe('funnelcakeClient', () => {
     fetchBulkUsers = client.fetchBulkUsers;
     fetchBulkVideoStats = client.fetchBulkVideoStats;
     searchProfiles = client.searchProfiles;
+    fetchRecommendations = client.fetchRecommendations;
   });
 
   afterEach(() => {
@@ -322,6 +324,98 @@ describe('funnelcakeClient', () => {
 
       expect(result.stats).toEqual([]);
       expect(result.missing).toContain(eventIds[0]);
+    });
+  });
+
+  describe('fetchRecommendations', () => {
+    it('sends cursor param when provided', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          videos: [{ id: 'v1', pubkey: TEST_PUBKEY, video_url: 'https://example.com/v.mp4', d_tag: 'd1', created_at: 1700000000, kind: 34236 }],
+          source: 'personalized',
+          has_more: true,
+          next_cursor: 'cursor-page2',
+          next_offset: 12,
+          fallback_applied: false,
+          limit: 12,
+          offset: 0,
+        }),
+      });
+
+      const result = await fetchRecommendations(API_URL, {
+        pubkey: TEST_PUBKEY,
+        limit: 12,
+        cursor: 'cursor-page1',
+        fallback: 'popular',
+      });
+
+      const [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      const requestUrl = new URL(url as string);
+      expect(requestUrl.searchParams.get('cursor')).toBe('cursor-page1');
+      expect(requestUrl.searchParams.has('offset')).toBe(false);
+      expect(result.has_more).toBe(true);
+      expect(result.next_cursor).toBe('cursor-page2');
+    });
+
+    it('sends offset when no cursor provided', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          videos: [],
+          source: 'popular',
+          has_more: false,
+          next_cursor: null,
+          next_offset: null,
+          fallback_applied: true,
+          limit: 12,
+          offset: 24,
+        }),
+      });
+
+      const result = await fetchRecommendations(API_URL, {
+        pubkey: TEST_PUBKEY,
+        limit: 12,
+        offset: 24,
+        fallback: 'popular',
+      });
+
+      const [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      const requestUrl = new URL(url as string);
+      expect(requestUrl.searchParams.get('offset')).toBe('24');
+      expect(requestUrl.searchParams.has('cursor')).toBe(false);
+      expect(result.has_more).toBe(false);
+      expect(result.next_cursor).toBeUndefined();
+    });
+
+    it('uses backend has_more instead of computing locally', async () => {
+      // Backend says has_more=false even though we got limit-count videos
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          videos: Array.from({ length: 12 }, (_, i) => ({
+            id: `v${i}`, pubkey: TEST_PUBKEY, video_url: 'https://example.com/v.mp4',
+            d_tag: `d${i}`, created_at: 1700000000, kind: 34236,
+          })),
+          source: 'popular',
+          has_more: false,
+          next_cursor: null,
+          next_offset: null,
+          fallback_applied: true,
+          limit: 12,
+          offset: 0,
+        }),
+      });
+
+      const result = await fetchRecommendations(API_URL, {
+        pubkey: TEST_PUBKEY,
+        limit: 12,
+        fallback: 'popular',
+      });
+
+      // Even though videoCount === limit, backend says no more
+      expect(result.has_more).toBe(false);
+      expect(result.next_cursor).toBeUndefined();
     });
   });
 

--- a/src/lib/funnelcakeClient.ts
+++ b/src/lib/funnelcakeClient.ts
@@ -441,6 +441,12 @@ export async function fetchUserFeed(
 interface FunnelcakeRecommendationsResponse {
   videos: FunnelcakeVideoRaw[];
   source: 'personalized' | 'popular' | 'recent';
+  limit: number;
+  offset: number;
+  has_more: boolean;
+  next_offset: number | null;
+  next_cursor: string | null;
+  fallback_applied: boolean;
 }
 
 /**

--- a/src/lib/funnelcakeClient.ts
+++ b/src/lib/funnelcakeClient.ts
@@ -449,9 +449,12 @@ interface FunnelcakeRecommendationsResponse {
 export interface FunnelcakeRecommendationsOptions {
   pubkey: string;
   limit?: number;
-  offset?: number;           // Offset for pagination (0-indexed)
+  cursor?: string;           // Preferred: opaque cursor from previous response
+  offset?: number;           // Compatibility fallback only
   category?: string;
   fallback?: 'popular' | 'recent';
+  content_safety?: string;
+  nsfw?: boolean;
   signal?: AbortSignal;
 }
 
@@ -465,19 +468,22 @@ export interface FunnelcakeRecommendationsOptions {
 export async function fetchRecommendations(
   apiUrl: string = API_CONFIG.funnelcake.baseUrl,
   options: FunnelcakeRecommendationsOptions
-): Promise<FunnelcakeResponse & { source?: string }> {
-  const { pubkey, limit = 20, offset, category, fallback, signal } = options;
+): Promise<FunnelcakeResponse & { source?: string; fallback_applied?: boolean }> {
+  const { pubkey, limit = 20, cursor, offset, category, fallback, content_safety, nsfw, signal } = options;
 
   const endpoint = API_CONFIG.funnelcake.endpoints.userRecommendations.replace('{pubkey}', pubkey);
 
+  // Prefer cursor over offset; if both sent, backend uses cursor
   const params: Record<string, string | number | boolean | undefined> = {
     limit,
-    offset,
+    ...(cursor ? { cursor } : offset !== undefined ? { offset } : {}),
     category,
     fallback,
+    content_safety,
+    nsfw,
   };
 
-  debugLog(`[FunnelcakeClient] Fetching recommendations for ${pubkey}`, { limit, offset, category, fallback });
+  debugLog(`[FunnelcakeClient] Fetching recommendations for ${pubkey}`, { limit, cursor, offset, category, fallback });
 
   const response = await funnelcakeRequest<FunnelcakeRecommendationsResponse>(
     apiUrl,
@@ -487,16 +493,15 @@ export async function fetchRecommendations(
   );
 
   const videoCount = response.videos?.length || 0;
-  const nextOffset = (offset || 0) + videoCount;
 
-  debugLog(`[FunnelcakeClient] Got ${videoCount} recommendations (source: ${response.source})`);
+  debugLog(`[FunnelcakeClient] Got ${videoCount} recommendations (source: ${response.source}, has_more: ${response.has_more}, fallback_applied: ${response.fallback_applied})`);
 
   return {
     videos: response.videos || [],
-    has_more: videoCount >= limit,
-    // Use offset-based pagination for recommendations
-    next_cursor: videoCount >= limit ? String(nextOffset) : undefined,
+    has_more: response.has_more ?? false,
+    next_cursor: response.next_cursor ?? undefined,
     source: response.source,
+    fallback_applied: response.fallback_applied,
   };
 }
 

--- a/src/lib/funnelcakeTransform.test.ts
+++ b/src/lib/funnelcakeTransform.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { transformFunnelcakeVideo } from './funnelcakeTransform';
-import type { FunnelcakeVideoRaw } from '@/types/funnelcake';
+import { transformFunnelcakeVideo, transformToVideoPage } from './funnelcakeTransform';
+import type { FunnelcakeVideoRaw, FunnelcakeResponse } from '@/types/funnelcake';
 
 function makeRawVideo(overrides: Partial<FunnelcakeVideoRaw> = {}): FunnelcakeVideoRaw {
   return {
@@ -45,5 +45,61 @@ describe('transformFunnelcakeVideo', () => {
     }));
 
     expect(video.loopCount).toBe(296752);
+  });
+});
+
+function makeResponse(overrides: Partial<FunnelcakeResponse> = {}): FunnelcakeResponse {
+  return {
+    videos: [makeRawVideo()],
+    has_more: true,
+    next_cursor: 'abc123',
+    ...overrides,
+  };
+}
+
+describe('transformToVideoPage', () => {
+  describe('cursor type (recommendations)', () => {
+    it('returns raw cursor string when cursorType is cursor', () => {
+      const page = transformToVideoPage(makeResponse({ next_cursor: 'opaque-cursor-xyz' }), 'cursor');
+      expect(page.rawCursor).toBe('opaque-cursor-xyz');
+      expect(page.nextCursor).toBeUndefined();
+      expect(page.offset).toBeUndefined();
+    });
+
+    it('returns no rawCursor when has_more is false', () => {
+      const page = transformToVideoPage(makeResponse({ has_more: false, next_cursor: 'opaque-cursor-xyz' }), 'cursor');
+      expect(page.rawCursor).toBeUndefined();
+      expect(page.hasMore).toBe(false);
+    });
+
+    it('returns no rawCursor when next_cursor is null/undefined', () => {
+      const page = transformToVideoPage(makeResponse({ has_more: true, next_cursor: undefined }), 'cursor');
+      expect(page.rawCursor).toBeUndefined();
+    });
+  });
+
+  describe('offset type', () => {
+    it('parses next_cursor as integer offset', () => {
+      const page = transformToVideoPage(makeResponse({ next_cursor: '24' }), 'offset');
+      expect(page.offset).toBe(24);
+      expect(page.rawCursor).toBeUndefined();
+    });
+  });
+
+  describe('timestamp type (default)', () => {
+    it('parses next_cursor as numeric timestamp', () => {
+      const page = transformToVideoPage(makeResponse({ next_cursor: '1700000000' }), 'timestamp');
+      expect(page.nextCursor).toBe(1700000000);
+      expect(page.rawCursor).toBeUndefined();
+      expect(page.offset).toBeUndefined();
+    });
+  });
+
+  it('stops pagination when has_more is false', () => {
+    const page = transformToVideoPage(makeResponse({ has_more: false }));
+    expect(page.hasMore).toBe(false);
+    expect(page.nextCursor).toBeUndefined();
+    expect(page.offset).toBeUndefined();
+    expect(page.rawCursor).toBeUndefined();
   });
 });

--- a/src/lib/funnelcakeTransform.ts
+++ b/src/lib/funnelcakeTransform.ts
@@ -170,11 +170,13 @@ export function transformFunnelcakeResponse(response: FunnelcakeResponse): Parse
  */
 export function transformToVideoPage(
   response: FunnelcakeResponse,
-  cursorType: 'timestamp' | 'offset' = 'timestamp'
+  cursorType: 'timestamp' | 'offset' | 'cursor' = 'timestamp'
 ): {
   videos: ParsedVideoData[];
   nextCursor: number | undefined;
   offset?: number;
+  /** Raw opaque cursor string for cursor-based pagination (recommendations) */
+  rawCursor?: string;
   hasMore: boolean;
 } {
   const videos = transformFunnelcakeResponse(response);
@@ -182,9 +184,13 @@ export function transformToVideoPage(
   // Parse next cursor based on pagination type
   let nextCursor: number | undefined;
   let offset: number | undefined;
+  let rawCursor: string | undefined;
 
   if (response.has_more && response.next_cursor) {
-    if (cursorType === 'offset') {
+    if (cursorType === 'cursor') {
+      // Opaque cursor: pass through as-is (recommendations)
+      rawCursor = response.next_cursor;
+    } else if (cursorType === 'offset') {
       offset = parseInt(response.next_cursor, 10);
     } else {
       // Timestamp cursor - parse as number
@@ -200,6 +206,7 @@ export function transformToVideoPage(
     videos,
     nextCursor,
     offset,
+    rawCursor,
     hasMore: response.has_more,
   };
 }

--- a/src/types/funnelcake.ts
+++ b/src/types/funnelcake.ts
@@ -213,4 +213,10 @@ export interface FunnelcakeProfile {
 export interface FunnelcakeRecommendationsResponse {
   videos: FunnelcakeVideoRaw[];
   source: 'personalized' | 'popular' | 'recent';
+  limit: number;
+  offset: number;
+  has_more: boolean;
+  next_offset: number | null;
+  next_cursor: string | null;
+  fallback_applied: boolean;
 }


### PR DESCRIPTION
## Summary
- Replace client-computed offset pagination with server-provided opaque cursors for `/api/users/{pubkey}/recommendations`
- Old client computed `has_more` locally (`videoCount >= limit`) and synthesized offsets, causing duplicate/overlapping pages when personalized results exhausted and popular fallback kicked in
- Now passes through backend's `has_more`, `next_cursor`, and `fallback_applied` fields directly

## Changes
- **`src/types/funnelcake.ts`** — Extended `FunnelcakeRecommendationsResponse` with new backend fields (`has_more`, `next_cursor`, `next_offset`, `fallback_applied`, `limit`, `offset`)
- **`src/lib/funnelcakeClient.ts`** — `fetchRecommendations` sends `cursor` param (preferred over offset), trusts backend `has_more`; added `content_safety`/`nsfw` params
- **`src/lib/funnelcakeTransform.ts`** — Added `'cursor'` type that preserves opaque string; returns `rawCursor` field
- **`src/hooks/useInfiniteVideosFunnelcake.ts`** — Recommendations pass opaque cursor as pageParam; `getNextPageParam` uses `recommendationsCursor`
- **Tests** — 9 new tests covering cursor/offset/timestamp pagination modes and termination

## Notes
- `offset` remains in `FunnelcakeRecommendationsOptions` as a compatibility fallback but the hook never uses it for recommendations
- Existing cross-page dedup in `VideoFeed.tsx` (by `pubkey:kind:d-tag`) still guards against any residual duplicates

## Test plan
- [ ] Verify For You feed loads first page without cursor/offset params
- [ ] Scroll past first page — subsequent requests should include `cursor` param
- [ ] Feed stops loading when `has_more` is false
- [ ] Switch users — pagination state resets
- [ ] Mixed personalized + popular fallback pages render without errors
- [ ] `npx vitest run` passes (482 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)