### PR TITLE
Fix thumbnail play button behavior

### DIFF
--- a/src/components/ThumbnailPlayer.test.tsx
+++ b/src/components/ThumbnailPlayer.test.tsx
@@ -1,0 +1,62 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ThumbnailPlayer } from './ThumbnailPlayer';
+
+vi.mock('@/hooks/useAdultVerification', () => ({
+  useAdultVerification: vi.fn(() => ({
+    isVerified: true,
+  })),
+  checkMediaAuth: vi.fn().mockResolvedValue({ authorized: true, status: 200 }),
+}));
+
+vi.mock('@/components/AgeVerificationOverlay', () => ({
+  AgeVerificationOverlay: () => <div>Age verification</div>,
+}));
+
+vi.mock('@/lib/debug', () => ({
+  verboseLog: vi.fn(),
+  debugError: vi.fn(),
+}));
+
+describe('ThumbnailPlayer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('lets the play button start playback without triggering the thumbnail click action', () => {
+    const handleThumbnailClick = vi.fn();
+    const handlePlayButtonClick = vi.fn();
+
+    render(
+      <ThumbnailPlayer
+        videoId="video-123"
+        src="https://example.com/video.mp4"
+        thumbnailUrl="https://example.com/thumb.jpg"
+        onClick={handleThumbnailClick}
+        onPlayButtonClick={handlePlayButtonClick}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText('Play video'));
+
+    expect(handlePlayButtonClick).toHaveBeenCalledTimes(1);
+    expect(handleThumbnailClick).not.toHaveBeenCalled();
+  });
+
+  it('still delegates container clicks to the thumbnail click action', () => {
+    const handleThumbnailClick = vi.fn();
+
+    render(
+      <ThumbnailPlayer
+        videoId="video-123"
+        src="https://example.com/video.mp4"
+        thumbnailUrl="https://example.com/thumb.jpg"
+        onClick={handleThumbnailClick}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('thumbnail-container'));
+
+    expect(handleThumbnailClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/ThumbnailPlayer.tsx
+++ b/src/components/ThumbnailPlayer.tsx
@@ -16,6 +16,7 @@ interface ThumbnailPlayerProps {
   duration?: number;
   className?: string;
   onClick?: () => void;
+  onPlayButtonClick?: () => void;
   onError?: () => void;
   onVideoDimensions?: (dimensions: { width: number; height: number; isVertical: boolean }) => void;
 }
@@ -27,6 +28,7 @@ export function ThumbnailPlayer({
   duration: _duration,
   className,
   onClick,
+  onPlayButtonClick,
   onError,
   onVideoDimensions,
 }: ThumbnailPlayerProps) {
@@ -165,6 +167,17 @@ export function ThumbnailPlayer({
             className="w-16 h-16 rounded-full bg-black/50 hover:bg-black/70 text-white backdrop-blur-sm"
             data-testid="thumbnail-play-button"
             aria-label="Play video"
+            onClick={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              onPlayButtonClick?.();
+            }}
+            onTouchStart={(event) => {
+              event.stopPropagation();
+            }}
+            onTouchEnd={(event) => {
+              event.stopPropagation();
+            }}
           >
             <Play className="h-8 w-8 ml-1" />
           </Button>

--- a/src/components/VideoCard.test.tsx
+++ b/src/components/VideoCard.test.tsx
@@ -1,0 +1,301 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ButtonHTMLAttributes, HTMLAttributes, ImgHTMLAttributes, ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ParsedVideoData } from '@/types/video';
+import { VideoCard } from './VideoCard';
+
+const playbackMocks = vi.hoisted(() => ({
+  activeVideoId: null as string | null,
+  setActiveVideo: vi.fn(),
+  setGlobalMuted: vi.fn(),
+  navigate: vi.fn(),
+  toast: vi.fn(),
+  share: vi.fn(),
+  muteAsync: vi.fn(),
+  deleteVideo: vi.fn(),
+  pinVideo: vi.fn(),
+  unpinVideo: vi.fn(),
+}));
+
+vi.mock('@/components/ui/card', () => ({
+  Card: ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+  CardContent: ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+}));
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) => <button {...props}>{children}</button>,
+}));
+
+vi.mock('@/components/ui/avatar', () => ({
+  Avatar: ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+  AvatarImage: (props: ImgHTMLAttributes<HTMLImageElement>) => <img {...props} />,
+  AvatarFallback: ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+}));
+
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuSeparator: () => <div />,
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/components/VideoPlayer', () => ({
+  VideoPlayer: ({ videoId }: { videoId: string }) => <div data-testid={`video-player-${videoId}`}>Video Player</div>,
+}));
+
+vi.mock('@/components/ThumbnailPlayer', () => ({
+  ThumbnailPlayer: ({
+    onClick,
+    onPlayButtonClick,
+  }: {
+    onClick?: () => void;
+    onPlayButtonClick?: () => void;
+  }) => (
+    <div data-testid="thumbnail-player">
+      <button onClick={onClick} type="button">Thumbnail</button>
+      <button aria-label="Play video" onClick={onPlayButtonClick} type="button">Play</button>
+    </div>
+  ),
+}));
+
+vi.mock('@/components/VideoCommentsModal', () => ({
+  VideoCommentsModal: () => null,
+}));
+
+vi.mock('@/components/VideoReactionsModal', () => ({
+  VideoReactionsModal: () => null,
+}));
+
+vi.mock('@/components/NoteContent', () => ({
+  NoteContent: ({ event }: { event: { content: string } }) => <div>{event.content}</div>,
+}));
+
+vi.mock('@/components/InlineNostrText', () => ({
+  InlineNostrText: ({ text }: { text: string }) => <>{text}</>,
+}));
+
+vi.mock('@/components/AddToListDialog', () => ({
+  AddToListDialog: () => null,
+}));
+
+vi.mock('@/components/ReportContentDialog', () => ({
+  ReportContentDialog: () => null,
+}));
+
+vi.mock('@/components/DeleteVideoDialog', () => ({
+  DeleteVideoDialog: () => null,
+}));
+
+vi.mock('@/components/ViewSourceDialog', () => ({
+  ViewSourceDialog: () => null,
+}));
+
+vi.mock('@/components/VideoVerificationBadgeRow', () => ({
+  VideoVerificationBadgeRow: () => <div>Badges</div>,
+}));
+
+vi.mock('@/components/SmartLink', () => ({
+  SmartLink: ({
+    children,
+    ownerPubkey: _ownerPubkey,
+    ...props
+  }: HTMLAttributes<HTMLAnchorElement> & { ownerPubkey?: string }) => <a {...props}>{children}</a>,
+}));
+
+vi.mock('@/hooks/useAuthor', () => ({
+  useAuthor: () => ({
+    data: {
+      metadata: {
+        name: 'Video Author',
+        picture: 'https://example.com/avatar.jpg',
+      },
+    },
+    isLoading: false,
+  }),
+}));
+
+vi.mock('@/hooks/useIsMobile', () => ({
+  useIsMobile: () => false,
+}));
+
+vi.mock('@/hooks/useModeration', () => ({
+  useMuteItem: () => ({
+    mutateAsync: playbackMocks.muteAsync,
+  }),
+}));
+
+vi.mock('@/hooks/useDeleteVideo', () => ({
+  useDeleteVideo: () => ({
+    mutate: playbackMocks.deleteVideo,
+    isPending: false,
+  }),
+  useCanDeleteVideo: () => false,
+}));
+
+vi.mock('@/hooks/usePinnedVideos', () => ({
+  useIsVideoPinned: () => false,
+  usePinVideo: () => ({
+    mutateAsync: playbackMocks.pinVideo,
+  }),
+  useUnpinVideo: () => ({
+    mutateAsync: playbackMocks.unpinVideo,
+  }),
+}));
+
+vi.mock('@/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({
+    user: null,
+  }),
+}));
+
+vi.mock('@/hooks/useVideoPlayback', () => ({
+  useVideoPlayback: () => ({
+    activeVideoId: playbackMocks.activeVideoId,
+    setActiveVideo: playbackMocks.setActiveVideo,
+    registerVideo: vi.fn(),
+    unregisterVideo: vi.fn(),
+    updateVideoVisibility: vi.fn(),
+    globalMuted: true,
+    setGlobalMuted: playbackMocks.setGlobalMuted,
+  }),
+}));
+
+vi.mock('@/hooks/useVideoLists', () => ({
+  useVideosInLists: () => ({
+    data: [],
+  }),
+}));
+
+vi.mock('@/hooks/useVideoReactions', () => ({
+  useVideoReactions: () => ({
+    data: null,
+  }),
+}));
+
+vi.mock('@/hooks/useToast', () => ({
+  useToast: () => ({
+    toast: playbackMocks.toast,
+  }),
+}));
+
+vi.mock('@/hooks/useShare', () => ({
+  useShare: () => ({
+    share: playbackMocks.share,
+  }),
+}));
+
+vi.mock('@/hooks/useDirectMessages', () => ({
+  useDmCapability: () => ({
+    canUseDirectMessages: false,
+  }),
+}));
+
+vi.mock('@/hooks/useSubdomainNavigate', () => ({
+  useSubdomainNavigate: () => playbackMocks.navigate,
+}));
+
+vi.mock('@/hooks/useBandwidthTier', () => ({
+  useBandwidthTier: () => 'default',
+}));
+
+vi.mock('@/hooks/useSubtitles', () => ({
+  useSubtitles: () => ({
+    cues: [],
+    hasSubtitles: false,
+  }),
+}));
+
+vi.mock('@/lib/generateProfile', () => ({
+  enhanceAuthorData: (data: { metadata?: Record<string, unknown> } | undefined, pubkey: string) => ({
+    metadata: data?.metadata ?? { name: pubkey },
+  }),
+}));
+
+vi.mock('@/lib/genUserName', () => ({
+  genUserName: () => 'Generated User',
+}));
+
+vi.mock('@/lib/utils', () => ({
+  cn: (...classes: Array<string | false | null | undefined>) => classes.filter(Boolean).join(' '),
+}));
+
+vi.mock('@/lib/formatUtils', () => ({
+  formatClassicVineViewBreakdown: () => '0 views',
+  formatViewCount: (count: number) => String(count),
+  formatCount: (count: number) => String(count),
+}));
+
+vi.mock('@/lib/imageUtils', () => ({
+  getSafeProfileImage: (url?: string) => url ?? '',
+}));
+
+vi.mock('@/lib/shareUtils', () => ({
+  getVideoShareData: () => ({}),
+}));
+
+vi.mock('@/lib/bandwidthTracker', () => ({
+  getOptimalVideoUrl: (url: string) => url,
+}));
+
+vi.mock('@/lib/debug', () => ({
+  debugLog: vi.fn(),
+}));
+
+const baseVideo = {
+  id: 'video-1',
+  kind: 34236,
+  pubkey: 'f'.repeat(64),
+  authorName: 'Video Author',
+  authorAvatar: 'https://example.com/avatar.jpg',
+  videoUrl: 'https://example.com/video.mp4',
+  thumbnailUrl: 'https://example.com/thumb.jpg',
+  duration: 6,
+  createdAt: 1_700_000_000,
+  hashtags: [],
+  reposts: [],
+  content: '',
+  title: 'Test Video',
+  likeCount: 0,
+  repostCount: 0,
+  commentCount: 0,
+  divineViewCount: 0,
+  loopCount: 0,
+  isVineMigrated: false,
+  originalVineTimestamp: undefined,
+  dimensions: '1080x1920',
+  fallbackVideoUrls: [],
+  hlsUrl: undefined,
+  vineId: 'vine-id-1',
+} as unknown as ParsedVideoData;
+
+describe('VideoCard', () => {
+  beforeEach(() => {
+    playbackMocks.activeVideoId = null;
+    playbackMocks.setActiveVideo.mockClear();
+    playbackMocks.setGlobalMuted.mockClear();
+    playbackMocks.navigate.mockClear();
+  });
+
+  it('marks a thumbnail-mode video active when inline playback starts', () => {
+    render(<VideoCard video={baseVideo} mode="thumbnail" />);
+
+    fireEvent.click(screen.getByLabelText('Play video'));
+
+    expect(playbackMocks.setActiveVideo).toHaveBeenCalledWith(baseVideo.id);
+    expect(screen.getByTestId(`video-player-${baseVideo.id}`)).toBeTruthy();
+  });
+
+  it('stops inline thumbnail playback when another video becomes active', () => {
+    const { rerender } = render(<VideoCard video={baseVideo} mode="thumbnail" />);
+
+    fireEvent.click(screen.getByLabelText('Play video'));
+    expect(screen.getByTestId(`video-player-${baseVideo.id}`)).toBeTruthy();
+
+    playbackMocks.activeVideoId = 'video-2';
+    rerender(<VideoCard video={baseVideo} mode="thumbnail" />);
+
+    expect(screen.queryByTestId(`video-player-${baseVideo.id}`)).toBeNull();
+    expect(screen.getByTestId('thumbnail-player')).toBeTruthy();
+  });
+});

