### PR TITLE
feat: resolve any NIP-05 on /profile/:id route

### DIFF
--- a/src/hooks/useNip05Pubkey.ts
+++ b/src/hooks/useNip05Pubkey.ts
@@ -1,0 +1,19 @@
+// ABOUTME: React Query hook that resolves a NIP-05 identifier to a hex pubkey
+// ABOUTME: via the standard .well-known/nostr.json endpoint.
+
+import { useQuery } from '@tanstack/react-query';
+import { resolveNip05ToPubkey } from '@/lib/nip05Resolve';
+
+export function useNip05Pubkey(nip05: string | undefined) {
+  return useQuery({
+    queryKey: ['nip05-pubkey', nip05?.toLowerCase()],
+    queryFn: async ({ signal }) => {
+      if (!nip05) return null;
+      return resolveNip05ToPubkey(nip05, { signal });
+    },
+    enabled: !!nip05 && nip05.includes('@'),
+    staleTime: 300_000,
+    gcTime: 900_000,
+    retry: false,
+  });
+}

--- a/src/lib/nip05Resolve.test.ts
+++ b/src/lib/nip05Resolve.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { parseNip05, resolveNip05ToPubkey } from './nip05Resolve';
+
+describe('parseNip05', () => {
+  it('splits name and domain', () => {
+    expect(parseNip05('alice@example.com')).toEqual({ name: 'alice', domain: 'example.com' });
+  });
+
+  it('defaults empty local part to _', () => {
+    expect(parseNip05('@example.com')).toEqual({ name: '_', domain: 'example.com' });
+  });
+
+  it('returns null for malformed input', () => {
+    expect(parseNip05('no-at-sign')).toBeNull();
+    expect(parseNip05('a@')).toBeNull();
+    expect(parseNip05('a@bad domain')).toBeNull();
+  });
+});
+
+describe('resolveNip05ToPubkey', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('returns the hex pubkey from the well-known response', async () => {
+    const pubkey = 'a'.repeat(64);
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ names: { traveltelly: pubkey } }),
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await resolveNip05ToPubkey('traveltelly@primal.net');
+
+    expect(result).toBe(pubkey);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://primal.net/.well-known/nostr.json?name=traveltelly',
+      expect.objectContaining({ headers: { Accept: 'application/json' } }),
+    );
+  });
+
+  it('returns null when HTTP response is not ok', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, status: 404 }) as unknown as typeof fetch;
+    expect(await resolveNip05ToPubkey('alice@example.com')).toBeNull();
+  });
+
+  it('returns null when the name is not present', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ names: { bob: 'b'.repeat(64) } }),
+    }) as unknown as typeof fetch;
+    expect(await resolveNip05ToPubkey('alice@example.com')).toBeNull();
+  });
+
+  it('returns null when the pubkey is not valid hex', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ names: { alice: 'not-hex' } }),
+    }) as unknown as typeof fetch;
+    expect(await resolveNip05ToPubkey('alice@example.com')).toBeNull();
+  });
+});

--- a/src/lib/nip05Resolve.ts
+++ b/src/lib/nip05Resolve.ts
@@ -1,0 +1,40 @@
+// ABOUTME: Resolve a NIP-05 identifier (name@domain) to a hex pubkey via the
+// ABOUTME: standard .well-known/nostr.json endpoint. Works for any domain.
+
+export interface Nip05Parts {
+  name: string;
+  domain: string;
+}
+
+export function parseNip05(nip05: string): Nip05Parts | null {
+  const trimmed = nip05.trim();
+  const atIndex = trimmed.lastIndexOf('@');
+  if (atIndex === -1) return null;
+  const name = trimmed.slice(0, atIndex) || '_';
+  const domain = trimmed.slice(atIndex + 1);
+  if (!domain || !/^[a-zA-Z0-9.-]+$/.test(domain)) return null;
+  if (!/^[a-zA-Z0-9._-]+$/.test(name)) return null;
+  return { name, domain };
+}
+
+export async function resolveNip05ToPubkey(
+  nip05: string,
+  options: { signal?: AbortSignal } = {},
+): Promise<string | null> {
+  const parts = parseNip05(nip05);
+  if (!parts) return null;
+
+  const url = `https://${parts.domain}/.well-known/nostr.json?name=${encodeURIComponent(parts.name)}`;
+
+  const response = await fetch(url, {
+    signal: options.signal,
+    headers: { Accept: 'application/json' },
+  });
+
+  if (!response.ok) return null;
+
+  const data = await response.json().catch(() => null) as { names?: Record<string, string> } | null;
+  const pubkey = data?.names?.[parts.name];
+  if (typeof pubkey !== 'string' || !/^[0-9a-f]{64}$/i.test(pubkey)) return null;
+  return pubkey.toLowerCase();
+}

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -21,6 +21,7 @@ import { useAuthor } from '@/hooks/useAuthor';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { getSubdomainUser } from '@/hooks/useSubdomainUser';
 import { useResolveSubdomainPubkey } from '@/hooks/useResolveSubdomainPubkey';
