### PR TITLE
feat: preserve search video feed context

### DIFF
--- a/docs/superpowers/plans/2026-04-16-search-video-feed.md
+++ b/docs/superpowers/plans/2026-04-16-search-video-feed.md
@@ -1,0 +1,111 @@
+# Search Video Feed Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve search context when opening a video so `/video/:id` behaves like a feed bounded to the active search result set.
+
+**Architecture:** Extend the existing route-based navigation context rather than introducing a new modal flow. Search results will generate search-aware detail URLs, and `VideoPage` will reconstruct adjacent videos from the same query and sort using the existing search data layer.
+
+**Tech Stack:** React 18, TypeScript, React Router, TanStack Query, Vitest, Testing Library, Vite
+
+---
+
+## File Map
+
+- Modify: `src/pages/SearchPage.tsx`
+- Modify: `src/pages/SearchPage.test.tsx`
+- Modify: `src/hooks/useVideoNavigation.ts`
+- Modify: `src/pages/VideoPage.tsx`
+- Add or modify test coverage near `src/pages/VideoPage.tsx`
+
+## Chunk 1: Search Entry Context
+
+### Task 1: Add failing coverage for search-result navigation URLs
+
+**Files:**
+- Modify: `src/pages/SearchPage.test.tsx`
+- Modify: `src/pages/SearchPage.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a test that renders search video results, clicks a result, and expects navigation to `/video/<id>?source=search&q=<query>&sort=<sort>&index=<n>`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vitest run src/pages/SearchPage.test.tsx`
+Expected: FAIL because search results still navigate to a bare video route.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Update search result rendering to pass a search navigation context into the video detail route.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `vitest run src/pages/SearchPage.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pages/SearchPage.tsx src/pages/SearchPage.test.tsx
+git commit -m "feat: preserve search context when opening videos"
+```
+
+## Chunk 2: Search-Aware Detail Navigation
+
+### Task 2: Add failing coverage for bounded search navigation on `VideoPage`
+
+**Files:**
+- Modify: `src/hooks/useVideoNavigation.ts`
+- Modify: `src/pages/VideoPage.tsx`
+- Add or modify: `src/pages/VideoPage.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a test that renders `VideoPage` with `source=search`, a query, a sort mode, and an index, then verifies adjacent search results are used for next/previous navigation.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vitest run src/pages/VideoPage.test.tsx`
+Expected: FAIL because `search` is not yet a supported navigation source.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Extend the navigation context and `VideoPage` to fetch and use search results when `source=search` is present.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `vitest run src/pages/VideoPage.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hooks/useVideoNavigation.ts src/pages/VideoPage.tsx src/pages/VideoPage.test.tsx
+git commit -m "feat: support bounded search navigation on video pages"
+```
+
+## Chunk 3: Regression Verification
+
+### Task 3: Confirm search flow and fallback behavior
+
+**Files:**
+- Verify: `src/pages/SearchPage.tsx`
+- Verify: `src/pages/VideoPage.tsx`
+
+- [ ] **Step 1: Run focused regression tests**
+
+Run: `vitest run src/pages/SearchPage.test.tsx src/pages/VideoPage.test.tsx`
+Expected: PASS
+
+- [ ] **Step 2: Run full verification**
+
+Run: `npm test`
+Expected: PASS with no new failures
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/pages/SearchPage.tsx src/pages/SearchPage.test.tsx src/hooks/useVideoNavigation.ts src/pages/VideoPage.tsx src/pages/VideoPage.test.tsx
+git commit -m "test: verify bounded search video feed flow"
+```

--- a/docs/superpowers/specs/2026-04-16-search-video-feed-design.md
+++ b/docs/superpowers/specs/2026-04-16-search-video-feed-design.md
@@ -1,0 +1,67 @@
+# Search Video Feed Design
+
+## Problem
+
+Search results currently open videos as isolated detail pages. Users can watch the selected clip, but they cannot continue scrolling through the rest of the current search result set as a feed.
+
+## Goal
+
+When a user clicks a video from search results, the detail route should preserve the search context and behave like a bounded feed. Scrolling or keyboard navigation should move to the next or previous video from that same search query, filter, and sort order.
+
+## Non-Goals
+
+- Redesign the search page layout.
+- Replace the `/video/:id` route with a fullscreen modal flow.
+- Encode full search result payloads into the URL.
+
+## Approved Behavior
+
+### Entry
+
+- Clicking a search result video navigates to `/video/:id`.
+- The route includes a navigation context with:
+  - `source=search`
+  - `q=<current query>`
+  - `sort=<current sort>`
+  - `index=<clicked result index>`
+
+### Feed Scope
+
+- The bounded feed is limited to the active search result set.
+- The result set is defined by the current query text, the `videos` filter, and the active sort mode.
+- Navigating between videos must not fall through into discovery, trending, or other broader feeds.
+
+### Detail Page
+
+- `VideoPage` treats search as a first-class navigation source.
+- When `source=search` is present, it loads adjacent search results and renders the existing sequential detail/feed experience.
+- Arrow key navigation and scroll-based progression stay within the search result set.
+
+### Fallbacks
+
+- Direct visits to `/video/:id` without search context keep the existing single-video behavior.
+- If the search context is malformed, empty, or cannot load surrounding results, the page still shows the selected video without bounded-feed navigation.
+
+## Architecture
+
+### Search Page
+
+- Search results use a search-aware navigation URL instead of a bare `/video/:id` link.
+- The URL generation stays close to the search result rendering path so query, sort, and clicked index are captured from current state.
+
+### Navigation Context
+
+- Extend `VideoNavigationContext` to support a `search` source and search-specific parameters.
+- Keep the shape narrow: only include data needed to reconstruct the result set on `VideoPage`.
+
+### Video Page
+
+- Parse search navigation parameters alongside existing hashtag/profile/discovery-style sources.
+- Use the search data to load the current result window and compute previous/next navigation targets.
+- Reuse existing route-based detail navigation instead of introducing a new overlay system.
+
+## Testing Strategy
+
+- Add a search page test that proves clicking a video navigates with `source=search`, `q`, `sort`, and `index`.
+- Add video page coverage for search navigation behavior, confirming the page can sequence through search results instead of behaving as a one-off detail view.
+- Run focused tests during the red/green cycle, then run the full project verification command before completion.

--- a/src/components/VideoCard.tsx
+++ b/src/components/VideoCard.tsx
@@ -38,7 +38,7 @@ import { cn } from '@/lib/utils';
 import { formatClassicVineViewBreakdown, formatViewCount, formatCount } from '@/lib/formatUtils';
 import { getSafeProfileImage } from '@/lib/imageUtils';
 import type { ViewTrafficSource } from '@/hooks/useViewEventPublisher';
-import type { VideoNavigationContext } from '@/hooks/useVideoNavigation';
+import { buildVideoNavigationUrl, type VideoNavigationContext } from '@/hooks/useVideoNavigation';
 import { useToast } from '@/hooks/useToast';
 import { useShare } from '@/hooks/useShare';
 import { useDmCapability } from '@/hooks/useDirectMessages';
@@ -100,8 +100,8 @@ export function VideoCard({
   commentCount = 0,
   viewCount = 0,
   showComments = false,
-  navigationContext: _navigationContext,
-  videoIndex: _videoIndex,
+  navigationContext,
+  videoIndex,
   trafficSource,
 }: VideoCardProps) {
   const authorData = useAuthor(video.pubkey, {
@@ -329,7 +329,10 @@ export function VideoCard({
   const handleThumbnailClick = () => {
     // In thumbnail mode (grid view), navigate to video page instead of playing inline
     if (mode === 'thumbnail') {
-      navigate(`/video/${video.id}`, { ownerPubkey: video.pubkey });
+      const targetUrl = navigationContext
+        ? buildVideoNavigationUrl(video.id, navigationContext, videoIndex)
+        : `/video/${video.id}`;
+      navigate(targetUrl, { ownerPubkey: video.pubkey });
     } else {
       setActiveVideo(video.id);
       setIsPlaying(true);

--- a/src/hooks/useVideoByIdFunnelcake.test.ts
+++ b/src/hooks/useVideoByIdFunnelcake.test.ts
@@ -138,4 +138,41 @@ describe('useVideoByIdFunnelcake', () => {
     expect(mockFetchVideoById).not.toHaveBeenCalled();
     expect(result.current.windowOffset).toBe(0);
   });
+
+  it('uses search results for navigation when search context is provided', async () => {
+    mockSearchVideos.mockResolvedValueOnce({
+      videos: [
+        { id: 'neighbor-1', pubkey: 'p'.repeat(64), d_tag: 'neighbor-1' },
+        { id: 'target-video', pubkey: 'p'.repeat(64), d_tag: 'target-video' },
+      ],
+      has_more: true,
+    });
+
+    const { result } = renderHook(
+      () => useVideoByIdFunnelcake({
+        videoId: 'target-video',
+        query: 'twerking',
+        sortMode: 'top',
+        currentIndex: 9,
+      }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.video?.id).toBe('target-video');
+    });
+
+    expect(mockSearchVideos).toHaveBeenCalledWith(
+      'https://api.divine.video',
+      expect.objectContaining({
+        query: 'twerking',
+        sort: 'loops',
+        limit: 16,
+        offset: 1,
+        signal: expect.any(AbortSignal),
+      })
+    );
+    expect(mockFetchVideoById).not.toHaveBeenCalled();
+    expect(result.current.videos?.map(video => video.id)).toEqual(['neighbor-1', 'target-video']);
+  });
 });

--- a/src/hooks/useVideoByIdFunnelcake.ts
+++ b/src/hooks/useVideoByIdFunnelcake.ts
@@ -8,11 +8,14 @@ import { getFunnelcakeUrl, DEFAULT_FUNNELCAKE_URL } from '@/config/relays';
 import { useAppContext } from '@/hooks/useAppContext';
 import { debugLog } from '@/lib/debug';
 import type { ParsedVideoData } from '@/types/video';
+import type { SortMode } from '@/types/nostr';
 
 interface UseVideoByIdOptions {
   videoId: string;
   pubkey?: string;   // Optional pubkey for profile context
   hashtag?: string;  // Optional hashtag for hashtag feed context
+  query?: string;    // Optional search query for bounded search navigation
+  sortMode?: SortMode | 'relevance';
   currentIndex?: number; // Optional global index from feed context for neighbor windowing
   enabled?: boolean;
 }
@@ -34,6 +37,22 @@ function getNavigationWindowOffset(currentIndex?: number): number {
   return Math.max(0, currentIndex - Math.floor(NAVIGATION_WINDOW_SIZE / 2));
 }
 
+function mapSearchSortModeToFunnelcakeSort(sortMode: SortMode | 'relevance' = 'relevance') {
+  switch (sortMode) {
+    case 'top':
+      return 'loops' as const;
+    case 'rising':
+    case 'controversial':
+      return 'engagement' as const;
+    case 'classic':
+      return 'loops' as const;
+    case 'hot':
+    case 'relevance':
+    default:
+      return 'trending' as const;
+  }
+}
+
 /**
  * Hook to fetch a single video by ID via Funnelcake REST API
  *
@@ -42,9 +61,12 @@ function getNavigationWindowOffset(currentIndex?: number): number {
  * The single video lookup is faster than WebSocket queries.
  */
 export function useVideoByIdFunnelcake(options: UseVideoByIdOptions): UseVideoByIdResult {
-  const { videoId, pubkey, hashtag, currentIndex, enabled = true } = options;
+  const { videoId, pubkey, hashtag, query, sortMode = 'relevance', currentIndex, enabled = true } = options;
   const { config } = useAppContext();
   const windowOffset = getNavigationWindowOffset(currentIndex);
+  const trimmedQuery = query?.trim();
+  const isHashtagSearch = !!trimmedQuery && trimmedQuery.startsWith('#');
+  const searchValue = isHashtagSearch ? trimmedQuery?.slice(1).toLowerCase() : trimmedQuery;
 
   // Determine API URL from current relay
   const funnelcakeUrl = getFunnelcakeUrl(config.relayUrl) || DEFAULT_FUNNELCAKE_URL;
@@ -91,21 +113,49 @@ export function useVideoByIdFunnelcake(options: UseVideoByIdOptions): UseVideoBy
     gcTime: 900000,    // 15 minutes
   });
 
-  const contextVideos = userVideosQuery.data ?? hashtagVideosQuery.data ?? null;
+  const searchVideosQuery = useQuery({
+    queryKey: ['funnelcake-search-videos', searchValue, sortMode, funnelcakeUrl, windowOffset],
+    queryFn: async ({ signal }) => {
+      if (!searchValue) return null;
+
+      debugLog(`[useVideoByIdFunnelcake] Fetching search videos for ${searchValue}`);
+      const response = await searchVideos(funnelcakeUrl, {
+        query: isHashtagSearch ? undefined : searchValue,
+        tag: isHashtagSearch ? searchValue : undefined,
+        sort: mapSearchSortModeToFunnelcakeSort(sortMode),
+        limit: NAVIGATION_WINDOW_SIZE,
+        offset: windowOffset,
+        classic: sortMode === 'classic' ? true : undefined,
+        platform: sortMode === 'classic' ? 'vine' : undefined,
+        signal,
+      });
+
+      return response.videos.map(transformFunnelcakeVideo);
+    },
+    enabled: enabled && !!searchValue && !pubkey && !hashtag,
+    staleTime: 300000,
+    gcTime: 900000,
+  });
+
+  const contextVideos = userVideosQuery.data ?? hashtagVideosQuery.data ?? searchVideosQuery.data ?? null;
   const contextVideo = contextVideos?.find(v => v.id === videoId || v.vineId === videoId) || null;
   const contextLoading = pubkey
     ? userVideosQuery.isLoading
     : hashtag
       ? hashtagVideosQuery.isLoading
-      : false;
+      : searchValue
+        ? searchVideosQuery.isLoading
+        : false;
   const contextError = pubkey
     ? (userVideosQuery.error as Error | null)
     : hashtag
       ? (hashtagVideosQuery.error as Error | null)
-      : null;
+      : searchValue
+        ? (searchVideosQuery.error as Error | null)
+        : null;
   const shouldLookupSingleVideo = enabled && (
-    (!pubkey && !hashtag)
-      || (((!!pubkey || !!hashtag) && !contextLoading && !contextVideo))
+    (!pubkey && !hashtag && !searchValue)
+      || (((!!pubkey || !!hashtag || !!searchValue) && !contextLoading && !contextVideo))
   );
 
   // Single video lookup (used when no context or as fallback)

--- a/src/hooks/useVideoNavigation.ts
+++ b/src/hooks/useVideoNavigation.ts
@@ -5,11 +5,14 @@ import { useSearchParams, useNavigate } from 'react-router-dom';
 import { useCallback, useMemo } from 'react';
 import { useVideoEvents } from './useVideoEvents';
 import type { ParsedVideoData } from '@/types/video';
+import type { SortMode } from '@/types/nostr';
 
 export interface VideoNavigationContext {
-  source: 'hashtag' | 'profile' | 'discovery' | 'home' | 'trending' | 'recent' | 'classics' | 'foryou' | 'category';
+  source: 'hashtag' | 'profile' | 'discovery' | 'home' | 'trending' | 'recent' | 'classics' | 'foryou' | 'category' | 'search';
   hashtag?: string;
   pubkey?: string;
+  query?: string;
+  sortMode?: SortMode | 'relevance';
   currentIndex?: number;
 }
 
@@ -42,13 +45,19 @@ export function useVideoNavigation(videoId: string, options: UseVideoNavigationO
       source,
       hashtag: searchParams.get('hashtag') || undefined,
       pubkey: searchParams.get('pubkey') || undefined,
+      query: searchParams.get('q') || undefined,
+      sortMode: searchParams.get('sort') as VideoNavigationContext['sortMode'],
       currentIndex: searchParams.get('index') ? parseInt(searchParams.get('index')!) : undefined,
     };
   }, [searchParams]);
 
   // Fetch videos based on context
   // Map 'foryou' to 'trending' for WebSocket fallback (foryou only works via Funnelcake API)
-  const feedTypeForWebSocket = context?.source === 'foryou' ? 'trending' : context?.source;
+  const feedTypeForWebSocket = context?.source === 'foryou'
+    ? 'trending'
+    : context?.source === 'search'
+      ? 'discovery'
+      : context?.source;
   const { data: videos, isLoading } = useVideoEvents(
     context ? {
       feedType: feedTypeForWebSocket,
@@ -89,6 +98,8 @@ export function useVideoNavigation(videoId: string, options: UseVideoNavigationO
 
     if (context.hashtag) params.set('hashtag', context.hashtag);
     if (context.pubkey) params.set('pubkey', context.pubkey);
+    if (context.query) params.set('q', context.query);
+    if (context.sortMode) params.set('sort', context.sortMode);
 
     return `/video/${video.id}?${params.toString()}`;
   }, [context]);
@@ -129,6 +140,8 @@ export function buildVideoNavigationUrl(
 
   if (context.hashtag) params.set('hashtag', context.hashtag);
   if (context.pubkey) params.set('pubkey', context.pubkey);
+  if (context.query) params.set('q', context.query);
+  if (context.sortMode) params.set('sort', context.sortMode);
   if (index !== undefined) params.set('index', index.toString());
 
   return `/video/${videoId}?${params.toString()}`;

--- a/src/pages/SearchPage.test.tsx
+++ b/src/pages/SearchPage.test.tsx
@@ -11,11 +11,18 @@ import type {
 import { nip19 } from 'nostr-tools';
 import SearchPage from './SearchPage';
 
-const { mockNavigate, mockFetchEventById, mockFetchVideoById, mockNostrQuery } = vi.hoisted(() => ({
+const {
+  mockNavigate,
+  mockFetchEventById,
+  mockFetchVideoById,
+  mockNostrQuery,
+  mockSearchVideosData,
+} = vi.hoisted(() => ({
   mockNavigate: vi.fn(),
   mockFetchEventById: vi.fn(),
   mockFetchVideoById: vi.fn(),
   mockNostrQuery: vi.fn(),
+  mockSearchVideosData: [] as Array<{ id: string; pubkey: string }>,
 }));
 
 vi.mock('@unhead/react', () => ({
@@ -71,7 +78,25 @@ vi.mock('@/components/ui/avatar', () => ({
 }));
 
 vi.mock('@/components/VideoCard', () => ({
-  VideoCard: () => <div data-testid="video-card" />,
+  VideoCard: ({
+    video,
+    navigationContext,
+    videoIndex,
+  }: {
+    video: { id: string };
+    navigationContext?: { source: string; query?: string; sortMode?: string };
+    videoIndex?: number;
+  }) => {
+    const href = navigationContext
+      ? `/video/${video.id}?source=${navigationContext.source}&q=${navigationContext.query}&sort=${navigationContext.sortMode}&index=${videoIndex}`
+      : `/video/${video.id}`;
+
+    return (
+      <button data-testid={`video-card-${video.id}`} onClick={() => mockNavigate(href)}>
+        open {video.id}
+      </button>
+    );
+  },
 }));
 
 vi.mock('react-infinite-scroll-component', () => ({
@@ -101,7 +126,7 @@ vi.mock('@/hooks/useAppContext', () => ({
 
 vi.mock('@/hooks/useInfiniteSearchVideos', () => ({
   useInfiniteSearchVideos: () => ({
-    data: { pages: [{ videos: [] }] },
+    data: { pages: [{ videos: mockSearchVideosData }] },
     fetchNextPage: vi.fn(),
     hasNextPage: false,
     isLoading: false,
@@ -144,6 +169,7 @@ function renderPage(initialEntries: string[] = ['/search']) {
 describe('SearchPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockSearchVideosData.length = 0;
   });
 
   afterEach(() => {
@@ -281,5 +307,18 @@ describe('SearchPage', () => {
     });
 
     expect(mockNavigate).toHaveBeenCalledWith(`/event/${eventId}`);
+  });
+
+  it('opens video results with bounded search context', async () => {
+    mockSearchVideosData.push(
+      { id: 'video-1', pubkey: 'a'.repeat(64) },
+      { id: 'video-2', pubkey: 'b'.repeat(64) },
+    );
+
+    renderPage(['/search?q=twerking&filter=videos&sort=top']);
+
+    fireEvent.click(screen.getAllByTestId('video-card-video-2')[0]!);
+
+    expect(mockNavigate).toHaveBeenCalledWith('/video/video-2?source=search&q=twerking&sort=top&index=1');
   });
 });

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -32,6 +32,7 @@ import { DEFAULT_FUNNELCAKE_URL, getFunnelcakeUrl } from '@/config/relays';
 import { fetchVideoById } from '@/lib/funnelcakeClient';
 import { fetchEventById } from '@/lib/eventLookup';
 import { buildResolvedEventRoute, buildVideoPath } from '@/lib/eventRouting';
+import type { VideoNavigationContext } from '@/hooks/useVideoNavigation';
 import {
   buildProfilePath,
   getDirectSearchTarget,
@@ -301,6 +302,17 @@ export function SearchPage() {
   // Check if we have any results
   const hasResults = videoResults.length > 0 || userResults.length > 0 || hashtagResults.length > 0;
 
+  const searchNavigationContext = useMemo<VideoNavigationContext | undefined>(() => {
+    const trimmedQuery = searchQuery.trim();
+    if (!trimmedQuery) return undefined;
+
+    return {
+      source: 'search',
+      query: trimmedQuery,
+      sortMode,
+    };
+  }, [searchQuery, sortMode]);
+
   return (
     <div className="min-h-screen bg-background">
       {/* Main content */}
@@ -447,8 +459,14 @@ export function SearchPage() {
                       </Button>
                     </div>
                     <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-                      {videoResults.slice(0, 6).map((video) => (
-                        <VideoCard key={video.id} video={video} mode="thumbnail" />
+                      {videoResults.slice(0, 6).map((video, index) => (
+                        <VideoCard
+                          key={video.id}
+                          video={video}
+                          mode="thumbnail"
+                          navigationContext={searchNavigationContext}
+                          videoIndex={index}
+                        />
                       ))}
                     </div>
                   </section>
@@ -540,8 +558,14 @@ export function SearchPage() {
                 }
               >
                 <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-                  {videoResults.map((video) => (
-                    <VideoCard key={video.id} video={video} mode="thumbnail" />
+                  {videoResults.map((video, index) => (
+                    <VideoCard
+                      key={video.id}
+                      video={video}
+                      mode="thumbnail"
+                      navigationContext={searchNavigationContext}
+                      videoIndex={index}
+                    />
                   ))}
                 </div>
               </InfiniteScroll>

--- a/src/pages/VideoPage.test.tsx
+++ b/src/pages/VideoPage.test.tsx
@@ -1,0 +1,192 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import type { HTMLAttributes, ReactNode } from 'react';
+import VideoPage from './VideoPage';
+
+const { mockNavigate } = vi.hoisted(() => ({
+  mockNavigate: vi.fn(),
+}));
+
+vi.mock('@unhead/react', () => ({
+  useSeoMeta: vi.fn(),
+}));
+
+vi.mock('@/hooks/useSubdomainNavigate', () => ({
+  useSubdomainNavigate: () => mockNavigate,
+}));
+
+vi.mock('@/hooks/useVideoByIdFunnelcake', () => ({
+  useVideoByIdFunnelcake: (options: { query?: string }) => {
+    const videos = [
+      {
+        id: 'video-1',
+        pubkey: 'a'.repeat(64),
+        kind: 34236,
+        createdAt: 1,
+        content: 'one',
+        videoUrl: 'https://example.com/1.mp4',
+        hashtags: [],
+        reposts: [],
+      },
+      {
+        id: 'video-2',
+        pubkey: 'b'.repeat(64),
+        kind: 34236,
+        createdAt: 2,
+        content: 'two',
+        videoUrl: 'https://example.com/2.mp4',
+        hashtags: [],
+        reposts: [],
+      },
+      {
+        id: 'video-3',
+        pubkey: 'c'.repeat(64),
+        kind: 34236,
+        createdAt: 3,
+        content: 'three',
+        videoUrl: 'https://example.com/3.mp4',
+        hashtags: [],
+        reposts: [],
+      },
+    ];
+
+    if (options.query === 'twerking') {
+      return {
+        video: videos[1],
+        videos,
+        windowOffset: 0,
+        isLoading: false,
+        error: null,
+      };
+    }
+
+    return {
+      video: videos[1],
+      videos: null,
+      windowOffset: 0,
+      isLoading: false,
+      error: null,
+    };
+  },
+}));
+
+vi.mock('@/hooks/useVideoNavigation', () => ({
+  useVideoNavigation: () => ({
+    context: null,
+    currentVideo: null,
+    videos: null,
+    hasNext: false,
+    hasPrevious: false,
+    goToNext: vi.fn(),
+    goToPrevious: vi.fn(),
+    isLoading: false,
+  }),
+}));
+
+vi.mock('@/hooks/useAuthor', () => ({
+  useAuthor: () => ({
+    data: { metadata: { display_name: 'Author' } },
+  }),
+}));
+
+vi.mock('@/hooks/useBatchedVideoInteractions', () => ({
+  useBatchedVideoInteractions: () => ({
+    interactions: new Map(),
+  }),
+}));
+
+vi.mock('@/hooks/useNostrPublish', () => ({
+  useNostrPublish: () => ({
+    mutateAsync: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/usePublishVideo', () => ({
+  useRepostVideo: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
+}));
+
+vi.mock('@/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({
+    user: null,
+  }),
+}));
+
+vi.mock('@/hooks/useVideoSocialMetrics', () => ({
+  useVideoSocialMetrics: () => ({
+    data: null,
+  }),
+}));
+
+vi.mock('@tanstack/react-query', async () => {
+  const actual = await vi.importActual<typeof import('@tanstack/react-query')>('@tanstack/react-query');
+  return {
+    ...actual,
+    useQueryClient: () => ({
+      invalidateQueries: vi.fn(),
+    }),
+  };
+});
+
+vi.mock('@/hooks/useToast', () => ({
+  useToast: () => ({
+    toast: vi.fn(),
+  }),
+}));
+
+vi.mock('@/components/VideoCard', () => ({
+  VideoCard: ({ video }: { video: { id: string } }) => <div data-testid="video-card">{video.id}</div>,
+}));
+
+vi.mock('@/components/ui/card', () => ({
+  Card: ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+  CardContent: ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+}));
+
+vi.mock('@/components/ui/skeleton', () => ({
+  Skeleton: (props: HTMLAttributes<HTMLDivElement>) => <div {...props} />,
+}));
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, ...props }: HTMLAttributes<HTMLButtonElement>) => <button {...props}>{children}</button>,
+}));
+
+vi.mock('react-infinite-scroll-component', () => ({
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+function renderPage(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/video/:id" element={<VideoPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('VideoPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('navigates through bounded search results while preserving search params', () => {
+    renderPage('/video/video-2?source=search&q=twerking&sort=top&index=1');
+
+    fireEvent.keyDown(document.body, { key: 'ArrowDown' });
+
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    const [target] = mockNavigate.mock.calls[0] ?? [];
+    expect(target).toBeTypeOf('string');
+
+    const url = new URL(String(target), 'https://divine.video');
+    expect(url.pathname).toBe('/video/video-3');
+    expect(url.searchParams.get('source')).toBe('search');
+    expect(url.searchParams.get('q')).toBe('twerking');
+    expect(url.searchParams.get('sort')).toBe('top');
+    expect(url.searchParams.get('index')).toBe('2');
+  });
+});

--- a/src/pages/VideoPage.tsx
+++ b/src/pages/VideoPage.tsx
@@ -38,6 +38,8 @@ export function VideoPage() {
       source,
       hashtag: searchParams.get('hashtag') || undefined,
       pubkey: searchParams.get('pubkey') || undefined,
+      query: searchParams.get('q') || undefined,
+      sortMode: searchParams.get('sort') as VideoNavigationContext['sortMode'],
       currentIndex: searchParams.get('index') ? parseInt(searchParams.get('index')!) : undefined,
     };
   }, [searchParams]);
@@ -53,6 +55,8 @@ export function VideoPage() {
     videoId: id || '',
     pubkey: context?.pubkey,
     hashtag: context?.hashtag,
+    query: context?.query,
+    sortMode: context?.sortMode,
     currentIndex: context?.currentIndex,
     enabled: !!id,
   });
@@ -99,6 +103,8 @@ export function VideoPage() {
 
     if (context.hashtag) params.set('hashtag', context.hashtag);
     if (context.pubkey) params.set('pubkey', context.pubkey);
+    if (context.query) params.set('q', context.query);
+    if (context.sortMode) params.set('sort', context.sortMode);
 
     return `/video/${video.id}?${params.toString()}`;
   }, [context]);
@@ -259,6 +265,13 @@ export function VideoPage() {
       } catch {
         navigate(`/profile/${context.pubkey}`, { ownerPubkey: context.pubkey });
       }
+    } else if (context?.source === 'search') {
+      const params = new URLSearchParams();
+      if (context.query) params.set('q', context.query);
+      params.set('filter', 'videos');
+      if (context.sortMode) params.set('sort', context.sortMode);
+      const target = params.toString() ? `/search?${params.toString()}` : '/search';
+      navigate(target);
     } else {
       navigate(-1); // Browser back
     }
@@ -571,6 +584,9 @@ export function VideoPage() {
                   Loading videos...
                 </>
               )}
+              {context.source === 'search' && (
+                <span>{context.query ? `Search: ${context.query}` : 'Search results'}</span>
+              )}
               {(context.source === 'discovery' || context.source === 'trending' || context.source === 'home') && (
                 <span className="capitalize">{context.source}</span>
               )}
@@ -628,6 +644,9 @@ export function VideoPage() {
                   <User className="h-4 w-4" />
                   {authorName}'s videos
                 </>
+              )}
+              {context.source === 'search' && (
+                <span>{context.query ? `Search: ${context.query}` : 'Search results'}</span>
               )}
               {(context.source === 'discovery' || context.source === 'trending' || context.source === 'home') && (
                 <span className="capitalize">{context.source}</span>
@@ -719,6 +738,14 @@ export function VideoPage() {
               >
                 <User className="h-3 w-3" />
                 {authorName}
+              </button>
+            )}
+            {context.source === 'search' && (
+              <button
+                onClick={handleGoBack}
+                className="text-muted-foreground hover:text-primary transition-colors text-xs"
+              >
+                {context.query ? `Search: ${context.query}` : 'Search results'}
               </button>
             )}
             {(context.source === 'discovery' || context.source === 'trending' || context.source === 'home') && (


### PR DESCRIPTION
## Summary
- preserve search query and sort context when opening a video from search results
- make VideoPage use bounded Funnelcake search neighbors for next/previous navigation
- add regression coverage for search entry routes and search-aware video navigation

## Test Plan
- [x] npm exec vitest run src/pages/SearchPage.test.tsx src/hooks/useVideoByIdFunnelcake.test.ts src/pages/VideoPage.test.tsx
- [x] npm test