### PR TITLE
fix: restore social previews for profile and category pages

### DIFF
--- a/compute-js/src/index.js
+++ b/compute-js/src/index.js
@@ -13,6 +13,8 @@ const publisherServer = PublisherServer.fromStaticPublishRc(rc);
 // Funnelcake API URL — edge worker calls origin directly (not via api.divine.video cache
 // to avoid Fastly→Fastly loops). Client-side code uses api.divine.video for caching.
 const FUNNELCAKE_API_URL = 'https://relay.divine.video';
+const DEFAULT_OG_IMAGE = 'https://divine.video/og.png';
+const DEFAULT_SITE_DESCRIPTION = 'Watch and share 6-second looping videos on the decentralized Nostr network.';
 
 // Apex domains we serve (used to detect subdomains)
 const APEX_DOMAINS = ['dvine.video', 'divine.video'];
@@ -147,18 +149,34 @@ async function handleRequest(event) {
     return new Response('Not Found', { status: 404 });
   }
 
-  // 5. Handle dynamic OG meta tags for video pages (for social media crawlers)
-  if (url.pathname.startsWith('/video/') && isSocialMediaCrawler(request)) {
-    console.log('Handling video OG tags for crawler, path:', url.pathname);
-    const videoId = url.pathname.split('/video/')[1]?.split('?')[0];
-    console.log('Video ID:', videoId);
-    if (videoId) {
-      const ogResponse = await handleVideoOgTags(request, videoId, url);
+  // 5. Handle dynamic OG meta tags for crawler requests
+  if (isSocialMediaCrawler(request)) {
+    if (url.pathname.startsWith('/video/')) {
+      console.log('Handling video OG tags for crawler, path:', url.pathname);
+      const videoId = url.pathname.split('/video/')[1]?.split('?')[0];
+      console.log('Video ID:', videoId);
+      if (videoId) {
+        const ogResponse = await handleVideoOgTags(request, videoId, url);
+        if (ogResponse) {
+          return ogResponse;
+        }
+      }
+      console.log('Falling through to SPA handler');
+    }
+
+    if (url.pathname.startsWith('/profile/')) {
+      const ogResponse = await handleProfileOgTags(request, url);
       if (ogResponse) {
         return ogResponse;
       }
     }
-    console.log('Falling through to SPA handler');
+
+    if (url.pathname === '/category' || url.pathname.startsWith('/category/')) {
+      const ogResponse = await handleCategoryOgTags(request, url);
+      if (ogResponse) {
+        return ogResponse;
+      }
+    }
   }
 
   // 6. Serve sw.js with no-cache to ensure browsers always get the latest service worker
@@ -831,14 +849,49 @@ function hexToNpub(hex) {
   return result;
 }
 
+function decodeNpubToHex(npub) {
+  const CHARSET = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l';
+  const normalized = (npub || '').toLowerCase();
+  if (!normalized.startsWith('npub1')) {
+    return null;
+  }
+
+  const separatorIndex = normalized.lastIndexOf('1');
+  if (separatorIndex === -1) {
+    return null;
+  }
+
+  const dataPart = normalized.slice(separatorIndex + 1);
+  if (dataPart.length < 6) {
+    return null;
+  }
+
+  const values = [...dataPart].map(char => CHARSET.indexOf(char));
+  if (values.some(value => value === -1)) {
+    return null;
+  }
+
+  const payload = values.slice(0, -6);
+  const decoded = convertBits(payload, 5, 8, false);
+  if (!decoded) {
+    return null;
+  }
+
+  return decoded.map(value => value.toString(16).padStart(2, '0')).join('');
+}
+
 function convertBits(data, fromBits, toBits, pad) {
   let acc = 0;
   let bits = 0;
   const result = [];
   const maxv = (1 << toBits) - 1;
+  const maxAcc = (1 << (fromBits + toBits - 1)) - 1;
   
   for (const value of data) {
-    acc = (acc << fromBits) | value;
+    if (value < 0 || (value >> fromBits) !== 0) {
+      return null;
+    }
+    acc = ((acc << fromBits) | value) & maxAcc;
     bits += fromBits;
     while (bits >= toBits) {
       bits -= toBits;
@@ -846,8 +899,12 @@ function convertBits(data, fromBits, toBits, pad) {
     }
   }
   
-  if (pad && bits > 0) {
-    result.push((acc << (toBits - bits)) & maxv);
+  if (pad) {
+    if (bits > 0) {
+      result.push((acc << (toBits - bits)) & maxv);
+    }
+  } else if (bits >= fromBits || ((acc << (toBits - bits)) & maxv) !== 0) {
+    return null;
   }
   
   return result;
@@ -967,8 +1024,10 @@ async function fetchVideoMetadata(videoId) {
     }
 
     const thumbnail = imeta.image || null;
-    const title = getTag('title') || null;
-    const content = event.content || '';
+    const summary = cleanText(getTag('summary'));
+    const alt = cleanText(getTag('alt'));
+    const content = cleanText(event.content);
+    const title = cleanText(getTag('title')) || alt || summary || truncateText(content, 80) || null;
 
     // Build a rich description with engagement stats
     const statsList = [];
@@ -977,11 +1036,13 @@ async function fetchVideoMetadata(videoId) {
     if (stats.reposts > 0) statsList.push(`${stats.reposts} 🔁`);
 
     let description;
-    if (content && content.trim()) {
-      // Use the content/caption if available
-      description = content.trim();
+    if (content) {
+      description = content;
+    } else if (summary) {
+      description = summary;
+    } else if (alt) {
+      description = alt;
     } else if (statsList.length > 0) {
-      // Show engagement stats
       description = `${statsList.join(' • ')} on Divine`;
     } else {
       description = 'Watch this short video on Divine';
@@ -992,8 +1053,8 @@ async function fetchVideoMetadata(videoId) {
     return {
       title: title || 'Video on Divine',
       description: description,
-      thumbnail: thumbnail || 'https://divine.video/og.avif',
-      authorName: getTag('author') || '',
+      thumbnail: thumbnail || DEFAULT_OG_IMAGE,
+      authorName: cleanText(getTag('author')) || cleanText(stats.author_name) || '',
       reactions: stats.reactions || 0,
       comments: stats.comments || 0,
     };
@@ -1001,6 +1062,90 @@ async function fetchVideoMetadata(videoId) {
     console.error('Failed to fetch video metadata:', err.message);
     return null;
   }
+}
+
+async function fetchProfileMetadata(pubkey) {
+  try {
+    const response = await fetch(`${FUNNELCAKE_API_URL}/api/users/${pubkey}`, {
+      backend: 'funnelcake',
+      method: 'GET',
+      headers: {
+        'Accept': 'application/json',
+        'Host': 'relay.divine.video',
+      },
+    });
+
+    if (!response.ok) {
+      console.log('Profile API returned:', response.status);
+      return null;
+    }
+
+    return await response.json();
+  } catch (err) {
+    console.error('Failed to fetch profile metadata:', err.message);
+    return null;
+  }
+}
+
+async function fetchCategoriesMetadata() {
+  try {
+    const response = await fetch(`${FUNNELCAKE_API_URL}/api/categories`, {
+      backend: 'funnelcake',
+      method: 'GET',
+      headers: {
+        'Accept': 'application/json',
+        'Host': 'relay.divine.video',
+      },
+    });
+
+    if (!response.ok) {
+      console.log('Categories API returned:', response.status);
+      return null;
+    }
+
+    return await response.json();
+  } catch (err) {
+    console.error('Failed to fetch category metadata:', err.message);
+    return null;
+  }
+}
+
+function buildCrawlerHtml({
+  title,
+  description,
+  image,
+  url,
+  ogType,
+  twitterCard = 'summary_large_image',
+  twitterCreator = '',
+}) {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${escapeHtml(title)}</title>
+
+  <meta property="og:type" content="${escapeHtml(ogType)}" />
+  <meta property="og:title" content="${escapeHtml(title)}" />
+  <meta property="og:description" content="${escapeHtml(description)}" />
+  <meta property="og:image" content="${escapeHtml(image)}" />
+  <meta property="og:url" content="${escapeHtml(url)}" />
+  <meta property="og:site_name" content="Divine" />
+
+  <meta name="twitter:card" content="${escapeHtml(twitterCard)}" />
+  <meta name="twitter:title" content="${escapeHtml(title)}" />
+  <meta name="twitter:description" content="${escapeHtml(description)}" />
+  <meta name="twitter:image" content="${escapeHtml(image)}" />
+  ${twitterCreator ? `<meta name="twitter:creator" content="${escapeHtml(twitterCreator)}" />` : ''}
+
+  <meta http-equiv="refresh" content="0;url=${escapeHtml(url)}">
+  <link rel="canonical" href="${escapeHtml(url)}" />
+</head>
+<body>
+  <p>Redirecting to <a href="${escapeHtml(url)}">${escapeHtml(title)}</a>...</p>
+</body>
+</html>`;
 }
 
 /**
@@ -1019,47 +1164,21 @@ async function handleVideoOgTags(request, videoId, url) {
 
     // Default meta values if video not found
     const title = videoMeta?.title || 'Video on Divine';
-    const description = videoMeta?.description || 'Watch this video on Divine - Short-form looping videos on Nostr';
-    const thumbnail = videoMeta?.thumbnail || 'https://divine.video/og.avif';
+    const description = videoMeta?.description || `Watch this video on Divine. ${DEFAULT_SITE_DESCRIPTION}`;
+    const thumbnail = videoMeta?.thumbnail || DEFAULT_OG_IMAGE;
     const authorName = videoMeta?.authorName || '';
     const videoUrl = `https://divine.video/video/${videoId}`;
 
     console.log('Generating OG HTML for video:', videoId, 'title:', title);
-
-    // Generate a minimal HTML page with OG tags for crawlers
-    // This is simpler than trying to inject into the SPA HTML
-    const html = `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>${escapeHtml(title)} - Divine</title>
-
-  <!-- Open Graph Meta Tags -->
-  <meta property="og:type" content="video.other" />
-  <meta property="og:title" content="${escapeHtml(title)}" />
-  <meta property="og:description" content="${escapeHtml(description)}" />
-  <meta property="og:image" content="${escapeHtml(thumbnail)}" />
-  <meta property="og:image:width" content="480" />
-  <meta property="og:image:height" content="480" />
-  <meta property="og:url" content="${escapeHtml(videoUrl)}" />
-  <meta property="og:site_name" content="Divine" />
-
-  <!-- Twitter Card Meta Tags -->
-  <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="${escapeHtml(title)}" />
-  <meta name="twitter:description" content="${escapeHtml(description)}" />
-  <meta name="twitter:image" content="${escapeHtml(thumbnail)}" />
-  ${authorName ? `<meta name="twitter:creator" content="${escapeHtml(authorName)}" />` : ''}
-
-  <!-- Redirect to actual page for any user who lands here -->
-  <meta http-equiv="refresh" content="0;url=${escapeHtml(videoUrl)}">
-  <link rel="canonical" href="${escapeHtml(videoUrl)}" />
-</head>
-<body>
-  <p>Redirecting to <a href="${escapeHtml(videoUrl)}">${escapeHtml(title)}</a>...</p>
-</body>
-</html>`;
+    const html = buildCrawlerHtml({
+      title,
+      description,
+      image: thumbnail,
+      url: videoUrl,
+      ogType: 'video.other',
+      twitterCard: 'summary_large_image',
+      twitterCreator: authorName,
+    });
 
     console.log('Generated OG HTML, length:', html.length);
 
@@ -1074,6 +1193,93 @@ async function handleVideoOgTags(request, videoId, url) {
   } catch (err) {
     console.error('handleVideoOgTags error:', err.message, err.stack);
     // Return the normal SPA on error
+    return await publisherServer.serveRequest(request);
+  }
+}
+
+async function handleProfileOgTags(request, url) {
+  try {
+    const npub = url.pathname.split('/profile/')[1]?.split('?')[0];
+    const pubkey = decodeNpubToHex(npub || '');
+    if (!pubkey) {
+      return null;
+    }
+
+    const profileMeta = await fetchProfileMetadata(pubkey);
+    const profile = profileMeta?.profile || {};
+    const stats = profileMeta?.stats || {};
+    const displayName = cleanText(profile.display_name) || cleanText(profile.name) || 'Profile on Divine';
+    const about = cleanText(profile.about);
+    const videoCount = typeof stats.video_count === 'number' ? stats.video_count : null;
+    const description = about
+      || (videoCount && videoCount > 0
+        ? `Watch ${displayName}'s ${videoCount} videos on Divine.`
+        : `Watch ${displayName}'s videos on Divine.`);
+    const image = cleanText(profile.picture) || DEFAULT_OG_IMAGE;
+    const profileUrl = `https://divine.video/profile/${npub}`;
+    const html = buildCrawlerHtml({
+      title: `${displayName} on Divine`,
+      description,
+      image,
+      url: profileUrl,
+      ogType: 'profile',
+      twitterCard: 'summary',
+    });
+
+    return new Response(html, {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/html; charset=utf-8',
+        'Cache-Control': 'public, max-age=300',
+        'Vary': 'User-Agent',
+      },
+    });
+  } catch (err) {
+    console.error('handleProfileOgTags error:', err.message, err.stack);
+    return await publisherServer.serveRequest(request);
+  }
+}
+
+async function handleCategoryOgTags(request, url) {
+  try {
+    const categoryName = url.pathname === '/category'
+      ? null
+      : decodeURIComponent(url.pathname.split('/category/')[1]?.split('?')[0] || '');
+
+    let title = 'Browse Categories - Divine';
+    let description = 'Explore video categories on Divine - comedy, music, dance, animals, sports, food, and more.';
+    let categoryUrl = 'https://divine.video/category';
+
+    if (categoryName) {
+      const categories = await fetchCategoriesMetadata();
+      const matchedCategory = categories?.find(category => category.name.toLowerCase() === categoryName.toLowerCase()) || null;
+      const label = humanizeCategoryName(categoryName);
+      title = `${label} Videos - Divine`;
+      description = typeof matchedCategory?.video_count === 'number'
+        ? `Explore ${matchedCategory.video_count} ${categoryName.toLowerCase()} videos on Divine.`
+        : `Explore ${categoryName.toLowerCase()} videos on Divine.`;
+      categoryUrl = `https://divine.video/category/${encodeURIComponent(categoryName)}`;
+    }
+
+    const html = buildCrawlerHtml({
+      title,
+      description,
+      image: DEFAULT_OG_IMAGE,
+      url: categoryUrl,
+      ogType: 'website',
+      twitterCard: 'summary_large_image',
+    });
+
+    return new Response(html, {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/html; charset=utf-8',
+        'Cache-Control': 'public, max-age=300',
+        'Vary': 'User-Agent',
+      },
+    });
+  } catch (err) {
+    console.error('handleCategoryOgTags error:', err.message, err.stack);
     return await publisherServer.serveRequest(request);
   }
 }
@@ -1108,4 +1314,34 @@ function escapeHtml(str) {
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#039;');
+}
+
+function cleanText(value) {
+  return (value || '').replace(/\s+/g, ' ').trim();
+}
+
+function truncateText(value, maxLength) {
+  const trimmed = cleanText(value);
+  if (trimmed.length <= maxLength) {
+    return trimmed;
+  }
+
+  return `${trimmed.slice(0, maxLength - 1).trimEnd()}…`;
+}
+
+function humanizeCategoryName(name) {
+  const normalized = cleanText(decodeURIComponent(name || '').toLowerCase());
+  if (!normalized) {
+    return 'Category';
+  }
+
+  if (normalized === 'diy') return 'DIY';
+  if (normalized === 'vlog') return 'Vlog';
+  if (normalized === 'ai') return 'AI';
+
+  return normalized
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
 }

--- a/functions/[[path]].test.ts
+++ b/functions/[[path]].test.ts
@@ -59,6 +59,55 @@ describe('functions/[[path]]', () => {
         });
       }
 
+      if (url.includes('/api/videos/blank-title')) {
+        return new Response(JSON.stringify({
+          event: {
+            id: 'blank-title',
+            content: 'Choo choo!\n\nInspired by nostr:npub15l5atkgtzladdezjdnjc7zhej7uvzjpxaj7mctpe2hnwyk85qqxqjuecgm',
+            tags: [
+              ['title', ''],
+              ['summary', 'Choo choo!'],
+              ['alt', ''],
+              ['imeta', 'url https://media.divine.video/blank-title.mp4', 'm video/mp4', 'image https://media.divine.video/blank-title.jpg'],
+            ],
+          },
+          stats: {
+            author_name: 'The Wall!',
+          },
+        }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+
+      if (url.includes('/api/users/076c979382b90f5d3a2b21f95e1ee86b6033f14c92e79b7fad3fe1f1073f4886')) {
+        return new Response(JSON.stringify({
+          pubkey: '076c979382b90f5d3a2b21f95e1ee86b6033f14c92e79b7fad3fe1f1073f4886',
+          profile: {
+            name: '',
+            display_name: 'The Wall!',
+            about: 'How can you have any pudding if you have not eaten your meat? ',
+            picture: 'https://media.divine.video/545aff83f83b4643f340747213e86520fac83596f899e8ea3117e0aa8b260f7b',
+          },
+          stats: {
+            video_count: 125,
+          },
+        }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+
+      if (url.includes('/api/categories')) {
+        return new Response(JSON.stringify([
+          { name: 'dance', video_count: 895 },
+          { name: 'music', video_count: 1812 },
+        ]), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+
       return new Response('not found', { status: 404 });
     }));
   });
@@ -100,5 +149,51 @@ describe('functions/[[path]]', () => {
     expect(response.status).toBe(200);
     expect(html).toContain(`<title>${'Divine Web - Short-form Looping Videos on Nostr'}</title>`);
     expect(html).not.toContain('property="og:video"');
+  });
+
+  it('uses summary text when the video title is blank', async () => {
+    const response = await onRequest({
+      request: new Request('https://divine.video/video/blank-title'),
+      next: async () => new Response('not found', { status: 404 }),
+      env: {},
+    });
+
+    const html = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(html).toContain('<title>Choo choo!</title>');
+    expect(html).toContain('property="og:title" content="Choo choo!"');
+    expect(html).toContain('name="twitter:title" content="Choo choo!"');
+  });
+
+  it('injects profile metadata for apex profile routes', async () => {
+    const response = await onRequest({
+      request: new Request('https://divine.video/profile/npub1qakf0yuzhy846w3ty8u4u8hgddsr8u2vjtneklad8lslzpelfzrqsy63m7'),
+      next: async () => new Response('not found', { status: 404 }),
+      env: {},
+    });
+
+    const html = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(html).toContain('<title>The Wall! on Divine</title>');
+    expect(html).toContain('property="og:title" content="The Wall! on Divine"');
+    expect(html).toContain('property="og:description" content="How can you have any pudding if you have not eaten your meat?"');
+    expect(html).toContain('property="og:image" content="https://media.divine.video/545aff83f83b4643f340747213e86520fac83596f899e8ea3117e0aa8b260f7b"');
+  });
+
+  it('injects category metadata for category routes', async () => {
+    const response = await onRequest({
+      request: new Request('https://divine.video/category/dance'),
+      next: async () => new Response('not found', { status: 404 }),
+      env: {},
+    });
+
+    const html = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(html).toContain('<title>Dance Videos - Divine</title>');
+    expect(html).toContain('property="og:title" content="Dance Videos - Divine"');
+    expect(html).toContain('property="og:description" content="Explore 895 dance videos on Divine."');
   });
 });

--- a/functions/[[path]].ts
+++ b/functions/[[path]].ts
@@ -1,31 +1,20 @@
 // ABOUTME: Cloudflare Pages Function to handle SPA routing and route-specific social metadata
 // ABOUTME: Returns index.html with a 200 status for SPA routes and injects per-video OG/Twitter tags for bots
 
+import {
+  buildCategoriesIndexMeta,
+  buildCategoryPageMeta,
+  buildProfilePageMeta,
+  buildVideoPageMeta,
+  decodeNpubToHex,
+  extractCategoryName,
+  extractProfileNpub,
+  type PageMeta,
+  type ProfileApiResponse,
+  type VideoApiResponse,
+} from '../src/lib/serverSocialMeta';
+
 const FUNNELCAKE_API_URL = 'https://relay.divine.video';
-const DEFAULT_OG_IMAGE = 'https://divine.video/og.png';
-
-interface VideoApiResponse {
-  event: {
-    id: string;
-    content: string;
-    tags: string[][];
-  };
-  stats?: {
-    author_name?: string;
-  };
-}
-
-interface PageMeta {
-  title: string;
-  description: string;
-  ogType: string;
-  url: string;
-  image: string;
-  imageAlt: string;
-  twitterCard: string;
-  videoUrl?: string;
-  videoMimeType?: string;
-}
 
 function escapeHtml(value: string): string {
   return value
@@ -38,45 +27,6 @@ function escapeHtml(value: string): string {
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-function truncateText(value: string, maxLength: number): string {
-  const trimmed = value.replace(/\s+/g, ' ').trim();
-  if (trimmed.length <= maxLength) {
-    return trimmed;
-  }
-
-  return `${trimmed.slice(0, maxLength - 1).trimEnd()}…`;
-}
-
-function getTagValue(tags: string[][], name: string): string | undefined {
-  return tags.find(tag => tag[0] === name)?.[1];
-}
-
-function parseImeta(tags: string[][]): { url?: string; image?: string; mimeType?: string } {
-  const imetaTag = tags.find(tag => tag[0] === 'imeta');
-  if (!imetaTag) {
-    return {};
-  }
-
-  const parsed: { url?: string; image?: string; mimeType?: string } = {};
-
-  for (let i = 1; i < imetaTag.length; i += 1) {
-    const part = imetaTag[i];
-    const separatorIndex = part.indexOf(' ');
-    if (separatorIndex === -1) {
-      continue;
-    }
-
-    const key = part.slice(0, separatorIndex);
-    const value = part.slice(separatorIndex + 1).trim();
-
-    if (key === 'url') parsed.url = value;
-    if (key === 'image') parsed.image = value;
-    if (key === 'm') parsed.mimeType = value;
-  }
-
-  return parsed;
 }
 
 function replaceTitle(html: string, title: string): string {
@@ -154,33 +104,79 @@ async function fetchVideoMeta(url: URL): Promise<PageMeta | null> {
       return null;
     }
 
-    const title = getTagValue(payload.event.tags, 'title')
-      || getTagValue(payload.event.tags, 'alt')
-      || 'Video on Divine';
-    const authorName = payload.stats?.author_name;
-    const description = truncateText(
-      getTagValue(payload.event.tags, 'summary')
-        || payload.event.content
-        || getTagValue(payload.event.tags, 'alt')
-        || (authorName ? `Watch this video by ${authorName} on Divine` : 'Watch this video on Divine'),
-      200
-    );
-    const media = parseImeta(payload.event.tags);
-
-    return {
-      title,
-      description,
-      ogType: 'video.other',
-      url: url.toString(),
-      image: media.image || DEFAULT_OG_IMAGE,
-      imageAlt: title,
-      twitterCard: 'summary_large_image',
-      videoUrl: media.url,
-      videoMimeType: media.mimeType,
-    };
+    return buildVideoPageMeta(url, payload);
   } catch {
     return null;
   }
+}
+
+async function fetchProfileMeta(url: URL): Promise<PageMeta | null> {
+  const npub = extractProfileNpub(url.pathname);
+  if (!npub) {
+    return null;
+  }
+
+  const pubkey = decodeNpubToHex(npub);
+  if (!pubkey) {
+    return null;
+  }
+
+  try {
+    const response = await fetch(`${FUNNELCAKE_API_URL}/api/users/${pubkey}`);
+    if (!response.ok) {
+      return null;
+    }
+
+    const payload = await response.json() as ProfileApiResponse;
+    if (!payload.profile) {
+      return null;
+    }
+
+    return buildProfilePageMeta(url, payload);
+  } catch {
+    return null;
+  }
+}
+
+async function fetchCategoryMeta(url: URL): Promise<PageMeta | null> {
+  if (url.pathname === '/category') {
+    return buildCategoriesIndexMeta(url);
+  }
+
+  const categoryName = extractCategoryName(url.pathname);
+  if (!categoryName) {
+    return null;
+  }
+
+  try {
+    const response = await fetch(`${FUNNELCAKE_API_URL}/api/categories`);
+    if (!response.ok) {
+      return buildCategoryPageMeta(url);
+    }
+
+    const payload = await response.json() as Array<{ name: string; video_count?: number }>;
+    const matchedCategory = payload.find(category => category.name.toLowerCase() === categoryName.toLowerCase());
+
+    return buildCategoryPageMeta(url, matchedCategory);
+  } catch {
+    return buildCategoryPageMeta(url);
+  }
+}
+
+async function fetchRouteMeta(url: URL): Promise<PageMeta | null> {
+  if (url.pathname.startsWith('/video/')) {
+    return fetchVideoMeta(url);
+  }
+
+  if (url.pathname === '/category' || url.pathname.startsWith('/category/')) {
+    return fetchCategoryMeta(url);
+  }
+
+  if (url.pathname.startsWith('/profile/')) {
+    return fetchProfileMeta(url);
+  }
+
+  return null;
 }
 
 export async function onRequest(context: {
@@ -209,7 +205,7 @@ export async function onRequest(context: {
       // Fetch index.html from the static assets
       const indexUrl = new URL('/index.html', context.request.url);
       const indexResponse = await fetch(indexUrl);
-      const meta = await fetchVideoMeta(url);
+      const meta = await fetchRouteMeta(url);
 
       if (meta) {
         const html = injectMetaTags(await indexResponse.text(), meta);

--- a/src/lib/serverSocialMeta.test.ts
+++ b/src/lib/serverSocialMeta.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildCategoriesIndexMeta,
+  buildCategoryPageMeta,
+  buildProfilePageMeta,
+  buildVideoPageMeta,
+  decodeNpubToHex,
+} from './serverSocialMeta';
+
+describe('serverSocialMeta', () => {
+  it('falls back to summary text when a video title tag is blank', () => {
+    const meta = buildVideoPageMeta(
+      new URL('https://divine.video/video/0b5bb00712dfcb9a835b0f81a64b003dec950f85e9176930aa9b9389f0da24cb'),
+      {
+        event: {
+          id: '34781043c7550cf930d01ba9d2d8ef537fbf8c175007b53d5e9fa2a310f92356',
+          content: 'Choo choo!\n\nInspired by nostr:npub15l5atkgtzladdezjdnjc7zhej7uvzjpxaj7mctpe2hnwyk85qqxqjuecgm',
+          tags: [
+            ['d', '0b5bb00712dfcb9a835b0f81a64b003dec950f85e9176930aa9b9389f0da24cb'],
+            ['title', ''],
+            ['summary', 'Choo choo!'],
+            ['alt', ''],
+            ['imeta', 'url https://media.divine.video/0b5bb00712dfcb9a835b0f81a64b003dec950f85e9176930aa9b9389f0da24cb', 'm video/mp4', 'image https://media.divine.video/97c2020b3aee67acc202fcff87ccebca8bd0ca60b32a4de0621c154869db0dfa'],
+          ],
+        },
+        stats: {
+          author_name: 'The Wall!',
+        },
+      }
+    );
+
+    expect(meta.title).toBe('Choo choo!');
+    expect(meta.description).toContain('Inspired by nostr:npub1');
+    expect(meta.image).toBe('https://media.divine.video/97c2020b3aee67acc202fcff87ccebca8bd0ca60b32a4de0621c154869db0dfa');
+    expect(meta.videoUrl).toBe('https://media.divine.video/0b5bb00712dfcb9a835b0f81a64b003dec950f85e9176930aa9b9389f0da24cb');
+  });
+
+  it('builds profile metadata for apex /profile/:npub routes', () => {
+    const meta = buildProfilePageMeta(
+      new URL('https://divine.video/profile/npub1qakf0yuzhy846w3ty8u4u8hgddsr8u2vjtneklad8lslzpelfzrqsy63m7'),
+      {
+        profile: {
+          display_name: 'The Wall!',
+          name: '',
+          about: 'How can you have any pudding if you have not eaten your meat? ',
+          picture: 'https://media.divine.video/545aff83f83b4643f340747213e86520fac83596f899e8ea3117e0aa8b260f7b',
+        },
+        stats: {
+          video_count: 125,
+        },
+      }
+    );
+
+    expect(meta.title).toBe('The Wall! on Divine');
+    expect(meta.description).toBe('How can you have any pudding if you have not eaten your meat?');
+    expect(meta.image).toBe('https://media.divine.video/545aff83f83b4643f340747213e86520fac83596f899e8ea3117e0aa8b260f7b');
+    expect(meta.url).toBe('https://divine.video/profile/npub1qakf0yuzhy846w3ty8u4u8hgddsr8u2vjtneklad8lslzpelfzrqsy63m7');
+  });
+
+  it('builds category metadata with a readable label and count-aware description', () => {
+    const meta = buildCategoryPageMeta(
+      new URL('https://divine.video/category/dance'),
+      { video_count: 895 }
+    );
+
+    expect(meta.title).toBe('Dance Videos - Divine');
+    expect(meta.description).toBe('Explore 895 dance videos on Divine.');
+    expect(meta.ogType).toBe('website');
+  });
+
+  it('builds generic categories index metadata', () => {
+    const meta = buildCategoriesIndexMeta(new URL('https://divine.video/category'));
+
+    expect(meta.title).toBe('Browse Categories - Divine');
+    expect(meta.description).toContain('Explore video categories on Divine');
+  });
+
+  it('decodes npub identifiers to hex pubkeys', () => {
+    expect(
+      decodeNpubToHex('npub1qakf0yuzhy846w3ty8u4u8hgddsr8u2vjtneklad8lslzpelfzrqsy63m7')
+    ).toBe('076c979382b90f5d3a2b21f95e1ee86b6033f14c92e79b7fad3fe1f1073f4886');
+  });
+});

--- a/src/lib/serverSocialMeta.ts
+++ b/src/lib/serverSocialMeta.ts
@@ -1,0 +1,308 @@
+const DEFAULT_OG_IMAGE = 'https://divine.video/og.png';
+const DEFAULT_SITE_DESCRIPTION = 'Watch and share 6-second looping videos on the decentralized Nostr network.';
+
+const CATEGORY_LABEL_OVERRIDES: Record<string, string> = {
+  diy: 'DIY',
+  vlog: 'Vlog',
+  ai: 'AI',
+};
+
+const BECH32_CHARSET = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l';
+
+export interface PageMeta {
+  title: string;
+  description: string;
+  ogType: string;
+  url: string;
+  image: string;
+  imageAlt: string;
+  twitterCard: string;
+  videoUrl?: string;
+  videoMimeType?: string;
+}
+
+export interface VideoApiResponse {
+  event: {
+    id: string;
+    content: string;
+    tags: string[][];
+  };
+  stats?: {
+    author_name?: string;
+  };
+}
+
+export interface ProfileApiResponse {
+  profile?: {
+    display_name?: string;
+    name?: string;
+    about?: string;
+    picture?: string;
+  };
+  stats?: {
+    video_count?: number;
+  };
+}
+
+function cleanText(value?: string | null): string {
+  return value?.replace(/\s+/g, ' ').trim() || '';
+}
+
+function pickFirstNonEmpty(...values: Array<string | undefined | null>): string | null {
+  for (const value of values) {
+    const cleaned = cleanText(value);
+    if (cleaned) {
+      return cleaned;
+    }
+  }
+
+  return null;
+}
+
+function truncateText(value: string, maxLength: number): string {
+  const trimmed = cleanText(value);
+  if (trimmed.length <= maxLength) {
+    return trimmed;
+  }
+
+  return `${trimmed.slice(0, maxLength - 1).trimEnd()}…`;
+}
+
+function getTagValue(tags: string[][], name: string): string | undefined {
+  return tags.find(tag => tag[0] === name)?.[1];
+}
+
+function parseImeta(tags: string[][]): { url?: string; image?: string; mimeType?: string } {
+  const imetaTag = tags.find(tag => tag[0] === 'imeta');
+  if (!imetaTag) {
+    return {};
+  }
+
+  const parsed: { url?: string; image?: string; mimeType?: string } = {};
+
+  for (let i = 1; i < imetaTag.length; i += 1) {
+    const part = imetaTag[i];
+    const separatorIndex = part.indexOf(' ');
+    if (separatorIndex === -1) {
+      continue;
+    }
+
+    const key = part.slice(0, separatorIndex);
+    const value = part.slice(separatorIndex + 1).trim();
+
+    if (key === 'url') parsed.url = value;
+    if (key === 'image') parsed.image = value;
+    if (key === 'm') parsed.mimeType = value;
+  }
+
+  return parsed;
+}
+
+function humanizeCategoryName(name: string): string {
+  const normalized = decodeURIComponent(name).trim().toLowerCase();
+  if (!normalized) {
+    return 'Category';
+  }
+
+  if (CATEGORY_LABEL_OVERRIDES[normalized]) {
+    return CATEGORY_LABEL_OVERRIDES[normalized];
+  }
+
+  return normalized
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function categoryDescription(name: string, videoCount?: number): string {
+  const normalized = cleanText(decodeURIComponent(name).toLowerCase()) || 'category';
+  if (typeof videoCount === 'number' && Number.isFinite(videoCount) && videoCount >= 0) {
+    return `Explore ${videoCount} ${normalized} videos on Divine.`;
+  }
+
+  return `Explore ${normalized} videos on Divine.`;
+}
+
+function convertBits(data: number[], fromBits: number, toBits: number, pad: boolean): number[] | null {
+  let acc = 0;
+  let bits = 0;
+  const result: number[] = [];
+  const maxv = (1 << toBits) - 1;
+  const maxAcc = (1 << (fromBits + toBits - 1)) - 1;
+
+  for (const value of data) {
+    if (value < 0 || (value >> fromBits) !== 0) {
+      return null;
+    }
+
+    acc = ((acc << fromBits) | value) & maxAcc;
+    bits += fromBits;
+
+    while (bits >= toBits) {
+      bits -= toBits;
+      result.push((acc >> bits) & maxv);
+    }
+  }
+
+  if (pad) {
+    if (bits > 0) {
+      result.push((acc << (toBits - bits)) & maxv);
+    }
+  } else if (bits >= fromBits || ((acc << (toBits - bits)) & maxv) !== 0) {
+    return null;
+  }
+
+  return result;
+}
+
+export function decodeNpubToHex(npub: string): string | null {
+  const normalized = npub.toLowerCase();
+  if (!normalized.startsWith('npub1')) {
+    return null;
+  }
+
+  const separatorIndex = normalized.lastIndexOf('1');
+  if (separatorIndex === -1) {
+    return null;
+  }
+
+  const dataPart = normalized.slice(separatorIndex + 1);
+  if (dataPart.length < 6) {
+    return null;
+  }
+
+  const values = [...dataPart].map(char => BECH32_CHARSET.indexOf(char));
+  if (values.some(value => value === -1)) {
+    return null;
+  }
+
+  const payload = values.slice(0, -6);
+  const decoded = convertBits(payload, 5, 8, false);
+  if (!decoded) {
+    return null;
+  }
+
+  return decoded.map(value => value.toString(16).padStart(2, '0')).join('');
+}
+
+export function extractProfileNpub(pathname: string): string | null {
+  const match = pathname.match(/^\/profile\/([^/]+)$/);
+  if (!match) {
+    return null;
+  }
+
+  return decodeURIComponent(match[1]);
+}
+
+export function extractCategoryName(pathname: string): string | null {
+  const match = pathname.match(/^\/category\/([^/]+)$/);
+  if (!match) {
+    return null;
+  }
+
+  return decodeURIComponent(match[1]);
+}
+
+export function buildVideoPageMeta(url: URL, payload: VideoApiResponse): PageMeta {
+  const authorName = cleanText(payload.stats?.author_name);
+  const title = pickFirstNonEmpty(
+    getTagValue(payload.event.tags, 'title'),
+    getTagValue(payload.event.tags, 'alt'),
+    getTagValue(payload.event.tags, 'summary'),
+    payload.event.content,
+    authorName ? `Video by ${authorName}` : null,
+    'Video on Divine'
+  ) || 'Video on Divine';
+
+  const description = truncateText(
+    pickFirstNonEmpty(
+      payload.event.content,
+      getTagValue(payload.event.tags, 'summary'),
+      getTagValue(payload.event.tags, 'alt'),
+      authorName ? `Watch this video by ${authorName} on Divine` : null,
+      'Watch this video on Divine'
+    ) || 'Watch this video on Divine',
+    200
+  );
+
+  const media = parseImeta(payload.event.tags);
+
+  return {
+    title,
+    description,
+    ogType: 'video.other',
+    url: url.toString(),
+    image: media.image || DEFAULT_OG_IMAGE,
+    imageAlt: title,
+    twitterCard: 'summary_large_image',
+    videoUrl: media.url,
+    videoMimeType: media.mimeType,
+  };
+}
+
+export function buildProfilePageMeta(url: URL, payload: ProfileApiResponse): PageMeta {
+  const displayName = pickFirstNonEmpty(
+    payload.profile?.display_name,
+    payload.profile?.name,
+    'Profile on Divine'
+  ) || 'Profile on Divine';
+  const about = cleanText(payload.profile?.about);
+  const videoCount = payload.stats?.video_count;
+  const description = about
+    || (typeof videoCount === 'number' && videoCount > 0
+      ? `Watch ${displayName}'s ${videoCount} videos on Divine.`
+      : `Watch ${displayName}'s videos on Divine.`);
+
+  return {
+    title: `${displayName} on Divine`,
+    description,
+    ogType: 'profile',
+    url: url.toString(),
+    image: cleanText(payload.profile?.picture) || DEFAULT_OG_IMAGE,
+    imageAlt: displayName,
+    twitterCard: 'summary',
+  };
+}
+
+export function buildCategoryPageMeta(
+  url: URL,
+  category: { video_count?: number } = {}
+): PageMeta {
+  const categoryName = extractCategoryName(url.pathname) || 'category';
+  const label = humanizeCategoryName(categoryName);
+
+  return {
+    title: `${label} Videos - Divine`,
+    description: categoryDescription(categoryName, category.video_count),
+    ogType: 'website',
+    url: url.toString(),
+    image: DEFAULT_OG_IMAGE,
+    imageAlt: `${label} videos on Divine`,
+    twitterCard: 'summary_large_image',
+  };
+}
+
+export function buildCategoriesIndexMeta(url: URL): PageMeta {
+  return {
+    title: 'Browse Categories - Divine',
+    description: 'Explore video categories on Divine - comedy, music, dance, animals, sports, food, and more.',
+    ogType: 'website',
+    url: url.toString(),
+    image: DEFAULT_OG_IMAGE,
+    imageAlt: 'Browse Divine video categories',
+    twitterCard: 'summary_large_image',
+  };
+}
+
+export function getDefaultPageMeta(url: URL): PageMeta {
+  return {
+    title: 'Divine Web - Short-form Looping Videos on Nostr',
+    description: DEFAULT_SITE_DESCRIPTION,
+    ogType: 'website',
+    url: url.toString(),
+    image: DEFAULT_OG_IMAGE,
+    imageAlt: 'Divine Web - Short-form looping videos on the Nostr network',
+    twitterCard: 'summary_large_image',
+  };
+}


### PR DESCRIPTION
## Summary
- restore server-side social preview metadata for apex profile and category routes
- improve video unfurl title fallback when Funnelcake returns a blank title tag
- align the Cloudflare Pages preview handler and the Fastly production edge worker with shared regression coverage

## Test Plan
- [x] `npx vitest run src/lib/serverSocialMeta.test.ts 'functions/[[path]].test.ts'`
- [x] `node --check compute-js/src/index.js`
- [x] `npm run test`