### PR TITLE
feat(type): refine brand typography (opsz, ss01, tighter display)

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,11 @@
     <!-- Google Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,500;12..96,600;12..96,700;12..96,800&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <!-- Inter Variable is loaded locally via @fontsource-variable/inter (see src/main.tsx).
+         Bricolage Grotesque stays on Google Fonts for now — there is no @fontsource-variable
+         build we trust yet. Variable axes (opsz 12..96, wght 400..800) are both requested
+         so font-optical-sizing: auto and heavier weights work across the display range. -->
+    <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,500;12..96,600;12..96,700;12..96,800&display=swap" rel="stylesheet">
 
     <!-- Performance: preconnect to divine API and media CDN (critical path) -->
     <link rel="dns-prefetch" href="//relay.divine.video" />

--- a/src/index.css
+++ b/src/index.css
@@ -197,16 +197,23 @@
 
   body {
     @apply bg-background text-foreground;
-    font-family: 'Inter', system-ui, -apple-system, sans-serif;
+    /* Inter Variable (loaded via @fontsource-variable/inter in src/main.tsx). */
+    font-family: 'Inter Variable', 'Inter', system-ui, -apple-system, sans-serif;
+    font-feature-settings: 'cv11' 1, 'ss01' 1;  /* Open letterforms, straight-sided i/j */
   }
 
   /* Brand headings: Bricolage Grotesque, Extra Bold for display (h1-h3),
-     Bold for subheadings (h4-h6). Per docs/brand/VISUAL_IDENTITY.md. */
+     Bold for subheadings (h4-h6). Per docs/brand/VISUAL_IDENTITY.md.
+     font-optical-sizing activates Bricolage's opsz axis (12..96) so display
+     sizes get the refined character shapes and body sizes get sturdier ones. */
   h1, h2, h3, h4, h5, h6 {
     font-family: 'Bricolage Grotesque', system-ui, -apple-system, sans-serif;
+    font-optical-sizing: auto;
     letter-spacing: -0.02em;
+    font-feature-settings: 'ss01' 1;  /* Single-story 'a' — more punk, less corporate */
   }
-  h1, h2, h3 { font-weight: 800; }
+  h1, h2 { font-weight: 800; letter-spacing: -0.03em; }  /* Display: tighter */
+  h3     { font-weight: 800; }
   h4, h5, h6 { font-weight: 700; }
 
   /* Ensure text inherits color inside primary-colored containers (buttons, tabs, etc.) */

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -26,6 +26,7 @@ export default {
 		extend: {
 			fontFamily: {
 				'sans': ['Inter Variable', 'Inter', 'system-ui', 'sans-serif'],
+				'display': ['Bricolage Grotesque', 'system-ui', 'sans-serif'],
 			},
 			colors: {
 				border: 'hsl(var(--border))',


### PR DESCRIPTION
## Summary

Small stacked PR (base: #247). One commit.

User invited a font decision. **Call: keep Bricolage Grotesque + Inter (brand spec is right — they carry the Playful Rebel energy without going too funky), but make them actually shine.**

### What changed

- **Activate Bricolage's opsz axis** via \`font-optical-sizing: auto\`. It was loaded variable (\`opsz 12..96\`) but the axis was dormant. Now h1 at display size renders the refined high-opsz character, and h4 at body size renders the sturdier low-opsz one.
- **Enable \`ss01\` on headings** — single-story \`a\`, straighter \`i\`/\`j\` tails. Reads more punk / hand-drawn, less corporate geometric sans.
- **Tighten h1/h2 tracking to -0.03em** so Extra Bold display can pack closer and read as a confident manifesto shape.
- **Drop the Google Fonts Inter request** — \`@fontsource-variable/inter\` was already imported in \`src/main.tsx\` making the Google request a redundant round-trip. Body font stack now prefers \`Inter Variable\` so the local file wins.
- **Enable Inter \`cv11\` + \`ss01\`** for open 4/6 and straight i/l — subtle "small but thoughtful" polish.
- **Add \`font-display\` Tailwind utility** pointing at Bricolage so components can reach for it directly when needed (e.g., a stat number in a card).

### Not changed

- Brand font pairing (Bricolage + Inter) — stays per \`docs/brand/VISUAL_IDENTITY.md\`.
- Font weights — h1–h3 still 800, h4–h6 still 700.
- Any component code.

## Test plan

- [x] \`npx vitest run\` — 556 passed, 2 skipped (pre-existing)
- [x] \`npx tsc\` — clean
- [x] \`npm run build\` — succeeds
- [ ] Manual QA on preview: watch for visual diff at very large display sizes (hero text, if any landing-page copy renders Bricolage at 48px+). The \`opsz\` auto + -0.03em tracking together should read more confident/bolder than before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)