### PR TITLE
Fix age-restricted profile video tiles

### DIFF
--- a/src/components/AgeRestrictedMediaPlaceholder.tsx
+++ b/src/components/AgeRestrictedMediaPlaceholder.tsx
@@ -1,0 +1,53 @@
+import { Lock } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+interface AgeRestrictedMediaPlaceholderProps {
+  actionLabel: string;
+  onAction: () => void;
+  title?: string;
+  className?: string;
+}
+
+export function AgeRestrictedMediaPlaceholder({
+  actionLabel,
+  onAction,
+  title,
+  className,
+}: AgeRestrictedMediaPlaceholderProps) {
+  return (
+    <div
+      className={cn(
+        'absolute inset-0 flex flex-col items-center justify-center gap-3 bg-neutral-950 px-4 py-6 text-center text-white',
+        className,
+      )}
+      data-testid="age-restricted-media-placeholder"
+    >
+      <div className="flex h-12 w-12 items-center justify-center rounded-full border border-white/20 bg-white/10">
+        <Lock className="h-5 w-5" />
+      </div>
+      <div className="space-y-1">
+        <p className="text-xs font-medium uppercase tracking-[0.24em] text-white/60">
+          Age-restricted
+        </p>
+        {title ? (
+          <p className="line-clamp-2 max-w-[18rem] text-sm text-white/85">
+            {title}
+          </p>
+        ) : null}
+      </div>
+      <Button
+        type="button"
+        variant="secondary"
+        className="bg-white text-black hover:bg-white/90"
+        onClick={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          onAction();
+        }}
+      >
+        {actionLabel}
+      </Button>
+    </div>
+  );
+}

--- a/src/components/ThumbnailPlayer.test.tsx
+++ b/src/components/ThumbnailPlayer.test.tsx
@@ -1,16 +1,21 @@
-import { fireEvent, render, screen } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ThumbnailPlayer } from './ThumbnailPlayer';
 