--- a/src/components/VideoCard.test.tsx
+++ b/src/components/VideoCard.test.tsx
@@ -41,7 +41,24 @@ vi.mock('@/components/ui/dropdown-menu', () => ({
 }));
 
 vi.mock('@/components/VideoPlayer', () => ({
-  VideoPlayer: ({ videoId }: { videoId: string }) => <div data-testid={`video-player-${videoId}`}>Video Player</div>,
+  VideoPlayer: ({
+    videoId,
+    onPlaybackStarted,
+  }: {
+    videoId: string;
+    onPlaybackStarted?: () => void;
+  }) => (
+    <div data-testid={`video-player-${videoId}`}>
+      Video Player
+      <button
+        aria-label={`start-playback-${videoId}`}
+        onClick={onPlaybackStarted}
+        type="button"
+      >
+        Start playback
+      </button>
+    </div>
+  ),
 }));
 
 vi.mock('@/components/ThumbnailPlayer', () => ({
@@ -284,6 +301,19 @@ describe('VideoCard', () => {
 
     expect(playbackMocks.setActiveVideo).toHaveBeenCalledWith(baseVideo.id);
     expect(screen.getByTestId(`video-player-${baseVideo.id}`)).toBeTruthy();
+  });
+
+  it('keeps the thumbnail visible until inline playback actually starts', () => {
+    render(<VideoCard video={baseVideo} mode="thumbnail" />);
+
+    fireEvent.click(screen.getByLabelText('Play video'));
+
+    expect(screen.getByTestId(`video-player-${baseVideo.id}`)).toBeTruthy();
+    expect(screen.getByTestId('thumbnail-player')).toBeTruthy();
+
+    fireEvent.click(screen.getByLabelText(`start-playback-${baseVideo.id}`));
+
+    expect(screen.queryByTestId('thumbnail-player')).toBeNull();
   });
 
   it('stops inline thumbnail playback when another video becomes active', () => {

--- a/src/components/VideoCard.tsx
+++ b/src/components/VideoCard.tsx
@@ -1,7 +1,7 @@
 // ABOUTME: Video card component for displaying individual videos in feeds
 // ABOUTME: Shows video player, metadata, author info, and social interactions
 
-import { useState, useCallback, useRef, useMemo } from 'react';
+import { useState, useCallback, useRef, useMemo, useEffect } from 'react';
 import { Heart, Repeat2, MessageCircle, Share, Eye, MoreVertical, Flag, UserX, Trash2, Volume2, VolumeX, Code, Users, ListPlus, Download, Maximize2, Captions, Pin, PinOff } from 'lucide-react';
 import { nip19 } from 'nostr-tools';
 import { Card, CardContent } from '@/components/ui/card';
@@ -241,7 +241,7 @@ export function VideoCard({
   const { canUseDirectMessages } = useDmCapability();
   const muteUser = useMuteItem();
   const navigate = useSubdomainNavigate();
-  const { globalMuted, setGlobalMuted } = useVideoPlayback();
+  const { activeVideoId, setActiveVideo, globalMuted, setGlobalMuted } = useVideoPlayback();
   const { cues: subtitleCues, hasSubtitles } = useSubtitles(video);
   // Subtitles default to ON when available, independent of mute state
   const [subtitlesVisible, setSubtitlesVisible] = useState(true);
@@ -330,21 +330,36 @@ export function VideoCard({
     if (mode === 'thumbnail') {
       navigate(`/video/${video.id}`, { ownerPubkey: video.pubkey });
     } else {
+      setActiveVideo(video.id);
       setIsPlaying(true);
       onPlay?.();
     }
   };
 
   const handleThumbnailPlayButtonClick = () => {
+    setActiveVideo(video.id);
     setIsPlaying(true);
     onPlay?.();
   };
 
   const handleVideoEnd = () => {
     if (mode === 'thumbnail') {
+      if (activeVideoId === video.id) {
+        setActiveVideo(null);
+      }
       setIsPlaying(false);
     }
   };
+
+  useEffect(() => {
+    if (mode !== 'thumbnail') {
+      return;
+    }
+
+    if (isPlaying && activeVideoId !== null && activeVideoId !== video.id) {
+      setIsPlaying(false);
+    }
+  }, [activeVideoId, isPlaying, mode, video.id]);
 
   const handleMuteUser = async () => {
     try {

--- a/src/components/VideoCard.tsx
+++ b/src/components/VideoCard.tsx
@@ -145,6 +145,7 @@ export function VideoCard({
   // Always start with video player visible in auto-play mode, but let VideoPlaybackContext control actual playback
   // The VideoPlayer component will only play when it's the activeVideoId (most visible)
   const [isPlaying, setIsPlaying] = useState(mode === 'auto-play');
+  const [showThumbnailDuringStartup, setShowThumbnailDuringStartup] = useState(false);
   const [showAddToListDialog, setShowAddToListDialog] = useState(false);
   const [showReportDialog, setShowReportDialog] = useState(false);
   const [showReportUserDialog, setShowReportUserDialog] = useState(false);
@@ -339,6 +340,7 @@ export function VideoCard({
   const handleThumbnailPlayButtonClick = () => {
     setActiveVideo(video.id);
     setIsPlaying(true);
+    setShowThumbnailDuringStartup(mode === 'thumbnail');
     onPlay?.();
   };
 
@@ -348,6 +350,7 @@ export function VideoCard({
         setActiveVideo(null);
       }
       setIsPlaying(false);
+      setShowThumbnailDuringStartup(false);
     }
   };
 
@@ -358,8 +361,30 @@ export function VideoCard({
 
     if (isPlaying && activeVideoId !== null && activeVideoId !== video.id) {
       setIsPlaying(false);
+      setShowThumbnailDuringStartup(false);
     }
   }, [activeVideoId, isPlaying, mode, video.id]);
+
+  useEffect(() => {
+    if (!isPlaying) {
+      setShowThumbnailDuringStartup(false);
+    }
+  }, [isPlaying]);
+
+  const handlePlaybackStarted = () => {
+    setShowThumbnailDuringStartup(false);
+    onPlaybackStarted?.();
+  };
+
+  const handleVideoError = () => {
+    setShowThumbnailDuringStartup(false);
+    // If MP4 failed and we haven't tried HLS yet, retry with HLS fallback
+    if (!mp4Failed && !effectiveHlsUrl && video.videoUrl?.includes('media.divine.video')) {
+      setMp4Failed(true);
+    } else {
+      setVideoError(true);
+    }
+  };
 
   const handleMuteUser = async () => {
     try {
@@ -548,34 +573,41 @@ export function VideoCard({
                   onVideoDimensions={handleThumbnailDimensions}
                 />
               ) : !videoError ? (
-                <VideoPlayer
-                  videoId={video.id}
-                  src={video.videoUrl}
-                  hlsUrl={effectiveHlsUrl}
-                  fallbackUrls={video.fallbackVideoUrls}
-                  poster={video.thumbnailUrl}
-                  blurhash={video.blurhash}
-                  isPriority={isPriority}
-                  className="w-full h-full"
-                  onLoadStart={() => setVideoError(false)}
-                  onError={() => {
-                    // If MP4 failed and we haven't tried HLS yet, retry with HLS fallback
-                    if (!mp4Failed && !effectiveHlsUrl && video.videoUrl?.includes('media.divine.video')) {
-                      setMp4Failed(true);
-                    } else {
-                      setVideoError(true);
-                    }
-                  }}
-                  onEnded={handleVideoEnd}
-                  onLoadedData={onLoadedData}
-                  onPlaybackStarted={onPlaybackStarted}
-                  onVideoDimensions={handleVideoDimensions}
-                  subtitleCues={subtitleCues}
-                  subtitlesVisible={showSubtitles}
-                  videoData={video}
-                  trafficSource={trafficSource}
-                  objectFit={isClassicVine ? 'cover' : 'contain'}
-                />
+                <>
+                  <VideoPlayer
+                    videoId={video.id}
+                    src={video.videoUrl}
+                    hlsUrl={effectiveHlsUrl}
+                    fallbackUrls={video.fallbackVideoUrls}
+                    poster={video.thumbnailUrl}
+                    blurhash={video.blurhash}
+                    isPriority={isPriority}
+                    className="w-full h-full"
+                    onLoadStart={() => setVideoError(false)}
+                    onError={handleVideoError}
+                    onEnded={handleVideoEnd}
+                    onLoadedData={onLoadedData}
+                    onPlaybackStarted={handlePlaybackStarted}
+                    onVideoDimensions={handleVideoDimensions}
+                    subtitleCues={subtitleCues}
+                    subtitlesVisible={showSubtitles}
+                    videoData={video}
+                    trafficSource={trafficSource}
+                    objectFit={isClassicVine ? 'cover' : 'contain'}
+                  />
+                  {mode === 'thumbnail' && showThumbnailDuringStartup && (
+                    <div className="absolute inset-0 z-20 pointer-events-none">
+                      <ThumbnailPlayer
+                        videoId={video.id}
+                        src={video.videoUrl}
+                        thumbnailUrl={video.thumbnailUrl}
+                        duration={video.duration}
+                        className="w-full h-full"
+                        onVideoDimensions={handleThumbnailDimensions}
+                      />
+                    </div>
+                  )}
+                </>
               ) : (
                 <div className="flex items-center justify-center h-full text-muted-foreground">
                   <p>Failed to load video</p>

--- a/src/components/VideoCard.tsx
+++ b/src/components/VideoCard.tsx
@@ -335,6 +335,11 @@ export function VideoCard({
     }
   };
 
+  const handleThumbnailPlayButtonClick = () => {
+    setIsPlaying(true);
+    onPlay?.();
+  };
+
   const handleVideoEnd = () => {
     if (mode === 'thumbnail') {
       setIsPlaying(false);
@@ -523,6 +528,7 @@ export function VideoCard({
                   duration={video.duration}
                   className="w-full h-full"
                   onClick={handleThumbnailClick}
+                  onPlayButtonClick={handleThumbnailPlayButtonClick}
                   onError={() => setVideoError(true)}
                   onVideoDimensions={handleThumbnailDimensions}
                 />


### PR DESCRIPTION
## Summary
- stop the hover play button from bubbling into thumbnail navigation
- start inline playback from the play button even on thumbnail-mode cards
- add a regression test covering play button clicks versus container clicks

## Test Plan
- [x] 
- [x] 
/Users/rabble/code/divine/divine-web/.worktrees/fix-video-hover-preview/compute-js/src/index-simple.js
  7:1  warning  Unused eslint-disable directive (no problems were reported from 'no-restricted-globals')

/Users/rabble/code/divine/divine-web/.worktrees/fix-video-hover-preview/compute-js/src/index.js
  31:1  warning  Unused eslint-disable directive (no problems were reported from 'no-restricted-globals')

/Users/rabble/code/divine/divine-web/.worktrees/fix-video-hover-preview/src/components/BlurhashImage.tsx
  115:17  warning  Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components  react-refresh/only-export-components

/Users/rabble/code/divine/divine-web/.worktrees/fix-video-hover-preview/src/components/FullscreenFeed.tsx
  176:6  warning  React Hook useEffect has missing dependencies: 'globalMuted' and 'setGlobalMuted'. Either include them or remove the dependency array  react-hooks/exhaustive-deps

/Users/rabble/code/divine/divine-web/.worktrees/fix-video-hover-preview/src/components/VideoPlayer.tsx
  268:8  warning  React Hook useEffect has a missing dependency: 'handleError'. Either include it or remove the dependency array    react-hooks/exhaustive-deps
  310:8  warning  React Hook useEffect has a missing dependency: 'handleError'. Either include it or remove the dependency array    react-hooks/exhaustive-deps
  334:8  warning  React Hook useCallback has a missing dependency: 'handleError'. Either include it or remove the dependency array  react-hooks/exhaustive-deps

/Users/rabble/code/divine/divine-web/.worktrees/fix-video-hover-preview/src/contexts/FullscreenFeedContext.tsx
  100:17  warning  Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components  react-refresh/only-export-components

/Users/rabble/code/divine/divine-web/.worktrees/fix-video-hover-preview/src/contexts/LoginDialogContext.tsx
  24:17  warning  Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components  react-refresh/only-export-components

/Users/rabble/code/divine/divine-web/.worktrees/fix-video-hover-preview/src/contexts/VideoPlaybackContext.tsx
  21:14  warning  Fast refresh only works when a file only exports components. Move your React context(s) to a separate file  react-refresh/only-export-components

/Users/rabble/code/divine/divine-web/.worktrees/fix-video-hover-preview/src/hooks/useMediaRecorder.ts
  198:6  warning  React Hook useCallback has a missing dependency: 'stopSegment'. Either include it or remove the dependency array  react-hooks/exhaustive-deps

/Users/rabble/code/divine/divine-web/.worktrees/fix-video-hover-preview/src/hooks/useVideoEvents.ts
  533:6  warning  React Hook useEffect has a missing dependency: 'queryResult'. Either include it or remove the dependency array  react-hooks/exhaustive-deps

/Users/rabble/code/divine/divine-web/.worktrees/fix-video-hover-preview/src/hooks/useVideoUpload.ts
  72:6  warning  React Hook useCallback has a missing dependency: 'getVideoDuration'. Either include it or remove the dependency array  react-hooks/exhaustive-deps

/Users/rabble/code/divine/divine-web/.worktrees/fix-video-hover-preview/src/pages/Support.tsx
  66:6  warning  React Hook useEffect has a missing dependency: 'ZENDESK_ENABLED'. Either include it or remove the dependency array  react-hooks/exhaustive-deps

✖ 14 problems (0 errors, 14 warnings)
  0 errors and 2 warnings potentially fixable with the `--fix` option. (existing warnings only)
- [x] 
 RUN  v3.2.4 /Users/rabble/code/divine/divine-web/.worktrees/fix-video-hover-preview

stdout | src/hooks/useWindowNostrJWT.test.ts > useWindowNostrJWT > should create signer when token is provided
[useWindowNostrJWT] Creating JWT signer...

stdout | src/hooks/useWindowNostrJWT.test.ts > useWindowNostrJWT > should create signer when token is provided
[useWindowNostrJWT] ✅ JWT signer ready, pubkey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa

stdout | src/hooks/useResolveSubdomainPubkey.test.ts > useResolveSubdomainPubkey > searches relay when nip05Stale is true and returns resolved pubkey
[useResolveSubdomainPubkey] Found correct pubkey: bb9f2abbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb via NIP-05: _@kirstenswasey.divine.video

 ✓ src/lib/funnelcakeClient.test.ts (18 tests) 156ms
stdout | src/hooks/useWindowNostrJWT.test.ts > useWindowNostrJWT > should auto-inject window.nostr when autoInject is true
[useWindowNostrJWT] Creating JWT signer...

stdout | src/hooks/useWindowNostrJWT.test.ts > useWindowNostrJWT > should auto-inject window.nostr when autoInject is true
[useWindowNostrJWT] ✅ JWT signer ready, pubkey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa

stdout | src/hooks/useWindowNostrJWT.test.ts > useWindowNostrJWT > should auto-inject window.nostr when autoInject is true
[useWindowNostrJWT] Auto-injecting window.nostr...
[injectWindowNostr] ✅ Injected window.nostr signer

stdout | src/hooks/useResolveSubdomainPubkey.test.ts > useResolveSubdomainPubkey > falls back to original pubkey when search finds no match
[useResolveSubdomainPubkey] No matching NIP-05 found for kirstenswasey.divine.video

stdout | src/hooks/useInfiniteSearchVideos.test.ts > useInfiniteSearchVideos > uses Funnelcake search results without falling back to relay search
[search/videos] starting {
  query: 'jack',
  parsedType: 'content',
  parsedValue: 'jack',
  searchType: 'auto',
  sortMode: 'relevance',
  cursor: null,
  pageSize: 20,
  debounceMs: 0
}

stdout | src/hooks/useInfiniteSearchVideos.test.ts > useInfiniteSearchVideos > uses Funnelcake search results without falling back to relay search
[search/videos] funnelcake query complete {
  query: 'jack',
  parsedType: 'content',
  parsedValue: 'jack',
  searchType: 'auto',
  sortMode: 'relevance',
  cursor: null,
  pageSize: 20,
  mode: 'funnelcake',
  apiMs: 1,
  totalMs: 3,
  returnedVideoCount: 1,
  hasMore: false,
  nextCursor: null
}

stdout | src/hooks/useWindowNostrJWT.test.ts > useWindowNostrJWT > should auto-inject window.nostr when autoInject is true
[removeWindowNostr] ✅ Removed window.nostr

stdout | src/hooks/useWindowNostrJWT.test.ts > useWindowNostrJWT > should auto-inject window.nostr when autoInject is true
[useWindowNostrJWT] Cleaning up window.nostr...

stdout | src/hooks/useWindowNostrJWT.test.ts > useWindowNostrJWT > should not inject window.nostr when autoInject is false
[useWindowNostrJWT] Creating JWT signer...

stdout | src/hooks/useWindowNostrJWT.test.ts > useWindowNostrJWT > should not inject window.nostr when autoInject is false
[useWindowNostrJWT] ✅ JWT signer ready, pubkey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa

 ✓ src/pages/AtUsernamePage.test.tsx (6 tests) 70ms
 ✓ src/hooks/useClassicVineArchiveStats.test.ts (2 tests) 182ms
stdout | src/hooks/useInfiniteSearchVideos.test.ts > useInfiniteSearchVideos > falls back to relay search when Funnelcake search throws
[search/videos] starting {
  query: 'jack',
  parsedType: 'content',
  parsedValue: 'jack',
  searchType: 'auto',
  sortMode: 'hot',
  cursor: null,
  pageSize: 20,
  debounceMs: 0
}

stdout | src/hooks/useInfiniteSearchVideos.test.ts > useInfiniteSearchVideos > falls back to relay search when Funnelcake search throws
[search/videos] relay query complete {
  query: 'jack',
  parsedType: 'content',
  parsedValue: 'jack',
  searchType: 'auto',
  sortMode: 'hot',
  cursor: null,
  pageSize: 20,
  mode: 'nip50',
  relayMs: 0,
  totalMs: 3,
  eventCount: 1,
  videoCount: 1
}

stdout | src/hooks/useWindowNostrJWT.test.ts > useWindowNostrJWT > should provide manual inject function
[useWindowNostrJWT] Creating JWT signer...

stdout | src/hooks/useWindowNostrJWT.test.ts > useWindowNostrJWT > should provide manual inject function
[useWindowNostrJWT] ✅ JWT signer ready, pubkey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa

stdout | src/hooks/useResolveSubdomainPubkey.test.ts > useResolveSubdomainPubkey > skips events with invalid JSON content
[useResolveSubdomainPubkey] Found correct pubkey: bb9f2abbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb via NIP-05: _@alice.divine.video

 ✓ src/hooks/useExternalIdentities.test.ts (44 tests) 227ms
 ✓ src/pages/SearchPage.test.tsx (6 tests) 142ms
 ✓ src/hooks/useInfiniteSearchVideos.test.ts (2 tests) 262ms
stdout | src/hooks/useWindowNostrJWT.test.ts > useWindowNostrJWT > should provide manual inject function
[injectWindowNostr] ✅ Injected window.nostr signer

 ✓ src/hooks/usePinnedVideos.test.ts (12 tests) 233ms
 ✓ src/hooks/useResolveSubdomainPubkey.test.ts (12 tests) 251ms
 ✓ src/hooks/useProfileJoinedDate.test.ts (4 tests) 282ms
 ✓ src/hooks/useProfileStats.test.ts (7 tests) 307ms
stdout | src/hooks/useWindowNostrJWT.test.ts > useWindowNostrJWT > should provide manual inject function
[removeWindowNostr] ✅ Removed window.nostr

stdout | src/hooks/useWindowNostrJWT.test.ts > useWindowNostrJWT > should provide manual remove function
[useWindowNostrJWT] Creating JWT signer...

stdout | src/hooks/useWindowNostrJWT.test.ts > useWindowNostrJWT > should provide manual remove function
[useWindowNostrJWT] ✅ JWT signer ready, pubkey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa

stdout | src/hooks/useWindowNostrJWT.test.ts > useWindowNostrJWT > should provide manual remove function
[useWindowNostrJWT] Auto-injecting window.nostr...
[injectWindowNostr] ✅ Injected window.nostr signer

stdout | src/hooks/useWindowNostrJWT.test.ts > useWindowNostrJWT > should provide manual remove function
[removeWindowNostr] ✅ Removed window.nostr

stdout | src/hooks/useWindowNostrJWT.test.ts > useWindowNostrJWT > should provide manual remove function
[useWindowNostrJWT] Cleaning up window.nostr...

stdout | src/hooks/useWindowNostrJWT.test.ts > useWindowNostrJWT > should clean up window.nostr on unmount
[useWindowNostrJWT] Creating JWT signer...

stdout | src/hooks/useWindowNostrJWT.test.ts > useWindowNostrJWT > should clean up window.nostr on unmount
[useWindowNostrJWT] ✅ JWT signer ready, pubkey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa

stdout | src/hooks/useWindowNostrJWT.test.ts > useWindowNostrJWT > should clean up window.nostr on unmount
[useWindowNostrJWT] Auto-injecting window.nostr...
[injectWindowNostr] ✅ Injected window.nostr signer

stdout | src/hooks/useWindowNostrJWT.test.ts > useWindowNostrJWT > should clean up window.nostr on unmount
[useWindowNostrJWT] Cleaning up window.nostr...
[removeWindowNostr] ✅ Removed window.nostr

stdout | src/hooks/useWindowNostrJWT.test.ts > useWindowNostrJWT > should handle token changes
[useWindowNostrJWT] Creating JWT signer...

stdout | src/hooks/useWindowNostrJWT.test.ts > useWindowNostrJWT > should handle token changes
[useWindowNostrJWT] ✅ JWT signer ready, pubkey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa

 ✓ src/components/VideoPlayer.test.tsx (3 tests) 229ms
stdout | src/hooks/useWindowNostrJWT.test.ts > useWindowNostrJWT > should handle token changes
[useWindowNostrJWT] Creating JWT signer...

stdout | src/hooks/useWindowNostrJWT.test.ts > useWindowNostrJWT > should handle token changes
[useWindowNostrJWT] ✅ JWT signer ready, pubkey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa

stdout | src/hooks/useWindowNostrJWT.test.ts > useWindowNostrJWT > should clear signer when token becomes null
[useWindowNostrJWT] Creating JWT signer...

stdout | src/hooks/useWindowNostrJWT.test.ts > useWindowNostrJWT > should clear signer when token becomes null
[useWindowNostrJWT] ✅ JWT signer ready, pubkey: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa

stdout | src/hooks/useSearchUsers.test.ts > useSearchUsers > uses the configured Funnelcake API URL and falls back on timeout
[search/users] starting { query: 'jack', limit: 20, debounceMs: 0 }

stdout | src/hooks/useSearchUsers.test.ts > useSearchUsers > uses the configured Funnelcake API URL and falls back on timeout
[search/users] completed {
  query: 'jack',
  limit: 20,
  mode: 'nip50',
  relayMs: 0,
  totalMs: 3,
  rawEventCount: 1,
  returnedUserCount: 1
}

stdout | src/hooks/useWindowNostrJWT.test.ts > useWindowNostrJWT > should handle initialization errors
[useWindowNostrJWT] Creating JWT signer...

 ✓ src/components/auth/LoginDialog.test.tsx (7 tests) 428ms
 ✓ src/hooks/useWindowNostrJWT.test.ts (11 tests) 597ms
stdout | src/hooks/useSearchUsers.test.ts > useSearchUsers > skips Funnelcake entirely when the circuit breaker marks it unavailable
[search/users] starting { query: 'jack', limit: 20, debounceMs: 0 }

stdout | src/hooks/useSearchUsers.test.ts > useSearchUsers > skips Funnelcake entirely when the circuit breaker marks it unavailable
[search/users] completed {
  query: 'jack',
  limit: 20,
  mode: 'nip50',
  relayMs: 1,
  totalMs: 1,
  rawEventCount: 1,
  returnedUserCount: 1
}

 ✓ src/hooks/useSearchUsers.test.ts (2 tests) 169ms
 ✓ src/pages/MessagesPage.test.tsx (2 tests) 134ms
 ✓ src/lib/eventCache.idb-transaction.test.ts (5 tests) 134ms
 ✓ src/hooks/useVideoByIdFunnelcake.test.ts (2 tests) 131ms
 ✓ src/components/auth/LocalNsecBanner.test.tsx (3 tests) 125ms
 ✓ src/hooks/usePublishIdentity.test.ts (5 tests) 142ms
 ✓ src/pages/EventPage.test.tsx (3 tests) 142ms
 ✓ src/pages/FAQPage.test.tsx (1 test) 241ms
 ✓ src/components/ViewSourceDialog.test.tsx (2 tests) 101ms
 ✓ src/pages/static-pages-i18n.test.tsx (10 tests) 344ms
 ✓ src/components/ProfileHeader.test.tsx (2 tests) 112ms
 ✓ src/hooks/useVideoProvider.test.ts (9 tests) 35ms
 ✓ src/hooks/useCurrentUser.test.ts (5 tests) 130ms
 ✓ src/pages/GetEmbedPage.test.tsx (10 tests) 216ms
 ✓ src/components/AppSidebar.test.tsx (3 tests) 175ms
 ✓ src/pages/UniversalUserPage.test.tsx (5 tests) 85ms
 ✓ src/hooks/useShare.test.ts (5 tests) 11ms
 ✓ src/lib/eventCache.idb-permission.test.ts (3 tests) 53ms
 ✓ src/lib/eventCache.test.ts (3 tests) 38ms
 ✓ src/components/UserListDialog.test.tsx (1 test) 116ms
 ✓ src/pages/AuthCallbackPage.test.tsx (2 tests) 66ms
 ✓ src/pages/Support.test.tsx (1 test) 76ms
 ✓ src/lib/localNsecAccount.test.ts (3 tests) 38ms
 ✓ src/pages/DiscoveryPage.test.tsx (1 test) 64ms
 ✓ src/components/auth/AccountSwitcher.test.tsx (1 test) 132ms
 ✓ src/lib/divineLogin.test.ts (6 tests) 96ms
 ✓ src/pages/CategoriesIndexPage.test.tsx (2 tests) 67ms
 ✓ src/components/AppHeader.test.tsx (1 test) 128ms
 ✓ src/hooks/useFollowRelationship.test.ts (5 tests) 58ms
 ✓ src/components/auth/LoginArea.test.tsx (1 test) 110ms
 ✓ src/components/BadgeImage.test.tsx (2 tests) 42ms
 ✓ src/pages/AuthCallbackPage.integration.test.tsx (1 test) 27ms
 ✓ src/pages/TagPage.test.tsx (2 tests) 50ms
 ✓ src/components/AppFooter.test.tsx (1 test) 58ms
 ✓ src/lib/followListCache.test.ts (2 tests) 26ms
 ✓ src/lib/shareUtils.test.ts (6 tests) 2ms
 ✓ src/lib/eventLookup.test.ts (3 tests) 4ms
 ✓ src/hooks/useDivineSession.test.tsx (2 tests) 17ms
 ✓ src/components/ThumbnailPlayer.test.tsx (2 tests) 25ms
 ✓ src/lib/notificationTransform.test.ts (26 tests) 14ms
 ✓ src/hooks/useViewEventPublisher.test.ts (7 tests) 24ms
 ✓ src/hooks/useVideoMetricsTracker.test.ts (10 tests) 94ms
 ✓ src/hooks/useAdultVerification.test.ts (1 test) 14ms
 ✓ src/components/comments/CommentForm.test.tsx (1 test) 20ms
 ✓ src/lib/funnelcakeFallbackReporting.test.ts (2 tests) 6ms
 ✓ src/lib/socialCache.test.ts (7 tests) 3ms
 ✓ src/lib/directSearch.test.ts (10 tests) 7ms
stdout | src/components/DivineJWTWindowNostr.test.tsx > DivineJWTWindowNostr > should render with verbose prop
[DivineJWTWindowNostr] ✅ window.nostr injected successfully!

stdout | src/components/DivineJWTWindowNostr.test.tsx > DivineJWTWindowNostr > should render with verbose prop
[DivineJWTWindowNostr] Signed in as: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa

 ✓ src/components/DivineJWTWindowNostr.test.tsx (6 tests) 15ms
 ✓ src/lib/crossSubdomainAuth.test.ts (23 tests) 4ms
 ✓ src/App.test.tsx (1 test) 13ms
 ✓ src/hooks/useDirectMessages.test.ts (1 test) 10ms
 ✓ functions/[[path]].test.ts (5 tests) 10ms
 ✓ src/lib/videoParser.test.ts (12 tests) 6ms
 ✓ src/lib/i18n/index.test.ts (4 tests) 4ms
stdout | src/lib/DivineJWTSigner.test.ts > DivineJWTSigner > uses the hosted divine signer RPC endpoint by default
[DivineJWTSigner] Fetching public key...

stdout | src/lib/DivineJWTSigner.test.ts > DivineJWTSigner > uses the hosted divine signer RPC endpoint by default
[DivineJWTSigner] ✅ Got public key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa

stdout | src/lib/DivineJWTSigner.test.ts > DivineJWTSigner > caches the fetched public key
[DivineJWTSigner] Fetching public key...

stdout | src/lib/DivineJWTSigner.test.ts > DivineJWTSigner > caches the fetched public key
[DivineJWTSigner] ✅ Got public key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa

stdout | src/lib/DivineJWTSigner.test.ts > DivineJWTSigner > coalesces concurrent public key lookups across signers that share a session token
[DivineJWTSigner] Fetching public key...

stdout | src/lib/DivineJWTSigner.test.ts > DivineJWTSigner > coalesces concurrent public key lookups across signers that share a session token
[DivineJWTSigner] ✅ Got public key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa

stdout | src/lib/DivineJWTSigner.test.ts > DivineJWTSigner > signs events via the nostr RPC contract
[DivineJWTSigner] Signing event kind 1 ...
[DivineJWTSigner] Fetching public key...

stdout | src/lib/DivineJWTSigner.test.ts > DivineJWTSigner > signs events via the nostr RPC contract
[DivineJWTSigner] ✅ Got public key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa

stdout | src/lib/DivineJWTSigner.test.ts > DivineJWTSigner > signs events via the nostr RPC contract
[DivineJWTSigner] ✅ Event signed: event-id-123

stdout | src/lib/DivineJWTSigner.test.ts > DivineJWTSigner > routes nip04 and nip44 encryption through the same RPC endpoint
[DivineJWTSigner] nip04.encrypt() called...

stdout | src/lib/DivineJWTSigner.test.ts > DivineJWTSigner > routes nip04 and nip44 encryption through the same RPC endpoint
[DivineJWTSigner] nip44.encrypt() called...

 ✓ src/lib/DivineJWTSigner.test.ts (5 tests) 7ms
 ✓ src/lib/cookieConsent.test.ts (10 tests) 6ms
stdout | src/lib/funnelcakeTransform.test.ts > transformToVideoPage > cursor type (recommendations) > returns raw cursor string when cursorType is cursor
[FunnelcakeTransform] Transformed 1/1 videos

stdout | src/lib/funnelcakeTransform.test.ts > transformToVideoPage > cursor type (recommendations) > returns no rawCursor when has_more is false
[FunnelcakeTransform] Transformed 1/1 videos

stdout | src/lib/funnelcakeTransform.test.ts > transformToVideoPage > cursor type (recommendations) > returns no rawCursor when next_cursor is null/undefined
[FunnelcakeTransform] Transformed 1/1 videos

stdout | src/lib/funnelcakeTransform.test.ts > transformToVideoPage > offset type > parses next_cursor as integer offset
[FunnelcakeTransform] Transformed 1/1 videos

stdout | src/lib/funnelcakeTransform.test.ts > transformToVideoPage > timestamp type (default) > parses next_cursor as numeric timestamp
[FunnelcakeTransform] Transformed 1/1 videos

stdout | src/lib/funnelcakeTransform.test.ts > transformToVideoPage > stops pagination when has_more is false
[FunnelcakeTransform] Transformed 1/1 videos

 ✓ src/lib/legacySocials.test.ts (2 tests) 2ms
 ✓ src/lib/funnelcakeTransform.test.ts (8 tests) 15ms
 ✓ src/hooks/useLoggedInAccounts.test.ts (1 test) 8ms
 ✓ src/lib/nip05Resolve.test.ts (7 tests) 7ms
 ✓ src/lib/inviteApi.test.ts (5 tests) 6ms
 ✓ src/lib/analyticsTransform.test.ts (14 tests) 3ms
 ✓ src/lib/vttParser.test.ts (18 tests) 10ms
 ✓ src/lib/verificationCache.test.ts (9 tests) 4ms
stdout | src/lib/bunkerToWindowNostr.test.ts > bunkerToWindowNostr > injectWindowNostr > should inject signer into window.nostr
[injectWindowNostr] ✅ Injected window.nostr signer

stdout | src/lib/bunkerToWindowNostr.test.ts > bunkerToWindowNostr > injectWindowNostr > should inject signer into window.nostr
[removeWindowNostr] ✅ Removed window.nostr

stdout | src/lib/bunkerToWindowNostr.test.ts > bunkerToWindowNostr > injectWindowNostr > should dispatch nostr:ready event
[injectWindowNostr] ✅ Injected window.nostr signer

stdout | src/lib/bunkerToWindowNostr.test.ts > bunkerToWindowNostr > injectWindowNostr > should dispatch nostr:ready event
[removeWindowNostr] ✅ Removed window.nostr

stdout | src/lib/bunkerToWindowNostr.test.ts > bunkerToWindowNostr > injectWindowNostr > should overwrite existing window.nostr
[injectWindowNostr] ✅ Injected window.nostr signer
[injectWindowNostr] ✅ Injected window.nostr signer

stdout | src/lib/bunkerToWindowNostr.test.ts > bunkerToWindowNostr > injectWindowNostr > should overwrite existing window.nostr
[removeWindowNostr] ✅ Removed window.nostr

stdout | src/lib/bunkerToWindowNostr.test.ts > bunkerToWindowNostr > removeWindowNostr > should remove window.nostr
[injectWindowNostr] ✅ Injected window.nostr signer
[removeWindowNostr] ✅ Removed window.nostr

stdout | src/lib/bunkerToWindowNostr.test.ts > bunkerToWindowNostr > removeWindowNostr > should handle multiple remove calls
[injectWindowNostr] ✅ Injected window.nostr signer
[removeWindowNostr] ✅ Removed window.nostr

 ✓ src/lib/bunkerToWindowNostr.test.ts (10 tests) 4ms
 ✓ src/lib/__tests__/nip05Utils.test.ts (16 tests) 2ms
 ✓ src/lib/dm.test.ts (4 tests) 3ms
 ✓ src/pages/HomePage.test.tsx (1 test) 38ms
 ✓ src/lib/videoVerification.test.ts (12 tests) 7ms
 ✓ src/lib/serverSocialMeta.test.ts (5 tests) 3ms
 ✓ src/lib/batchUtils.test.ts (9 tests) 2ms
 ✓ src/lib/i18n/locales.test.ts (1 test) 6ms
 ✓ src/lib/authHandoff.test.ts (3 tests) 2ms
 ✓ src/lib/formatUtils.test.ts (5 tests) 1ms
 ✓ src/lib/i18n/config.test.ts (6 tests) 2ms
 ✓ src/lib/eventRouting.test.ts (4 tests) 2ms
 ✓ src/lib/profileStats.test.ts (1 test) 1ms

 Test Files  90 passed (90)
      Tests  531 passed (531)
   Start at  13:48:57
   Duration  5.11s (transform 2.77s, setup 4.99s, collect 14.39s, tests 7.47s, environment 24.02s, prepare 4.07s)
- [x] vite v6.4.0 building for production...
transforming...
✓ 2932 modules transformed.
rendering chunks...
computing gzip size...
dist/manifest.webmanifest                                        0.86 kB
dist/index.html                                                  7.19 kB │ gzip:   2.14 kB
dist/assets/pacifico-vietnamese-400-normal-CLnUcRoK.woff         8.92 kB
dist/assets/inter-vietnamese-wght-normal-CBcvBZtf.woff2         10.25 kB
dist/assets/inter-greek-ext-wght-normal-DlzME5K_.woff2          11.23 kB
dist/assets/pacifico-vietnamese-400-normal-CNs27uJ4.woff2       11.33 kB
dist/assets/pacifico-cyrillic-400-normal-BtlfDWif.woff          17.09 kB
dist/assets/inter-cyrillic-wght-normal-DqGufNeO.woff2           18.75 kB
dist/assets/inter-greek-wght-normal-CkhJZR-_.woff2              19.00 kB
dist/assets/pacifico-cyrillic-ext-400-normal-BH1b5rOk.woff      20.86 kB
dist/assets/pacifico-cyrillic-400-normal-DS5_g9Hw.woff2         22.89 kB
dist/assets/pacifico-latin-ext-400-normal-nyRvH6_c.woff         25.63 kB
dist/assets/inter-cyrillic-ext-wght-normal-BOeWTOD4.woff2       25.96 kB
dist/assets/pacifico-latin-400-normal-DArfF-vd.woff             27.10 kB
dist/assets/pacifico-cyrillic-ext-400-normal-BuyJL26e.woff2     28.83 kB
dist/assets/pacifico-latin-ext-400-normal-Ba3kv-va.woff2        31.08 kB
dist/assets/pacifico-latin-400-normal-7HIToT7q.woff2            32.28 kB
dist/assets/inter-latin-wght-normal-Dx4kXJAl.woff2              48.26 kB
dist/assets/inter-latin-ext-wght-normal-DO1Apj_S.woff2          85.07 kB
dist/assets/index-BLmNimB-.css                                 112.24 kB │ gzip:  19.15 kB
dist/assets/pure-CrCuge0V.js                                     1.50 kB │ gzip:   0.75 kB
dist/assets/nip19-DYPefhNV.js                                    3.52 kB │ gzip:   1.40 kB
dist/assets/index-xHcEWS0l.js                                2,713.59 kB │ gzip: 808.09 kB
✓ built in 3.12s

PWA v1.1.0
mode      generateSW
precache  18 entries (2807.54 KiB)
files generated
  dist/sw.js
  dist/workbox-a3cf1d8c.js
