### PR TITLE
Add durable async DM outbox sends

### DIFF
--- a/docs/superpowers/plans/2026-04-13-dm-outbox-async-send.md
+++ b/docs/superpowers/plans/2026-04-13-dm-outbox-async-send.md
@@ -1,0 +1,490 @@
+# DM Outbox Async Send Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make DM sending instant and durable by clearing the composer immediately, rendering optimistic `sending` rows immediately, persisting pending/failed sends across reloads, and reconciling them against relay-fetched DMs.
+
+**Architecture:** Add a local persisted DM outbox that stores plain send intent per logged-in user, then merge outbox items into the DM query results as client-side messages. Move optimistic insertion from `useDmSend` success time to mutation start, update delivery state on publish completion, and add retry/reconciliation behavior in the DM hook layer so conversation and inbox views stay consistent.
+
+**Tech Stack:** TypeScript, React, React Query, Vitest, Vite, localStorage
+
+---
+
+## Chunk 1: Outbox Data Model and Storage
+
+### Task 1: Add failing tests for the local DM outbox model
+
+**Files:**
+- Create: `src/lib/dmOutbox.test.ts`
+- Create: `src/lib/dmOutbox.ts`
+- Modify: `src/lib/dm.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add tests in `src/lib/dmOutbox.test.ts` that define the storage contract:
+
+```ts
+it('writes and reads outbox records per owner pubkey', () => {
+  const record = createDmOutboxRecord({
+    ownerPubkey: TEST_PUBKEY,
+    participantPubkeys: [RECIPIENT_PUBKEY],
+    content: 'hello',
+  });
+
+  writeDmOutbox(TEST_PUBKEY, [record]);
+
+  expect(readDmOutbox(TEST_PUBKEY)).toEqual([record]);
+  expect(readDmOutbox('c'.repeat(64))).toEqual([]);
+});
+
+it('updates an existing outbox record by clientId', () => {
+  const record = createDmOutboxRecord({
+    ownerPubkey: TEST_PUBKEY,
+    participantPubkeys: [RECIPIENT_PUBKEY],
+    content: 'hello',
+  });
+
+  const updated = { ...record, deliveryState: 'failed', errorMessage: 'boom' as const };
+
+  writeDmOutbox(TEST_PUBKEY, [record]);
+  upsertDmOutboxRecord(TEST_PUBKEY, updated);
+
+  expect(readDmOutbox(TEST_PUBKEY)).toEqual([updated]);
+});
+
+it('demotes stale sending records to failed during hydration', () => {
+  const stale = {
+    ...createDmOutboxRecord({
+      ownerPubkey: TEST_PUBKEY,
+      participantPubkeys: [RECIPIENT_PUBKEY],
+      content: 'hello',
+    }),
+    deliveryState: 'sending' as const,
+    lastAttemptAt: 1,
+  };
+
+  expect(hydrateDmOutbox(TEST_PUBKEY, 3600)).toEqual([
+    expect.objectContaining({ deliveryState: 'failed' }),
+  ]);
+});
+```
+
+- [ ] **Step 2: Run the focused tests to verify failure**
+
+Run: `npx vitest run src/lib/dmOutbox.test.ts`
+Expected: FAIL because the outbox module and types do not exist yet.
+
+### Task 2: Implement the minimal outbox storage module
+
+**Files:**
+- Create: `src/lib/dmOutbox.ts`
+- Create: `src/lib/dmOutbox.test.ts`
+- Modify: `src/lib/dm.ts`
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `src/lib/dmOutbox.ts` with:
+
+```ts
+export interface DmOutboxRecord {
+  clientId: string;
+  ownerPubkey: string;
+  participantPubkeys: string[];
+  content: string;
+  share?: DmSharePayload;
+  createdAt: number;
+  lastAttemptAt: number;
+  deliveryState: 'sending' | 'failed' | 'sent';
+  errorMessage?: string;
+  retryCount: number;
+}
+
+export function createDmOutboxRecord(input: {
+  ownerPubkey: string;
+  participantPubkeys: string[];
+  content: string;
+  share?: DmSharePayload;
+}): DmOutboxRecord { /* minimal implementation */ }
+
+export function readDmOutbox(ownerPubkey?: string): DmOutboxRecord[] { /* localStorage-backed */ }
+export function writeDmOutbox(ownerPubkey: string, records: DmOutboxRecord[]): void { /* localStorage-backed */ }
+export function upsertDmOutboxRecord(ownerPubkey: string, record: DmOutboxRecord): DmOutboxRecord[] { /* replace by clientId */ }
+export function removeDmOutboxRecord(ownerPubkey: string, clientId: string): DmOutboxRecord[] { /* filter by clientId */ }
+export function hydrateDmOutbox(ownerPubkey: string, staleAfterSeconds: number): DmOutboxRecord[] { /* stale sending -> failed */ }
+```
+
+Extend `DmMessage` in `src/lib/dm.ts` with optional client-only fields:
+
+```ts
+clientId?: string;
+deliveryState?: 'sending' | 'failed' | 'sent';
+errorMessage?: string;
+isOptimistic?: boolean;
+```
+
+- [ ] **Step 4: Run the focused tests to verify they pass**
+
+Run: `npx vitest run src/lib/dmOutbox.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/dm.ts src/lib/dmOutbox.ts src/lib/dmOutbox.test.ts
+git commit -m "Add DM outbox storage model"
+```
+
+## Chunk 2: Merge Outbox Records into DM Queries
+
+### Task 3: Add failing tests for merging optimistic outbox messages into DM queries
+
+**Files:**
+- Modify: `src/hooks/useDirectMessages.test.ts`
+- Modify: `src/hooks/useDirectMessages.ts`
+- Modify: `src/lib/dmOutbox.ts`
+
+- [ ] **Step 1: Extend hook tests with merge expectations**
+
+Add tests in `src/hooks/useDirectMessages.test.ts` for:
+
+```ts
+it('includes persisted sending outbox messages in the DM message cache', async () => {
+  seedDmOutbox(TEST_PUBKEY, [{
+    clientId: 'local-1',
+    ownerPubkey: TEST_PUBKEY,
+    participantPubkeys: [RECIPIENT_PUBKEY],
+    content: 'hello',
+    createdAt: 1234567890,
+    lastAttemptAt: 1234567890,
+    deliveryState: 'sending',
+    retryCount: 0,
+  }]);
+
+  const { result } = renderHook(() => useDmConversation(encodeConversationId([RECIPIENT_PUBKEY])), {
+    wrapper: createWrapper(queryClient),
+  });
+
+  expect(result.current.data).toEqual([
+    expect.objectContaining({
+      clientId: 'local-1',
+      content: 'hello',
+      deliveryState: 'sending',
+      isOptimistic: true,
+    }),
+  ]);
+});
+
+it('removes an optimistic outbox row when a matching fetched DM arrives', async () => {
+  // seed local outbox record and fetched remote DM with matching fingerprint
+  // expect merged result to contain only the fetched DM
+});
+```
+
+- [ ] **Step 2: Run the focused tests to verify failure**
+
+Run: `npx vitest run src/hooks/useDirectMessages.test.ts`
+Expected: FAIL because the hooks do not yet merge persisted outbox records.
+
+### Task 4: Implement outbox/query merge and reconciliation helpers
+
+**Files:**
+- Modify: `src/hooks/useDirectMessages.ts`
+- Modify: `src/lib/dm.ts`
+- Modify: `src/lib/dmOutbox.ts`
+- Modify: `src/hooks/useDirectMessages.test.ts`
+
+- [ ] **Step 3: Add reconciliation helpers**
+
+Add helper logic either in `src/lib/dmOutbox.ts` or `src/lib/dm.ts` for:
+
+```ts
+export function buildDmReconciliationFingerprint(input: {
+  senderPubkey: string;
+  participantPubkeys: string[];
+  content: string;
+  share?: DmSharePayload;
+  createdAt: number;
+}): string { /* stable normalized fingerprint */ }
+
+export function convertOutboxRecordToDmMessage(record: DmOutboxRecord): DmMessage { /* optimistic row */ }
+
+export function mergeFetchedAndOutboxMessages(
+  fetched: DmMessage[],
+  outbox: DmOutboxRecord[],
+): { messages: DmMessage[]; reconciledClientIds: string[] } { /* optimistic merge + dedupe */ }
+```
+
+- [ ] **Step 4: Wire merge logic into the DM hooks**
+
+Update `useDmMessages()` so it:
+
+- hydrates the local outbox for the current user
+- merges fetched messages with outbox messages
+- removes reconciled outbox items from storage after a match
+
+Keep the merged list sorted by `createdAt`.
+
+- [ ] **Step 5: Run the focused tests to verify they pass**
+
+Run: `npx vitest run src/hooks/useDirectMessages.test.ts`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/hooks/useDirectMessages.ts src/hooks/useDirectMessages.test.ts src/lib/dm.ts src/lib/dmOutbox.ts
+git commit -m "Merge DM outbox into message queries"
+```
+
+## Chunk 3: Make Sending Optimistic at Mutation Start
+
+### Task 5: Add failing tests for immediate optimistic send behavior
+
+**Files:**
+- Modify: `src/hooks/useDirectMessages.test.ts`
+- Modify: `src/hooks/useDirectMessages.ts`
+
+- [ ] **Step 1: Add tests for onMutate optimism**
+
+Add focused hook tests:
+
+```ts
+it('adds an optimistic sending message before publish resolves', async () => {
+  let resolvePublish!: () => void;
+  mockPublishDmMessages.mockImplementation(() => new Promise<void>((resolve) => {
+    resolvePublish = resolve;
+  }));
+
+  const { result } = renderHook(() => useDmSend(), { wrapper: createWrapper(queryClient) });
+
+  act(() => {
+    result.current.mutate({
+      participantPubkeys: [RECIPIENT_PUBKEY],
+      content: 'hi support',
+    });
+  });
+
+  expect(queryClient.getQueryData(['dm', 'messages', TEST_PUBKEY, 300])).toEqual([
+    expect.objectContaining({
+      content: 'hi support',
+      deliveryState: 'sending',
+      isOptimistic: true,
+    }),
+  ]);
+
+  await act(async () => {
+    resolvePublish();
+  });
+});
+
+it('keeps the optimistic row as failed when publish rejects', async () => {
+  mockPublishDmMessages.mockRejectedValue(new Error('signal has been aborted'));
+
+  // trigger mutation and assert failed state remains in cache/storage
+});
+```
+
+- [ ] **Step 2: Run the focused tests to verify failure**
+
+Run: `npx vitest run src/hooks/useDirectMessages.test.ts`
+Expected: FAIL because optimism still happens in `onSuccess`.
+
+### Task 6: Move optimistic insertion to `onMutate` and update delivery state on completion
+
+**Files:**
+- Modify: `src/hooks/useDirectMessages.ts`
+- Modify: `src/lib/dm.ts`
+- Modify: `src/lib/dmOutbox.ts`
+- Modify: `src/hooks/useDirectMessages.test.ts`
+
+- [ ] **Step 3: Refactor `useDmSend()` around outbox-first mutation flow**
+
+Change the mutation shape to:
+
+```ts
+onMutate: ({ participantPubkeys, content, share }) => {
+  const record = createDmOutboxRecord({ ownerPubkey: user.pubkey, participantPubkeys, content, share });
+  upsertDmOutboxRecord(user.pubkey, record);
+  insertOptimisticDmIntoAllCaches(queryClient, user.pubkey, convertOutboxRecordToDmMessage(record));
+  return { clientId: record.clientId };
+},
+mutationFn: async (...) => {
+  const relayUrls = await resolveDmWriteRelays(...);
+  const wraps = await createDmGiftWraps(...);
+  await publishDmMessages(relayUrls, wraps, AbortSignal.timeout(10000));
+  return { relayUrls, wraps };
+},
+onSuccess: (_, __, context) => markOutboxRecordSent(user.pubkey, context.clientId),
+onError: (error, __, context) => markOutboxRecordFailed(user.pubkey, context.clientId, error),
+```
+
+Do not remove the optimistic row on failure.
+
+- [ ] **Step 4: Run the focused tests to verify they pass**
+
+Run: `npx vitest run src/hooks/useDirectMessages.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hooks/useDirectMessages.ts src/hooks/useDirectMessages.test.ts src/lib/dm.ts src/lib/dmOutbox.ts
+git commit -m "Make DM sends optimistic and durable"
+```
+
+## Chunk 4: Conversation UI for Sending and Retry
+
+### Task 7: Add failing page tests for immediate composer clear and failed retry UI
+
+**Files:**
+- Create: `src/pages/ConversationPage.test.tsx`
+- Modify: `src/pages/ConversationPage.tsx`
+
+- [ ] **Step 1: Write the failing UI tests**
+
+Create `src/pages/ConversationPage.test.tsx` with cases like:
+
+```ts
+it('clears the composer immediately after send is triggered', async () => {
+  mockUseDmSendReturn.mutate.mockImplementation(() => undefined);
+
+  renderConversationPage();
+  await user.type(screen.getByRole('textbox'), 'hello');
+  await user.keyboard('{Enter}');
+
+  expect(screen.getByRole('textbox')).toHaveValue('');
+});
+
+it('renders a sending indicator for optimistic messages', () => {
+  mockConversationMessages([
+    buildTestDm({ clientId: 'local-1', content: 'hello', deliveryState: 'sending', isOptimistic: true }),
+  ]);
+
+  renderConversationPage();
+
+  expect(screen.getByText(/sending/i)).toBeInTheDocument();
+});
+
+it('renders retry for failed optimistic messages', async () => {
+  // seed failed optimistic message and assert retry affordance is visible/clickable
+});
+```
+
+- [ ] **Step 2: Run the focused tests to verify failure**
+
+Run: `npx vitest run src/pages/ConversationPage.test.tsx`
+Expected: FAIL because the page still awaits the mutation and has no sending/failed UI.
+
+### Task 8: Update the conversation page to use fire-and-forget send UX
+
+**Files:**
+- Create: `src/pages/ConversationPage.test.tsx`
+- Modify: `src/pages/ConversationPage.tsx`
+- Modify: `src/hooks/useDirectMessages.ts`
+
+- [ ] **Step 3: Stop awaiting network completion in the composer**
+
+Update `handleSend()` so it:
+
+- trims and validates the draft
+- stores the outgoing text locally
+- clears the draft immediately
+- calls `sendMessage.mutate(...)` instead of awaiting `mutateAsync(...)`
+- preserves share-removal navigation behavior without waiting on publish
+
+- [ ] **Step 4: Render delivery-state UI in `MessageBubble`**
+
+Add small state text below the message timestamp:
+
+```tsx
+{message.deliveryState === 'sending' && <span>Sending…</span>}
+{message.deliveryState === 'failed' && (
+  <>
+    <span>Failed to send</span>
+    <button onClick={() => retryMessage(message)}>Retry</button>
+  </>
+)}
+```
+
+Implement retry by routing the failed message back through `useDmSend` using its stored `clientId`/outbox record rather than creating a duplicate local item.
+
+- [ ] **Step 5: Run the focused tests to verify they pass**
+
+Run: `npx vitest run src/pages/ConversationPage.test.tsx`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/pages/ConversationPage.tsx src/pages/ConversationPage.test.tsx src/hooks/useDirectMessages.ts
+git commit -m "Update DM conversation UI for background sends"
+```
+
+## Chunk 5: Inbox Preview and Full Verification
+
+### Task 9: Add failing tests for inbox previews with optimistic DMs
+
+**Files:**
+- Modify: `src/pages/MessagesPage.test.tsx`
+- Modify: `src/pages/MessagesPage.tsx`
+
+- [ ] **Step 1: Extend inbox tests**
+
+Add a test ensuring a conversation containing an optimistic local DM still renders a correct preview row:
+
+```ts
+it('shows optimistic sending or failed messages in the inbox preview', () => {
+  // mock conversation query containing a local optimistic last message
+  // assert the preview text uses message content and row remains visible
+});
+```
+
+- [ ] **Step 2: Run the focused tests to verify failure**
+
+Run: `npx vitest run src/pages/MessagesPage.test.tsx`
+Expected: FAIL if preview logic drops or mishandles optimistic DMs.
+
+### Task 10: Finish inbox polish and run full verification
+
+**Files:**
+- Modify: `src/pages/MessagesPage.tsx`
+- Modify: `src/pages/MessagesPage.test.tsx`
+- Modify: `docs/superpowers/specs/2026-04-13-dm-outbox-async-send-design.md`
+- Modify: `docs/superpowers/plans/2026-04-13-dm-outbox-async-send.md`
+- Modify: `src/hooks/useDirectMessages.ts`
+- Modify: `src/lib/dm.ts`
+- Modify: `src/lib/dmOutbox.ts`
+- Modify: `src/lib/dmOutbox.test.ts`
+- Modify: `src/pages/ConversationPage.tsx`
+- Modify: `src/pages/ConversationPage.test.tsx`
+
+- [ ] **Step 3: Ensure inbox rows remain correct for optimistic last messages**
+
+Update preview rendering only if needed so `ConversationRow` handles optimistic last messages without special-case regressions.
+
+- [ ] **Step 4: Run the focused inbox tests**
+
+Run: `npx vitest run src/pages/MessagesPage.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Run the full repository verification suite**
+
+Run: `npm run test`
+Expected: PASS
+
+- [ ] **Step 6: Commit the full change**
+
+```bash
+git add docs/superpowers/specs/2026-04-13-dm-outbox-async-send-design.md \
+  docs/superpowers/plans/2026-04-13-dm-outbox-async-send.md \
+  src/hooks/useDirectMessages.ts \
+  src/hooks/useDirectMessages.test.ts \
+  src/lib/dm.ts \
+  src/lib/dmOutbox.ts \
+  src/lib/dmOutbox.test.ts \
+  src/pages/ConversationPage.tsx \
+  src/pages/ConversationPage.test.tsx \
+  src/pages/MessagesPage.tsx \
+  src/pages/MessagesPage.test.tsx
+git commit -m "Add durable async DM outbox"
+```

