### PR TITLE
feat: Phase 2 — brand-card treatment on feature surfaces

### DIFF
--- a/src/components/ProfileHeader.tsx
+++ b/src/components/ProfileHeader.tsx
@@ -364,7 +364,7 @@ export function ProfileHeader({
           <div className="flex-shrink-0 self-center sm:self-start flex gap-2">
             <Button
               onClick={handleFollowClick}
-              variant={isFollowing ? "outline" : "default"}
+              variant={isFollowing ? "outline" : "sticker"}
               size="sm"
               className="min-w-[100px]"
               data-testid="follow-button"

--- a/src/components/VideoCard.tsx
+++ b/src/components/VideoCard.tsx
@@ -4,7 +4,7 @@
 import { useState, useCallback, useRef, useMemo, useEffect } from 'react';
 import { Heart, Repeat2, MessageCircle, Share, Eye, MoreVertical, Flag, UserX, Trash2, Volume2, VolumeX, Code, Users, ListPlus, Download, Maximize2, Captions, Pin, PinOff } from 'lucide-react';
 import { nip19 } from 'nostr-tools';
-import { Card, CardContent } from '@/components/ui/card';
+import { Card, CardContent, type CardAccent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
@@ -77,6 +77,12 @@ interface VideoCardProps {
   navigationContext?: VideoNavigationContext;
   videoIndex?: number;
   trafficSource?: ViewTrafficSource;
+  /**
+   * Brand accent color that drives the card's offset shadow. Used to
+   * visually distinguish feed types (trending=pink, classic=violet, etc.)
+   * without changing copy or layout. Defaults to green.
+   */
+  accent?: CardAccent;
 }
 
 export function VideoCard({
@@ -103,6 +109,7 @@ export function VideoCard({
   navigationContext: _navigationContext,
   videoIndex: _videoIndex,
   trafficSource,
+  accent = 'green',
 }: VideoCardProps) {
   const authorData = useAuthor(video.pubkey, {
     initialName: video.authorName,
@@ -497,7 +504,7 @@ export function VideoCard({
         />
       )}
 
-    <Card className={cn('overflow-hidden', className)}>
+    <Card variant="brand" accent={accent} className={cn('overflow-hidden', className)}>
       {/* Repost indicator - NEW: Show repost count */}
       {hasReposts && (
         <div className="flex items-center gap-2 px-4 pt-3 text-sm text-muted-foreground">

--- a/src/components/VideoCardWithMetrics.tsx
+++ b/src/components/VideoCardWithMetrics.tsx
@@ -2,6 +2,7 @@
 // ABOUTME: MUST be defined outside of parent component to prevent remounting on re-renders
 
 import { VideoCard } from '@/components/VideoCard';
+import type { CardAccent } from '@/components/ui/card';
 import { useDeferredVideoMetrics } from '@/hooks/useDeferredVideoMetrics';
 import { useOptimisticLike } from '@/hooks/useOptimisticLike';
 import { useOptimisticRepost } from '@/hooks/useOptimisticRepost';
@@ -24,6 +25,7 @@ interface VideoCardWithMetricsProps {
   onEnterFullscreen?: () => void;
   onPlaybackStarted?: () => void;
   navigationContext?: VideoNavigationContext;
+  accent?: CardAccent;
 }
 
 // IMPORTANT: This component is defined at module level to prevent React from
@@ -40,6 +42,7 @@ function VideoCardWithMetricsInner({
   onEnterFullscreen,
   onPlaybackStarted,
   navigationContext,
+  accent,
 }: VideoCardWithMetricsProps) {
   const { user } = useCurrentUser();
   const { toast } = useToast();
@@ -126,6 +129,7 @@ function VideoCardWithMetricsInner({
       showComments={showComments}
       navigationContext={navigationContext}
       videoIndex={index}
+      accent={accent}
       data-testid="video-card"
     />
   );

--- a/src/components/VideoFeed.tsx
+++ b/src/components/VideoFeed.tsx
@@ -12,7 +12,7 @@ import { useBatchedAuthors } from '@/hooks/useBatchedAuthors';
 import { useContentModeration } from '@/hooks/useModeration';
 import { useFeedPerformanceInstrumentation } from '@/hooks/useFeedPerformanceInstrumentation';
 import { useProofModeEnrichment } from '@/hooks/useProofModeEnrichment';
-import { Card, CardContent } from '@/components/ui/card';
+import { Card, CardContent, type CardAccent } from '@/components/ui/card';
 import { Loader2 } from 'lucide-react';
 import InfiniteScroll from 'react-infinite-scroll-component';
 import type { ParsedVideoData } from '@/types/video';
@@ -37,6 +37,12 @@ interface VideoFeedProps {
   className?: string;
   verifiedOnly?: boolean; // Filter to show only ProofMode verified videos
   mode?: 'auto-play' | 'thumbnail'; // Display mode for video cards
+  /**
+   * Brand accent color applied to each VideoCard's offset shadow.
+   * Used to give each feed type a distinct visual identity
+   * (e.g. pink = trending, violet = classics). Defaults to green.
+   */
+  accent?: CardAccent;
   'data-testid'?: string;
   'data-hashtag-testid'?: string;
   'data-profile-testid'?: string;
@@ -53,6 +59,7 @@ export function VideoFeed({
   className,
   verifiedOnly = false,
   mode = 'auto-play',
+  accent,
   'data-testid': testId,
   'data-hashtag-testid': hashtagTestId,
   'data-profile-testid': profileTestId,
@@ -505,6 +512,7 @@ export function VideoFeed({
               onCloseComments={handleCloseComments}
               onEnterFullscreen={() => handleEnterFullscreen(index)}
               onPlaybackStarted={() => handlePlaybackStarted(video)}
+              accent={accent}
               navigationContext={{
                 source: feedType,
                 hashtag,

--- a/src/pages/DiscoveryPage.tsx
+++ b/src/pages/DiscoveryPage.tsx
@@ -184,6 +184,7 @@ export function DiscoveryPage() {
               feedType="trending"
               sortMode="hot"
               verifiedOnly={verifiedOnly}
+              accent="pink"
               data-testid="video-feed-hot"
               className="space-y-6"
               key="hot"

--- a/src/pages/DiscoveryPage.tsx
+++ b/src/pages/DiscoveryPage.tsx
@@ -173,6 +173,7 @@ export function DiscoveryPage() {
             <VideoFeed
               feedType="classics"
               verifiedOnly={verifiedOnly}
+              accent="violet"
               data-testid="video-feed-classics"
               className="space-y-6"
               key="classics"

--- a/src/pages/TrendingPage.tsx
+++ b/src/pages/TrendingPage.tsx
@@ -82,6 +82,7 @@ export function TrendingPage() {
         <VideoFeed
           feedType="trending"
           sortMode={sortMode}
+          accent="pink"
           data-testid="video-feed-trending"
           className="space-y-6"
         />


### PR DESCRIPTION
## Summary

Third PR of the brand refresh. **Stacks on #246 (Phase 1), which stacks on #245 (Phase 0).** Merge order: #245 → #246 → #247.

Applies the brand-card treatment to VideoCard (thick dark-green border, 22px radius, chunky brand-accent offset shadow) and introduces accent rotation per feed type so each major feed has a distinct visual identity.

### Commits (5)

- `feat(ui): apply brand-card treatment to VideoCard with accent prop` — VideoCard now renders with `variant="brand"` and accepts a new `accent` prop (`CardAccent` union). Defaults to `green`.
- `feat(ui): thread accent prop through VideoFeed to VideoCard` — plumbs the accent through the shared feed wrapper so pages can set a surface-level accent in one place.
- `feat(ui): accent=pink on trending feed cards` — applies to both `TrendingPage` and the Hot tab on `DiscoveryPage`.
- `feat(ui): accent=violet on classic viners feed cards` — applies to the Classics tab on `DiscoveryPage`.
- `feat(ui): apply sticker variant to ProfileHeader Follow CTA` — Follow (when not following) uses the sticker variant; Following stays outline.

### Accent palette

| Feed type | Accent | Signal |
|---|---|---|
| Home / general | green (default) | primary brand |
| Trending / Hot | pink | energetic / viral |
| Classic Viners / archive | violet | history / nostalgia |
| Profile, search, hashtag | green (default) | neutral |

## Not in this PR

- **Verified/Human accent (blue).** There's no standalone \"verified\" feed — `verifiedOnly` is a per-tab toggle on DiscoveryPage, so applying blue there would fight the tab-specific accent (pink on Hot, violet on Classics). Revisit if/when a dedicated verified feed route lands, or layer blue as a secondary visual (e.g., verified badge shimmer) rather than replacing the primary accent.
- **AppHeader / AppSidebar styling.** Both already use `/divine-logo.svg` (brand asset) and `bg-primary` (brand green) for active nav states. No changes needed.

## Test plan

- [x] `npx vitest run` — 556 passed, 2 skipped
- [x] `npx tsc -p tsconfig.app.json --noEmit` — clean
- [x] `npm run build` — succeeds
- [x] `npm run test:visual` — passes (preview page is primitives only; feed visuals aren't in baseline)
- [ ] Manual QA: visit `/trending`, `/discovery?tab=hot`, `/discovery?tab=classics`, a profile page, and the home feed. Confirm each shows a distinct accent offset shadow on video cards. Profile page's Follow button should render as the chunky sticker variant.

## Concerns / follow-ups

1. **Visual density on mobile.** Three distinct bright offset shadows (green / pink / violet) across an infinite-scroll feed may read as loud on narrow viewports where cards stack without breathing room. Flagging for preview-deploy review. If it's too much, two reasonable options: (a) reduce the shadow offset on mobile to 3px 3px (we already have `brand-offset-shadow-sm-*` utilities), (b) drop the accent on mobile entirely and keep it as a desktop-only signal.

2. **Wired into VideoFeed only.** The accent prop threads through VideoFeed → VideoCardWithMetrics → VideoCard. Pages that render VideoCard directly (e.g., VideoPage — the single-video detail page) still show default green. That's correct for now; change only if a specific surface needs its own accent.

3. **brand-card hover behavior.** Unlike brand-sticker, brand-card has no hover lift. Cards in a feed hovering and lifting would be visually noisy. If a specific card (e.g., a featured / pinned video) should animate, that's a per-surface opt-in via Tailwind classes, not a primitive change.

## What's next

- **Phase 3**: Lucide → Phosphor codemod across ~107 files, with `IconContext.Provider` at app root for `weight=\"bold\"` default.
- **Phase 4**: microcopy rewrite.
- **Phase 5**: landing page rebuild + gradient guardrail enablement.
- **Phase 6**: a11y + docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)