### PR TITLE
feat: route staging funnelcake api host

### DIFF
--- a/compute-js/fastly.toml
+++ b/compute-js/fastly.toml
@@ -35,6 +35,13 @@ service_id = "WfOrPTFYmwwxRvqrfralLA"
   override_host = "relay.divine.video"
   use_ssl = true
 
+[[backends]]
+  name = "funnelcake_staging"
+  address = "relay.staging.divine.video"
+  port = 443
+  override_host = "relay.staging.divine.video"
+  use_ssl = true
+
 [setup]
 
   [setup.kv_stores]

--- a/compute-js/src/funnelcakeOrigin.js
+++ b/compute-js/src/funnelcakeOrigin.js
@@ -1,0 +1,30 @@
+const PRODUCTION_TARGET = {
+  apiHost: 'api.divine.video',
+  origin: 'https://relay.divine.video',
+  hostHeader: 'relay.divine.video',
+  backend: 'funnelcake',
+};
+
+const STAGING_TARGET = {
+  apiHost: 'api.staging.divine.video',
+  origin: 'https://relay.staging.divine.video',
+  hostHeader: 'relay.staging.divine.video',
+  backend: 'funnelcake_staging',
+};
+
+const TARGETS_BY_HOST = new Map([
+  ['api.divine.video', PRODUCTION_TARGET],
+  ['divine.video', PRODUCTION_TARGET],
+  ['www.divine.video', PRODUCTION_TARGET],
+  ['dvine.video', PRODUCTION_TARGET],
+  ['api.staging.divine.video', STAGING_TARGET],
+  ['staging.divine.video', STAGING_TARGET],
+]);
+
+export function getFunnelcakeOriginForApiHost(host = '') {
+  return TARGETS_BY_HOST.get(host) ?? PRODUCTION_TARGET;
+}
+
+export function buildFunnelcakeUrl(target, path) {
+  return new URL(path, target.origin).toString();
+}

--- a/compute-js/src/funnelcakeOrigin.test.ts
+++ b/compute-js/src/funnelcakeOrigin.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { getFunnelcakeOriginForApiHost } from './funnelcakeOrigin.js';
+
+describe('getFunnelcakeOriginForApiHost', () => {
+  it('maps the production API host to the production relay origin', () => {
+    expect(getFunnelcakeOriginForApiHost('api.divine.video')).toEqual({
+      apiHost: 'api.divine.video',
+      origin: 'https://relay.divine.video',
+      hostHeader: 'relay.divine.video',
+      backend: 'funnelcake',
+    });
+  });
+
+  it('maps the staging API host to the staging relay origin', () => {
+    expect(getFunnelcakeOriginForApiHost('api.staging.divine.video')).toEqual({
+      apiHost: 'api.staging.divine.video',
+      origin: 'https://relay.staging.divine.video',
+      hostHeader: 'relay.staging.divine.video',
+      backend: 'funnelcake_staging',
+    });
+  });
+
+  it('falls back to the production relay for unknown hosts', () => {
+    expect(getFunnelcakeOriginForApiHost('example.com')).toEqual({
+      apiHost: 'api.divine.video',
+      origin: 'https://relay.divine.video',
+      hostHeader: 'relay.divine.video',
+      backend: 'funnelcake',
+    });
+  });
+});

--- a/compute-js/src/index.js
+++ b/compute-js/src/index.js
@@ -7,12 +7,9 @@ import { KVStore } from 'fastly:kv-store';
 import { SecretStore } from 'fastly:secret-store';
 import { PublisherServer } from '@fastly/compute-js-static-publish';
 import rc from '../static-publish.rc.js';
+import { buildFunnelcakeUrl, getFunnelcakeOriginForApiHost } from './funnelcakeOrigin.js';
 
 const publisherServer = PublisherServer.fromStaticPublishRc(rc);
-
-// Funnelcake API URL — edge worker calls origin directly (not via api.divine.video cache
-// to avoid Fastly→Fastly loops). Client-side code uses api.divine.video for caching.
-const FUNNELCAKE_API_URL = 'https://relay.divine.video';
 const DEFAULT_OG_IMAGE = 'https://divine.video/og.png';
 const DEFAULT_SITE_DESCRIPTION = 'Watch and share 6-second looping videos on the decentralized Nostr network.';
 