+import { useNip05Pubkey } from '@/hooks/useNip05Pubkey';
 import { useVideoProvider } from '@/hooks/useVideoProvider';
 import { useFunnelcakeProfile } from '@/hooks/useFunnelcakeProfile';
 import { useProfileJoinedDate } from '@/hooks/useProfileJoinedDate';
@@ -52,9 +53,11 @@ export function ProfilePage() {
   // Use resolved pubkey when KV store mapping is stale
   const identifier = npub || nip19Param || (resolved.isResolved ? resolved.npub : subdomainUser?.npub);
 
-  // Decode npub to get pubkey
+  // Decode npub to get pubkey. Accepts npub1..., 64-char hex, or a NIP-05 (name@domain).
   let pubkey: string | null = null;
   let error: string | null = null;
+  const isNip05 = !!identifier && identifier.includes('@');
+  const nip05Query = useNip05Pubkey(isNip05 ? identifier : undefined);
 
   if (identifier) {
     try {
@@ -68,6 +71,12 @@ export function ProfilePage() {
       } else if (/^[0-9a-fA-F]{64}$/.test(identifier)) {
         // Valid 64-char hex pubkey
         pubkey = identifier;
+      } else if (isNip05) {
+        if (nip05Query.data) {
+          pubkey = nip05Query.data;
+        } else if (nip05Query.isFetched && !nip05Query.data) {
+          error = `Could not resolve NIP-05: ${identifier}`;
+        }
       } else {
         error = 'Invalid profile identifier';
       }
@@ -247,6 +256,17 @@ export function ProfilePage() {
     twitterDescription: metadata?.about || `${displayName}'s profile on Divine`,
     twitterImage: metadata?.picture || '/app_icon.avif',
   });
+
+  // Show spinner while resolving a NIP-05 identifier in the URL
+  if (isNip05 && nip05Query.isLoading) {
+    return (
+      <div className="container mx-auto px-4 py-6">
+        <div className="max-w-4xl mx-auto flex items-center justify-center py-12">
+          <Loader2 className="w-8 h-8 animate-spin text-muted-foreground" />
+        </div>
+      </div>
+    );
+  }
 
   // Show spinner while resolving stale subdomain mapping
   if (resolved.isSearching && subdomainUser?.nip05Stale) {


### PR DESCRIPTION
## Summary
- `/profile/<name@domain>` now works for any NIP-05 provider (primal.net, iris.to, nostr.build, self-hosted, etc.) by resolving via the standard `.well-known/nostr.json` endpoint
- Keeps the human-readable URL in place (no redirect to npub)
- Shows a spinner while resolving; clean error if the identifier can't be resolved

## Implementation
- `src/lib/nip05Resolve.ts` — pure resolver: `GET https://<domain>/.well-known/nostr.json?name=<name>` → hex pubkey
- `src/hooks/useNip05Pubkey.ts` — React Query wrapper (5-min `staleTime`, 15-min `gcTime`, no retry)
- `src/pages/ProfilePage.tsx` — accepts npub, 64-char hex, or `name@domain`

## Test plan
- [x] `npx vitest run src/lib/nip05Resolve.test.ts` — parser + resolver unit tests pass
- [x] `npx tsc --noEmit` clean
- [ ] Manual: visit `/profile/traveltelly@primal.net` and confirm the profile renders
- [ ] Manual: visit `/profile/<invalid>@example.com` and confirm the error card shows
- [ ] Manual: confirm existing `/profile/npub1...` and `/profile/<hex>` routes still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)