--- a/docs/superpowers/specs/2026-04-13-dm-outbox-async-send-design.md
+++ b/docs/superpowers/specs/2026-04-13-dm-outbox-async-send-design.md
@@ -1,0 +1,176 @@
+# DM Outbox Async Send Design
+
+**Date:** 2026-04-13
+**Branch:** `docs/dm-outbox-async-send`
+
+## Problem
+
+The current DM composer blocks on the send mutation. In [src/pages/ConversationPage.tsx](/Users/rabble/code/divine/divine-web/.worktrees/dm-outbox-async-send/src/pages/ConversationPage.tsx:157), `handleSend()` awaits `sendMessage.mutateAsync(...)` before clearing the draft, so users cannot quickly send a message and move on to another conversation.
+
+The current optimistic behavior is also too late. In [src/hooks/useDirectMessages.ts](/Users/rabble/code/divine/divine-web/.worktrees/dm-outbox-async-send/src/hooks/useDirectMessages.ts:229), the outgoing DM is inserted into cache only in `onSuccess`, after the publish step has already completed.
+
+## Goal
+
+Make DM sending feel instant and stay reliable:
+
+1. Clear the composer immediately on send.
+2. Show the new DM in the thread immediately with a visible `sending` state.
+3. Continue publish work in the background while the user navigates freely.
+4. Persist pending and failed sends across route changes and reloads.
+5. Keep failed messages visible with retry instead of dropping them.
+
+## Protocol Constraints
+
+This design follows current Nostr DM protocol guidance:
+
+- NIP-17 private messages are unsigned `kind:14` rumors that must be sealed (`kind:13`) and gift-wrapped (`kind:1059`) to each recipient and to the sender individually.
+- NIP-17 says clients should publish DM gift wraps to relays listed in recipients' `kind:10050` relay list metadata events.
+- NIP-59 gift wraps are transport envelopes, not stable client-side message identities.
+- NIP-01 relay `OK` responses indicate whether an event was accepted; `duplicate:` still counts as acceptance.
+
+Because gift wraps are randomized transport envelopes, the persisted outbox should store the plain send intent, not prebuilt wraps.
+
+## Decision
+
+Add a durable local DM outbox and move optimistic rendering to mutation start:
+
+1. Persist a per-user outbox in `localStorage`.
+2. Represent pending DMs as client-side messages merged into the DM query cache.
+3. Insert the optimistic message in `onMutate`, before publish starts.
+4. Regenerate seals and gift wraps on every send or retry attempt.
+5. Mark an outbox item `sent` when the publish pipeline succeeds.
+6. Mark an outbox item `failed` when publish throws, and keep it visible with retry.
+7. Reconcile local outbox items away once the matching relay-fetched DM appears.
+
+## User Experience
+
+When the user presses send:
+
+- The textarea clears immediately.
+- Focus remains on the composer so the user can keep typing.
+- A new message row appears immediately with a small `Sending…` indicator.
+- The user can navigate to another conversation without waiting for network completion.
+
+If background publish succeeds:
+
+- The message remains in place.
+- Its transient `Sending…` state disappears.
+- Once the real relay-fetched DM is present, the local outbox placeholder is removed.
+
+If background publish fails:
+
+- The message remains visible in the thread.
+- It shows a `Failed to send` state plus a retry affordance.
+- Retry reuses the same local outbox record so the row updates in place rather than duplicating.
+
+## Architecture
+
+### Outbox Storage
+
+Add a client-side outbox record with:
+
+- `clientId`
+- `ownerPubkey`
+- `participantPubkeys`
+- `content`
+- optional `share`
+- `createdAt`
+- `lastAttemptAt`
+- `deliveryState: 'sending' | 'failed' | 'sent'`
+- optional `errorMessage`
+- `retryCount`
+
+Store records under a per-user key such as `dm:outbox:<ownerPubkey>`.
+
+### DM View Model
+
+Extend the client-side `DmMessage` shape with optional local delivery metadata:
+
+- `clientId?`
+- `deliveryState?`
+- `errorMessage?`
+- `isOptimistic?`
+
+Remote DMs do not need to persist these fields; they are only for local rendering and reconciliation.
+
+### Send Flow
+
+`useDmSend` becomes responsible for:
+
+1. Creating a local outbox item during `onMutate`.
+2. Writing it to `localStorage`.
+3. Merging the optimistic message into all active DM message caches.
+4. Running relay resolution, gift-wrap creation, and publish in the background.
+5. Updating the outbox item to `sent` or `failed` afterward.
+
+### Query Merge
+
+`useDmMessages` should merge:
+
+- relay-fetched DMs from `fetchDmMessages()`
+- local outbox records for the current user
+
+The merged result is the source of truth for:
+
+- conversation thread rendering
+- conversation previews
+- unread state calculations
+
+## Reconciliation Rules
+
+Each optimistic record gets a stable `clientId`. Matching between local and fetched DMs should use a conservative fingerprint from:
+
+- sender pubkey
+- sorted participant set
+- normalized content
+- normalized share payload
+- near creation time
+
+When a fetched DM matches an outbox record:
+
+- remove the local outbox record
+- keep only the real fetched DM in the merged result
+
+Stale `sending` records that survive reload without a matching fetched copy should be demoted to `failed` after a timeout-based hydration check.
+
+## Failure Semantics
+
+DM failure should only reflect the DM publish pipeline itself. Unrelated console noise such as:
+
+- blocked analytics scripts
+- unrelated notification `401`s
+- relay reconnect noise
+- media fetch failures
+
+must not flip a message to failed unless `useDmSend`'s publish promise rejects.
+
+## Scope
+
+In scope:
+
+- Durable local DM outbox
+- Immediate composer clear and optimistic thread rendering
+- `sending` / `failed` message UI states
+- Retry from failed messages
+- Outbox persistence across reload and navigation
+- Reconciliation between optimistic and fetched messages
+
+Out of scope:
+
+- Cross-device outbox sync
+- Guaranteed relay delivery receipts beyond current publish success semantics
+- NIP-17 policy tightening for recipients missing `kind:10050`
+- Background service worker send retries
+
+## Testing
+
+Add coverage for:
+
+- optimistic insertion before publish resolves
+- immediate composer clear
+- failure state retention
+- retry reusing the same optimistic row
+- outbox hydration from `localStorage`
+- reconciliation removing the optimistic placeholder when a fetched DM matches
+
+Run focused DM tests first, then `npm run test`.