@@ -41,6 +38,7 @@ async function handleRequest(event) {
   // Check for original host passed by divine-router
   const originalHost = request.headers.get('X-Original-Host');
   const hostnameToUse = originalHost || url.hostname;
+  const funnelcakeTarget = getFunnelcakeOriginForApiHost(hostnameToUse);
 
   console.log('Request hostname:', url.hostname, 'original:', originalHost, 'path:', url.pathname);
 
@@ -156,7 +154,7 @@ async function handleRequest(event) {
       const videoId = url.pathname.split('/video/')[1]?.split('?')[0];
       console.log('Video ID:', videoId);
       if (videoId) {
-        const ogResponse = await handleVideoOgTags(request, videoId, url);
+        const ogResponse = await handleVideoOgTags(request, videoId, url, funnelcakeTarget);
         if (ogResponse) {
           return ogResponse;
         }
@@ -165,14 +163,14 @@ async function handleRequest(event) {
     }
 
     if (url.pathname.startsWith('/profile/')) {
-      const ogResponse = await handleProfileOgTags(request, url);
+      const ogResponse = await handleProfileOgTags(request, url, funnelcakeTarget);
       if (ogResponse) {
         return ogResponse;
       }
     }
 
     if (url.pathname === '/category' || url.pathname.startsWith('/category/')) {
-      const ogResponse = await handleCategoryOgTags(request, url);
+      const ogResponse = await handleCategoryOgTags(request, url, funnelcakeTarget);
       if (ogResponse) {
         return ogResponse;
       }
@@ -201,14 +199,9 @@ async function handleRequest(event) {
   // 7b. Proxy RSS feed requests to the relay backend (serves application/rss+xml)
   if (url.pathname.startsWith('/feed/') || url.pathname === '/feed') {
     console.log('Proxying RSS feed request to relay:', url.pathname);
-    const feedUrl = `${FUNNELCAKE_API_URL}${url.pathname}${url.search}`;
-    return fetch(feedUrl, {
-      backend: 'funnelcake',
+    return fetchFromFunnelcake(funnelcakeTarget, `${url.pathname}${url.search}`, {
       method: request.method,
-      headers: {
-        'Accept': request.headers.get('Accept') || '*/*',
-        'Host': 'relay.divine.video',
-      },
+      accept: request.headers.get('Accept') || '*/*',
     });
   }
 
@@ -230,7 +223,7 @@ async function handleRequest(event) {
       try {
         let html = await response.text();
         const feedType = discoveryFeedType || 'trending';
-        const feedData = await fetchFeedData(feedType);
+        const feedData = await fetchFeedData(feedType, funnelcakeTarget);
         if (feedData) {
           let injection = `<script>window.__DIVINE_FEED__=${JSON.stringify(feedData)};window.__DIVINE_FEED_TYPE__="${feedType}";</script>`;
           const firstVideo = feedData.videos?.[0] || feedData[0];
@@ -285,12 +278,28 @@ function getFeedApiUrl(feedType) {
   }
 }
 
+function fetchFromFunnelcake(target, path, options = {}) {
+  const {
+    method = 'GET',
+    accept = 'application/json',
+  } = options;
+
+  return fetch(buildFunnelcakeUrl(target, path), {
+    backend: target.backend,
+    method,
+    headers: {
+      'Accept': accept,
+      'Host': target.hostHeader,
+    },
+  });
+}
+
 /**
  * Fetch feed data with KV cache (stale-while-revalidate pattern).
  * Returns cached data if fresh (<60s), otherwise fetches from Funnelcake API
  * and updates the cache for the next request.
  */
-async function fetchFeedData(feedType = 'trending') {
+async function fetchFeedData(feedType = 'trending', funnelcakeTarget = getFunnelcakeOriginForApiHost()) {
   const CACHE_KEY = `cache:feed:${feedType}`;
   const CACHE_TTL_SECONDS = 60;
 
@@ -316,14 +325,7 @@ async function fetchFeedData(feedType = 'trending') {
   let feedData = null;
   try {
     const apiPath = getFeedApiUrl(feedType);
-    const resp = await fetch(`https://relay.divine.video${apiPath}`, {
-      backend: 'funnelcake',
-      method: 'GET',
-      headers: {
-        'Accept': 'application/json',
-        'Host': 'relay.divine.video',
-      },
-    });
+    const resp = await fetchFromFunnelcake(funnelcakeTarget, apiPath);
     if (resp.ok) {
       feedData = await resp.json();
       // 3. Update KV cache (fire and forget)
@@ -666,6 +668,7 @@ async function handleSubdomainProfile(subdomain, url, request, originalHostname)
 
   // Use original hostname if provided (from divine-router), otherwise use url.hostname
   const hostnameToUse = originalHostname || url.hostname;
+  const funnelcakeTarget = getFunnelcakeOriginForApiHost(hostnameToUse);
 
   if (isAsset) {
     // Serve static assets normally via publisherServer
@@ -696,14 +699,7 @@ async function handleSubdomainProfile(subdomain, url, request, originalHostname)
   // Try to fetch user profile from Funnelcake for richer data
   let profileData = null;
   try {
-    const profileResponse = await fetch(`https://relay.divine.video/api/users/${userData.pubkey}`, {
-      backend: 'funnelcake',
-      method: 'GET',
-      headers: {
-        'Accept': 'application/json',
-        'Host': 'relay.divine.video',
-      },
-    });
+    const profileResponse = await fetchFromFunnelcake(funnelcakeTarget, `/api/users/${userData.pubkey}`);
     if (profileResponse.ok) {
       profileData = await profileResponse.json();
     }
@@ -981,17 +977,10 @@ function isSocialMediaCrawler(request) {
 /**
  * Fetch video metadata from Funnelcake API using Fastly backend
  */
-async function fetchVideoMetadata(videoId) {
+async function fetchVideoMetadata(videoId, funnelcakeTarget = getFunnelcakeOriginForApiHost()) {
   try {
     // Use the /api/videos/{id} endpoint
-    const response = await fetch(`https://relay.divine.video/api/videos/${videoId}`, {
-      backend: 'funnelcake',
-      method: 'GET',
-      headers: {
-        'Accept': 'application/json',
-        'Host': 'relay.divine.video',
-      },
-    });
+    const response = await fetchFromFunnelcake(funnelcakeTarget, `/api/videos/${videoId}`);
 
     if (!response.ok) {
       console.log('Funnelcake API returned:', response.status);
@@ -1064,16 +1053,9 @@ async function fetchVideoMetadata(videoId) {
   }
 }
 
-async function fetchProfileMetadata(pubkey) {
+async function fetchProfileMetadata(pubkey, funnelcakeTarget = getFunnelcakeOriginForApiHost()) {
   try {
-    const response = await fetch(`${FUNNELCAKE_API_URL}/api/users/${pubkey}`, {
-      backend: 'funnelcake',
-      method: 'GET',
-      headers: {
-        'Accept': 'application/json',
-        'Host': 'relay.divine.video',
-      },
-    });
+    const response = await fetchFromFunnelcake(funnelcakeTarget, `/api/users/${pubkey}`);
 
     if (!response.ok) {
       console.log('Profile API returned:', response.status);
@@ -1087,16 +1069,9 @@ async function fetchProfileMetadata(pubkey) {
   }
 }
 
-async function fetchCategoriesMetadata() {
+async function fetchCategoriesMetadata(funnelcakeTarget = getFunnelcakeOriginForApiHost()) {
   try {
-    const response = await fetch(`${FUNNELCAKE_API_URL}/api/categories`, {
-      backend: 'funnelcake',
-      method: 'GET',
-      headers: {
-        'Accept': 'application/json',
-        'Host': 'relay.divine.video',
-      },
-    });
+    const response = await fetchFromFunnelcake(funnelcakeTarget, '/api/categories');
 
     if (!response.ok) {
       console.log('Categories API returned:', response.status);
@@ -1152,12 +1127,12 @@ function buildCrawlerHtml({
  * Handle video page requests for social media crawlers
  * Injects dynamic OG meta tags with video-specific content
  */
-async function handleVideoOgTags(request, videoId, url) {
+async function handleVideoOgTags(request, videoId, url, funnelcakeTarget) {
   try {
     // Fetch video metadata from Funnelcake
     let videoMeta = null;
     try {
-      videoMeta = await fetchVideoMetadata(videoId);
+      videoMeta = await fetchVideoMetadata(videoId, funnelcakeTarget);
     } catch (e) {
       console.error('Failed to fetch video metadata:', e.message);
     }
@@ -1197,7 +1172,7 @@ async function handleVideoOgTags(request, videoId, url) {
   }
 }
 
-async function handleProfileOgTags(request, url) {
+async function handleProfileOgTags(request, url, funnelcakeTarget) {
   try {
     const npub = url.pathname.split('/profile/')[1]?.split('?')[0];
     const pubkey = decodeNpubToHex(npub || '');
@@ -1205,7 +1180,7 @@ async function handleProfileOgTags(request, url) {
       return null;
     }
 
-    const profileMeta = await fetchProfileMetadata(pubkey);
+    const profileMeta = await fetchProfileMetadata(pubkey, funnelcakeTarget);
     const profile = profileMeta?.profile || {};
     const stats = profileMeta?.stats || {};
     const displayName = cleanText(profile.display_name) || cleanText(profile.name) || 'Profile on Divine';
@@ -1240,7 +1215,7 @@ async function handleProfileOgTags(request, url) {
   }
 }
 
-async function handleCategoryOgTags(request, url) {
+async function handleCategoryOgTags(request, url, funnelcakeTarget) {
   try {
     const categoryName = url.pathname === '/category'
       ? null
@@ -1251,7 +1226,7 @@ async function handleCategoryOgTags(request, url) {
     let categoryUrl = 'https://divine.video/category';
 
     if (categoryName) {
-      const categories = await fetchCategoriesMetadata();
+      const categories = await fetchCategoriesMetadata(funnelcakeTarget);
       const matchedCategory = categories?.find(category => category.name.toLowerCase() === categoryName.toLowerCase()) || null;
       const label = humanizeCategoryName(categoryName);
       title = `${label} Videos - Divine`;

--- a/docs/superpowers/plans/2026-04-15-api-staging-funnelcake-host.md
+++ b/docs/superpowers/plans/2026-04-15-api-staging-funnelcake-host.md
@@ -1,0 +1,98 @@
+# API Staging Funnelcake Host Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Route `api.staging.divine.video` to `relay.staging.divine.video` while keeping `api.divine.video` on `relay.divine.video`.
+
+**Architecture:** Introduce explicit host mapping helpers instead of production-only string literals. Use the compute helper for proxied Funnelcake reads and update the client relay helper so staging relay URLs resolve to the staging API host.
+
+**Tech Stack:** JavaScript, TypeScript, Fastly Compute, Vitest, Vite
+
+---
+
+## Chunk 1: Lock The Mappings With Tests
+
+### Task 1: Add compute host mapping tests
+
+**Files:**
+- Create: `compute-js/src/funnelcakeOrigin.test.ts`
+- Create: `compute-js/src/funnelcakeOrigin.js`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+it('maps the staging API host to the staging relay origin', () => {
+  expect(getFunnelcakeOriginForApiHost('api.staging.divine.video')).toEqual({
+    apiHost: 'api.staging.divine.video',
+    origin: 'https://relay.staging.divine.video',
+    hostHeader: 'relay.staging.divine.video',
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run compute-js/src/funnelcakeOrigin.test.ts`
+Expected: FAIL because the helper does not exist yet.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create a small pure helper that maps known API hosts to origin URL and Host header values, defaulting unknown hosts to production.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run compute-js/src/funnelcakeOrigin.test.ts`
+Expected: PASS
+
+### Task 2: Add relay helper tests
+
+**Files:**
+- Create: `src/config/relays.test.ts`
+- Modify: `src/config/relays.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+it('maps the staging Divine relay to the staging API host', () => {
+  expect(getFunnelcakeUrl('wss://relay.staging.divine.video')).toBe('https://api.staging.divine.video');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/config/relays.test.ts`
+Expected: FAIL because staging is not recognized yet.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Extend the Divine Funnelcake host allowlist and rewrite logic for the staging host pair without changing non-Divine behavior.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/config/relays.test.ts`
+Expected: PASS
+
+## Chunk 2: Wire The Compute Service To The Helper
+
+### Task 3: Replace compute hard-coding
+
+**Files:**
+- Modify: `compute-js/src/index.js`
+- Modify: `compute-js/src/funnelcakeOrigin.js`
+
+- [ ] **Step 1: Import the helper into the compute entrypoint**
+- [ ] **Step 2: Use the effective request host to resolve the correct Funnelcake origin**
+- [ ] **Step 3: Replace direct `relay.divine.video` fetch URLs and `Host` headers in each REST proxy path**
+- [ ] **Step 4: Run `npx vitest run compute-js/src/funnelcakeOrigin.test.ts src/config/relays.test.ts`**
+
+## Chunk 3: Verify End To End
+
+### Task 4: Final verification
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-04-15-api-staging-funnelcake-host-design.md`
+- Modify: `docs/superpowers/plans/2026-04-15-api-staging-funnelcake-host.md`
+
+- [ ] **Step 1: Review docs for accuracy after implementation**
+- [ ] **Step 2: Run `npm test`**
+- [ ] **Step 3: Review `git diff --stat` and `git status --short`**

--- a/docs/superpowers/plans/2026-04-16-funnelcake-dev-selector.md
+++ b/docs/superpowers/plans/2026-04-16-funnelcake-dev-selector.md
@@ -1,0 +1,95 @@
+# Funnelcake Developer Selector Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a small in-app debug control that lets developers switch Funnelcake REST reads between Auto, Production, and Staging.
+
+**Architecture:** Centralize Funnelcake base URL resolution in API config and surface a small selector in the existing moderation debug panel. Persist the mode in `localStorage` and invalidate REST-backed queries when it changes.
+
+**Tech Stack:** TypeScript, React, React Query, Vitest, Testing Library
+
+---
+
+## Chunk 1: Lock Resolver Behavior With Tests
+
+### Task 1: Add API resolver tests
+
+**Files:**
+- Create: `src/config/api.test.ts`
+- Modify: `src/config/api.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+it('uses the staging API in auto mode on staging.divine.video', () => {
+  expect(resolveFunnelcakeBaseUrl({ hostname: 'staging.divine.video', mode: 'auto' })).toBe('https://api.staging.divine.video');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/config/api.test.ts`
+Expected: FAIL because the resolver does not exist yet.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add a small mode enum, `localStorage` helpers, and a resolver for the effective base URL.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/config/api.test.ts`
+Expected: PASS
+
+## Chunk 2: Add The Debug Selector
+
+### Task 2: Add moderation debug control tests
+
+**Files:**
+- Create: `src/pages/ModerationSettingsPage.test.tsx`
+- Modify: `src/pages/ModerationSettingsPage.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+it('lets the developer switch Funnelcake API mode to staging from the debug panel', async () => {
+  // render page, open debug panel, change selector, assert localStorage and visible effective URL
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/pages/ModerationSettingsPage.test.tsx`
+Expected: FAIL because the selector is not rendered yet.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add the selector to the existing debug panel and invalidate React Query caches after mode changes.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/pages/ModerationSettingsPage.test.tsx`
+Expected: PASS
+
+## Chunk 3: Wire The App To The Resolver
+
+### Task 3: Replace direct base URL reads
+
+**Files:**
+- Modify: `src/config/api.ts`
+- Modify: Funnelcake consumer files that currently read `API_CONFIG.funnelcake.baseUrl`
+
+- [ ] **Step 1: Replace direct base URL reads with the resolver-backed value**
+- [ ] **Step 2: Keep non-Funnelcake API config unchanged**
+- [ ] **Step 3: Run `npx vitest run src/config/api.test.ts src/pages/ModerationSettingsPage.test.tsx src/config/relays.test.ts`**
+
+## Chunk 4: Final Verification
+
+### Task 4: Verify and finalize
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-04-16-funnelcake-dev-selector-design.md`
+- Modify: `docs/superpowers/plans/2026-04-16-funnelcake-dev-selector.md`
+
+- [ ] **Step 1: Review docs for accuracy after implementation**
+- [ ] **Step 2: Run `npm test`**
+- [ ] **Step 3: Review `git status --short` and update the existing PR branch**

--- a/docs/superpowers/specs/2026-04-15-api-staging-funnelcake-host-design.md
+++ b/docs/superpowers/specs/2026-04-15-api-staging-funnelcake-host-design.md
@@ -1,0 +1,40 @@
+# API Staging Funnelcake Host Design
+
+## Goal
+
+Allow the Fastly-cached Funnelcake API to serve both `api.divine.video` and `api.staging.divine.video`, with each hostname proxying to the matching relay origin.
+
+## Scope
+
+- Add explicit API host to Funnelcake origin mapping for the Fastly compute service.
+- Extend the web relay helper so staging relay URLs resolve to the staging API hostname.
+- Add tests that lock the production and staging mappings in place.
+
+## Design
+
+### Host Mapping
+
+Use an explicit mapping instead of hard-coded production-only strings:
+
+- `api.divine.video` -> `https://relay.divine.video`
+- `api.staging.divine.video` -> `https://relay.staging.divine.video`
+
+Unknown hosts should fall back to the production origin so existing behavior stays stable.
+
+### Compute Service
+
+The compute service already derives an effective request host from `X-Original-Host` or `url.hostname`. Reuse that host value to choose the correct Funnelcake origin for every proxied REST read, including feed injection, OG metadata lookups, and user/category fetches.
+
+The Fastly backend stays named `funnelcake`; only the request URL and `Host` header need to change per incoming API hostname.
+
+### Web Client
+
+The relay helper in `src/config/relays.ts` should keep treating Divine relay hosts as Funnelcake-capable, and should additionally rewrite `wss://relay.staging.divine.video` to `https://api.staging.divine.video`.
+
+This keeps staging aligned with the production behavior without requiring each caller to special-case the host pair.
+
+## Testing
+
+- Add a compute-focused unit test for the API host to origin mapping helper.
+- Add a relay helper test covering production, staging, and non-Divine relays.
+- Run the targeted tests first, then the full repo verification command before finishing.

--- a/docs/superpowers/specs/2026-04-16-funnelcake-dev-selector-design.md
+++ b/docs/superpowers/specs/2026-04-16-funnelcake-dev-selector-design.md
@@ -1,0 +1,57 @@
+# Funnelcake Developer Selector Design
+
+## Goal
+
+Give developers a small in-app debug control that switches Funnelcake REST reads between automatic hostname-based routing, forced production, and forced staging.
+
+## Scope
+
+- Add a resolver for the effective Funnelcake API base URL.
+- Persist a developer-selected mode in `localStorage`.
+- Expose a compact selector in the existing moderation debug panel.
+- Invalidate relevant React Query caches when the mode changes so subsequent REST reads use the new host.
+
+## Design
+
+### Modes
+
+The selector will support three modes:
+
+- `auto`: follow the app hostname
+- `production`: always use `https://api.divine.video`
+- `staging`: always use `https://api.staging.divine.video`
+
+`auto` resolves as:
+
+- `staging.divine.video` -> `https://api.staging.divine.video`
+- all other hostnames -> `https://api.divine.video`
+
+### Resolver
+
+Move Funnelcake base URL selection behind a small resolver in `src/config/api.ts`. Code that currently reads `API_CONFIG.funnelcake.baseUrl` should instead read the resolved value so the same logic applies everywhere.
+
+The effective base URL should be chosen in this order:
+
+1. Developer override mode from `localStorage`
+2. Hostname-based `auto` mode
+3. Environment fallback only when needed for nonstandard deployments
+
+### UI Placement
+
+Use the existing debug panel on the moderation settings page. It already has a “Show Debug Info” control, so adding the developer selector there avoids exposing new settings to normal users.
+
+The panel should show:
+
+- current mode
+- effective Funnelcake base URL
+- a short note that changing the selector affects future REST reads
+
+### Cache Behavior
+
+When the mode changes, invalidate common Funnelcake-backed queries so the next fetch reflects the new base URL. The invalidation should be broad enough to refresh search/profile/feed REST reads without requiring a full page reload.
+
+## Testing
+
+- Add resolver tests for all three modes and hostname behaviors.
+- Add a moderation settings page test covering the debug selector and persistence.
+- Run targeted tests first, then the full `npm test` suite.

--- a/src/components/HashtagExplorer.tsx
+++ b/src/components/HashtagExplorer.tsx
@@ -10,8 +10,8 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Hash, Search, Play, Loader2 } from 'lucide-react';
+import { getFunnelcakeBaseUrl } from '@/config/api';
 import { fetchPopularHashtags } from '@/lib/funnelcakeClient';
-import { DEFAULT_FUNNELCAKE_URL } from '@/config/relays';
 
 interface HashtagStats {
   tag: string;
@@ -32,7 +32,7 @@ function useHashtagStats() {
         AbortSignal.timeout(10000),
       ]);
 
-      const hashtags = await fetchPopularHashtags(DEFAULT_FUNNELCAKE_URL, 100, signal);
+      const hashtags = await fetchPopularHashtags(getFunnelcakeBaseUrl(), 100, signal);
 
       // Transform to HashtagStats format with rank
       const stats: HashtagStats[] = hashtags.map((h, index) => ({

--- a/src/config/api.test.ts
+++ b/src/config/api.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  clearFunnelcakeApiModeOverride,
+  getFunnelcakeApiModeOverride,
+  resolveFunnelcakeBaseUrl,
+  setFunnelcakeApiModeOverride,
+} from './api';
+
+function installLocalStorageMock() {
+  const store = new Map<string, string>();
+
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        store.set(key, value);
+      },
+      removeItem: (key: string) => {
+        store.delete(key);
+      },
+      clear: () => {
+        store.clear();
+      },
+    },
+  });
+}
+
+describe('resolveFunnelcakeBaseUrl', () => {
+  it('uses the staging API in auto mode on staging.divine.video', () => {
+    expect(resolveFunnelcakeBaseUrl({
+      hostname: 'staging.divine.video',
+      mode: 'auto',
+    })).toBe('https://api.staging.divine.video');
+  });
+
+  it('uses the production API in auto mode on divine.video', () => {
+    expect(resolveFunnelcakeBaseUrl({
+      hostname: 'divine.video',
+      mode: 'auto',
+    })).toBe('https://api.divine.video');
+  });
+
+  it('uses the environment fallback for unknown hosts in auto mode', () => {
+    expect(resolveFunnelcakeBaseUrl({
+      hostname: 'localhost',
+      mode: 'auto',
+      envBaseUrl: 'https://api.preview.divine.video',
+    })).toBe('https://api.preview.divine.video');
+  });
+
+  it('forces the production API when production mode is selected', () => {
+    expect(resolveFunnelcakeBaseUrl({
+      hostname: 'staging.divine.video',
+      mode: 'production',
+    })).toBe('https://api.divine.video');
+  });
+
+  it('forces the staging API when staging mode is selected', () => {
+    expect(resolveFunnelcakeBaseUrl({
+      hostname: 'divine.video',
+      mode: 'staging',
+    })).toBe('https://api.staging.divine.video');
+  });
+});
+
+describe('Funnelcake API mode override storage', () => {
+  beforeEach(() => {
+    installLocalStorageMock();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  it('defaults to auto when no override is stored', () => {
+    expect(getFunnelcakeApiModeOverride()).toBe('auto');
+  });
+
+  it('persists the selected override mode', () => {
+    setFunnelcakeApiModeOverride('staging');
+
+    expect(getFunnelcakeApiModeOverride()).toBe('staging');
+  });
+
+  it('clears the override back to auto', () => {
+    setFunnelcakeApiModeOverride('production');
+
+    clearFunnelcakeApiModeOverride();
+
+    expect(getFunnelcakeApiModeOverride()).toBe('auto');
+  });
+});

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -1,6 +1,101 @@
 // ABOUTME: API configuration for external services
 // ABOUTME: Centralized settings for Funnelcake and other REST APIs
 
+export const FUNNELCAKE_PRODUCTION_API_URL = 'https://api.divine.video';
+export const FUNNELCAKE_STAGING_API_URL = 'https://api.staging.divine.video';
+export const FUNNELCAKE_API_MODE_OVERRIDE_KEY = 'divine_dev_funnelcake_api_mode';
+
+export type FunnelcakeApiMode = 'auto' | 'production' | 'staging';
+
+interface ResolveFunnelcakeBaseUrlOptions {
+  mode?: FunnelcakeApiMode;
+  hostname?: string;
+  envBaseUrl?: string;
+}
+
+function getCurrentHostname(): string {
+  if (typeof window === 'undefined') {
+    return '';
+  }
+
+  return window.location.hostname;
+}
+
+function getSafeLocalStorage(): Pick<Storage, 'getItem' | 'setItem' | 'removeItem'> | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const storage = window.localStorage;
+  if (!storage) {
+    return null;
+  }
+
+  return (
+    typeof storage.getItem === 'function'
+    && typeof storage.setItem === 'function'
+    && typeof storage.removeItem === 'function'
+  )
+    ? storage
+    : null;
+}
+
+function resolveAutoFunnelcakeBaseUrl(hostname: string, envBaseUrl?: string): string {
+  if (hostname === 'staging.divine.video' || hostname.endsWith('.staging.divine.video')) {
+    return FUNNELCAKE_STAGING_API_URL;
+  }
+
+  if (envBaseUrl && hostname !== 'divine.video' && hostname !== 'www.divine.video') {
+    return envBaseUrl;
+  }
+
+  return FUNNELCAKE_PRODUCTION_API_URL;
+}
+
+export function resolveFunnelcakeBaseUrl(options: ResolveFunnelcakeBaseUrlOptions = {}): string {
+  const mode = options.mode ?? 'auto';
+  const hostname = options.hostname ?? getCurrentHostname();
+  const envBaseUrl = options.envBaseUrl;
+
+  switch (mode) {
+    case 'production':
+      return FUNNELCAKE_PRODUCTION_API_URL;
+    case 'staging':
+      return FUNNELCAKE_STAGING_API_URL;
+    case 'auto':
+    default:
+      return resolveAutoFunnelcakeBaseUrl(hostname, envBaseUrl);
+  }
+}
+
+export function getFunnelcakeApiModeOverride(): FunnelcakeApiMode {
+  const storage = getSafeLocalStorage();
+  const stored = storage?.getItem(FUNNELCAKE_API_MODE_OVERRIDE_KEY);
+  if (stored === 'production' || stored === 'staging' || stored === 'auto') {
+    return stored;
+  }
+
+  return 'auto';
+}
+
+export function setFunnelcakeApiModeOverride(mode: FunnelcakeApiMode): void {
+  const storage = getSafeLocalStorage();
+  storage?.setItem(FUNNELCAKE_API_MODE_OVERRIDE_KEY, mode);
+}
+
+export function clearFunnelcakeApiModeOverride(): void {
+  const storage = getSafeLocalStorage();
+  storage?.removeItem(FUNNELCAKE_API_MODE_OVERRIDE_KEY);
+}
+
+export function getFunnelcakeBaseUrl(): string {
+  return resolveFunnelcakeBaseUrl({
+    mode: getFunnelcakeApiModeOverride(),
+    hostname: getCurrentHostname(),
+    envBaseUrl: import.meta.env.VITE_FUNNELCAKE_API_URL,
+  });
+}
+
 /**
  * API configuration for Funnelcake REST endpoints
  *
@@ -10,7 +105,9 @@
  */
 export const API_CONFIG = {
   funnelcake: {
-    baseUrl: import.meta.env.VITE_FUNNELCAKE_API_URL || 'https://api.divine.video',
+    get baseUrl() {
+      return getFunnelcakeBaseUrl();
+    },
     // Request timeout in milliseconds (profile API should be fast)
     timeout: 5000,
     // Endpoints

--- a/src/config/relays.test.ts
+++ b/src/config/relays.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { getFunnelcakeUrl, hasFunnelcake } from './relays';
+
+describe('hasFunnelcake', () => {
+  it('recognizes the production Divine relay', () => {
+    expect(hasFunnelcake('wss://relay.divine.video')).toBe(true);
+  });
+
+  it('recognizes the staging Divine relay', () => {
+    expect(hasFunnelcake('wss://relay.staging.divine.video')).toBe(true);
+  });
+
+  it('rejects non-Divine relays', () => {
+    expect(hasFunnelcake('wss://relay.damus.io')).toBe(false);
+  });
+});
+
+describe('getFunnelcakeUrl', () => {
+  it('maps the production Divine relay to the production API host', () => {
+    expect(getFunnelcakeUrl('wss://relay.divine.video')).toBe('https://api.divine.video');
+  });
+
+  it('maps the staging Divine relay to the staging API host', () => {
+    expect(getFunnelcakeUrl('wss://relay.staging.divine.video')).toBe('https://api.staging.divine.video');
+  });
+
+  it('returns null for non-Divine relays', () => {
+    expect(getFunnelcakeUrl('wss://relay.damus.io')).toBeNull();
+  });
+});

--- a/src/config/relays.ts
+++ b/src/config/relays.ts
@@ -224,7 +224,13 @@ export const toLegacyFormat = (relays: RelayConfig[]): { url: string; name: stri
  */
 const DIVINE_FUNNELCAKE_HOSTS = [
   'relay.divine.video',
+  'relay.staging.divine.video',
 ];
+
+const DIVINE_FUNNELCAKE_API_HOSTS: Record<string, string> = {
+  'relay.divine.video': 'api.divine.video',
+  'relay.staging.divine.video': 'api.staging.divine.video',
+};
 
 /**
  * Check if a relay URL supports the Funnelcake REST API
@@ -248,11 +254,14 @@ export function getFunnelcakeUrl(relayUrl: string): string | null {
   if (!hasFunnelcake(relayUrl)) {
     return null;
   }
-  // Route REST API calls through the Fastly-cached api.divine.video endpoint
-  return relayUrl
-    .replace('wss://relay.divine.video', 'https://api.divine.video')
-    .replace('wss://', 'https://')
-    .replace('ws://', 'http://');
+  const parsed = new URL(relayUrl.replace('wss://', 'https://').replace('ws://', 'http://'));
+  const apiHost = DIVINE_FUNNELCAKE_API_HOSTS[parsed.hostname];
+
+  if (!apiHost) {
+    return null;
+  }
+
+  return `https://${apiHost}`;
 }
 
 /**

--- a/src/hooks/useCategories.ts
+++ b/src/hooks/useCategories.ts
@@ -2,8 +2,8 @@
 // ABOUTME: Merges API data (video counts) with static icon config
 
 import { useQuery } from '@tanstack/react-query';
+import { getFunnelcakeBaseUrl } from '@/config/api';
 import { fetchCategories } from '@/lib/funnelcakeClient';
-import { DEFAULT_FUNNELCAKE_URL } from '@/config/relays';
 import { getCategoryConfig } from '@/lib/constants/categories';
 import type { FunnelcakeCategory } from '@/types/funnelcake';
 import type { CategoryConfig } from '@/lib/constants/categories';
@@ -16,7 +16,7 @@ export function useCategories() {
   return useQuery<CategoryWithConfig[]>({
     queryKey: ['categories'],
     queryFn: async ({ signal }) => {
-      const categories = await fetchCategories(DEFAULT_FUNNELCAKE_URL, signal);
+      const categories = await fetchCategories(getFunnelcakeBaseUrl(), signal);
       // Only show categories with enough videos to be meaningful
       const MIN_VIDEO_COUNT = 5;
       return categories

--- a/src/hooks/useFunnelcakeProfile.ts
+++ b/src/hooks/useFunnelcakeProfile.ts
@@ -3,8 +3,7 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { type FunnelcakeProfile } from '@/lib/funnelcakeClient';
-import { DEFAULT_FUNNELCAKE_URL } from '@/config/relays';
-import { API_CONFIG } from '@/config/api';
+import { API_CONFIG, getFunnelcakeBaseUrl } from '@/config/api';
 import { debugLog } from '@/lib/debug';
 
 interface UseFunnelcakeProfileResult {
@@ -29,7 +28,7 @@ export function useFunnelcakeProfile(
       if (!pubkey) return null;
 
       const endpoint = API_CONFIG.funnelcake.endpoints.userProfile.replace('{pubkey}', pubkey);
-      const url = `${DEFAULT_FUNNELCAKE_URL}${endpoint}`;
+      const url = `${getFunnelcakeBaseUrl()}${endpoint}`;
 
       debugLog(`[useFunnelcakeProfile] Fetching: ${url}`);
 

--- a/src/hooks/useInfiniteVideosFunnelcake.ts
+++ b/src/hooks/useInfiniteVideosFunnelcake.ts
@@ -3,6 +3,7 @@
 
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { useState } from 'react';
+import { getFunnelcakeBaseUrl } from '@/config/api';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
 import type { ParsedVideoData } from '@/types/video';
 import type { FunnelcakeFetchOptions } from '@/types/funnelcake';
@@ -10,7 +11,6 @@ import { fetchVideos, searchVideos, fetchUserVideos, fetchUserFeed, fetchRecomme
 import { transformToVideoPage } from '@/lib/funnelcakeTransform';
 import { debugLog } from '@/lib/debug';
 import { performanceMonitor } from '@/lib/performanceMonitoring';
-import { DEFAULT_FUNNELCAKE_URL } from '@/config/relays';
 
 export type FunnelcakeFeedType = 'trending' | 'recent' | 'classics' | 'hashtag' | 'profile' | 'home' | 'recommendations' | 'category';
 export type FunnelcakeSortMode = 'trending' | 'recent' | 'loops' | 'engagement' | 'classic';
@@ -145,8 +145,8 @@ export function useInfiniteVideosFunnelcake({
   // - Classics always use Divine's Funnelcake
   // - Other feeds use provided apiUrl or default
   const effectiveApiUrl = feedType === 'classics'
-    ? DEFAULT_FUNNELCAKE_URL
-    : (apiUrl || DEFAULT_FUNNELCAKE_URL);
+    ? getFunnelcakeBaseUrl()
+    : (apiUrl || getFunnelcakeBaseUrl());
 
   return useInfiniteQuery<FunnelcakeVideoPage, Error>({
     queryKey: ['funnelcake-videos', feedType, effectiveApiUrl, sortMode, hashtag, category, pubkey, pageSize, randomStartOffset],

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -2,9 +2,9 @@
 // ABOUTME: Provides infinite scroll, unread count polling, and mark-as-read
 
 import { useInfiniteQuery, useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { getFunnelcakeBaseUrl } from '@/config/api';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { fetchNotifications, fetchUnreadCount, markNotificationsRead } from '@/lib/funnelcakeClient';
-import { DEFAULT_FUNNELCAKE_URL } from '@/config/relays';
 import { debugLog } from '@/lib/debug';
 import type { NotificationsResponse } from '@/types/notification';
 
@@ -17,7 +17,7 @@ const NOTIFICATIONS_PAGE_SIZE = 30;
 export function useNotifications() {
   const { user, signer } = useCurrentUser();
   const pubkey = user?.pubkey;
-  const apiUrl = DEFAULT_FUNNELCAKE_URL;
+  const apiUrl = getFunnelcakeBaseUrl();
 
   return useInfiniteQuery<NotificationsResponse, Error>({
     queryKey: ['notifications', pubkey],
@@ -58,7 +58,7 @@ export function useNotifications() {
 export function useUnreadNotificationCount() {
   const { user, signer } = useCurrentUser();
   const pubkey = user?.pubkey;
-  const apiUrl = DEFAULT_FUNNELCAKE_URL;
+  const apiUrl = getFunnelcakeBaseUrl();
 
   return useQuery<number, Error>({
     queryKey: ['notifications-unread-count', pubkey],
@@ -86,7 +86,7 @@ export function useUnreadNotificationCount() {
 export function useMarkNotificationsRead() {
   const { user, signer } = useCurrentUser();
   const pubkey = user?.pubkey;
-  const apiUrl = DEFAULT_FUNNELCAKE_URL;
+  const apiUrl = getFunnelcakeBaseUrl();
   const queryClient = useQueryClient();
 
   return useMutation({

--- a/src/hooks/useSearchHashtags.ts
+++ b/src/hooks/useSearchHashtags.ts
@@ -3,8 +3,8 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { useState, useEffect } from 'react';
+import { getFunnelcakeBaseUrl } from '@/config/api';
 import { fetchTrendingHashtags } from '@/lib/funnelcakeClient';
-import { DEFAULT_FUNNELCAKE_URL } from '@/config/relays';
 
 interface UseSearchHashtagsOptions {
   query: string;
@@ -76,7 +76,7 @@ export function useSearchHashtags(options: UseSearchHashtagsOptions) {
 
       const fetchStartedAt = performance.now();
       const hashtags = await fetchTrendingHashtags(
-        DEFAULT_FUNNELCAKE_URL,
+        getFunnelcakeBaseUrl(),
         100,
         signal,
       );

--- a/src/hooks/useVideoByIdFunnelcake.ts
+++ b/src/hooks/useVideoByIdFunnelcake.ts
@@ -2,9 +2,10 @@
 // ABOUTME: Provides fast video lookup for VideoPage with profile and hashtag context support
 
 import { useQuery } from '@tanstack/react-query';
+import { getFunnelcakeBaseUrl } from '@/config/api';
 import { fetchVideoById, fetchUserVideos, searchVideos } from '@/lib/funnelcakeClient';
 import { transformFunnelcakeVideo } from '@/lib/funnelcakeTransform';
-import { getFunnelcakeUrl, DEFAULT_FUNNELCAKE_URL } from '@/config/relays';
+import { getFunnelcakeUrl } from '@/config/relays';
 import { useAppContext } from '@/hooks/useAppContext';
 import { debugLog } from '@/lib/debug';
 import type { ParsedVideoData } from '@/types/video';
@@ -47,7 +48,7 @@ export function useVideoByIdFunnelcake(options: UseVideoByIdOptions): UseVideoBy
   const windowOffset = getNavigationWindowOffset(currentIndex);
 
   // Determine API URL from current relay
-  const funnelcakeUrl = getFunnelcakeUrl(config.relayUrl) || DEFAULT_FUNNELCAKE_URL;
+  const funnelcakeUrl = getFunnelcakeUrl(config.relayUrl) || getFunnelcakeBaseUrl();
 
   // If we have a pubkey, fetch all their videos for navigation context
   const userVideosQuery = useQuery({

--- a/src/hooks/useVideoProvider.ts
+++ b/src/hooks/useVideoProvider.ts
@@ -2,10 +2,11 @@
 // ABOUTME: Uses an explicit support matrix so unsupported feeds never collapse into generic queries
 
 import { useAppContext } from '@/hooks/useAppContext';
+import { getFunnelcakeBaseUrl } from '@/config/api';
 import { useInfiniteVideos } from '@/hooks/useInfiniteVideos';
 import { useResolvedRelayCapabilities } from '@/hooks/useRelayCapabilities';
 import { useInfiniteVideosFunnelcake, type FunnelcakeFeedType, type FunnelcakeSortMode } from '@/hooks/useInfiniteVideosFunnelcake';
-import { hasFunnelcake, getFunnelcakeUrl, DEFAULT_FUNNELCAKE_URL } from '@/config/relays';
+import { hasFunnelcake, getFunnelcakeUrl } from '@/config/relays';
 import { debugLog } from '@/lib/debug';
 import type { RelayCapabilities } from '@/lib/relayCapabilities';
 import type { SortMode } from '@/types/nostr';
@@ -162,7 +163,7 @@ export function chooseVideoDataSource({
   const websocketSupported = websocketFeedType
     ? canServeFeedViaWebsocket(feedType, sortMode, relayCapabilities)
     : false;
-  const apiUrl = relayFunnelcakeUrl || DEFAULT_FUNNELCAKE_URL;
+  const apiUrl = relayFunnelcakeUrl || getFunnelcakeBaseUrl();
 
   // Feed reads prefer Funnelcake REST. Keep a websocket route available as a
   // recovery path for feeds the selected relay can still serve directly.
@@ -285,7 +286,7 @@ export function useFunnelcakeSupport(): {
   const { config } = useAppContext();
   const relayUrl = config.relayUrl;
 
-  const funnelcakeUrl = getFunnelcakeUrl(relayUrl) || DEFAULT_FUNNELCAKE_URL;
+  const funnelcakeUrl = getFunnelcakeUrl(relayUrl) || getFunnelcakeBaseUrl();
   const supported = true;
   const enabled = true;
 

--- a/src/hooks/useVideoSocialMetrics.ts
+++ b/src/hooks/useVideoSocialMetrics.ts
@@ -4,8 +4,9 @@
 import { UserInteractions, SHORT_VIDEO_KIND } from '@/types/video';
 import { useQuery } from '@tanstack/react-query';
 import { useNostr } from '@nostrify/react';
+import { getFunnelcakeBaseUrl } from '@/config/api';
 import { useAppContext } from '@/hooks/useAppContext';
-import { DEFAULT_FUNNELCAKE_URL, getFunnelcakeUrl, hasFunnelcake } from '@/config/relays';
+import { getFunnelcakeUrl, hasFunnelcake } from '@/config/relays';
 import { fetchVideoStats } from '@/lib/funnelcakeClient';
 import { isFunnelcakeAvailable } from '@/lib/funnelcakeHealth';
 import { debugLog } from '@/lib/debug';
@@ -44,8 +45,8 @@ export function useVideoSocialMetrics(
 ) {
   const { config } = useAppContext();
   const apiUrl = hasFunnelcake(config.relayUrl)
-    ? (getFunnelcakeUrl(config.relayUrl) || DEFAULT_FUNNELCAKE_URL)
-    : DEFAULT_FUNNELCAKE_URL;
+    ? (getFunnelcakeUrl(config.relayUrl) || getFunnelcakeBaseUrl())
+    : getFunnelcakeBaseUrl();
 
   return useQuery({
     queryKey: ['video-social-metrics', videoId, videoPubkey, vineId],

--- a/src/lib/feedUrls.ts
+++ b/src/lib/feedUrls.ts
@@ -1,15 +1,13 @@
 // ABOUTME: RSS feed URL builders for all feed types
 // ABOUTME: Centralized feed URL generation using API_CONFIG base URL
 
-import { API_CONFIG } from '@/config/api';
-
-const base = API_CONFIG.funnelcake.baseUrl;
+import { getFunnelcakeBaseUrl } from '@/config/api';
 
 export const feedUrls = {
-  latest: () => `${base}/feed/latest`,
-  trending: () => `${base}/feed/trending`,
-  userVideos: (npub: string) => `${base}/feed/${npub}/videos`,
-  userFeed: (npub: string) => `${base}/feed/${npub}/feed`,
-  hashtag: (tag: string) => `${base}/feed/tag/${encodeURIComponent(tag)}`,
-  category: (name: string) => `${base}/feed/category/${encodeURIComponent(name)}`,
+  latest: () => `${getFunnelcakeBaseUrl()}/feed/latest`,
+  trending: () => `${getFunnelcakeBaseUrl()}/feed/trending`,
+  userVideos: (npub: string) => `${getFunnelcakeBaseUrl()}/feed/${npub}/videos`,
+  userFeed: (npub: string) => `${getFunnelcakeBaseUrl()}/feed/${npub}/feed`,
+  hashtag: (tag: string) => `${getFunnelcakeBaseUrl()}/feed/tag/${encodeURIComponent(tag)}`,
+  category: (name: string) => `${getFunnelcakeBaseUrl()}/feed/category/${encodeURIComponent(name)}`,
 };

--- a/src/pages/LeaderboardPage.tsx
+++ b/src/pages/LeaderboardPage.tsx
@@ -6,11 +6,11 @@ import { Link } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { useSeoMeta } from '@unhead/react';
 import { Trophy, Video, User, Clock, Calendar, CalendarDays, CalendarRange, Infinity as InfinityIcon } from 'lucide-react';
+import { getFunnelcakeBaseUrl } from '@/config/api';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Skeleton } from '@/components/ui/skeleton';
-import { DEFAULT_FUNNELCAKE_URL } from '@/config/relays';
 import { nip19 } from 'nostr-tools';
 
 type TimePeriod = 'alltime' | 'day' | 'week' | 'month' | 'year';
@@ -140,7 +140,7 @@ function VideoLeaderboard({ period }: { period: TimePeriod }) {
       });
 
       const response = await fetch(
-        `${DEFAULT_FUNNELCAKE_URL}/api/leaderboard/videos?${params}`,
+        `${getFunnelcakeBaseUrl()}/api/leaderboard/videos?${params}`,
         { signal }
       );
 
@@ -161,7 +161,7 @@ function VideoLeaderboard({ period }: { period: TimePeriod }) {
       if (pubkeysNeedingNames.length > 0) {
         try {
           const profilesResponse = await fetch(
-            `${DEFAULT_FUNNELCAKE_URL}/api/users/bulk`,
+            `${getFunnelcakeBaseUrl()}/api/users/bulk`,
             {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
@@ -281,7 +281,7 @@ function CreatorLeaderboard({ period }: { period: TimePeriod }) {
       });
 
       const response = await fetch(
-        `${DEFAULT_FUNNELCAKE_URL}/api/leaderboard/creators?${params}`,
+        `${getFunnelcakeBaseUrl()}/api/leaderboard/creators?${params}`,
         { signal }
       );
 

--- a/src/pages/ModerationSettingsPage.test.tsx
+++ b/src/pages/ModerationSettingsPage.test.tsx
@@ -1,0 +1,185 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ButtonHTMLAttributes, HTMLAttributes, InputHTMLAttributes, ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ModerationSettingsPage from './ModerationSettingsPage';
+
+const {
+  mockToast,
+  mockNostrQuery,
+  mockInvalidateQueries,
+} = vi.hoisted(() => ({
+  mockToast: vi.fn(),
+  mockNostrQuery: vi.fn(),
+  mockInvalidateQueries: vi.fn(),
+}));
+
+vi.mock('@/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({
+    user: { pubkey: 'f'.repeat(64) },
+  }),
+}));
+
+vi.mock('@/hooks/useModeration', () => ({
+  useMuteList: () => ({
+    data: [],
+    isLoading: false,
+  }),
+  useMuteItem: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
+  useUnmuteItem: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
+  useReportHistory: () => ({
+    data: [],
+  }),
+}));
+
+vi.mock('@/hooks/useAuthor', () => ({
+  useAuthor: () => ({
+    data: {
+      metadata: {
+        name: 'alice',
+      },
+    },
+  }),
+}));
+
+vi.mock('@/hooks/useToast', () => ({
+  useToast: () => ({
+    toast: mockToast,
+  }),
+}));
+
+vi.mock('@nostrify/react', () => ({
+  useNostr: () => ({
+    nostr: {
+      query: mockNostrQuery,
+    },
+  }),
+}));
+
+vi.mock('@/components/ui/card', () => ({
+  Card: ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+  CardContent: ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+  CardHeader: ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+  CardTitle: ({ children, ...props }: HTMLAttributes<HTMLHeadingElement>) => <h2 {...props}>{children}</h2>,
+  CardDescription: ({ children, ...props }: HTMLAttributes<HTMLParagraphElement>) => <p {...props}>{children}</p>,
+}));
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) => <button {...props}>{children}</button>,
+}));
+
+vi.mock('@/components/ui/input', () => ({
+  Input: (props: InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+}));
+
+vi.mock('@/components/ui/label', () => ({
+  Label: ({ children, ...props }: HTMLAttributes<HTMLLabelElement>) => <label {...props}>{children}</label>,
+}));
+
+vi.mock('@/components/ui/tabs', () => ({
+  Tabs: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  TabsList: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  TabsTrigger: ({ children, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) => <button {...props}>{children}</button>,
+  TabsContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/components/ui/select', () => ({
+  Select: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SelectTrigger: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SelectValue: () => null,
+  SelectContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SelectItem: ({ children }: { children: ReactNode; value: string }) => <div>{children}</div>,
+}));
+
+vi.mock('@/components/ui/badge', () => ({
+  Badge: ({ children, ...props }: HTMLAttributes<HTMLSpanElement>) => <span {...props}>{children}</span>,
+}));
+
+vi.mock('@/components/ui/skeleton', () => ({
+  Skeleton: (props: HTMLAttributes<HTMLDivElement>) => <div {...props} />,
+}));
+
+vi.mock('@/components/ui/avatar', () => ({
+  Avatar: ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+  AvatarImage: (props: HTMLAttributes<HTMLImageElement>) => <img {...props} />,
+  AvatarFallback: ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+}));
+
+vi.mock('@tanstack/react-query', async () => {
+  const actual = await vi.importActual<typeof import('@tanstack/react-query')>('@tanstack/react-query');
+  return {
+    ...actual,
+    useQueryClient: () => ({
+      invalidateQueries: mockInvalidateQueries,
+    }),
+  };
+});
+
+function installLocalStorageMock() {
+  const store = new Map<string, string>();
+
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        store.set(key, value);
+      },
+      removeItem: (key: string) => {
+        store.delete(key);
+      },
+      clear: () => {
+        store.clear();
+      },
+    },
+  });
+}
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ModerationSettingsPage />
+    </QueryClientProvider>,
+  );
+}
+
+describe('ModerationSettingsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    installLocalStorageMock();
+    localStorage.clear();
+    mockNostrQuery.mockResolvedValue([]);
+  });
+
+  it('lets the developer switch Funnelcake API mode to staging from the debug panel', async () => {
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: /show debug info/i }));
+
+    fireEvent.change(screen.getByRole('combobox', { name: /funnelcake api/i }), {
+      target: { value: 'staging' },
+    });
+
+    await waitFor(() => {
+      expect(localStorage.getItem('divine_dev_funnelcake_api_mode')).toBe('staging');
+    });
+
+    expect(screen.getByText('https://api.staging.divine.video')).toBeInTheDocument();
+    expect(mockInvalidateQueries).toHaveBeenCalled();
+  });
+});

--- a/src/pages/ModerationSettingsPage.tsx
+++ b/src/pages/ModerationSettingsPage.tsx
@@ -1,6 +1,7 @@
 // ABOUTME: Settings page for content moderation
 // ABOUTME: Manage mute lists, view report history, and configure filtering
 
+import { useQueryClient } from '@tanstack/react-query';
 import { useState, useEffect } from 'react';
 import { useMuteList, useMuteItem, useUnmuteItem, useReportHistory } from '@/hooks/useModeration';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
@@ -29,6 +30,13 @@ import { useToast } from '@/hooks/useToast';
 import { MuteType, REPORT_REASON_LABELS } from '@/types/moderation';
 import { genUserName } from '@/lib/genUserName';
 import { getSafeProfileImage } from '@/lib/imageUtils';
+import {
+  getFunnelcakeApiModeOverride,
+  resolveFunnelcakeBaseUrl,
+  setFunnelcakeApiModeOverride,
+  type FunnelcakeApiMode,
+} from '@/config/api';
+import { resetAllFunnelcakeCircuits } from '@/lib/funnelcakeHealth';
 import { formatDistanceToNow } from 'date-fns';
 import { nip19 } from 'nostr-tools';
 import type { NostrEvent } from '@nostrify/nostrify';
@@ -73,6 +81,7 @@ function MutedUserItem({ pubkey, reason, onUnmute }: {
 export default function ModerationSettingsPage() {
   const { user } = useCurrentUser();
   const { nostr } = useNostr();
+  const queryClient = useQueryClient();
   const { toast } = useToast();
   const { data: muteList = [], isLoading: muteListLoading } = useMuteList();
   const { data: reportHistory = [] } = useReportHistory();
@@ -84,10 +93,16 @@ export default function ModerationSettingsPage() {
   const [muteReason, setMuteReason] = useState('');
   const [showDebug, setShowDebug] = useState(false);
   const [rawMuteEvent, setRawMuteEvent] = useState<NostrEvent | null>(null);
+  const [funnelcakeApiMode, setFunnelcakeApiMode] = useState<FunnelcakeApiMode>(() => getFunnelcakeApiModeOverride());
 
   const mutedUsers = muteList.filter(item => item.type === MuteType.USER);
   const mutedHashtags = muteList.filter(item => item.type === MuteType.HASHTAG);
   const mutedKeywords = muteList.filter(item => item.type === MuteType.KEYWORD);
+  const effectiveFunnelcakeBaseUrl = resolveFunnelcakeBaseUrl({
+    mode: funnelcakeApiMode,
+    hostname: window.location.hostname,
+    envBaseUrl: import.meta.env.VITE_FUNNELCAKE_API_URL,
+  });
 
   // Debug: Log state
   console.log('[ModerationSettingsPage] Render state:', {
@@ -126,6 +141,21 @@ export default function ModerationSettingsPage() {
 
     fetchRawEvent();
   }, [user, showDebug, nostr, muteList.length]); // Re-fetch when mute list changes
+
+  const handleFunnelcakeApiModeChange = async (nextMode: FunnelcakeApiMode) => {
+    setFunnelcakeApiModeOverride(nextMode);
+    setFunnelcakeApiMode(nextMode);
+    resetAllFunnelcakeCircuits();
+    await queryClient.invalidateQueries();
+    toast({
+      title: 'Funnelcake API updated',
+      description: `Using ${resolveFunnelcakeBaseUrl({
+        mode: nextMode,
+        hostname: window.location.hostname,
+        envBaseUrl: import.meta.env.VITE_FUNNELCAKE_API_URL,
+      })} for future REST reads.`,
+    });
+  };
 
   const handleMute = async () => {
     if (!muteValue.trim()) {
@@ -249,6 +279,33 @@ export default function ModerationSettingsPage() {
               </div>
               <div>
                 <strong>Mute list loading:</strong> {muteListLoading ? 'Yes' : 'No'}
+              </div>
+              <div className="pt-2 border-t border-yellow-600/50 space-y-2">
+                <div>
+                  <strong>Funnelcake API mode:</strong>
+                </div>
+                <div className="flex flex-col gap-2 text-foreground not-italic font-sans">
+                  <Label htmlFor="funnelcake-api-mode">Funnelcake API</Label>
+                  <select
+                    id="funnelcake-api-mode"
+                    aria-label="Funnelcake API"
+                    className="h-10 rounded-md border border-input bg-background px-3 py-2 text-sm"
+                    value={funnelcakeApiMode}
+                    onChange={(event) => {
+                      void handleFunnelcakeApiModeChange(event.target.value as FunnelcakeApiMode);
+                    }}
+                  >
+                    <option value="auto">Auto</option>
+                    <option value="production">Production</option>
+                    <option value="staging">Staging</option>
+                  </select>
+                  <p className="text-xs text-muted-foreground">
+                    Auto follows hostname: staging uses staging, everything else uses production.
+                  </p>
+                  <div className="text-xs">
+                    <strong>Effective base URL:</strong> {effectiveFunnelcakeBaseUrl}
+                  </div>
+                </div>
               </div>
               <div>
                 <strong>Total mute items:</strong> {muteList.length}

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -23,12 +23,13 @@ import InfiniteScroll from 'react-infinite-scroll-component';
 import { useInfiniteSearchVideos } from '@/hooks/useInfiniteSearchVideos';
 import { useSearchUsers } from '@/hooks/useSearchUsers';
 import { useSearchHashtags, type HashtagResult } from '@/hooks/useSearchHashtags';
+import { getFunnelcakeBaseUrl } from '@/config/api';
 import { genUserName } from '@/lib/genUserName';
 import { getSafeProfileImage } from '@/lib/imageUtils';
 import type { SortMode } from '@/types/nostr';
 import { SEARCH_SORT_MODES as SORT_MODES } from '@/lib/constants/sortModes';
 import { useAppContext } from '@/hooks/useAppContext';
-import { DEFAULT_FUNNELCAKE_URL, getFunnelcakeUrl } from '@/config/relays';
+import { getFunnelcakeUrl } from '@/config/relays';
 import { fetchVideoById } from '@/lib/funnelcakeClient';
 import { fetchEventById } from '@/lib/eventLookup';
 import { buildResolvedEventRoute, buildVideoPath } from '@/lib/eventRouting';
@@ -170,7 +171,7 @@ export function SearchPage() {
       directLookupAbortRef.current?.abort();
       const controller = new AbortController();
       directLookupAbortRef.current = controller;
-      const funnelcakeUrl = getFunnelcakeUrl(config.relayUrl) || DEFAULT_FUNNELCAKE_URL;
+      const funnelcakeUrl = getFunnelcakeUrl(config.relayUrl) || getFunnelcakeBaseUrl();
       const configuredRelayUrls = config.relayUrls || [config.relayUrl];
 
       if (isHexIdentifier(normalized)) {


### PR DESCRIPTION
## Summary
- add explicit Fastly Funnelcake host mapping for production and staging API hosts
- route \ through a dedicated staging backend to \
- extend relay mapping tests so staging relay URLs resolve to \

## Test Plan
- [x] npx vitest run compute-js/src/funnelcakeOrigin.test.ts src/config/relays.test.ts
- [x] npm test
- [x] cd compute-js && npm install && npm run build