+const mockUseAdultVerification = vi.fn();
+
 vi.mock('@/hooks/useAdultVerification', () => ({
-  useAdultVerification: vi.fn(() => ({
-    isVerified: true,
-  })),
+  useAdultVerification: () => mockUseAdultVerification(),
   checkMediaAuth: vi.fn().mockResolvedValue({ authorized: true, status: 200 }),
+  fetchWithAuth: vi.fn(async (url: string, authHeader: string | null) =>
+    fetch(url, {
+      headers: authHeader ? { Authorization: authHeader } : {},
+    })
+  ),
 }));
 
 vi.mock('@/components/AgeVerificationOverlay', () => ({
-  AgeVerificationOverlay: () => <div>Age verification</div>,
+  AgeVerificationOverlay: () => <div data-testid="age-verification-overlay">Age verification</div>,
 }));
 
 vi.mock('@/lib/debug', () => ({
@@ -21,6 +26,23 @@ vi.mock('@/lib/debug', () => ({
 describe('ThumbnailPlayer', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseAdultVerification.mockReturnValue({
+      isVerified: true,
+      getAuthHeader: vi.fn().mockResolvedValue('Nostr signed-auth-header'),
+    });
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      blob: async () => new Blob(['thumb'], { type: 'image/jpeg' }),
+    }) as typeof fetch;
+
+    global.URL.createObjectURL = vi.fn().mockReturnValue('blob:protected-thumb');
+    global.URL.revokeObjectURL = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it('lets the play button start playback without triggering the thumbnail click action', () => {
@@ -58,5 +80,31 @@ describe('ThumbnailPlayer', () => {
     fireEvent.click(screen.getByTestId('thumbnail-container'));
 
     expect(handleThumbnailClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('fetches protected thumbnail images with auth when the viewer is verified', async () => {
+    render(
+      <ThumbnailPlayer
+        videoId="restricted-video"
+        src="https://media.divine.video/restricted-video"
+        thumbnailUrl="https://media.divine.video/restricted-video.jpg"
+      />
+    );
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://media.divine.video/restricted-video.jpg',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Nostr signed-auth-header',
+          }),
+        })
+      );
+    });
+
+    expect(screen.getByTestId('video-thumbnail')).toHaveAttribute(
+      'src',
+      'blob:protected-thumb'
+    );
   });
 });

--- a/src/components/ThumbnailPlayer.tsx
+++ b/src/components/ThumbnailPlayer.tsx
@@ -7,7 +7,7 @@ import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { useAdultVerification, checkMediaAuth } from '@/hooks/useAdultVerification';
 import { AgeVerificationOverlay } from '@/components/AgeVerificationOverlay';
-import { useAuthenticatedMediaUrl } from '@/hooks/useAuthenticatedMediaUrl';
+import { isProtectedDivineMediaUrl, useAuthenticatedMediaUrl } from '@/hooks/useAuthenticatedMediaUrl';
 import { verboseLog, debugError } from '@/lib/debug';
 
 interface ThumbnailPlayerProps {
@@ -100,6 +100,8 @@ export function ThumbnailPlayer({
   const { mediaUrl: authenticatedMediaUrl, isLoading: authMediaLoading } = useAuthenticatedMediaUrl(baseThumbnailUrl, {
     enabled: !requiresAuth,
   });
+  const overlayThumbnailUrl = authenticatedMediaUrl ||
+    (baseThumbnailUrl && !isProtectedDivineMediaUrl(baseThumbnailUrl) ? baseThumbnailUrl : undefined);
   // Generate thumbnail from video if no thumbnail URL provided
   const effectiveThumbnailUrl = thumbnailUrl
     ? authenticatedMediaUrl
@@ -124,7 +126,7 @@ export function ThumbnailPlayer({
       {requiresAuth ? (
         <AgeVerificationOverlay
           onVerified={handleAgeVerified}
-          thumbnailUrl={thumbnailUrl}
+          thumbnailUrl={overlayThumbnailUrl}
         />
       ) : authMediaLoading ? (
         <div

--- a/src/components/ThumbnailPlayer.tsx
+++ b/src/components/ThumbnailPlayer.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { useAdultVerification, checkMediaAuth } from '@/hooks/useAdultVerification';
 import { AgeVerificationOverlay } from '@/components/AgeVerificationOverlay';
+import { useAuthenticatedMediaUrl } from '@/hooks/useAuthenticatedMediaUrl';
 import { verboseLog, debugError } from '@/lib/debug';
 
 interface ThumbnailPlayerProps {
@@ -95,8 +96,14 @@ export function ThumbnailPlayer({
     onClick?.();
   };
 
+  const baseThumbnailUrl = thumbnailUrl || src;
+  const { mediaUrl: authenticatedMediaUrl, isLoading: authMediaLoading } = useAuthenticatedMediaUrl(baseThumbnailUrl, {
+    enabled: !requiresAuth,
+  });
   // Generate thumbnail from video if no thumbnail URL provided
-  const effectiveThumbnailUrl = thumbnailUrl || generateThumbnailFromVideo(src);
+  const effectiveThumbnailUrl = thumbnailUrl
+    ? authenticatedMediaUrl
+    : generateThumbnailFromVideo(authenticatedMediaUrl || src);
 
   // Check if the thumbnail URL is actually a video file or same as source
   const isVideoThumbnail = effectiveThumbnailUrl === src ||
@@ -119,6 +126,16 @@ export function ThumbnailPlayer({
           onVerified={handleAgeVerified}
           thumbnailUrl={thumbnailUrl}
         />
+      ) : authMediaLoading ? (
+        <div
+          className="w-full h-full flex items-center justify-center bg-gray-800 text-gray-400"
+          data-testid="thumbnail-placeholder"
+        >
+          <div className="text-center">
+            <Play className="h-12 w-12 mx-auto mb-2 opacity-50" />
+            <p className="text-sm">Video Preview</p>
+          </div>
+        </div>
       ) : !thumbnailError && effectiveThumbnailUrl ? (
         /* Thumbnail image or video */
         isVideoThumbnail || useVideoFallback ? (

--- a/src/components/VideoCard.test.tsx
+++ b/src/components/VideoCard.test.tsx
@@ -1,5 +1,10 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import type { ButtonHTMLAttributes, HTMLAttributes, ImgHTMLAttributes, ReactNode } from 'react';
+import type {
+  ButtonHTMLAttributes,
+  HTMLAttributes,
+  ImgHTMLAttributes,
+  ReactNode,
+} from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ParsedVideoData } from '@/types/video';
 import { VideoCard } from './VideoCard';
@@ -17,27 +22,53 @@ const playbackMocks = vi.hoisted(() => ({
   unpinVideo: vi.fn(),
 }));
 
+const authMocks = vi.hoisted(() => ({
+  openLoginDialog: vi.fn(),
+  confirmAdult: vi.fn(),
+  useCurrentUser: vi.fn(),
+  useAdultVerification: vi.fn(),
+}));
+
 vi.mock('@/components/ui/card', () => ({
-  Card: ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
-  CardContent: ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+  Card: ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => (
+    <div {...props}>{children}</div>
+  ),
+  CardContent: ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => (
+    <div {...props}>{children}</div>
+  ),
 }));
 
 vi.mock('@/components/ui/button', () => ({
-  Button: ({ children, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) => <button {...props}>{children}</button>,
+  Button: ({
+    children,
+    ...props
+  }: ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
 }));
 
 vi.mock('@/components/ui/avatar', () => ({
-  Avatar: ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+  Avatar: ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => (
+    <div {...props}>{children}</div>
+  ),
   AvatarImage: (props: ImgHTMLAttributes<HTMLImageElement>) => <img {...props} />,
-  AvatarFallback: ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+  AvatarFallback: ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => (
+    <div {...props}>{children}</div>
+  ),
 }));
 
 vi.mock('@/components/ui/dropdown-menu', () => ({
   DropdownMenu: ({ children }: { children: ReactNode }) => <div>{children}</div>,
-  DropdownMenuContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
-  DropdownMenuItem: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuItem: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
   DropdownMenuSeparator: () => <div />,
-  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
 }));
 
 vi.mock('@/components/VideoPlayer', () => ({
@@ -70,8 +101,12 @@ vi.mock('@/components/ThumbnailPlayer', () => ({
     onPlayButtonClick?: () => void;
   }) => (
     <div data-testid="thumbnail-player">
-      <button onClick={onClick} type="button">Thumbnail</button>
-      <button aria-label="Play video" onClick={onPlayButtonClick} type="button">Play</button>
+      <button onClick={onClick} type="button">
+        Thumbnail
+      </button>
+      <button aria-label="Play video" onClick={onPlayButtonClick} type="button">
+        Play
+      </button>
     </div>
   ),
 }));
@@ -85,7 +120,9 @@ vi.mock('@/components/VideoReactionsModal', () => ({
 }));
 
 vi.mock('@/components/NoteContent', () => ({
-  NoteContent: ({ event }: { event: { content: string } }) => <div>{event.content}</div>,
+  NoteContent: ({ event }: { event: { content: string } }) => (
+    <div>{event.content}</div>
+  ),
 }));
 
 vi.mock('@/components/InlineNostrText', () => ({
@@ -117,7 +154,9 @@ vi.mock('@/components/SmartLink', () => ({
     children,
     ownerPubkey: _ownerPubkey,
     ...props
-  }: HTMLAttributes<HTMLAnchorElement> & { ownerPubkey?: string }) => <a {...props}>{children}</a>,
+  }: HTMLAttributes<HTMLAnchorElement> & { ownerPubkey?: string }) => (
+    <a {...props}>{children}</a>
+  ),
 }));
 
 vi.mock('@/hooks/useAuthor', () => ({
@@ -161,9 +200,11 @@ vi.mock('@/hooks/usePinnedVideos', () => ({
 }));
 
 vi.mock('@/hooks/useCurrentUser', () => ({
-  useCurrentUser: () => ({
-    user: null,
-  }),
+  useCurrentUser: () => authMocks.useCurrentUser(),
+}));
+
+vi.mock('@/hooks/useAdultVerification', () => ({
+  useAdultVerification: () => authMocks.useAdultVerification(),
 }));
 
 vi.mock('@/hooks/useVideoPlayback', () => ({
@@ -223,8 +264,17 @@ vi.mock('@/hooks/useSubtitles', () => ({
   }),
 }));
 
+vi.mock('@/contexts/LoginDialogContext', () => ({
+  useLoginDialog: () => ({
+    openLoginDialog: authMocks.openLoginDialog,
+  }),
+}));
+
 vi.mock('@/lib/generateProfile', () => ({
-  enhanceAuthorData: (data: { metadata?: Record<string, unknown> } | undefined, pubkey: string) => ({
+  enhanceAuthorData: (
+    data: { metadata?: Record<string, unknown> } | undefined,
+    pubkey: string
+  ) => ({
     metadata: data?.metadata ?? { name: pubkey },
   }),
 }));
@@ -234,7 +284,8 @@ vi.mock('@/lib/genUserName', () => ({
 }));
 
 vi.mock('@/lib/utils', () => ({
-  cn: (...classes: Array<string | false | null | undefined>) => classes.filter(Boolean).join(' '),
+  cn: (...classes: Array<string | false | null | undefined>) =>
+    classes.filter(Boolean).join(' '),
 }));
 
 vi.mock('@/lib/formatUtils', () => ({
@@ -258,6 +309,25 @@ vi.mock('@/lib/bandwidthTracker', () => ({
 vi.mock('@/lib/debug', () => ({
   debugLog: vi.fn(),
 }));
+
+function makeVideo(overrides: Partial<ParsedVideoData> = {}): ParsedVideoData {
+  return {
+    id: 'video-1',
+    pubkey: 'f'.repeat(64),
+    kind: 34236,
+    createdAt: 1700000000,
+    content: 'Test video',
+    title: 'Test video',
+    videoUrl: 'https://media.divine.video/video-1',
+    thumbnailUrl: 'https://media.divine.video/video-1.jpg',
+    hashtags: [],
+    vineId: 'vine-id-1',
+    reposts: [],
+    isVineMigrated: false,
+    ageRestricted: false,
+    ...overrides,
+  };
+}
 
 const baseVideo = {
   id: 'video-1',
@@ -292,6 +362,19 @@ describe('VideoCard', () => {
     playbackMocks.setActiveVideo.mockClear();
     playbackMocks.setGlobalMuted.mockClear();
     playbackMocks.navigate.mockClear();
+    playbackMocks.toast.mockClear();
+    playbackMocks.share.mockClear();
+    authMocks.openLoginDialog.mockClear();
+    authMocks.confirmAdult.mockClear();
+    authMocks.useCurrentUser.mockReturnValue({ user: null });
+    authMocks.useAdultVerification.mockReturnValue({
+      isVerified: false,
+      confirmAdult: authMocks.confirmAdult,
+      revokeVerification: vi.fn(),
+      getAuthHeader: vi.fn(),
+      isLoading: false,
+      hasSigner: false,
+    });
   });
 
   it('marks a thumbnail-mode video active when inline playback starts', () => {
@@ -327,5 +410,55 @@ describe('VideoCard', () => {
 
     expect(screen.queryByTestId(`video-player-${baseVideo.id}`)).toBeNull();
     expect(screen.getByTestId('thumbnail-player')).toBeTruthy();
+  });
+
+  it('shows a logged-out gated card instead of mounting thumbnail media', () => {
+    render(
+      <VideoCard
+        video={makeVideo({
+          ageRestricted: true,
+          title: 'Constructive criticism',
+        })}
+        mode="thumbnail"
+      />
+    );
+
+    expect(screen.getByText('Log in to view')).toBeInTheDocument();
+    expect(screen.queryByTestId('thumbnail-player')).not.toBeInTheDocument();
+    expect(screen.queryByTestId(/video-player-/)).not.toBeInTheDocument();
+  });
+
+  it('shows an age-verification prompt for logged-in viewers who are not verified', () => {
+    authMocks.useCurrentUser.mockReturnValue({
+      user: { pubkey: 'a'.repeat(64) },
+    });
+
+    render(
+      <VideoCard
+        video={makeVideo({
+          ageRestricted: true,
+        })}
+        mode="thumbnail"
+      />
+    );
+
+    expect(screen.getByText('Verify age to view')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Verify age to view' }));
+    expect(authMocks.confirmAdult).toHaveBeenCalledTimes(1);
+  });
+
+  it('still renders the thumbnail player for unrestricted videos', () => {
+    render(
+      <VideoCard
+        video={makeVideo({
+          ageRestricted: false,
+        })}
+        mode="thumbnail"
+      />
+    );
+
+    expect(screen.getByTestId('thumbnail-player')).toBeInTheDocument();
+    expect(screen.queryByText('Log in to view')).not.toBeInTheDocument();
   });
 });

--- a/src/components/VideoCard.tsx
+++ b/src/components/VideoCard.tsx
@@ -26,6 +26,7 @@ import { useMuteItem } from '@/hooks/useModeration';
 import { useDeleteVideo, useCanDeleteVideo } from '@/hooks/useDeleteVideo';
 import { useIsVideoPinned, usePinVideo, useUnpinVideo } from '@/hooks/usePinnedVideos';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
+import { useAdultVerification } from '@/hooks/useAdultVerification';
 import { useVideoPlayback } from '@/hooks/useVideoPlayback';
 import { useVideosInLists } from '@/hooks/useVideoLists';
 import { enhanceAuthorData } from '@/lib/generateProfile';
@@ -51,6 +52,8 @@ import { getOptimalVideoUrl } from '@/lib/bandwidthTracker';
 import { useBandwidthTier } from '@/hooks/useBandwidthTier';
 import { useSubtitles } from '@/hooks/useSubtitles';
 import { debugLog } from '@/lib/debug';
+import { useLoginDialog } from '@/contexts/LoginDialogContext';
+import { AgeRestrictedMediaPlaceholder } from '@/components/AgeRestrictedMediaPlaceholder';
 
 interface VideoCardProps {
   video: ParsedVideoData;
@@ -255,6 +258,8 @@ export function VideoCard({
   const isPinned = useIsVideoPinned(coordinate);
   const { mutateAsync: pinVideo } = usePinVideo();
   const { mutateAsync: unpinVideo } = useUnpinVideo();
+  const { isVerified: isAdultVerified, confirmAdult } = useAdultVerification();
+  const { openLoginDialog } = useLoginDialog();
 
   // Get reactions data for the modal
   const { data: reactions } = useVideoReactions(video.id, video.pubkey, video.vineId);
@@ -297,6 +302,7 @@ export function VideoCard({
   const timestamp = video.originalVineTimestamp || video.createdAt;
 
   const date = new Date(timestamp * 1000);
+  const isAgeGated = video.ageRestricted === true && (!currentUser || !isAdultVerified);
 
   // Calculate timeAgo only for pre-2025 videos
   const isFrom2025 = date.getFullYear() >= 2025;
@@ -318,6 +324,15 @@ export function VideoCard({
 
   const handleCommentsClick = () => {
     onOpenComments?.(video);
+  };
+
+  const handleAgeGateAction = () => {
+    if (currentUser) {
+      confirmAdult();
+      return;
+    }
+
+    openLoginDialog();
   };
 
   const handleCloseCommentsModal = (open: boolean) => {
@@ -560,7 +575,13 @@ export function VideoCard({
                 maxWidth: effectiveAspectRatio <= 1.1 ? `calc(70vh * ${effectiveAspectRatio})` : undefined,
               }}
             >
-              {!isPlaying ? (
+              {isAgeGated ? (
+                <AgeRestrictedMediaPlaceholder
+                  actionLabel={currentUser ? 'Verify age to view' : 'Log in to view'}
+                  onAction={handleAgeGateAction}
+                  title={video.title || video.content}
+                />
+              ) : !isPlaying ? (
                 <ThumbnailPlayer
                   videoId={video.id}
                   src={video.videoUrl}

--- a/src/components/VideoGrid.test.tsx
+++ b/src/components/VideoGrid.test.tsx
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { VideoGrid } from './VideoGrid';
+import type { ParsedVideoData } from '@/types/video';
+
+const mockNavigate = vi.fn();
+const mockOpenLoginDialog = vi.fn();
+const mockUseCurrentUser = vi.fn();
+const mockUseAdultVerification = vi.fn();
+
+vi.mock('@/hooks/useSubdomainNavigate', () => ({
+  useSubdomainNavigate: () => mockNavigate,
+}));
+
+vi.mock('@/contexts/LoginDialogContext', () => ({
+  useLoginDialog: () => ({
+    openLoginDialog: mockOpenLoginDialog,
+  }),
+}));
+
+vi.mock('@/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => mockUseCurrentUser(),
+}));
+
+vi.mock('@/hooks/useAdultVerification', () => ({
+  useAdultVerification: () => mockUseAdultVerification(),
+}));
+
+function makeVideo(overrides: Partial<ParsedVideoData> = {}): ParsedVideoData {
+  return {
+    id: 'video-1',
+    pubkey: 'f'.repeat(64),
+    kind: 34236,
+    createdAt: 1700000000,
+    content: 'Test video',
+    videoUrl: 'https://media.divine.video/video-1',
+    thumbnailUrl: 'https://media.divine.video/video-1.jpg',
+    hashtags: [],
+    vineId: 'vine-id-1',
+    reposts: [],
+    isVineMigrated: false,
+    ...overrides,
+  };
+}
+
+describe('VideoGrid age-restricted gating', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseCurrentUser.mockReturnValue({ user: null });
+    mockUseAdultVerification.mockReturnValue({ isVerified: false });
+  });
+
+  it('renders a logged-out gated tile without mounting restricted media elements', () => {
+    render(
+      <VideoGrid
+        videos={[
+          makeVideo({
+            id: 'restricted-video',
+            title: 'Constructive criticism',
+            ageRestricted: true,
+          }),
+        ]}
+      />
+    );
+
+    expect(screen.getByText('Log in to view')).toBeInTheDocument();
+    expect(screen.getByText('Age-restricted')).toBeInTheDocument();
+    expect(screen.queryByTestId('video-thumbnail-restricted-video')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('video-player-restricted-video')).not.toBeInTheDocument();
+  });
+
+  it('opens the login dialog when the gated tile is clicked', () => {
+    render(
+      <VideoGrid
+        videos={[
+          makeVideo({
+            id: 'restricted-video',
+            ageRestricted: true,
+          }),
+        ]}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('video-grid-item'));
+
+    expect(mockOpenLoginDialog).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('renders unrestricted videos with their thumbnail media as before', () => {
+    render(
+      <VideoGrid
+        videos={[
+          makeVideo({
+            id: 'public-video',
+            ageRestricted: false,
+          }),
+        ]}
+      />
+    );
+
+    expect(screen.getByTestId('video-thumbnail-public-video')).toBeInTheDocument();
+    expect(screen.queryByText('Log in to view')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/VideoGrid.test.tsx
+++ b/src/components/VideoGrid.test.tsx
@@ -1,5 +1,5 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { VideoGrid } from './VideoGrid';
 import type { ParsedVideoData } from '@/types/video';
 
@@ -24,6 +24,9 @@ vi.mock('@/hooks/useCurrentUser', () => ({
 
 vi.mock('@/hooks/useAdultVerification', () => ({
   useAdultVerification: () => mockUseAdultVerification(),
+  fetchWithAuth: vi.fn(async (url: string, authHeader: string | null) => fetch(url, {
+    headers: authHeader ? { Authorization: authHeader } : {},
+  })),
 }));
 
 function makeVideo(overrides: Partial<ParsedVideoData> = {}): ParsedVideoData {
@@ -47,7 +50,18 @@ describe('VideoGrid age-restricted gating', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockUseCurrentUser.mockReturnValue({ user: null });
-    mockUseAdultVerification.mockReturnValue({ isVerified: false });
+    mockUseAdultVerification.mockReturnValue({ isVerified: false, confirmAdult: vi.fn(), getAuthHeader: vi.fn() });
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      blob: async () => new Blob(['thumb'], { type: 'image/jpeg' }),
+    }) as typeof fetch;
+    global.URL.createObjectURL = vi.fn().mockReturnValue('blob:grid-thumb');
+    global.URL.revokeObjectURL = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it('renders a logged-out gated tile without mounting restricted media elements', () => {
@@ -101,5 +115,39 @@ describe('VideoGrid age-restricted gating', () => {
 
     expect(screen.getByTestId('video-thumbnail-public-video')).toBeInTheDocument();
     expect(screen.queryByText('Log in to view')).not.toBeInTheDocument();
+  });
+
+  it('fetches protected thumbnails with auth for verified viewers', async () => {
+    mockUseCurrentUser.mockReturnValue({ user: { pubkey: 'a'.repeat(64) } });
+    mockUseAdultVerification.mockReturnValue({
+      isVerified: true,
+      confirmAdult: vi.fn(),
+      getAuthHeader: vi.fn().mockResolvedValue('Nostr grid-auth-header'),
+    });
+
+    render(
+      <VideoGrid
+        videos={[
+          makeVideo({
+            id: 'verified-restricted-video',
+            ageRestricted: true,
+            thumbnailUrl: 'https://media.divine.video/verified-restricted-video.jpg',
+          }),
+        ]}
+      />
+    );
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://media.divine.video/verified-restricted-video.jpg',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Nostr grid-auth-header',
+          }),
+        }),
+      );
+    });
+
+    expect(screen.getByTestId('video-thumbnail-verified-restricted-video')).toHaveAttribute('src', 'blob:grid-thumb');
   });
 });

--- a/src/components/VideoGrid.tsx
+++ b/src/components/VideoGrid.tsx
@@ -6,6 +6,10 @@ import { useSubdomainNavigate } from '@/hooks/useSubdomainNavigate';
 import { Play, Repeat } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { AgeRestrictedMediaPlaceholder } from '@/components/AgeRestrictedMediaPlaceholder';
+import { useLoginDialog } from '@/contexts/LoginDialogContext';
+import { useCurrentUser } from '@/hooks/useCurrentUser';
+import { useAdultVerification } from '@/hooks/useAdultVerification';
 import { cn } from '@/lib/utils';
 import type { ParsedVideoData } from '@/types/video';
 import { buildVideoNavigationUrl, type VideoNavigationContext } from '@/hooks/useVideoNavigation';
@@ -36,6 +40,9 @@ function truncateText(text: string, maxLength: number = 50): string {
 
 export function VideoGrid({ videos, loading = false, className, navigationContext }: VideoGridProps) {
   const navigate = useSubdomainNavigate();
+  const { user } = useCurrentUser();
+  const { isVerified: isAdultVerified, confirmAdult } = useAdultVerification();
+  const { openLoginDialog } = useLoginDialog();
   const [hoveredVideo, setHoveredVideo] = useState<string | null>(null);
   const [failedThumbnails, setFailedThumbnails] = useState<Set<string>>(new Set());
   const videoRefs = useRef<Map<string, HTMLVideoElement>>(new Map());
@@ -47,9 +54,14 @@ export function VideoGrid({ videos, loading = false, className, navigationContex
     navigate(url);
   };
 
-  const handleKeyDown = (event: React.KeyboardEvent, videoId: string, index: number) => {
+  const handleKeyDown = (event: React.KeyboardEvent, videoId: string, index: number, isAgeGated: boolean) => {
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault();
+      if (isAgeGated) {
+        handleAgeGateAction();
+        return;
+      }
+
       handleVideoClick(videoId, index);
     }
   };
@@ -58,7 +70,17 @@ export function VideoGrid({ videos, loading = false, className, navigationContex
     setFailedThumbnails((prev) => new Set(prev).add(videoId));
   };
 
-  const handleMouseEnter = (videoId: string) => {
+  const handleAgeGateAction = () => {
+    if (user) {
+      confirmAdult();
+      return;
+    }
+
+    openLoginDialog();
+  };
+
+  const handleMouseEnter = (videoId: string, isAgeGated: boolean) => {
+    if (isAgeGated) return;
     setHoveredVideo(videoId);
     // Auto-play video on hover if thumbnail failed
     if (failedThumbnails.has(videoId)) {
@@ -71,7 +93,8 @@ export function VideoGrid({ videos, loading = false, className, navigationContex
     }
   };
 
-  const handleMouseLeave = (videoId: string) => {
+  const handleMouseLeave = (videoId: string, isAgeGated: boolean) => {
+    if (isAgeGated) return;
     setHoveredVideo(null);
     // Pause video when not hovering if thumbnail failed
     if (failedThumbnails.has(videoId)) {
@@ -128,22 +151,36 @@ export function VideoGrid({ videos, loading = false, className, navigationContex
         const isHovered = hoveredVideo === video.id;
         const thumbnailFailed = failedThumbnails.has(video.id);
         const shouldShowVideo = !video.thumbnailUrl || thumbnailFailed;
+        const isAgeGated = video.ageRestricted === true && (!user || !isAdultVerified);
 
         return (
           <Card
             key={video.id}
             className="overflow-hidden cursor-pointer transition-transform hover:scale-105 group"
             data-testid="video-grid-item"
-            onClick={() => handleVideoClick(video.id, index)}
-            onKeyDown={(e) => handleKeyDown(e, video.id, index)}
-            onMouseEnter={() => handleMouseEnter(video.id)}
-            onMouseLeave={() => handleMouseLeave(video.id)}
+            onClick={() => {
+              if (isAgeGated) {
+                handleAgeGateAction();
+                return;
+              }
+
+              handleVideoClick(video.id, index);
+            }}
+            onKeyDown={(e) => handleKeyDown(e, video.id, index, isAgeGated)}
+            onMouseEnter={() => handleMouseEnter(video.id, isAgeGated)}
+            onMouseLeave={() => handleMouseLeave(video.id, isAgeGated)}
             tabIndex={0}
             data-video-id={video.id}
           >
             <div className="aspect-square relative bg-muted" data-thumbnail-container="true">
               {/* Video Thumbnail or Actual Video */}
-              {shouldShowVideo && video.videoUrl ? (
+              {isAgeGated ? (
+                <AgeRestrictedMediaPlaceholder
+                  actionLabel={user ? 'Verify age to view' : 'Log in to view'}
+                  onAction={handleAgeGateAction}
+                  title={video.title || video.content}
+                />
+              ) : shouldShowVideo && video.videoUrl ? (
                 <video
                   ref={(el) => {
                     if (el) {
@@ -198,17 +235,19 @@ export function VideoGrid({ videos, loading = false, className, navigationContex
               )}
 
               {/* Play Overlay */}
-              <div
-                className="absolute inset-0 bg-black/20 flex items-center justify-center transition-opacity group-hover:bg-black/40"
-                data-testid={`play-overlay-${video.id}`}
-              >
-                <div className="bg-white/90 rounded-full p-3 transition-transform group-hover:scale-110">
-                  <Play className="w-6 h-6 text-black fill-black" />
+              {!isAgeGated && (
+                <div
+                  className="absolute inset-0 bg-black/20 flex items-center justify-center transition-opacity group-hover:bg-black/40"
+                  data-testid={`play-overlay-${video.id}`}
+                >
+                  <div className="bg-white/90 rounded-full p-3 transition-transform group-hover:scale-110">
+                    <Play className="w-6 h-6 text-black fill-black" />
+                  </div>
                 </div>
-              </div>
+              )}
 
               {/* Loop Count Badge */}
-              {video.loopCount !== undefined && video.loopCount > 0 && (
+              {!isAgeGated && video.loopCount !== undefined && video.loopCount > 0 && (
                 <div className="absolute bottom-2 right-2">
                   <Badge variant="secondary" className="text-xs bg-black/80 text-white">
                     <Repeat className="w-3 h-3 mr-1" />
@@ -218,7 +257,7 @@ export function VideoGrid({ videos, loading = false, className, navigationContex
               )}
 
               {/* Metadata Overlay */}
-              {isHovered && (video.content || video.hashtags.length > 0) && (
+              {!isAgeGated && isHovered && (video.content || video.hashtags.length > 0) && (
                 <div
                   className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/80 to-transparent p-4 text-white"
                   data-testid={`metadata-overlay-${video.id}`}

--- a/src/components/VideoGrid.tsx
+++ b/src/components/VideoGrid.tsx
@@ -10,6 +10,7 @@ import { AgeRestrictedMediaPlaceholder } from '@/components/AgeRestrictedMediaPl
 import { useLoginDialog } from '@/contexts/LoginDialogContext';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { useAdultVerification } from '@/hooks/useAdultVerification';
+import { useAuthenticatedMediaUrl } from '@/hooks/useAuthenticatedMediaUrl';
 import { cn } from '@/lib/utils';
 import type { ParsedVideoData } from '@/types/video';
 import { buildVideoNavigationUrl, type VideoNavigationContext } from '@/hooks/useVideoNavigation';
@@ -19,6 +20,13 @@ interface VideoGridProps {
   loading?: boolean;
   className?: string;
   navigationContext?: VideoNavigationContext;
+}
+
+interface VideoGridMediaProps {
+  video: ParsedVideoData;
+  thumbnailFailed: boolean;
+  onThumbnailError: (videoId: string) => void;
+  videoRefs: React.MutableRefObject<Map<string, HTMLVideoElement>>;
 }
 
 function formatLoops(loops?: number): string {
@@ -36,6 +44,95 @@ function formatLoops(loops?: number): string {
 function truncateText(text: string, maxLength: number = 50): string {
   if (text.length <= maxLength) return text;
   return text.slice(0, maxLength) + '...';
+}
+
+function VideoGridMedia({
+  video,
+  thumbnailFailed,
+  onThumbnailError,
+  videoRefs,
+}: VideoGridMediaProps) {
+  const shouldShowVideo = !video.thumbnailUrl || thumbnailFailed;
+  const baseThumbnailUrl = video.thumbnailUrl || video.videoUrl;
+  const { mediaUrl: authenticatedMediaUrl, isLoading } = useAuthenticatedMediaUrl(baseThumbnailUrl, {
+    enabled: true,
+  });
+
+  if (isLoading) {
+    return (
+      <div
+        className="w-full h-full bg-muted flex items-center justify-center"
+        data-testid={`video-placeholder-${video.id}`}
+      >
+        <Play className="w-12 h-12 text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (shouldShowVideo && authenticatedMediaUrl) {
+    return (
+      <video
+        ref={(el) => {
+          if (el) {
+            videoRefs.current.set(video.id, el);
+          } else {
+            videoRefs.current.delete(video.id);
+          }
+        }}
+        className="w-full h-full object-cover"
+        src={authenticatedMediaUrl}
+        muted
+        loop
+        playsInline
+        preload="metadata"
+        crossOrigin="anonymous"
+        data-testid={`video-player-${video.id}`}
+        onError={() => onThumbnailError(video.id)}
+      />
+    );
+  }
+
+  if (authenticatedMediaUrl) {
+    const isVideoThumbnail = (video.thumbnailUrl === video.videoUrl) ||
+      !!video.thumbnailUrl?.match(/\.(mp4|webm|mov|m3u8|mpd|avi|mkv|ogv|ogg)($|\?|#)/i) ||
+      !!video.thumbnailUrl?.includes('/manifest/');
+
+    if (isVideoThumbnail) {
+      return (
+        <video
+          className="w-full h-full object-cover"
+          src={`${authenticatedMediaUrl}#t=0.1`}
+          muted
+          playsInline
+          preload="metadata"
+          crossOrigin="anonymous"
+          data-testid={`video-thumbnail-${video.id}`}
+          onError={() => onThumbnailError(video.id)}
+        />
+      );
+    }
+
+    return (
+      <img
+        className="w-full h-full object-cover"
+        src={authenticatedMediaUrl}
+        alt={video.content || 'Video thumbnail'}
+        loading="lazy"
+        crossOrigin="anonymous"
+        data-testid={`video-thumbnail-${video.id}`}
+        onError={() => onThumbnailError(video.id)}
+      />
+    );
+  }
+
+  return (
+    <div
+      className="w-full h-full bg-muted flex items-center justify-center"
+      data-testid={`video-placeholder-${video.id}`}
+    >
+      <Play className="w-12 h-12 text-muted-foreground" />
+    </div>
+  );
 }
 
 export function VideoGrid({ videos, loading = false, className, navigationContext }: VideoGridProps) {
@@ -150,7 +247,6 @@ export function VideoGrid({ videos, loading = false, className, navigationContex
       {videos.map((video, index) => {
         const isHovered = hoveredVideo === video.id;
         const thumbnailFailed = failedThumbnails.has(video.id);
-        const shouldShowVideo = !video.thumbnailUrl || thumbnailFailed;
         const isAgeGated = video.ageRestricted === true && (!user || !isAdultVerified);
 
         return (
@@ -180,58 +276,13 @@ export function VideoGrid({ videos, loading = false, className, navigationContex
                   onAction={handleAgeGateAction}
                   title={video.title || video.content}
                 />
-              ) : shouldShowVideo && video.videoUrl ? (
-                <video
-                  ref={(el) => {
-                    if (el) {
-                      videoRefs.current.set(video.id, el);
-                    } else {
-                      videoRefs.current.delete(video.id);
-                    }
-                  }}
-                  className="w-full h-full object-cover"
-                  src={video.videoUrl}
-                  muted
-                  loop
-                  playsInline
-                  preload="metadata"
-                  crossOrigin="anonymous"
-                  data-testid={`video-player-${video.id}`}
-                  onError={() => handleThumbnailError(video.id)}
-                />
-              ) : video.thumbnailUrl ? (
-                // Check if thumbnail URL is actually a video file
-                video.thumbnailUrl === video.videoUrl ||
-                video.thumbnailUrl.match(/\.(mp4|webm|mov|m3u8|mpd|avi|mkv|ogv|ogg)($|\?|#)/i) ||
-                video.thumbnailUrl.includes('/manifest/') ? (
-                  <video
-                    className="w-full h-full object-cover"
-                    src={`${video.thumbnailUrl}#t=0.1`}
-                    muted
-                    playsInline
-                    preload="metadata"
-                    crossOrigin="anonymous"
-                    data-testid={`video-thumbnail-${video.id}`}
-                    onError={() => handleThumbnailError(video.id)}
-                  />
-                ) : (
-                  <img
-                    className="w-full h-full object-cover"
-                    src={video.thumbnailUrl}
-                    alt={video.content || 'Video thumbnail'}
-                    loading="lazy"
-                    crossOrigin="anonymous"
-                    data-testid={`video-thumbnail-${video.id}`}
-                    onError={() => handleThumbnailError(video.id)}
-                  />
-                )
               ) : (
-                <div
-                  className="w-full h-full bg-muted flex items-center justify-center"
-                  data-testid={`video-placeholder-${video.id}`}
-                >
-                  <Play className="w-12 h-12 text-muted-foreground" />
-                </div>
+                <VideoGridMedia
+                  video={video}
+                  thumbnailFailed={thumbnailFailed}
+                  onThumbnailError={handleThumbnailError}
+                  videoRefs={videoRefs}
+                />
               )}
 
               {/* Play Overlay */}

--- a/src/components/VideoPlayer.test.tsx
+++ b/src/components/VideoPlayer.test.tsx
@@ -2,7 +2,7 @@
 // ABOUTME: Verifies video loading, auth handling, and URL management
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { VideoPlayer } from './VideoPlayer';
 
 // Mock dependencies
@@ -51,6 +51,21 @@ vi.mock('@/lib/debug', () => ({
 
 vi.mock('@/lib/analytics', () => ({
   trackFirstVideoPlayback: vi.fn(),
+}));
+
+vi.mock('@/components/AgeRestrictedMediaPlaceholder', () => ({
+  AgeRestrictedMediaPlaceholder: ({
+    actionLabel,
+    title,
+  }: {
+    actionLabel: string;
+    title?: string;
+  }) => (
+    <div data-testid="age-restricted-media-placeholder">
+      <div>{title ?? 'Age-restricted'}</div>
+      <button type="button">{actionLabel}</button>
+    </div>
+  ),
 }));
 
 vi.mock('hls.js', () => ({
@@ -304,6 +319,38 @@ describe('VideoPlayer', () => {
 
       expect(getAuthHeader).toHaveBeenCalledTimes(1);
       expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows an age-restricted placeholder instead of a broken video message when verified viewers get 401', async () => {
+      const fetchSpy = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+      });
+
+      global.fetch = fetchSpy as typeof fetch;
+
+      const { useAdultVerification } = await import('@/hooks/useAdultVerification');
+      (useAdultVerification as ReturnType<typeof vi.fn>).mockReturnValue({
+        isVerified: true,
+        isLoading: false,
+        hasSigner: true,
+        getAuthHeader: vi.fn().mockResolvedValue('Nostr test-auth-header'),
+      });
+
+      render(
+        <VideoPlayer
+          videoId="verified-auth-placeholder"
+          src="https://media.divine.video/protected-video"
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('age-restricted-media-placeholder')).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText('Failed to load video')).not.toBeInTheDocument();
+      expect(screen.getByText('Age-restricted video')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
     });
   });
 });

--- a/src/components/VideoPlayer.test.tsx
+++ b/src/components/VideoPlayer.test.tsx
@@ -20,6 +20,12 @@ vi.mock('@/hooks/useIsMobile', () => ({
   useIsMobile: vi.fn(() => false),
 }));
 
+vi.mock('@/hooks/useCurrentUser', () => ({
+  useCurrentUser: vi.fn(() => ({
+    user: { pubkey: 'a'.repeat(64) },
+  })),
+}));
+
 vi.mock('@/hooks/useAdultVerification', () => ({
   useAdultVerification: vi.fn(() => ({
     isVerified: false,
@@ -262,6 +268,42 @@ describe('VideoPlayer', () => {
       if (createObjectURLSpy.mock.calls.length > 0) {
         expect(revokeObjectURLSpy).toHaveBeenCalledWith('blob:test-123');
       }
+    });
+  });
+
+  describe('protected media auth failures', () => {
+    it('does not retry age verification indefinitely for already verified viewers when media fetch returns 401', async () => {
+      const getAuthHeader = vi.fn().mockResolvedValue('Nostr test-auth-header');
+      const fetchSpy = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+      });
+
+      global.fetch = fetchSpy as typeof fetch;
+
+      const { useAdultVerification } = await import('@/hooks/useAdultVerification');
+      (useAdultVerification as ReturnType<typeof vi.fn>).mockReturnValue({
+        isVerified: true,
+        isLoading: false,
+        hasSigner: true,
+        getAuthHeader,
+      });
+
+      render(
+        <VideoPlayer
+          videoId="verified-auth-failure"
+          src="https://media.divine.video/protected-video"
+        />
+      );
+
+      await waitFor(() => {
+        expect(fetchSpy).toHaveBeenCalled();
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(getAuthHeader).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -781,7 +781,11 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
           // Check for 401/403 auth errors
           if (data.response && (data.response.code === 401 || data.response.code === 403)) {
             debugError(`[VideoPlayer ${videoId}] Auth required (${data.response.code})`);
-            setRequiresAuth(true);
+            if (isAdultVerified) {
+              setHasError(true);
+            } else {
+              setRequiresAuth(true);
+            }
             setIsLoading(false);
             hls.destroy();
             return;
@@ -850,7 +854,11 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
                     };
                   } else if (response.status === 401 || response.status === 403) {
                     debugError(`[VideoPlayer ${videoId}] Auth failed even with NIP-98 (${response.status})`);
-                    setRequiresAuth(true);
+                    if (isAdultVerified) {
+                      setHasError(true);
+                    } else {
+                      setRequiresAuth(true);
+                    }
                     setIsLoading(false);
                   } else {
                     debugError(`[VideoPlayer ${videoId}] Fetch failed: ${response.status}`);
@@ -858,8 +866,9 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
                     setIsLoading(false);
                   }
                 } else {
-                  // No auth header available, try without
-                  video.src = currentUrl;
+                  debugError(`[VideoPlayer ${videoId}] Missing auth header for protected media`);
+                  setHasError(true);
+                  setIsLoading(false);
                 }
               } catch (error) {
                 // Ignore abort errors, they're expected when effect re-runs
@@ -1046,7 +1055,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
         )}
 
         {/* Age verification required (401/403) */}
-        {requiresAuth && (
+        {requiresAuth && !isAdultVerified && (
           <AgeVerificationOverlay
             onVerified={handleAgeVerified}
             thumbnailUrl={overlayPosterUrl}

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -18,6 +18,7 @@ import { AgeVerificationOverlay } from '@/components/AgeVerificationOverlay';
 import { SubtitleOverlay } from '@/components/SubtitleOverlay';
 import { createAuthLoader } from '@/lib/hlsAuthLoader';
 import { bandwidthTracker } from '@/lib/bandwidthTracker';
+import { useAuthenticatedMediaUrl } from '@/hooks/useAuthenticatedMediaUrl';
 import Hls from 'hls.js';
 
 // Maximum playback duration limit - videos loop back to start after this many seconds
@@ -123,6 +124,9 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
 
     // Adult verification hook
     const { isVerified: isAdultVerified, getAuthHeader } = useAdultVerification();
+    const { mediaUrl: authenticatedPosterUrl } = useAuthenticatedMediaUrl(poster, {
+      enabled: !!poster && !requiresAuth && !authCheckPending,
+    });
 
     // Mobile-specific state
     const [touchState, setTouchState] = useState<TouchState | null>(null);
@@ -971,7 +975,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
           // HLS.js is used when hlsUrl is provided and Hls.isSupported()
           // Only show poster after auth check passes - prevents 401 errors from poster URL
           // During auth check, blurhash provides the visual placeholder
-          poster={(requiresAuth || authCheckPending) ? undefined : poster}
+          poster={(requiresAuth || authCheckPending) ? undefined : authenticatedPosterUrl}
           muted // Start muted, will be controlled via effect
           autoPlay={false} // Never autoplay, we control playback programmatically
           loop
@@ -1043,7 +1047,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
         {requiresAuth && (
           <AgeVerificationOverlay
             onVerified={handleAgeVerified}
-            thumbnailUrl={poster}
+            thumbnailUrl={authenticatedPosterUrl || poster}
             blurhash={blurhash}
           />
         )}

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -15,6 +15,7 @@ import type { ParsedVideoData } from '@/types/video';
 import type { VttCue } from '@/lib/vttParser';
 import { BlurhashPlaceholder, isValidBlurhash } from '@/components/BlurhashImage';
 import { AgeVerificationOverlay } from '@/components/AgeVerificationOverlay';
+import { AgeRestrictedMediaPlaceholder } from '@/components/AgeRestrictedMediaPlaceholder';
 import { SubtitleOverlay } from '@/components/SubtitleOverlay';
 import { createAuthLoader } from '@/lib/hlsAuthLoader';
 import { bandwidthTracker } from '@/lib/bandwidthTracker';
@@ -114,6 +115,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
     const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
     const [hasError, setHasError] = useState(false);
     const [requiresAuth, setRequiresAuth] = useState(false);
+    const [authDeniedAfterVerification, setAuthDeniedAfterVerification] = useState(false);
     const [authCheckPending, setAuthCheckPending] = useState(true); // Start true, set false after check completes
     const [authRetryCount, setAuthRetryCount] = useState(0);
     const [currentUrlIndex, setCurrentUrlIndex] = useState(0);
@@ -494,6 +496,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
         setIsLoading(true);
       }
       setHasError(false);
+      setAuthDeniedAfterVerification(false);
       onLoadStart?.();
     };
 
@@ -541,6 +544,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
       // Mark as loaded and hide blurhash permanently
       setIsLoading(false);
       setHasLoadedOnce(true);
+      setAuthDeniedAfterVerification(false);
 
       // Emit first video load metric (only once)
       if (loadDuration > 0 && typeof window !== 'undefined') {
@@ -618,6 +622,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
       setAuthCheckPending(false); // No need to re-check, user just verified
       setIsLoading(true);
       setHasError(false);
+      setAuthDeniedAfterVerification(false);
       setAuthRetryCount(prev => prev + 1);
       setCurrentUrlIndex(0);
     }, [videoId]);
@@ -782,7 +787,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
           if (data.response && (data.response.code === 401 || data.response.code === 403)) {
             debugError(`[VideoPlayer ${videoId}] Auth required (${data.response.code})`);
             if (isAdultVerified) {
-              setHasError(true);
+              setAuthDeniedAfterVerification(true);
             } else {
               setRequiresAuth(true);
             }
@@ -805,6 +810,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
         hlsRef.current = hls;
         setIsLoading(true);
         setHasError(false);
+        setAuthDeniedAfterVerification(false);
 
       } else if (hlsUrl && video.canPlayType('application/vnd.apple.mpegurl')) {
         // Native HLS support (Safari)
@@ -812,6 +818,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
         video.src = hlsUrl;
         setIsLoading(true);
         setHasError(false);
+        setAuthDeniedAfterVerification(false);
 
       } else {
         // Fall back to regular MP4 playback
@@ -855,7 +862,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
                   } else if (response.status === 401 || response.status === 403) {
                     debugError(`[VideoPlayer ${videoId}] Auth failed even with NIP-98 (${response.status})`);
                     if (isAdultVerified) {
-                      setHasError(true);
+                      setAuthDeniedAfterVerification(true);
                     } else {
                       setRequiresAuth(true);
                     }
@@ -886,6 +893,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
           }
           setIsLoading(true);
           setHasError(false);
+          setAuthDeniedAfterVerification(false);
         }
       }
       } // end loadVideoSource
@@ -1042,8 +1050,17 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
           </div>
         )}
 
+        {/* Auth denied after verification */}
+        {authDeniedAfterVerification && (
+          <AgeRestrictedMediaPlaceholder
+            title="Age-restricted video"
+            actionLabel="Retry"
+            onAction={handleAgeVerified}
+          />
+        )}
+
         {/* Error state */}
-        {hasError && !requiresAuth && (
+        {hasError && !requiresAuth && !authDeniedAfterVerification && (
           <div className="absolute inset-0 flex items-center justify-center text-muted-foreground">
             <div className="text-center">
               <div>Failed to load video</div>

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -18,7 +18,7 @@ import { AgeVerificationOverlay } from '@/components/AgeVerificationOverlay';
 import { SubtitleOverlay } from '@/components/SubtitleOverlay';
 import { createAuthLoader } from '@/lib/hlsAuthLoader';
 import { bandwidthTracker } from '@/lib/bandwidthTracker';
-import { useAuthenticatedMediaUrl } from '@/hooks/useAuthenticatedMediaUrl';
+import { isProtectedDivineMediaUrl, useAuthenticatedMediaUrl } from '@/hooks/useAuthenticatedMediaUrl';
 import Hls from 'hls.js';
 
 // Maximum playback duration limit - videos loop back to start after this many seconds
@@ -127,6 +127,8 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
     const { mediaUrl: authenticatedPosterUrl } = useAuthenticatedMediaUrl(poster, {
       enabled: !!poster && !requiresAuth && !authCheckPending,
     });
+    const overlayPosterUrl = authenticatedPosterUrl ||
+      (poster && !isProtectedDivineMediaUrl(poster) ? poster : undefined);
 
     // Mobile-specific state
     const [touchState, setTouchState] = useState<TouchState | null>(null);
@@ -1047,7 +1049,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
         {requiresAuth && (
           <AgeVerificationOverlay
             onVerified={handleAgeVerified}
-            thumbnailUrl={authenticatedPosterUrl || poster}
+            thumbnailUrl={overlayPosterUrl}
             blurhash={blurhash}
           />
         )}

--- a/src/hooks/useAuthenticatedMediaUrl.test.ts
+++ b/src/hooks/useAuthenticatedMediaUrl.test.ts
@@ -1,0 +1,47 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAuthenticatedMediaUrl } from './useAuthenticatedMediaUrl';
+
+const mockUseAdultVerification = vi.fn();
+
+vi.mock('@/hooks/useAdultVerification', () => ({
+  useAdultVerification: () => mockUseAdultVerification(),
+  fetchWithAuth: vi.fn(async (url: string, authHeader: string | null) => fetch(url, {
+    headers: authHeader ? { Authorization: authHeader } : {},
+  })),
+}));
+
+describe('useAuthenticatedMediaUrl', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseAdultVerification.mockReturnValue({
+      isVerified: true,
+      getAuthHeader: vi.fn().mockResolvedValue('Nostr signed-auth-header'),
+    });
+  });
+
+  it('does not fall back to the raw protected URL when authenticated fetch fails', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+    }) as typeof fetch;
+
+    const { result } = renderHook(() =>
+      useAuthenticatedMediaUrl('https://media.divine.video/protected-thumbnail.jpg'),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.mediaUrl).toBeUndefined();
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://media.divine.video/protected-thumbnail.jpg',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Nostr signed-auth-header',
+        }),
+      }),
+    );
+  });
+});

--- a/src/hooks/useAuthenticatedMediaUrl.ts
+++ b/src/hooks/useAuthenticatedMediaUrl.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { fetchWithAuth, useAdultVerification } from '@/hooks/useAdultVerification';
 
-function isProtectedDivineMediaUrl(url: string): boolean {
+export function isProtectedDivineMediaUrl(url: string): boolean {
   try {
     const parsed = new URL(url);
     return parsed.hostname === 'media.divine.video';
@@ -47,7 +47,7 @@ export function useAuthenticatedMediaUrl(
         const authHeader = await getAuthHeader(url);
         if (!authHeader) {
           if (!cancelled) {
-            setMediaUrl(url);
+            setMediaUrl(undefined);
             setIsLoading(false);
           }
           return;
@@ -75,7 +75,7 @@ export function useAuthenticatedMediaUrl(
         setIsLoading(false);
       } catch {
         if (!cancelled) {
-          setMediaUrl(url);
+          setMediaUrl(undefined);
           setIsLoading(false);
         }
       }

--- a/src/hooks/useAuthenticatedMediaUrl.ts
+++ b/src/hooks/useAuthenticatedMediaUrl.ts
@@ -1,0 +1,99 @@
+import { useEffect, useRef, useState } from 'react';
+import { fetchWithAuth, useAdultVerification } from '@/hooks/useAdultVerification';
+
+function isProtectedDivineMediaUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.hostname === 'media.divine.video';
+  } catch {
+    return false;
+  }
+}
+
+interface UseAuthenticatedMediaUrlOptions {
+  enabled?: boolean;
+}
+
+export function useAuthenticatedMediaUrl(
+  url: string | null | undefined,
+  options: UseAuthenticatedMediaUrlOptions = {},
+): {
+  mediaUrl: string | undefined;
+  isLoading: boolean;
+} {
+  const { enabled = true } = options;
+  const { isVerified, getAuthHeader } = useAdultVerification();
+  const [mediaUrl, setMediaUrl] = useState<string | undefined>(url ?? undefined);
+  const [isLoading, setIsLoading] = useState(false);
+  const objectUrlRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const shouldAuthenticate = !!url && enabled && isVerified && isProtectedDivineMediaUrl(url);
+
+    if (!shouldAuthenticate) {
+      setMediaUrl(url ?? undefined);
+      setIsLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    let nextObjectUrl: string | null = null;
+
+    setMediaUrl(undefined);
+    setIsLoading(true);
+
+    void (async () => {
+      try {
+        const authHeader = await getAuthHeader(url);
+        if (!authHeader) {
+          if (!cancelled) {
+            setMediaUrl(url);
+            setIsLoading(false);
+          }
+          return;
+        }
+
+        const response = await fetchWithAuth(url, authHeader);
+        if (!response.ok) {
+          throw new Error(`Failed to load media asset: ${response.status}`);
+        }
+
+        const blob = await response.blob();
+        nextObjectUrl = URL.createObjectURL(blob);
+
+        if (cancelled) {
+          URL.revokeObjectURL(nextObjectUrl);
+          return;
+        }
+
+        if (objectUrlRef.current) {
+          URL.revokeObjectURL(objectUrlRef.current);
+        }
+
+        objectUrlRef.current = nextObjectUrl;
+        setMediaUrl(nextObjectUrl);
+        setIsLoading(false);
+      } catch {
+        if (!cancelled) {
+          setMediaUrl(url);
+          setIsLoading(false);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, getAuthHeader, isVerified, url]);
+
+  useEffect(() => (
+    () => {
+      if (objectUrlRef.current) {
+        URL.revokeObjectURL(objectUrlRef.current);
+        objectUrlRef.current = null;
+      }
+    }
+  ), []);
+
+  return { mediaUrl, isLoading };
+}

--- a/src/hooks/useInfiniteVideosFunnelcake.ts
+++ b/src/hooks/useInfiniteVideosFunnelcake.ts
@@ -7,6 +7,7 @@ import { useCurrentUser } from '@/hooks/useCurrentUser';
 import type { ParsedVideoData } from '@/types/video';
 import type { FunnelcakeFetchOptions } from '@/types/funnelcake';
 import { fetchVideos, searchVideos, fetchUserVideos, fetchUserFeed, fetchRecommendations } from '@/lib/funnelcakeClient';
+import { enrichAgeRestrictedVideos } from '@/lib/ageRestrictedVideos';
 import { transformToVideoPage } from '@/lib/funnelcakeTransform';
 import { debugLog } from '@/lib/debug';
 import { performanceMonitor } from '@/lib/performanceMonitoring';
@@ -276,6 +277,9 @@ export function useInfiniteVideosFunnelcake({
       const parseStart = performance.now();
       const cursorType = feedType === 'recommendations' ? 'cursor' : 'timestamp';
       const page = transformToVideoPage(response, cursorType);
+      const enrichedVideos = feedType === 'profile'
+        ? await enrichAgeRestrictedVideos(page.videos, signal)
+        : page.videos;
       const parseTime = performance.now() - parseStart;
 
       const totalTime = performance.now() - totalStart;
@@ -285,7 +289,7 @@ export function useInfiniteVideosFunnelcake({
         relayUrl: effectiveApiUrl,
         queryType: `funnelcake-${feedType}`,
         duration: queryTime,
-        eventCount: page.videos.length,
+        eventCount: enrichedVideos.length,
         filters: JSON.stringify({ feedType, sortMode, hashtag, pubkey }),
       });
 
@@ -294,17 +298,17 @@ export function useInfiniteVideosFunnelcake({
         queryTime,
         parseTime,
         totalTime,
-        videoCount: page.videos.length,
+        videoCount: enrichedVideos.length,
         sortMode,
       });
 
-      debugLog(`[useInfiniteVideosFunnelcake] Got ${page.videos.length} videos in ${queryTime.toFixed(0)}ms`, {
+      debugLog(`[useInfiniteVideosFunnelcake] Got ${enrichedVideos.length} videos in ${queryTime.toFixed(0)}ms`, {
         hasMore: page.hasMore,
         nextCursor: page.nextCursor,
       });
 
       return {
-        videos: page.videos,
+        videos: enrichedVideos,
         nextCursor: page.nextCursor,
         offset: page.offset,
         recommendationsCursor: page.rawCursor,

--- a/src/hooks/useSubtitles.test.ts
+++ b/src/hooks/useSubtitles.test.ts
@@ -1,0 +1,121 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useSubtitles } from './useSubtitles';
+import type { ParsedVideoData } from '@/types/video';
+
+const mockNostrQuery = vi.fn();
+const mockUseAdultVerification = vi.fn();
+
+vi.mock('@nostrify/react', () => ({
+  useNostr: () => ({
+    nostr: {
+      query: mockNostrQuery,
+    },
+  }),
+}));
+
+vi.mock('@/hooks/useAdultVerification', () => ({
+  useAdultVerification: () => mockUseAdultVerification(),
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+}
+
+function makeVideo(overrides: Partial<ParsedVideoData> = {}): ParsedVideoData {
+  return {
+    id: 'video-1',
+    pubkey: 'f'.repeat(64),
+    kind: 34236,
+    createdAt: 1700000000,
+    content: 'Test video',
+    title: 'Test video',
+    videoUrl: 'https://media.divine.video/4a31d696c2275e60dbfe2359e6ff006f78a30f5df11c7290233a7860c4e8c31e',
+    thumbnailUrl: 'https://media.divine.video/4a31d696c2275e60dbfe2359e6ff006f78a30f5df11c7290233a7860c4e8c31e.jpg',
+    hashtags: [],
+    vineId: 'vine-id-1',
+    reposts: [],
+    isVineMigrated: false,
+    ageRestricted: false,
+    ...overrides,
+  };
+}
+
+describe('useSubtitles protected media auth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockNostrQuery.mockResolvedValue([]);
+    mockUseAdultVerification.mockReturnValue({
+      isVerified: false,
+      isLoading: false,
+      hasSigner: false,
+      getAuthHeader: vi.fn().mockResolvedValue(null),
+    });
+  });
+
+  it('sends authorization headers for age-restricted CDN subtitle requests', async () => {
+    const getAuthHeader = vi.fn().mockResolvedValue('Nostr subtitles-auth');
+    mockUseAdultVerification.mockReturnValue({
+      isVerified: true,
+      isLoading: false,
+      hasSigner: true,
+      getAuthHeader,
+    });
+
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve('WEBVTT\n\n00:00.000 --> 00:01.000\nhello'),
+    });
+    global.fetch = fetchSpy as typeof fetch;
+
+    const { result } = renderHook(
+      () => useSubtitles(makeVideo({ ageRestricted: true })),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.hasSubtitles).toBe(true);
+    });
+
+    expect(getAuthHeader).toHaveBeenCalledWith(
+      'https://media.divine.video/4a31d696c2275e60dbfe2359e6ff006f78a30f5df11c7290233a7860c4e8c31e/vtt',
+      'GET'
+    );
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://media.divine.video/4a31d696c2275e60dbfe2359e6ff006f78a30f5df11c7290233a7860c4e8c31e/vtt',
+      expect.objectContaining({
+        headers: { Authorization: 'Nostr subtitles-auth' },
+        signal: expect.any(AbortSignal),
+      })
+    );
+  });
+
+  it('does not make raw CDN subtitle requests for age-restricted media without auth', async () => {
+    const fetchSpy = vi.fn();
+    global.fetch = fetchSpy as typeof fetch;
+
+    const { result } = renderHook(
+      () => useSubtitles(makeVideo({ ageRestricted: true })),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(result.current.hasSubtitles).toBe(false);
+  });
+});

--- a/src/hooks/useSubtitles.ts
+++ b/src/hooks/useSubtitles.ts
@@ -5,6 +5,8 @@ import { useNostr } from '@nostrify/react';
 import { useQuery } from '@tanstack/react-query';
 import { parseVtt, type VttCue } from '@/lib/vttParser';
 import type { ParsedVideoData } from '@/types/video';
+import { useAdultVerification } from '@/hooks/useAdultVerification';
+import { isProtectedDivineMediaUrl } from '@/hooks/useAuthenticatedMediaUrl';
 
 interface UseSubtitlesResult {
   cues: VttCue[];
@@ -60,14 +62,16 @@ export function useSubtitles(
   video: ParsedVideoData | null | undefined,
 ): UseSubtitlesResult {
   const { nostr } = useNostr();
+  const { isVerified: isAdultVerified, getAuthHeader } = useAdultVerification();
 
   const hasEmbeddedContent = !!video?.textTrackContent;
   const hasRef = !!video?.textTrackRef;
   const cdnHash = video?.videoUrl ? extractCdnHash(video.videoUrl) : null;
+  const requiresProtectedCdnAuth = !!video?.ageRestricted && !!video?.videoUrl && isProtectedDivineMediaUrl(video.videoUrl);
   const queryEnabled = !!video && (hasEmbeddedContent || hasRef || !!cdnHash);
 
   const { data: cues = [], isLoading } = useQuery({
-    queryKey: ['subtitles', video?.id, video?.textTrackRef, cdnHash],
+    queryKey: ['subtitles', video?.id, video?.textTrackRef, cdnHash, requiresProtectedCdnAuth, isAdultVerified],
     queryFn: async ({ signal }) => {
       if (!video) return [];
 
@@ -102,7 +106,24 @@ export function useSubtitles(
       if (cdnHash) {
         try {
           const vttUrl = `https://media.divine.video/${cdnHash}/vtt`;
-          const response = await fetch(vttUrl, { signal });
+          const response = requiresProtectedCdnAuth
+            ? await (async () => {
+                const authHeader = await getAuthHeader(vttUrl, 'GET');
+                if (!authHeader) {
+                  return null;
+                }
+
+                return fetch(vttUrl, {
+                  headers: { Authorization: authHeader },
+                  signal,
+                });
+              })()
+            : await fetch(vttUrl, { signal });
+
+          if (!response) {
+            return [];
+          }
+
           if (response.ok) {
             const text = await response.text();
             if (text.trim().startsWith('WEBVTT')) {

--- a/src/hooks/useVideoPrefetch.test.ts
+++ b/src/hooks/useVideoPrefetch.test.ts
@@ -1,0 +1,71 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { useVideoPrefetch } from './useVideoPrefetch';
+import type { ParsedVideoData } from '@/types/video';
+
+function makeVideo(overrides: Partial<ParsedVideoData> = {}): ParsedVideoData {
+  return {
+    id: 'video-1',
+    pubkey: 'f'.repeat(64),
+    kind: 34236,
+    createdAt: 1700000000,
+    content: 'Test video',
+    videoUrl: 'https://media.divine.video/video-1',
+    thumbnailUrl: 'https://media.divine.video/video-1.jpg',
+    hashtags: [],
+    vineId: 'vine-id-1',
+    reposts: [],
+    isVineMigrated: false,
+    ...overrides,
+  };
+}
+
+describe('useVideoPrefetch', () => {
+  beforeEach(() => {
+    document.head.querySelectorAll('link[rel="prefetch"]').forEach((link) => link.remove());
+  });
+
+  afterEach(() => {
+    document.head.querySelectorAll('link[rel="prefetch"]').forEach((link) => link.remove());
+  });
+
+  it('does not prefetch age-restricted media.divine.video assets', () => {
+    renderHook(() =>
+      useVideoPrefetch('video-1', [
+        makeVideo({ id: 'video-1' }),
+        makeVideo({
+          id: 'restricted-video',
+          ageRestricted: true,
+          videoUrl: 'https://media.divine.video/restricted-video',
+          thumbnailUrl: 'https://media.divine.video/restricted-video.jpg',
+        }),
+      ]),
+    );
+
+    const prefetchHrefs = Array.from(document.head.querySelectorAll('link[rel="prefetch"]'))
+      .map((link) => (link as HTMLLinkElement).href);
+
+    expect(prefetchHrefs).not.toContain('https://media.divine.video/restricted-video');
+    expect(prefetchHrefs).not.toContain('https://media.divine.video/restricted-video.jpg');
+  });
+
+  it('continues prefetching unrestricted upcoming media', () => {
+    renderHook(() =>
+      useVideoPrefetch('video-1', [
+        makeVideo({ id: 'video-1' }),
+        makeVideo({
+          id: 'public-video',
+          ageRestricted: false,
+          videoUrl: 'https://media.divine.video/public-video',
+          thumbnailUrl: 'https://media.divine.video/public-video.jpg',
+        }),
+      ]),
+    );
+
+    const prefetchHrefs = Array.from(document.head.querySelectorAll('link[rel="prefetch"]'))
+      .map((link) => (link as HTMLLinkElement).href);
+
+    expect(prefetchHrefs).toContain('https://media.divine.video/public-video');
+    expect(prefetchHrefs).toContain('https://media.divine.video/public-video.jpg');
+  });
+});

--- a/src/hooks/useVideoPrefetch.ts
+++ b/src/hooks/useVideoPrefetch.ts
@@ -7,6 +7,14 @@ import { debugLog } from '@/lib/debug';
 
 const PREFETCH_COUNT = 3;
 
+function isProtectedDivineMediaUrl(url: string): boolean {
+  try {
+    return new URL(url).hostname === 'media.divine.video';
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Prefetch upcoming video URLs when the active video changes.
  * Inserts <link rel="prefetch"> elements into <head> for the next
@@ -49,10 +57,12 @@ export function useVideoPrefetch(
     // Collect unique URLs to prefetch (video URL + thumbnail)
     const urlsToPrefetch: { url: string; as: string }[] = [];
     for (const video of nextVideos) {
-      if (video.videoUrl) {
+      const shouldSkipProtectedMediaPrefetch = !!video.ageRestricted;
+
+      if (video.videoUrl && !(shouldSkipProtectedMediaPrefetch && isProtectedDivineMediaUrl(video.videoUrl))) {
         urlsToPrefetch.push({ url: video.videoUrl, as: 'video' });
       }
-      if (video.thumbnailUrl) {
+      if (video.thumbnailUrl && !(shouldSkipProtectedMediaPrefetch && isProtectedDivineMediaUrl(video.thumbnailUrl))) {
         urlsToPrefetch.push({ url: video.thumbnailUrl, as: 'image' });
       }
     }

--- a/src/lib/ageRestrictedVideos.test.ts
+++ b/src/lib/ageRestrictedVideos.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { enrichAgeRestrictedVideos } from './ageRestrictedVideos';
+import type { ParsedVideoData } from '@/types/video';
+
+const mockFetchVideoModerationStatus = vi.fn();
+
+vi.mock('@/lib/videoVerification', () => ({
+  fetchVideoModerationStatus: (...args: unknown[]) => mockFetchVideoModerationStatus(...args),
+}));
+
+function makeVideo(overrides: Partial<ParsedVideoData> = {}): ParsedVideoData {
+  return {
+    id: 'video-1',
+    pubkey: 'f'.repeat(64),
+    kind: 34236,
+    createdAt: 1700000000,
+    content: 'Test video',
+    videoUrl: 'https://media.divine.video/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+    thumbnailUrl: 'https://media.divine.video/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef.jpg',
+    sha256: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+    hashtags: [],
+    vineId: 'vine-id-1',
+    reposts: [],
+    isVineMigrated: false,
+    ...overrides,
+  };
+}
+
+describe('enrichAgeRestrictedVideos', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('keeps explicit age-restricted flags without extra moderation lookups', async () => {
+    const result = await enrichAgeRestrictedVideos([
+      makeVideo({
+        ageRestricted: true,
+      }),
+    ]);
+
+    expect(result[0].ageRestricted).toBe(true);
+    expect(mockFetchVideoModerationStatus).not.toHaveBeenCalled();
+  });
+
+  it('marks videos as age-restricted when the moderation proxy says so', async () => {
+    mockFetchVideoModerationStatus.mockResolvedValue({
+      ageRestricted: true,
+    });
+
+    const result = await enrichAgeRestrictedVideos([
+      makeVideo({
+        ageRestricted: false,
+      }),
+    ]);
+
+    expect(result[0].ageRestricted).toBe(true);
+    expect(mockFetchVideoModerationStatus).toHaveBeenCalledWith(
+      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+      undefined,
+    );
+  });
+});

--- a/src/lib/ageRestrictedVideos.ts
+++ b/src/lib/ageRestrictedVideos.ts
@@ -1,0 +1,35 @@
+import type { ParsedVideoData } from '@/types/video';
+import { fetchVideoModerationStatus } from '@/lib/videoVerification';
+
+const moderationAgeGateCache = new Map<string, boolean>();
+
+export async function enrichAgeRestrictedVideos(
+  videos: ParsedVideoData[],
+  signal?: AbortSignal,
+): Promise<ParsedVideoData[]> {
+  return Promise.all(videos.map(async (video) => {
+    if (video.ageRestricted === true) {
+      return video;
+    }
+
+    if (!video.sha256) {
+      return video;
+    }
+
+    const cached = moderationAgeGateCache.get(video.sha256);
+    if (cached !== undefined) {
+      return cached ? { ...video, ageRestricted: true } : video;
+    }
+
+    const status = await fetchVideoModerationStatus(video.sha256, signal);
+    if (!status) {
+      return video;
+    }
+
+    moderationAgeGateCache.set(video.sha256, status.ageRestricted === true);
+
+    return status.ageRestricted === true
+      ? { ...video, ageRestricted: true }
+      : video;
+  }));
+}

--- a/src/lib/funnelcakeTransform.test.ts
+++ b/src/lib/funnelcakeTransform.test.ts
@@ -46,6 +46,14 @@ describe('transformFunnelcakeVideo', () => {
 
     expect(video.loopCount).toBe(296752);
   });
+
+  it('preserves the age-restricted flag from the API payload', () => {
+    const video = transformFunnelcakeVideo(makeRawVideo({
+      age_restricted: true,
+    }));
+
+    expect(video.ageRestricted).toBe(true);
+  });
 });
 
 function makeResponse(overrides: Partial<FunnelcakeResponse> = {}): FunnelcakeResponse {

--- a/src/lib/funnelcakeTransform.ts
+++ b/src/lib/funnelcakeTransform.ts
@@ -86,6 +86,7 @@ export function transformFunnelcakeVideo(raw: FunnelcakeVideoRaw): ParsedVideoDa
     title: raw.title,
     dimensions: raw.dim, // Video dimensions from API (e.g., "1080x1920")
     sha256: extractSha256FromVideoUrl(raw.video_url),
+    ageRestricted: raw.age_restricted === true || raw.moderation_status === 'age_restricted',
     hashtags,
 
     // Vine-specific fields

--- a/src/types/funnelcake.ts
+++ b/src/types/funnelcake.ts
@@ -23,6 +23,8 @@ export interface FunnelcakeVideoRaw {
   dim?: string;           // Video dimensions (e.g., "1080x1920")
   author_name?: string;   // Cached author display name
   author_avatar?: string; // Cached author avatar URL
+  age_restricted?: boolean;
+  moderation_status?: string;
 
   // Social metrics - main videos endpoint uses embedded_* prefix
   reactions?: number;      // Like count (user videos endpoint)

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -83,6 +83,7 @@ export interface ParsedVideoData {
   duration?: number;
   dimensions?: string; // Video dimensions from imeta dim tag (e.g., "1080x1920")
   sha256?: string; // Content hash from imeta x or Divine-hosted media URL
+  ageRestricted?: boolean;
   hashtags: string[];
   vineId: string | null;
   loopCount?: number;


### PR DESCRIPTION
## Summary
- add explicit locked placeholders for age-restricted profile videos so logged-out and unverified viewers see a gated state instead of broken tiles
- preserve  from video payloads and enrich profile-feed videos through the moderation proxy when the public API omits the flag
- add regression coverage for transform, moderation enrichment, grid gating, and card gating behavior

## Test Plan
- [x] npx vitest run src/lib/funnelcakeTransform.test.ts src/lib/ageRestrictedVideos.test.ts src/components/VideoGrid.test.tsx src/components/VideoCard.test.tsx
- [x] npm run test