--- a/src/hooks/useDirectMessages.test.ts
+++ b/src/hooks/useDirectMessages.test.ts
@@ -195,7 +195,110 @@ describe('useDirectMessages', () => {
     expect(readDmOutbox(TEST_PUBKEY)).toEqual([]);
   });
 
-  it('adds the outgoing message to existing DM message caches immediately after a successful send', async () => {
+  it('adds an optimistic sending message before publish resolves', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_234_567_890_000);
+
+    let resolvePublish: (() => void) | undefined;
+    mockPublishDmMessages.mockImplementation(() => new Promise<void>((resolve) => {
+      resolvePublish = resolve;
+    }));
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+    queryClient.setQueryData(['dm', 'messages', TEST_PUBKEY, 300], []);
+
+    const { result } = renderHook(() => useDmSend(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      result.current.mutate({
+        participantPubkeys: [RECIPIENT_PUBKEY],
+        content: 'hi support',
+      });
+    });
+
+    expect(queryClient.getQueryData(['dm', 'messages', TEST_PUBKEY, 300])).toEqual([
+      expect.objectContaining({
+        content: 'hi support',
+        deliveryState: 'sending',
+        isOptimistic: true,
+      }),
+    ]);
+
+    await act(async () => {
+      resolvePublish?.();
+    });
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData(['dm', 'messages', TEST_PUBKEY, 300])).toEqual([
+        expect.objectContaining({
+          content: 'hi support',
+          deliveryState: 'sent',
+          isOptimistic: true,
+        }),
+      ]);
+    });
+    expect(readDmOutbox(TEST_PUBKEY)).toEqual([
+      expect.objectContaining({
+        content: 'hi support',
+        deliveryState: 'sent',
+      }),
+    ]);
+    expect(mockToast).not.toHaveBeenCalled();
+  });
+
+  it('keeps the optimistic row as failed when publish rejects', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_234_567_890_000);
+
+    mockPublishDmMessages.mockRejectedValue(new Error('signal has been aborted'));
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+    queryClient.setQueryData(['dm', 'messages', TEST_PUBKEY, 300], []);
+
+    const { result } = renderHook(() => useDmSend(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await expect(result.current.mutateAsync({
+        participantPubkeys: [RECIPIENT_PUBKEY],
+        content: 'hi support',
+      })).rejects.toThrow('signal has been aborted');
+    });
+
+    expect(queryClient.getQueryData(['dm', 'messages', TEST_PUBKEY, 300])).toEqual([
+      expect.objectContaining({
+        content: 'hi support',
+        deliveryState: 'failed',
+        errorMessage: 'signal has been aborted',
+        isOptimistic: true,
+      }),
+    ]);
+    expect(readDmOutbox(TEST_PUBKEY)).toEqual([
+      expect.objectContaining({
+        content: 'hi support',
+        deliveryState: 'failed',
+        errorMessage: 'signal has been aborted',
+      }),
+    ]);
+    expect(mockToast).toHaveBeenCalled();
+  });
+
+  it('marks the optimistic row as sent after a successful send', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_234_567_890_000);
+
     const queryClient = new QueryClient({
       defaultOptions: {
         queries: { retry: false },
@@ -218,14 +321,15 @@ describe('useDirectMessages', () => {
 
     expect(queryClient.getQueryData(['dm', 'messages', TEST_PUBKEY, 300])).toEqual([
       expect.objectContaining({
-        conversationId: encodeConversationId([RECIPIENT_PUBKEY]),
-        wrapId: 'self-wrap-id',
-        rumorId: 'self-wrap-id',
-        senderPubkey: TEST_PUBKEY,
-        participantPubkeys: [RECIPIENT_PUBKEY, TEST_PUBKEY].sort(),
-        peerPubkeys: [RECIPIENT_PUBKEY],
         content: 'hi support',
-        isOutgoing: true,
+        deliveryState: 'sent',
+        isOptimistic: true,
+      }),
+    ]);
+    expect(readDmOutbox(TEST_PUBKEY)).toEqual([
+      expect.objectContaining({
+        content: 'hi support',
+        deliveryState: 'sent',
       }),
     ]);
     expect(mockToast).not.toHaveBeenCalled();

--- a/src/hooks/useDirectMessages.test.ts
+++ b/src/hooks/useDirectMessages.test.ts
@@ -83,6 +83,7 @@ function createWrapper(queryClient: QueryClient) {
 
 describe('useDirectMessages', () => {
   beforeEach(() => {
+    vi.restoreAllMocks();
     vi.clearAllMocks();
     localStorageMock.clear();
     mockResolveDmReadRelays.mockResolvedValue(['wss://relay.example']);
@@ -193,6 +194,47 @@ describe('useDirectMessages', () => {
       }),
     ]);
     expect(readDmOutbox(TEST_PUBKEY)).toEqual([]);
+  });
+
+  it('keeps fetched messages visible when outbox persistence fails', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_234_567_890_000);
+    vi.spyOn(globalThis.localStorage, 'setItem').mockImplementation(() => {
+      throw new Error('storage blocked');
+    });
+
+    mockFetchDmMessages.mockResolvedValue([{
+      conversationId: encodeConversationId([RECIPIENT_PUBKEY]),
+      wrapId: 'remote-wrap-id',
+      rumorId: 'remote-rumor-id',
+      senderPubkey: RECIPIENT_PUBKEY,
+      participantPubkeys: [RECIPIENT_PUBKEY, TEST_PUBKEY].sort(),
+      peerPubkeys: [RECIPIENT_PUBKEY],
+      content: 'hello',
+      createdAt: 1_234_567_892,
+      isOutgoing: false,
+    }]);
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+    const { result } = renderHook(
+      () => useDmConversation(encodeConversationId([RECIPIENT_PUBKEY])),
+      { wrapper: createWrapper(queryClient) },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual([
+      expect.objectContaining({
+        wrapId: 'remote-wrap-id',
+        content: 'hello',
+        isOutgoing: false,
+      }),
+    ]);
   });
 
   it('adds an optimistic sending message before publish resolves', async () => {

--- a/src/hooks/useDirectMessages.test.ts
+++ b/src/hooks/useDirectMessages.test.ts
@@ -296,6 +296,85 @@ describe('useDirectMessages', () => {
     expect(mockToast).toHaveBeenCalled();
   });
 
+  it('retries a failed message by reusing the same optimistic row', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_234_567_890_000);
+
+    let resolvePublish: (() => void) | undefined;
+    mockPublishDmMessages.mockImplementation(() => new Promise<void>((resolve) => {
+      resolvePublish = resolve;
+    }));
+
+    writeDmOutbox(TEST_PUBKEY, [{
+      clientId: 'local-1',
+      ownerPubkey: TEST_PUBKEY,
+      participantPubkeys: [RECIPIENT_PUBKEY],
+      content: 'retry me',
+      createdAt: 1_234_567_890,
+      lastAttemptAt: 1_234_567_890,
+      deliveryState: 'failed',
+      errorMessage: 'signal has been aborted',
+      retryCount: 0,
+    }]);
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+    queryClient.setQueryData(['dm', 'messages', TEST_PUBKEY, 300], [
+      {
+        conversationId: encodeConversationId([RECIPIENT_PUBKEY]),
+        wrapId: 'optimistic:local-1',
+        rumorId: 'optimistic:local-1',
+        senderPubkey: TEST_PUBKEY,
+        participantPubkeys: [RECIPIENT_PUBKEY, TEST_PUBKEY].sort(),
+        peerPubkeys: [RECIPIENT_PUBKEY],
+        content: 'retry me',
+        createdAt: 1_234_567_890,
+        isOutgoing: true,
+        clientId: 'local-1',
+        deliveryState: 'failed' as const,
+        errorMessage: 'signal has been aborted',
+        isOptimistic: true,
+      },
+    ]);
+
+    const { result } = renderHook(() => useDmSend(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      result.current.mutate({
+        clientId: 'local-1',
+        participantPubkeys: [RECIPIENT_PUBKEY],
+        content: 'retry me',
+      });
+    });
+
+    expect(queryClient.getQueryData(['dm', 'messages', TEST_PUBKEY, 300])).toEqual([
+      expect.objectContaining({
+        clientId: 'local-1',
+        content: 'retry me',
+        deliveryState: 'sending',
+        errorMessage: undefined,
+        isOptimistic: true,
+      }),
+    ]);
+    expect(readDmOutbox(TEST_PUBKEY)).toEqual([
+      expect.objectContaining({
+        clientId: 'local-1',
+        deliveryState: 'sending',
+        retryCount: 1,
+      }),
+    ]);
+
+    await act(async () => {
+      resolvePublish?.();
+    });
+  });
+
   it('marks the optimistic row as sent after a successful send', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(1_234_567_890_000);
 

--- a/src/hooks/useDirectMessages.test.ts
+++ b/src/hooks/useDirectMessages.test.ts
@@ -1,15 +1,43 @@
 import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { act, renderHook } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const TEST_PUBKEY = 'a'.repeat(64);
 const RECIPIENT_PUBKEY = 'b'.repeat(64);
 
+const mockResolveDmReadRelays = vi.fn();
 const mockResolveDmWriteRelays = vi.fn();
+const mockFetchDmMessages = vi.fn();
 const mockCreateDmGiftWraps = vi.fn();
 const mockPublishDmMessages = vi.fn();
 const mockToast = vi.fn();
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+
+  return {
+    getItem: (key: string) => store[key] || null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+    get length() {
+      return Object.keys(store).length;
+    },
+    key: (index: number) => Object.keys(store)[index] || null,
+  };
+})();
+
+Object.defineProperty(globalThis, 'localStorage', {
+  value: localStorageMock,
+  writable: true,
+});
 
 vi.mock('@/hooks/useCurrentUser', () => ({
   useCurrentUser: () => ({
@@ -35,14 +63,17 @@ vi.mock('@/lib/dm', async () => {
   const actual = await vi.importActual<typeof import('@/lib/dm')>('@/lib/dm');
   return {
     ...actual,
+    resolveDmReadRelays: (...args: unknown[]) => mockResolveDmReadRelays(...args),
     resolveDmWriteRelays: (...args: unknown[]) => mockResolveDmWriteRelays(...args),
+    fetchDmMessages: (...args: unknown[]) => mockFetchDmMessages(...args),
     createDmGiftWraps: (...args: unknown[]) => mockCreateDmGiftWraps(...args),
     publishDmMessages: (...args: unknown[]) => mockPublishDmMessages(...args),
   };
 });
 
 import { encodeConversationId } from '@/lib/dm';
-import { useDmSend } from './useDirectMessages';
+import { readDmOutbox, writeDmOutbox } from '@/lib/dmOutbox';
+import { useDmConversation, useDmSend } from './useDirectMessages';
 
 function createWrapper(queryClient: QueryClient) {
   return function Wrapper({ children }: { children: React.ReactNode }) {
@@ -50,23 +81,118 @@ function createWrapper(queryClient: QueryClient) {
   };
 }
 
-describe('useDmSend', () => {
+describe('useDirectMessages', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorageMock.clear();
+    mockResolveDmReadRelays.mockResolvedValue(['wss://relay.example']);
     mockResolveDmWriteRelays.mockResolvedValue(['wss://relay.example']);
+    mockFetchDmMessages.mockResolvedValue([]);
     mockCreateDmGiftWraps.mockResolvedValue([
       {
         id: 'self-wrap-id',
-        created_at: 1234567890,
+        created_at: 1_234_567_890,
         tags: [['p', TEST_PUBKEY]],
       },
       {
         id: 'recipient-wrap-id',
-        created_at: 1234567890,
+        created_at: 1_234_567_890,
         tags: [['p', RECIPIENT_PUBKEY]],
       },
     ]);
     mockPublishDmMessages.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    localStorageMock.clear();
+  });
+
+  it('includes persisted sending outbox messages in the DM message cache', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_234_567_890_000);
+
+    writeDmOutbox(TEST_PUBKEY, [{
+      clientId: 'local-1',
+      ownerPubkey: TEST_PUBKEY,
+      participantPubkeys: [RECIPIENT_PUBKEY],
+      content: 'hello',
+      createdAt: 1_234_567_890,
+      lastAttemptAt: 1_234_567_890,
+      deliveryState: 'sending',
+      retryCount: 0,
+    }]);
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+    const { result } = renderHook(
+      () => useDmConversation(encodeConversationId([RECIPIENT_PUBKEY])),
+      { wrapper: createWrapper(queryClient) },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual([
+      expect.objectContaining({
+        clientId: 'local-1',
+        content: 'hello',
+        deliveryState: 'sending',
+        isOptimistic: true,
+      }),
+    ]);
+  });
+
+  it('removes an optimistic outbox row when a matching fetched DM arrives', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_234_567_890_000);
+
+    writeDmOutbox(TEST_PUBKEY, [{
+      clientId: 'local-1',
+      ownerPubkey: TEST_PUBKEY,
+      participantPubkeys: [RECIPIENT_PUBKEY],
+      content: 'hello',
+      createdAt: 1_234_567_890,
+      lastAttemptAt: 1_234_567_890,
+      deliveryState: 'sending',
+      retryCount: 0,
+    }]);
+
+    mockFetchDmMessages.mockResolvedValue([{
+      conversationId: encodeConversationId([RECIPIENT_PUBKEY]),
+      wrapId: 'remote-wrap-id',
+      rumorId: 'remote-rumor-id',
+      senderPubkey: TEST_PUBKEY,
+      participantPubkeys: [RECIPIENT_PUBKEY, TEST_PUBKEY].sort(),
+      peerPubkeys: [RECIPIENT_PUBKEY],
+      content: 'hello',
+      createdAt: 1_234_567_892,
+      isOutgoing: true,
+    }]);
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+    const { result } = renderHook(
+      () => useDmConversation(encodeConversationId([RECIPIENT_PUBKEY])),
+      { wrapper: createWrapper(queryClient) },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual([
+      expect.objectContaining({
+        wrapId: 'remote-wrap-id',
+        rumorId: 'remote-rumor-id',
+        content: 'hello',
+      }),
+    ]);
+    expect(readDmOutbox(TEST_PUBKEY)).toEqual([]);
   });
 
   it('adds the outgoing message to existing DM message caches immediately after a successful send', async () => {

--- a/src/hooks/useDirectMessages.ts
+++ b/src/hooks/useDirectMessages.ts
@@ -5,7 +5,6 @@ import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { toast } from '@/hooks/useToast';
 import { useAppContext } from '@/hooks/useAppContext';
 import {
-  buildOptimisticDmMessage,
   buildDmShareTags,
   createDmGiftWraps,
   fetchDmMessages,
@@ -18,7 +17,16 @@ import {
   type DmMessage,
   type DmSharePayload,
 } from '@/lib/dm';
-import { hydrateDmOutbox, mergeFetchedAndOutboxMessages, removeDmOutboxRecord } from '@/lib/dmOutbox';
+import {
+  convertOutboxRecordToDmMessage,
+  createDmOutboxRecord,
+  hydrateDmOutbox,
+  markDmOutboxRecordFailed,
+  markDmOutboxRecordSent,
+  mergeFetchedAndOutboxMessages,
+  removeDmOutboxRecord,
+  upsertDmOutboxRecord,
+} from '@/lib/dmOutbox';
 
 const DM_QUERY_KEY = ['dm'];
 const DM_READ_STATE_EVENT = 'dm:read-state';
@@ -28,6 +36,10 @@ interface SendDmInput {
   participantPubkeys: string[];
   content: string;
   share?: DmSharePayload;
+}
+
+interface SendDmMutationContext {
+  clientId?: string;
 }
 
 function getDmReadStorageKey(ownerPubkey?: string): string {
@@ -61,6 +73,68 @@ function writeDmReadState(ownerPubkey: string | undefined, nextState: Record<str
   } catch {
     // Ignore persistence failures and keep the in-memory state.
   }
+}
+
+function getDmMessageQueryLimits(queryClient: ReturnType<typeof useQueryClient>, ownerPubkey: string): number[] {
+  const limits = new Set<number>([200, 300]);
+  const existingMessageQueries = queryClient.getQueriesData<DmMessage[]>({
+    queryKey: [...DM_QUERY_KEY, 'messages', ownerPubkey],
+  });
+
+  for (const [queryKey] of existingMessageQueries) {
+    const maybeLimit = queryKey[3];
+    if (typeof maybeLimit === 'number') {
+      limits.add(maybeLimit);
+    }
+  }
+
+  return [...limits];
+}
+
+function updateDmMessageCaches(
+  queryClient: ReturnType<typeof useQueryClient>,
+  ownerPubkey: string,
+  updater: (existingMessages: DmMessage[]) => DmMessage[],
+) {
+  for (const limit of getDmMessageQueryLimits(queryClient, ownerPubkey)) {
+    queryClient.setQueryData<DmMessage[]>(
+      [...DM_QUERY_KEY, 'messages', ownerPubkey, limit],
+      (existingMessages: DmMessage[] = []) => updater(existingMessages),
+    );
+  }
+}
+
+function insertOptimisticDmIntoAllCaches(
+  queryClient: ReturnType<typeof useQueryClient>,
+  ownerPubkey: string,
+  optimisticMessage: DmMessage,
+) {
+  updateDmMessageCaches(queryClient, ownerPubkey, (existingMessages) => {
+    const nextMessages = [
+      ...existingMessages.filter((message) => message.clientId !== optimisticMessage.clientId),
+      optimisticMessage,
+    ];
+
+    return nextMessages.sort((left, right) => left.createdAt - right.createdAt);
+  });
+}
+
+function updateOptimisticDmInAllCaches(
+  queryClient: ReturnType<typeof useQueryClient>,
+  ownerPubkey: string,
+  clientId: string,
+  updates: Pick<DmMessage, 'deliveryState' | 'errorMessage'>,
+) {
+  updateDmMessageCaches(queryClient, ownerPubkey, (existingMessages) => existingMessages.map((message) => {
+    if (message.clientId !== clientId) {
+      return message;
+    }
+
+    return {
+      ...message,
+      ...updates,
+    };
+  }));
 }
 
 export function useDmCapability() {
@@ -227,7 +301,27 @@ export function useDmSend() {
   const { user, signer } = useCurrentUser();
   const { config } = useAppContext();
 
-  return useMutation({
+  return useMutation<{ relayUrls: string[]; wraps: Awaited<ReturnType<typeof createDmGiftWraps>> }, Error, SendDmInput, SendDmMutationContext>({
+    onMutate: ({ participantPubkeys, content, share }) => {
+      if (!user?.pubkey) {
+        return {};
+      }
+
+      const record = createDmOutboxRecord({
+        ownerPubkey: user.pubkey,
+        participantPubkeys,
+        content,
+        share,
+      });
+
+      const optimisticMessage = convertOutboxRecordToDmMessage(record);
+      upsertDmOutboxRecord(user.pubkey, record);
+
+      insertOptimisticDmIntoAllCaches(queryClient, user.pubkey, optimisticMessage);
+      return {
+        clientId: record.clientId,
+      };
+    },
     mutationFn: async ({ participantPubkeys, content, share }: SendDmInput) => {
       if (!user?.pubkey) {
         throw new Error('You need to log in before sending a message');
@@ -261,46 +355,26 @@ export function useDmSend() {
       await publishDmMessages(relayUrls, wraps, AbortSignal.timeout(10000));
       return { relayUrls, wraps };
     },
-    onSuccess: async ({ wraps }, variables) => {
-      const optimisticMessage = buildOptimisticDmMessage({
-        currentUserPubkey: user?.pubkey || '',
-        participantPubkeys: variables.participantPubkeys,
-        content: variables.content,
-        share: variables.share,
-        wraps,
-      });
-
-      if (user?.pubkey && optimisticMessage) {
-        const limitsToUpdate = new Set<number>([200, 300]);
-        const existingMessageQueries = queryClient.getQueriesData<DmMessage[]>({
-          queryKey: [...DM_QUERY_KEY, 'messages', user.pubkey],
-        });
-
-        for (const [queryKey] of existingMessageQueries) {
-          const maybeLimit = queryKey[3];
-          if (typeof maybeLimit === 'number') {
-            limitsToUpdate.add(maybeLimit);
-          }
-        }
-
-        const mergeOptimisticMessage = (existingMessages: DmMessage[] = []) => {
-          const nextMessages = [
-            ...existingMessages.filter((message) => message.wrapId !== optimisticMessage.wrapId),
-            optimisticMessage,
-          ];
-
-          return nextMessages.sort((a, b) => a.createdAt - b.createdAt);
-        };
-
-        for (const limit of limitsToUpdate) {
-          queryClient.setQueryData<DmMessage[]>(
-            [...DM_QUERY_KEY, 'messages', user.pubkey, limit],
-            mergeOptimisticMessage,
-          );
-        }
+    onSuccess: (_result, _variables, context) => {
+      if (!user?.pubkey || !context?.clientId) {
+        return;
       }
+
+      markDmOutboxRecordSent(user.pubkey, context.clientId);
+      updateOptimisticDmInAllCaches(queryClient, user.pubkey, context.clientId, {
+        deliveryState: 'sent',
+        errorMessage: undefined,
+      });
     },
-    onError: (error) => {
+    onError: (error, _variables, context) => {
+      if (user?.pubkey && context?.clientId) {
+        markDmOutboxRecordFailed(user.pubkey, context.clientId, error.message);
+        updateOptimisticDmInAllCaches(queryClient, user.pubkey, context.clientId, {
+          deliveryState: 'failed',
+          errorMessage: error.message,
+        });
+      }
+
       toast({
         title: 'Message failed',
         description: error instanceof Error ? error.message : 'Unable to send your message right now',

--- a/src/hooks/useDirectMessages.ts
+++ b/src/hooks/useDirectMessages.ts
@@ -18,9 +18,11 @@ import {
   type DmMessage,
   type DmSharePayload,
 } from '@/lib/dm';
+import { hydrateDmOutbox, mergeFetchedAndOutboxMessages, removeDmOutboxRecord } from '@/lib/dmOutbox';
 
 const DM_QUERY_KEY = ['dm'];
 const DM_READ_STATE_EVENT = 'dm:read-state';
+const DM_OUTBOX_STALE_AFTER_SECONDS = 60;
 
 interface SendDmInput {
   participantPubkeys: string[];
@@ -140,13 +142,22 @@ export function useDmMessages(limit = 200) {
         signal: AbortSignal.any([signal, AbortSignal.timeout(5000)]),
       });
 
-      return fetchDmMessages({
+      const fetchedMessages = await fetchDmMessages({
         signer,
         currentUserPubkey: user.pubkey,
         relayUrls,
         signal: AbortSignal.any([signal, AbortSignal.timeout(15000)]),
         limit,
       });
+
+      const hydratedOutbox = hydrateDmOutbox(user.pubkey, DM_OUTBOX_STALE_AFTER_SECONDS);
+      const { messages, reconciledClientIds } = mergeFetchedAndOutboxMessages(fetchedMessages, hydratedOutbox);
+
+      for (const clientId of reconciledClientIds) {
+        removeDmOutboxRecord(user.pubkey, clientId);
+      }
+
+      return messages;
     },
     enabled: Boolean(user?.pubkey && signer?.nip44),
     staleTime: 30_000,

--- a/src/hooks/useDirectMessages.ts
+++ b/src/hooks/useDirectMessages.ts
@@ -22,6 +22,7 @@ import {
   createDmOutboxRecord,
   hydrateDmOutbox,
   markDmOutboxRecordFailed,
+  markDmOutboxRecordSending,
   markDmOutboxRecordSent,
   mergeFetchedAndOutboxMessages,
   removeDmOutboxRecord,
@@ -33,6 +34,7 @@ const DM_READ_STATE_EVENT = 'dm:read-state';
 const DM_OUTBOX_STALE_AFTER_SECONDS = 60;
 
 interface SendDmInput {
+  clientId?: string;
   participantPubkeys: string[];
   content: string;
   share?: DmSharePayload;
@@ -302,20 +304,33 @@ export function useDmSend() {
   const { config } = useAppContext();
 
   return useMutation<{ relayUrls: string[]; wraps: Awaited<ReturnType<typeof createDmGiftWraps>> }, Error, SendDmInput, SendDmMutationContext>({
-    onMutate: ({ participantPubkeys, content, share }) => {
+    onMutate: ({ clientId, participantPubkeys, content, share }) => {
       if (!user?.pubkey) {
         return {};
       }
 
-      const record = createDmOutboxRecord({
-        ownerPubkey: user.pubkey,
-        participantPubkeys,
-        content,
-        share,
-      });
+      const record = clientId
+        ? markDmOutboxRecordSending(user.pubkey, clientId, {
+          participantPubkeys,
+          content,
+          share,
+        }) || createDmOutboxRecord({
+          ownerPubkey: user.pubkey,
+          participantPubkeys,
+          content,
+          share,
+        })
+        : createDmOutboxRecord({
+          ownerPubkey: user.pubkey,
+          participantPubkeys,
+          content,
+          share,
+        });
 
       const optimisticMessage = convertOutboxRecordToDmMessage(record);
-      upsertDmOutboxRecord(user.pubkey, record);
+      if (!clientId || record.clientId !== clientId) {
+        upsertDmOutboxRecord(user.pubkey, record);
+      }
 
       insertOptimisticDmIntoAllCaches(queryClient, user.pubkey, optimisticMessage);
       return {

--- a/src/lib/dm.ts
+++ b/src/lib/dm.ts
@@ -27,6 +27,8 @@ export interface DmSharePayload {
   vineId?: string;
 }
 
+export type DmDeliveryState = 'sending' | 'failed' | 'sent';
+
 export interface DmMessage {
   conversationId: string;
   wrapId: string;
@@ -39,6 +41,10 @@ export interface DmMessage {
   isOutgoing: boolean;
   share?: DmSharePayload;
   subject?: string;
+  clientId?: string;
+  deliveryState?: DmDeliveryState;
+  errorMessage?: string;
+  isOptimistic?: boolean;
 }
 
 export interface DmConversation {

--- a/src/lib/dmOutbox.test.ts
+++ b/src/lib/dmOutbox.test.ts
@@ -101,4 +101,20 @@ describe('dmOutbox', () => {
       }),
     ]);
   });
+
+  it('does not throw when localStorage writes fail', () => {
+    const record = createDmOutboxRecord({
+      ownerPubkey: TEST_PUBKEY,
+      participantPubkeys: [RECIPIENT_PUBKEY],
+      content: 'hello',
+    });
+
+    vi.spyOn(globalThis.localStorage, 'setItem').mockImplementation(() => {
+      throw new Error('storage blocked');
+    });
+
+    expect(() => writeDmOutbox(TEST_PUBKEY, [record])).not.toThrow();
+    expect(() => upsertDmOutboxRecord(TEST_PUBKEY, record)).not.toThrow();
+    expect(() => hydrateDmOutbox(TEST_PUBKEY, 3600)).not.toThrow();
+  });
 });

--- a/src/lib/dmOutbox.test.ts
+++ b/src/lib/dmOutbox.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  createDmOutboxRecord,
+  hydrateDmOutbox,
+  readDmOutbox,
+  upsertDmOutboxRecord,
+  writeDmOutbox,
+} from './dmOutbox';
+
+const TEST_PUBKEY = 'a'.repeat(64);
+const RECIPIENT_PUBKEY = 'b'.repeat(64);
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+
+  return {
+    getItem: (key: string) => store[key] || null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+    get length() {
+      return Object.keys(store).length;
+    },
+    key: (index: number) => Object.keys(store)[index] || null,
+  };
+})();
+
+Object.defineProperty(globalThis, 'localStorage', {
+  value: localStorageMock,
+  writable: true,
+});
+
+beforeEach(() => {
+  localStorageMock.clear();
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  localStorageMock.clear();
+});
+
+describe('dmOutbox', () => {
+  it('writes and reads outbox records per owner pubkey', () => {
+    const record = createDmOutboxRecord({
+      ownerPubkey: TEST_PUBKEY,
+      participantPubkeys: [RECIPIENT_PUBKEY],
+      content: 'hello',
+    });
+
+    writeDmOutbox(TEST_PUBKEY, [record]);
+
+    expect(readDmOutbox(TEST_PUBKEY)).toEqual([record]);
+    expect(readDmOutbox('c'.repeat(64))).toEqual([]);
+  });
+
+  it('updates an existing outbox record by clientId', () => {
+    const record = createDmOutboxRecord({
+      ownerPubkey: TEST_PUBKEY,
+      participantPubkeys: [RECIPIENT_PUBKEY],
+      content: 'hello',
+    });
+
+    const updated = {
+      ...record,
+      deliveryState: 'failed' as const,
+      errorMessage: 'boom',
+    };
+
+    writeDmOutbox(TEST_PUBKEY, [record]);
+    upsertDmOutboxRecord(TEST_PUBKEY, updated);
+
+    expect(readDmOutbox(TEST_PUBKEY)).toEqual([updated]);
+  });
+
+  it('demotes stale sending records to failed during hydration', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(3_700_000);
+
+    const stale = {
+      ...createDmOutboxRecord({
+        ownerPubkey: TEST_PUBKEY,
+        participantPubkeys: [RECIPIENT_PUBKEY],
+        content: 'hello',
+      }),
+      deliveryState: 'sending' as const,
+      lastAttemptAt: 1,
+    };
+
+    writeDmOutbox(TEST_PUBKEY, [stale]);
+
+    expect(hydrateDmOutbox(TEST_PUBKEY, 3600)).toEqual([
+      expect.objectContaining({
+        clientId: stale.clientId,
+        deliveryState: 'failed',
+      }),
+    ]);
+  });
+});

--- a/src/lib/dmOutbox.ts
+++ b/src/lib/dmOutbox.ts
@@ -178,6 +178,10 @@ export function upsertDmOutboxRecord(ownerPubkey: string, record: DmOutboxRecord
   return nextRecords;
 }
 
+export function getDmOutboxRecord(ownerPubkey: string, clientId: string): DmOutboxRecord | undefined {
+  return readDmOutbox(ownerPubkey).find((record) => record.clientId === clientId);
+}
+
 export function removeDmOutboxRecord(ownerPubkey: string, clientId: string): DmOutboxRecord[] {
   const nextRecords = readDmOutbox(ownerPubkey).filter((record) => record.clientId !== clientId);
   writeDmOutbox(ownerPubkey, nextRecords);
@@ -268,4 +272,42 @@ export function mergeFetchedAndOutboxMessages(
     messages,
     reconciledClientIds,
   };
+}
+
+export function markDmOutboxRecordSent(ownerPubkey: string, clientId: string): DmOutboxRecord | undefined {
+  const record = getDmOutboxRecord(ownerPubkey, clientId);
+  if (!record) {
+    return undefined;
+  }
+
+  const updatedRecord = {
+    ...record,
+    deliveryState: 'sent' as const,
+    errorMessage: undefined,
+    lastAttemptAt: nowInSeconds(),
+  };
+
+  upsertDmOutboxRecord(ownerPubkey, updatedRecord);
+  return updatedRecord;
+}
+
+export function markDmOutboxRecordFailed(
+  ownerPubkey: string,
+  clientId: string,
+  errorMessage: string,
+): DmOutboxRecord | undefined {
+  const record = getDmOutboxRecord(ownerPubkey, clientId);
+  if (!record) {
+    return undefined;
+  }
+
+  const updatedRecord = {
+    ...record,
+    deliveryState: 'failed' as const,
+    errorMessage,
+    lastAttemptAt: nowInSeconds(),
+  };
+
+  upsertDmOutboxRecord(ownerPubkey, updatedRecord);
+  return updatedRecord;
 }

--- a/src/lib/dmOutbox.ts
+++ b/src/lib/dmOutbox.ts
@@ -1,6 +1,7 @@
-import type { DmDeliveryState, DmSharePayload } from './dm';
+import { encodeConversationId, type DmDeliveryState, type DmMessage, type DmSharePayload } from './dm';
 
 const DM_OUTBOX_STORAGE_PREFIX = 'dm:outbox:';
+const DM_RECONCILIATION_WINDOW_SECONDS = 5;
 
 export interface DmOutboxRecord {
   clientId: string;
@@ -52,6 +53,43 @@ function normalizeRecord(record: DmOutboxRecord): DmOutboxRecord {
     ...record,
     participantPubkeys: [...new Set(record.participantPubkeys)].sort(),
   };
+}
+
+function normalizeContent(content: string): string {
+  return content.trim();
+}
+
+function normalizeSharePayload(share?: DmSharePayload): string {
+  if (!share) {
+    return '';
+  }
+
+  return JSON.stringify({
+    url: share.url,
+    title: share.title || '',
+    videoId: share.videoId || '',
+    videoPubkey: share.videoPubkey || '',
+    vineId: share.vineId || '',
+  });
+}
+
+function isReconciledDmMessage(outboxRecord: DmOutboxRecord, message: DmMessage): boolean {
+  return (
+    buildDmReconciliationFingerprint({
+      senderPubkey: outboxRecord.ownerPubkey,
+      participantPubkeys: [outboxRecord.ownerPubkey, ...outboxRecord.participantPubkeys],
+      content: outboxRecord.content,
+      share: outboxRecord.share,
+      createdAt: 0,
+    }) === buildDmReconciliationFingerprint({
+      senderPubkey: message.senderPubkey,
+      participantPubkeys: message.participantPubkeys,
+      content: message.content,
+      share: message.share,
+      createdAt: 0,
+    }) &&
+    Math.abs(outboxRecord.createdAt - message.createdAt) <= DM_RECONCILIATION_WINDOW_SECONDS
+  );
 }
 
 function isDmOutboxRecord(value: unknown): value is DmOutboxRecord {
@@ -166,4 +204,68 @@ export function hydrateDmOutbox(ownerPubkey: string, staleAfterSeconds: number):
 
   writeDmOutbox(ownerPubkey, hydrated);
   return hydrated;
+}
+
+export function buildDmReconciliationFingerprint(input: {
+  senderPubkey: string;
+  participantPubkeys: string[];
+  content: string;
+  share?: DmSharePayload;
+  createdAt: number;
+}): string {
+  return JSON.stringify({
+    senderPubkey: input.senderPubkey,
+    participantPubkeys: [...new Set(input.participantPubkeys)].sort(),
+    content: normalizeContent(input.content),
+    share: normalizeSharePayload(input.share),
+    createdAt: input.createdAt,
+  });
+}
+
+export function convertOutboxRecordToDmMessage(record: DmOutboxRecord): DmMessage {
+  const peerPubkeys = [...new Set(
+    record.participantPubkeys.filter((pubkey) => pubkey !== record.ownerPubkey),
+  )].sort();
+  const participantPubkeys = [...new Set([record.ownerPubkey, ...peerPubkeys])].sort();
+
+  return {
+    conversationId: encodeConversationId(peerPubkeys),
+    wrapId: `optimistic:${record.clientId}`,
+    rumorId: `optimistic:${record.clientId}`,
+    senderPubkey: record.ownerPubkey,
+    participantPubkeys,
+    peerPubkeys,
+    content: record.content,
+    createdAt: record.createdAt,
+    isOutgoing: true,
+    share: record.share,
+    clientId: record.clientId,
+    deliveryState: record.deliveryState,
+    errorMessage: record.errorMessage,
+    isOptimistic: true,
+  };
+}
+
+export function mergeFetchedAndOutboxMessages(
+  fetched: DmMessage[],
+  outbox: DmOutboxRecord[],
+): { messages: DmMessage[]; reconciledClientIds: string[] } {
+  const reconciledClientIds: string[] = [];
+  const optimisticMessages: DmMessage[] = [];
+
+  for (const record of outbox) {
+    if (fetched.some((message) => isReconciledDmMessage(record, message))) {
+      reconciledClientIds.push(record.clientId);
+      continue;
+    }
+
+    optimisticMessages.push(convertOutboxRecordToDmMessage(record));
+  }
+
+  const messages = [...fetched, ...optimisticMessages].sort((left, right) => left.createdAt - right.createdAt);
+
+  return {
+    messages,
+    reconciledClientIds,
+  };
 }

--- a/src/lib/dmOutbox.ts
+++ b/src/lib/dmOutbox.ts
@@ -32,11 +32,15 @@ function nowInSeconds(): number {
 }
 
 function getLocalStorage(): Storage | undefined {
-  if (typeof globalThis === 'undefined' || !('localStorage' in globalThis)) {
+  try {
+    if (typeof globalThis === 'undefined' || !('localStorage' in globalThis)) {
+      return undefined;
+    }
+
+    return globalThis.localStorage;
+  } catch {
     return undefined;
   }
-
-  return globalThis.localStorage;
 }
 
 function buildClientId(ownerPubkey: string, participantPubkeys: string[], createdAt: number): string {
@@ -162,10 +166,14 @@ export function writeDmOutbox(ownerPubkey: string, records: DmOutboxRecord[]): v
     return;
   }
 
-  storage.setItem(
-    getStorageKey(ownerPubkey),
-    JSON.stringify(records.map(normalizeRecord)),
-  );
+  try {
+    storage.setItem(
+      getStorageKey(ownerPubkey),
+      JSON.stringify(records.map(normalizeRecord)),
+    );
+  } catch {
+    // Persistence is best-effort. DM rendering should still work without storage.
+  }
 }
 
 export function upsertDmOutboxRecord(ownerPubkey: string, record: DmOutboxRecord): DmOutboxRecord[] {

--- a/src/lib/dmOutbox.ts
+++ b/src/lib/dmOutbox.ts
@@ -291,6 +291,31 @@ export function markDmOutboxRecordSent(ownerPubkey: string, clientId: string): D
   return updatedRecord;
 }
 
+export function markDmOutboxRecordSending(
+  ownerPubkey: string,
+  clientId: string,
+  input?: Pick<DmOutboxRecord, 'participantPubkeys' | 'content' | 'share'>,
+): DmOutboxRecord | undefined {
+  const record = getDmOutboxRecord(ownerPubkey, clientId);
+  if (!record) {
+    return undefined;
+  }
+
+  const updatedRecord = {
+    ...record,
+    participantPubkeys: input?.participantPubkeys || record.participantPubkeys,
+    content: input?.content ?? record.content,
+    share: input?.share ?? record.share,
+    deliveryState: 'sending' as const,
+    errorMessage: undefined,
+    lastAttemptAt: nowInSeconds(),
+    retryCount: record.retryCount + 1,
+  };
+
+  upsertDmOutboxRecord(ownerPubkey, updatedRecord);
+  return updatedRecord;
+}
+
 export function markDmOutboxRecordFailed(
   ownerPubkey: string,
   clientId: string,

--- a/src/lib/dmOutbox.ts
+++ b/src/lib/dmOutbox.ts
@@ -1,0 +1,169 @@
+import type { DmDeliveryState, DmSharePayload } from './dm';
+
+const DM_OUTBOX_STORAGE_PREFIX = 'dm:outbox:';
+
+export interface DmOutboxRecord {
+  clientId: string;
+  ownerPubkey: string;
+  participantPubkeys: string[];
+  content: string;
+  share?: DmSharePayload;
+  createdAt: number;
+  lastAttemptAt: number;
+  deliveryState: DmDeliveryState;
+  errorMessage?: string;
+  retryCount: number;
+}
+
+interface CreateDmOutboxRecordInput {
+  ownerPubkey: string;
+  participantPubkeys: string[];
+  content: string;
+  share?: DmSharePayload;
+}
+
+function getStorageKey(ownerPubkey: string): string {
+  return `${DM_OUTBOX_STORAGE_PREFIX}${ownerPubkey}`;
+}
+
+function nowInSeconds(): number {
+  return Math.round(Date.now() / 1000);
+}
+
+function getLocalStorage(): Storage | undefined {
+  if (typeof globalThis === 'undefined' || !('localStorage' in globalThis)) {
+    return undefined;
+  }
+
+  return globalThis.localStorage;
+}
+
+function buildClientId(ownerPubkey: string, participantPubkeys: string[], createdAt: number): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return `dm-${crypto.randomUUID()}`;
+  }
+
+  const randomPart = Math.random().toString(36).slice(2, 10);
+  return `dm-${ownerPubkey.slice(0, 8)}-${participantPubkeys.join('-').slice(0, 16)}-${createdAt}-${randomPart}`;
+}
+
+function normalizeRecord(record: DmOutboxRecord): DmOutboxRecord {
+  return {
+    ...record,
+    participantPubkeys: [...new Set(record.participantPubkeys)].sort(),
+  };
+}
+
+function isDmOutboxRecord(value: unknown): value is DmOutboxRecord {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const record = value as Partial<DmOutboxRecord>;
+
+  return (
+    typeof record.clientId === 'string' &&
+    typeof record.ownerPubkey === 'string' &&
+    Array.isArray(record.participantPubkeys) &&
+    record.participantPubkeys.every((pubkey) => typeof pubkey === 'string') &&
+    typeof record.content === 'string' &&
+    typeof record.createdAt === 'number' &&
+    typeof record.lastAttemptAt === 'number' &&
+    (record.deliveryState === 'sending' || record.deliveryState === 'failed' || record.deliveryState === 'sent') &&
+    typeof record.retryCount === 'number'
+  );
+}
+
+export function createDmOutboxRecord(input: CreateDmOutboxRecordInput): DmOutboxRecord {
+  const createdAt = nowInSeconds();
+  const participantPubkeys = [...new Set(input.participantPubkeys)].sort();
+
+  return {
+    clientId: buildClientId(input.ownerPubkey, participantPubkeys, createdAt),
+    ownerPubkey: input.ownerPubkey,
+    participantPubkeys,
+    content: input.content,
+    share: input.share,
+    createdAt,
+    lastAttemptAt: createdAt,
+    deliveryState: 'sending',
+    retryCount: 0,
+  };
+}
+
+export function readDmOutbox(ownerPubkey?: string): DmOutboxRecord[] {
+  if (!ownerPubkey) {
+    return [];
+  }
+
+  const storage = getLocalStorage();
+  if (!storage) {
+    return [];
+  }
+
+  const serialized = storage.getItem(getStorageKey(ownerPubkey));
+  if (!serialized) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(serialized) as unknown;
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed.filter(isDmOutboxRecord).map(normalizeRecord);
+  } catch {
+    return [];
+  }
+}
+
+export function writeDmOutbox(ownerPubkey: string, records: DmOutboxRecord[]): void {
+  const storage = getLocalStorage();
+  if (!storage) {
+    return;
+  }
+
+  storage.setItem(
+    getStorageKey(ownerPubkey),
+    JSON.stringify(records.map(normalizeRecord)),
+  );
+}
+
+export function upsertDmOutboxRecord(ownerPubkey: string, record: DmOutboxRecord): DmOutboxRecord[] {
+  const records = readDmOutbox(ownerPubkey);
+  const nextRecords = records.some((existing) => existing.clientId === record.clientId)
+    ? records.map((existing) => (existing.clientId === record.clientId ? normalizeRecord(record) : existing))
+    : [...records, normalizeRecord(record)];
+
+  writeDmOutbox(ownerPubkey, nextRecords);
+  return nextRecords;
+}
+
+export function removeDmOutboxRecord(ownerPubkey: string, clientId: string): DmOutboxRecord[] {
+  const nextRecords = readDmOutbox(ownerPubkey).filter((record) => record.clientId !== clientId);
+  writeDmOutbox(ownerPubkey, nextRecords);
+  return nextRecords;
+}
+
+export function hydrateDmOutbox(ownerPubkey: string, staleAfterSeconds: number): DmOutboxRecord[] {
+  const now = nowInSeconds();
+  const hydrated = readDmOutbox(ownerPubkey).map((record) => {
+    if (record.deliveryState !== 'sending') {
+      return record;
+    }
+
+    if ((now - record.lastAttemptAt) <= staleAfterSeconds) {
+      return record;
+    }
+
+    return {
+      ...record,
+      deliveryState: 'failed' as const,
+      errorMessage: record.errorMessage || 'Send timed out',
+    };
+  });
+
+  writeDmOutbox(ownerPubkey, hydrated);
+  return hydrated;
+}

--- a/src/pages/ConversationPage.test.tsx
+++ b/src/pages/ConversationPage.test.tsx
@@ -1,0 +1,163 @@
+import userEvent from '@testing-library/user-event';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { DmMessage } from '@/lib/dm';
+import { encodeConversationId } from '@/lib/dm';
+import ConversationPage from './ConversationPage';
+
+const RECIPIENT_PUBKEY = 'b'.repeat(64);
+const CONVERSATION_ID = encodeConversationId([RECIPIENT_PUBKEY]);
+
+const {
+  directMessageState,
+  mockNavigate,
+  mockMarkConversationRead,
+  mockSendMutate,
+  mockSendMutateAsync,
+} = vi.hoisted(() => ({
+  directMessageState: {
+    messages: [] as DmMessage[],
+    latestMessageAt: 0,
+    lastReadAt: 0,
+    isLoading: false,
+    isPending: false,
+    share: null as null,
+  },
+  mockNavigate: vi.fn(),
+  mockMarkConversationRead: vi.fn(),
+  mockSendMutate: vi.fn(),
+  mockSendMutateAsync: vi.fn(),
+}));
+
+vi.mock('@/hooks/useDirectMessages', () => ({
+  useDmCapability: () => ({ canUseDirectMessages: true }),
+  useDmConversation: () => ({
+    data: directMessageState.messages,
+    isLoading: directMessageState.isLoading,
+    latestMessageAt: directMessageState.latestMessageAt,
+    lastReadAt: directMessageState.lastReadAt,
+    markConversationRead: mockMarkConversationRead,
+  }),
+  useDmSend: () => ({
+    mutate: mockSendMutate,
+    mutateAsync: mockSendMutateAsync,
+    isPending: directMessageState.isPending,
+  }),
+  useParsedDmShare: () => directMessageState.share,
+}));
+
+vi.mock('@/hooks/useBatchedAuthors', () => ({
+  useBatchedAuthors: () => ({
+    data: {
+      [RECIPIENT_PUBKEY]: {
+        metadata: {
+          display_name: 'Inbox Friend',
+          name: 'inboxfriend',
+          picture: 'https://example.com/friend.png',
+        },
+      },
+    },
+  }),
+}));
+
+vi.mock('@/hooks/useSubdomainNavigate', () => ({
+  useSubdomainNavigate: () => mockNavigate,
+}));
+
+function buildMessage(overrides: Partial<DmMessage> = {}): DmMessage {
+  return {
+    conversationId: CONVERSATION_ID,
+    wrapId: 'wrap-1',
+    rumorId: 'rumor-1',
+    senderPubkey: 'a'.repeat(64),
+    participantPubkeys: ['a'.repeat(64), RECIPIENT_PUBKEY],
+    peerPubkeys: [RECIPIENT_PUBKEY],
+    content: 'hello',
+    createdAt: 1_234_567_890,
+    isOutgoing: true,
+    ...overrides,
+  };
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={[`/messages/${CONVERSATION_ID}`]}>
+      <Routes>
+        <Route path="/messages/:conversationId" element={<ConversationPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('ConversationPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    directMessageState.messages = [];
+    directMessageState.latestMessageAt = 0;
+    directMessageState.lastReadAt = 0;
+    directMessageState.isLoading = false;
+    directMessageState.isPending = false;
+    directMessageState.share = null;
+    mockSendMutate.mockImplementation(() => undefined);
+    mockSendMutateAsync.mockImplementation(() => new Promise<void>(() => undefined));
+  });
+
+  it('clears the composer immediately after send is triggered', async () => {
+    const user = userEvent.setup();
+
+    renderPage();
+
+    const composer = screen.getByRole('textbox');
+
+    await user.type(composer, 'hello');
+    await user.keyboard('{Enter}');
+
+    await waitFor(() => expect(mockSendMutate).toHaveBeenCalledWith({
+      participantPubkeys: [RECIPIENT_PUBKEY],
+      content: 'hello',
+      share: undefined,
+    }));
+    expect(composer).toHaveValue('');
+  });
+
+  it('renders a sending indicator for optimistic messages', () => {
+    directMessageState.messages = [
+      buildMessage({
+        clientId: 'local-1',
+        deliveryState: 'sending',
+        isOptimistic: true,
+      }),
+    ];
+
+    renderPage();
+
+    expect(screen.getByText(/sending/i)).toBeInTheDocument();
+  });
+
+  it('renders retry for failed optimistic messages', async () => {
+    const user = userEvent.setup();
+
+    directMessageState.messages = [
+      buildMessage({
+        clientId: 'local-1',
+        content: 'hello again',
+        deliveryState: 'failed',
+        errorMessage: 'signal has been aborted',
+        isOptimistic: true,
+      }),
+    ];
+
+    renderPage();
+
+    await user.click(screen.getByRole('button', { name: /retry/i }));
+
+    expect(mockSendMutate).toHaveBeenCalledWith({
+      clientId: 'local-1',
+      participantPubkeys: [RECIPIENT_PUBKEY],
+      content: 'hello again',
+      share: undefined,
+    });
+  });
+});

--- a/src/pages/ConversationPage.tsx
+++ b/src/pages/ConversationPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { ArrowLeft, ArrowUp, Link2, Loader2, X } from 'lucide-react';
+import { ArrowLeft, ArrowUp, Link2, X } from 'lucide-react';
 import { Link, useLocation, useParams } from 'react-router-dom';
 
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
@@ -33,7 +33,13 @@ function getDisplayName(pubkey: string, metadata?: { display_name?: string; name
   return metadata?.display_name || metadata?.name || genUserName(pubkey);
 }
 
-function MessageBubble({ message }: { message: DmMessage }) {
+function MessageBubble({
+  message,
+  onRetry,
+}: {
+  message: DmMessage;
+  onRetry?: (message: DmMessage) => void;
+}) {
   const videoPath = message.share?.vineId || message.share?.videoId
     ? `/video/${message.share.vineId || message.share.videoId}`
     : undefined;
@@ -102,13 +108,33 @@ function MessageBubble({ message }: { message: DmMessage }) {
 
         <div
           className={cn(
-            'mt-2 text-[11px]',
+            'mt-2 flex items-center gap-2 text-[11px]',
             message.isOutgoing
               ? 'text-primary-foreground/70'
               : 'text-muted-foreground',
           )}
         >
-          {formatRelativeTime(message.createdAt)}
+          <span>{formatRelativeTime(message.createdAt)}</span>
+          {message.deliveryState === 'sending' && <span>Sending...</span>}
+          {message.deliveryState === 'failed' && (
+            <>
+              <span>Failed to send</span>
+              {message.clientId && onRetry && (
+                <button
+                  type="button"
+                  className={cn(
+                    'rounded-full border px-2 py-0.5 text-[11px] font-semibold transition-colors',
+                    message.isOutgoing
+                      ? 'border-primary-foreground/30 text-primary-foreground hover:bg-primary-foreground/10'
+                      : 'border-border text-foreground hover:bg-muted',
+                  )}
+                  onClick={() => onRetry(message)}
+                >
+                  Retry
+                </button>
+              )}
+            </>
+          )}
         </div>
       </div>
     </div>
@@ -167,33 +193,43 @@ export function ConversationPage() {
 
   const sharelessPath = conversationId ? getDmConversationPath(peerPubkeys) : '/messages';
 
-  const handleSend = async () => {
+  const handleSend = () => {
     const trimmedDraft = draft.trim();
     if (!peerPubkeys.length || (!trimmedDraft && !share)) {
       return;
     }
 
-    try {
-      await sendMessage.mutateAsync({
-        participantPubkeys: peerPubkeys,
-        content: trimmedDraft,
-        share,
-      });
+    const content = trimmedDraft;
+    setDraft('');
 
-      setDraft('');
+    sendMessage.mutate({
+      participantPubkeys: peerPubkeys,
+      content,
+      share: share ?? undefined,
+    });
 
-      if (share) {
-        navigate(sharelessPath, { replace: true });
-      }
-    } catch {
-      // Mutation error state and toast are handled by the hook.
+    if (share) {
+      navigate(sharelessPath, { replace: true });
     }
   };
 
-  const handleComposerKeyDown = async (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+  const handleRetry = (message: DmMessage) => {
+    if (!message.clientId) {
+      return;
+    }
+
+    sendMessage.mutate({
+      clientId: message.clientId,
+      participantPubkeys: message.peerPubkeys,
+      content: message.content,
+      share: message.share,
+    });
+  };
+
+  const handleComposerKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (event.key === 'Enter' && !event.shiftKey) {
       event.preventDefault();
-      await handleSend();
+      handleSend();
     }
   };
 
@@ -283,7 +319,11 @@ export function ConversationPage() {
               )}
 
               {messages.map((message) => (
-                <MessageBubble key={message.wrapId} message={message} />
+                <MessageBubble
+                  key={message.clientId || message.wrapId}
+                  message={message}
+                  onRetry={handleRetry}
+                />
               ))}
             </div>
 
@@ -321,13 +361,9 @@ export function ConversationPage() {
                 <Button
                   className="h-12 w-12 rounded-full"
                   onClick={handleSend}
-                  disabled={sendMessage.isPending || (!draft.trim() && !share)}
+                  disabled={!draft.trim() && !share}
                 >
-                  {sendMessage.isPending ? (
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                  ) : (
-                    <ArrowUp className="h-4 w-4" />
-                  )}
+                  <ArrowUp className="h-4 w-4" />
                 </Button>
               </div>
             </div>

--- a/src/pages/MessagesPage.test.tsx
+++ b/src/pages/MessagesPage.test.tsx
@@ -26,7 +26,7 @@ const { mockNavigate, mockConversations, mockAuthorMap } = vi.hoisted(() => ({
         isOutgoing: false,
       },
     },
-  ] satisfies DmConversation[],
+  ] as DmConversation[],
   mockAuthorMap: {
     ['78a5c21b5166dc1474b64ddf7454bf79e6b5d6b4a77148593bf1e866b73c2738']: {
       metadata: {
@@ -71,6 +71,18 @@ function renderPage() {
 
 describe('MessagesPage', () => {
   beforeEach(async () => {
+    mockConversations[0].lastMessage = {
+      conversationId: 'conversation-1',
+      wrapId: 'wrap-1',
+      rumorId: 'rumor-1',
+      senderPubkey: 'b'.repeat(64),
+      participantPubkeys: ['b'.repeat(64)],
+      peerPubkeys: ['b'.repeat(64)],
+      content: 'Hello from the inbox',
+      createdAt: 1_700_000_000,
+      isOutgoing: false,
+    };
+
     const storage = new Map<string, string>();
 
     Object.defineProperty(window, 'localStorage', {
@@ -103,5 +115,33 @@ describe('MessagesPage', () => {
     expect(headerSection).not.toBeNull();
     expect(screen.getByText(/divine support/i)).toBeInTheDocument();
     expect(within(headerSection as HTMLElement).queryByText(/divine support/i)).not.toBeInTheDocument();
+  });
+
+  it('shows sending state in the conversation preview for optimistic last messages', () => {
+    mockConversations[0].lastMessage = {
+      ...mockConversations[0].lastMessage,
+      content: 'Sending this now',
+      isOutgoing: true,
+      deliveryState: 'sending',
+      isOptimistic: true,
+    } as DmConversation['lastMessage'];
+
+    renderPage();
+
+    expect(screen.getByText(/sending\.\.\. sending this now/i)).toBeInTheDocument();
+  });
+
+  it('shows failed state in the conversation preview for failed last messages', () => {
+    mockConversations[0].lastMessage = {
+      ...mockConversations[0].lastMessage,
+      content: 'This one failed',
+      isOutgoing: true,
+      deliveryState: 'failed',
+      isOptimistic: true,
+    } as DmConversation['lastMessage'];
+
+    renderPage();
+
+    expect(screen.getByText(/failed to send: this one failed/i)).toBeInTheDocument();
   });
 });

--- a/src/pages/MessagesPage.tsx
+++ b/src/pages/MessagesPage.tsx
@@ -30,6 +30,20 @@ function getDisplayName(pubkey: string, metadata?: { display_name?: string; name
   return metadata?.display_name || metadata?.name || genUserName(pubkey);
 }
 
+function getConversationPreview(message: DmConversation['lastMessage']): string {
+  const preview = getDmMessagePreview(message);
+
+  if (message.deliveryState === 'sending') {
+    return `Sending... ${preview}`;
+  }
+
+  if (message.deliveryState === 'failed') {
+    return `Failed to send: ${preview}`;
+  }
+
+  return preview;
+}
+
 function ConversationSkeleton() {
   return (
     <div className="rounded-[28px] border border-border/80 bg-card/70 p-4 backdrop-blur-sm">
@@ -94,7 +108,7 @@ function ConversationRow({ conversation, names, pictures, onClick }: Conversatio
 
           <div className="mt-2 flex items-center gap-3">
             <p className="min-w-0 flex-1 truncate text-sm text-muted-foreground">
-              {getDmMessagePreview(conversation.lastMessage)}
+              {getConversationPreview(conversation.lastMessage)}
             </p>
             {conversation.unreadCount > 0 && (
               <span className="inline-flex min-w-6 items-center justify-center rounded-full bg-primary px-2 py-1 text-[11px] font-semibold text-primary-foreground">


### PR DESCRIPTION
## Summary
- add a durable local DM outbox that persists optimistic send intent, merges outbox entries into DM queries, and reconciles them against fetched messages
- make conversation sends fire-and-forget with immediate composer clearing, sending/failed states, and retry that reuses the same optimistic row
- polish inbox previews for pending and failed outgoing DMs, and include the implementation spec/plan docs used for the work

## Test Plan
- [x] `npx vitest run src/lib/dmOutbox.test.ts src/hooks/useDirectMessages.test.ts src/pages/ConversationPage.test.tsx`
- [x] `npx vitest run src/pages/MessagesPage.test.tsx`
- [x] `npm run test`
