### PR TITLE
Improve textarea autosize and DM composer layout

### DIFF
--- a/docs/superpowers/plans/2026-04-17-shared-textarea-autosize.md
+++ b/docs/superpowers/plans/2026-04-17-shared-textarea-autosize.md
@@ -1,0 +1,230 @@
+# Shared Textarea Autosize Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every shared textarea grow with its content while preserving each form's current starting height, and update the DM composer to start at two lines and reset cleanly after a successful send.
+
+**Architecture:** Add autosize behavior to the shared `Textarea` component so existing consumers inherit the behavior without duplicating page-level measurement code. Keep the DM conversation page focused on composition behavior by only changing its baseline sizing and send/reset assertions, while dedicated tests cover shared autosize mechanics and DM-specific success/failure behavior.
+
+**Tech Stack:** TypeScript, React 18, Vitest, Testing Library, Vite, TailwindCSS
+
+---
+
+## Chunk 1: Shared Textarea Autosize
+
+### Task 1: Add failing tests for shared autosize behavior
+
+**Files:**
+- Create: `src/components/ui/textarea.test.tsx`
+- Modify: `src/components/ui/textarea.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/components/ui/textarea.test.tsx` with focused tests that define the shared contract:
+
+```tsx
+it('preserves the current baseline height before content grows', () => {
+  render(<Textarea rows={3} value="" onChange={() => undefined} />);
+  const textarea = screen.getByRole('textbox');
+
+  mockTextareaHeights(textarea, { offsetHeight: 96, scrollHeight: 96 });
+
+  expect(textarea.style.height).toBe('96px');
+});
+
+it('grows to the content height until it reaches the max height', async () => {
+  render(<Textarea value={'line 1\nline 2\nline 3'} onChange={() => undefined} />);
+  const textarea = screen.getByRole('textbox');
+
+  mockTextareaHeights(textarea, { offsetHeight: 80, scrollHeight: 180 });
+
+  await waitFor(() => expect(textarea.style.height).toBe('180px'));
+  expect(textarea.style.overflowY).toBe('hidden');
+});
+
+it('switches to internal scrolling after the max height is reached', async () => {
+  render(<Textarea value={'long value'} onChange={() => undefined} maxAutoHeight="120px" />);
+  const textarea = screen.getByRole('textbox');
+
+  mockTextareaHeights(textarea, { offsetHeight: 80, scrollHeight: 240 });
+
+  await waitFor(() => expect(textarea.style.height).toBe('120px'));
+  expect(textarea.style.overflowY).toBe('auto');
+});
+
+it('resets back to the measured baseline when the controlled value clears', async () => {
+  const { rerender } = render(<Textarea value={'long value'} onChange={() => undefined} />);
+  const textarea = screen.getByRole('textbox');
+
+  mockTextareaHeights(textarea, { offsetHeight: 80, scrollHeight: 180 });
+  rerender(<Textarea value="" onChange={() => undefined} />);
+  mockTextareaHeights(textarea, { offsetHeight: 80, scrollHeight: 80 });
+
+  await waitFor(() => expect(textarea.style.height).toBe('80px'));
+});
+```
+
+Use a local helper in the test file to define `offsetHeight` and `scrollHeight` on the rendered textarea, since jsdom will not calculate them for you.
+
+- [ ] **Step 2: Run the focused tests to verify failure**
+
+Run: `npx vitest run src/components/ui/textarea.test.tsx`
+Expected: FAIL because the shared textarea does not autosize and does not support a max-height override yet.
+
+### Task 2: Implement the shared autosize behavior
+
+**Files:**
+- Create: `src/components/ui/textarea.test.tsx`
+- Modify: `src/components/ui/textarea.tsx`
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Update `src/components/ui/textarea.tsx` to:
+
+```tsx
+export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
+  autosize?: boolean;
+  maxAutoHeight?: string | number;
+}
+
+const DEFAULT_MAX_AUTO_HEIGHT = '40svh';
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ autosize = true, maxAutoHeight = DEFAULT_MAX_AUTO_HEIGHT, className, style, ...props }, forwardedRef) => {
+    const innerRef = React.useRef<HTMLTextAreaElement | null>(null);
+    const baselineHeightRef = React.useRef<number | null>(null);
+
+    const resizeToFit = React.useCallback(() => {
+      const node = innerRef.current;
+      if (!node || !autosize) return;
+
+      node.style.height = 'auto';
+      const baseline = baselineHeightRef.current ?? node.offsetHeight;
+      baselineHeightRef.current = baseline;
+
+      const resolvedMaxHeight = resolveAutoHeight(maxAutoHeight, node);
+      const nextHeight = Math.max(baseline, Math.min(node.scrollHeight, resolvedMaxHeight));
+
+      node.style.height = `${nextHeight}px`;
+      node.style.overflowY = node.scrollHeight > resolvedMaxHeight ? 'auto' : 'hidden';
+    }, [autosize, maxAutoHeight]);
+
+    React.useLayoutEffect(() => {
+      resizeToFit();
+    }, [resizeToFit, props.value, props.defaultValue]);
+
+    return <textarea ref={mergeRefs(forwardedRef, innerRef)} style={style} {...props} />;
+  },
+);
+```
+
+Keep the current default Tailwind classes intact. Implement any small helpers you need inside this file so the component remains self-contained.
+
+- [ ] **Step 4: Run the focused tests to verify they pass**
+
+Run: `npx vitest run src/components/ui/textarea.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/ui/textarea.tsx src/components/ui/textarea.test.tsx
+git commit -m "Add shared textarea autosize behavior"
+```
+
+## Chunk 2: DM Composer Integration and Regression Coverage
+
+### Task 3: Add failing tests for the DM composer baseline and reset behavior
+
+**Files:**
+- Modify: `src/pages/ConversationPage.test.tsx`
+- Modify: `src/pages/ConversationPage.tsx`
+
+- [ ] **Step 1: Extend the conversation page tests**
+
+Add or update tests in `src/pages/ConversationPage.test.tsx` so they define the new DM-specific behavior:
+
+```tsx
+it('renders the composer with a two-line baseline', () => {
+  renderPage();
+  expect(screen.getByRole('textbox')).toHaveAttribute('rows', '2');
+});
+
+it('clears the composer only after a successful send', async () => {
+  const user = userEvent.setup();
+  mockSendMutateAsync.mockResolvedValueOnce(undefined);
+
+  renderPage();
+  const composer = screen.getByRole('textbox');
+
+  await user.type(composer, 'hello');
+  await user.keyboard('{Enter}');
+
+  await waitFor(() => expect(mockSendMutateAsync).toHaveBeenCalledWith({
+    participantPubkeys: [RECIPIENT_PUBKEY],
+    content: 'hello',
+    share: undefined,
+  }));
+  expect(composer).toHaveValue('');
+});
+
+it('keeps the composer content when send fails', async () => {
+  const user = userEvent.setup();
+  mockSendMutateAsync.mockRejectedValueOnce(new Error('publish failed'));
+
+  renderPage();
+  const composer = screen.getByRole('textbox');
+
+  await user.type(composer, 'hello');
+  await user.keyboard('{Enter}');
+
+  await waitFor(() => expect(mockSendMutateAsync).toHaveBeenCalled());
+  expect(composer).toHaveValue('hello');
+});
+```
+
+Keep the existing keyboard behavior assertions for `Enter` send paths. Remove or rewrite any older test that expects the draft to clear before the send promise resolves.
+
+- [ ] **Step 2: Run the focused tests to verify failure**
+
+Run: `npx vitest run src/pages/ConversationPage.test.tsx`
+Expected: FAIL because the composer currently starts at one row and the success/failure assertions do not match the new contract.
+
+### Task 4: Implement the DM composer changes and confirm focused coverage
+
+**Files:**
+- Modify: `src/pages/ConversationPage.tsx`
+- Modify: `src/pages/ConversationPage.test.tsx`
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Update `src/pages/ConversationPage.tsx` so the composer textarea:
+
+```tsx
+<Textarea
+  value={draft}
+  rows={2}
+  className="min-h-[calc(theme(spacing.5)*2+theme(fontSize.sm[1].lineHeight)+theme(spacing.6))] ..."
+  onChange={(event) => setDraft(event.target.value)}
+  onKeyDown={handleComposerKeyDown}
+/>
+```
+
+Keep `handleSend()` async, but only call `setDraft('')` after `sendMessage.mutateAsync(...)` resolves successfully. Do not clear in the `catch` path. Keep the send button bottom-aligned with the textarea container.
+
+- [ ] **Step 4: Run the focused tests to verify they pass**
+
+Run: `npx vitest run src/pages/ConversationPage.test.tsx src/components/ui/textarea.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Run the full verification suite**
+
+Run: `npm run test`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/ui/textarea.tsx src/components/ui/textarea.test.tsx src/pages/ConversationPage.tsx src/pages/ConversationPage.test.tsx
+git commit -m "Improve textarea autosize and DM composer layout"
+```

--- a/docs/superpowers/specs/2026-04-17-shared-textarea-autosize-design.md
+++ b/docs/superpowers/specs/2026-04-17-shared-textarea-autosize-design.md
@@ -1,0 +1,106 @@
+# Shared Textarea Autosize Design
+
+**Date:** 2026-04-17
+**Branch:** `fix/dm-composer-autosize`
+
+## Problem
+
+The current DM composer in [src/pages/ConversationPage.tsx](/Users/rabble/code/divine/divine-web/.worktrees/fix-dm-composer-autosize/src/pages/ConversationPage.tsx:302) uses the shared [src/components/ui/textarea.tsx](/Users/rabble/code/divine/divine-web/.worktrees/fix-dm-composer-autosize/src/components/ui/textarea.tsx:7) with a fixed-feeling single-line layout. On desktop it looks cramped inside the thread card, and on small screens it does not scale naturally as longer messages wrap.
+
+The shared textarea also does not autosize anywhere in the app. Forms such as profile editing, comments, wallet setup, and video metadata rely on `rows` or `min-h-*` classes for their starting size, then stay fixed even as content grows.
+
+The current DM send flow clears the draft only after a successful mutation resolves, but the composer layout does not reset in a way that visibly matches the cleared state.
+
+## Goal
+
+Improve message composition without introducing one-off DM-only behavior:
+
+1. Make the shared textarea autosize as users type.
+2. Preserve each existing form's starting height so current layouts do not unexpectedly shrink or expand on first render.
+3. Make the DM composer start at a roomier two-line baseline on mobile and desktop.
+4. Cap textarea growth and switch to internal scrolling once the cap is reached.
+5. Clear the DM draft only after a successful send, and reset the composer height back to its baseline when that happens.
+6. Preserve the current DM keyboard behavior: `Enter` sends and `Shift+Enter` inserts a newline.
+
+## Decision
+
+Implement autosizing in the shared `Textarea` component and make it the default behavior for existing consumers.
+
+The DM composer will opt into a two-line baseline by setting its initial size through existing props and classes, while the shared autosize behavior handles growth and reset. Other forms will keep their current `rows` or `min-h-*` starting height and gain only the new growth behavior.
+
+## User Experience
+
+### Shared Textareas
+
+For every screen that uses the shared textarea:
+
+- The field renders at its current baseline height.
+- As content grows, the field expands smoothly with it.
+- Once the field reaches its height cap, the textarea stops growing and scrolls internally.
+- Programmatic value changes such as form resets also trigger the same resize logic.
+
+### DM Composer
+
+For the thread composer specifically:
+
+- The textarea starts at two visible lines.
+- The send button stays anchored at the bottom-right as the composer grows.
+- On successful send, the draft clears and the composer snaps back to its two-line baseline.
+- On failed send, the draft stays intact so the user can retry or edit it.
+
+## Architecture
+
+### Shared Textarea Behavior
+
+Update [src/components/ui/textarea.tsx](/Users/rabble/code/divine/divine-web/.worktrees/fix-dm-composer-autosize/src/components/ui/textarea.tsx:1) so the component:
+
+1. Measures its rendered baseline height after `rows`, default classes, and caller-provided classes have applied.
+2. Resets its inline height to that baseline before measuring `scrollHeight`.
+3. Sets its height to the smaller of content height and a default maximum such as `40svh`.
+4. Switches `overflow-y` between hidden and auto depending on whether content has reached the cap.
+5. Re-runs sizing when the controlled `value`, `defaultValue`, or layout-affecting inputs change.
+
+The component should remain usable as a drop-in textarea. Add an escape hatch prop only if needed to disable autosize or override the max height for a future screen.
+
+### DM Conversation Layout
+
+Update [src/pages/ConversationPage.tsx](/Users/rabble/code/divine/divine-web/.worktrees/fix-dm-composer-autosize/src/pages/ConversationPage.tsx:302) so the composer row:
+
+- Gives the textarea a two-line baseline.
+- Keeps the send button bottom-aligned as the textarea grows.
+- Relies on the shared textarea autosize behavior instead of page-local resize code.
+
+The existing `handleSend()` contract remains the source of truth for clearing the draft. A successful mutation should continue to reset the controlled value, which will now also reset the autosized height.
+
+## Error Handling
+
+- Failed sends must not clear the DM draft.
+- Autosize failures must degrade safely to a normal textarea instead of blocking input.
+- If a textarea is empty, its height should return to the measured baseline rather than staying expanded from previous content.
+
+## Scope
+
+In scope:
+
+- Shared textarea autosize behavior
+- DM composer two-line baseline
+- DM composer reset after successful send
+- Tests covering autosize growth and DM reset behavior
+
+Out of scope:
+
+- Rich text, attachments, or composer toolbar changes
+- Changing DM send semantics beyond the existing success/failure contract
+- Restyling unrelated forms beyond the autosize behavior they inherit from the shared component
+
+## Testing
+
+Add coverage for:
+
+- shared textarea growth from its existing baseline
+- shared textarea reset when controlled values are cleared
+- shared textarea cap behavior switching to internal scroll
+- DM composer clearing and height reset after a successful send
+- DM composer preserving the draft after a failed send
+
+Run focused component/page tests first, then run `npm run test`.

--- a/src/components/ui/textarea.test.tsx
+++ b/src/components/ui/textarea.test.tsx
@@ -26,13 +26,13 @@ function installTextareaHeights(initialHeights: { offsetHeight: number; scrollHe
       if (offsetHeightDescriptor) {
         Object.defineProperty(HTMLTextAreaElement.prototype, 'offsetHeight', offsetHeightDescriptor);
       } else {
-        delete (HTMLTextAreaElement.prototype as HTMLTextAreaElement).offsetHeight;
+        Reflect.deleteProperty(HTMLTextAreaElement.prototype, 'offsetHeight');
       }
 
       if (scrollHeightDescriptor) {
         Object.defineProperty(HTMLTextAreaElement.prototype, 'scrollHeight', scrollHeightDescriptor);
       } else {
-        delete (HTMLTextAreaElement.prototype as HTMLTextAreaElement).scrollHeight;
+        Reflect.deleteProperty(HTMLTextAreaElement.prototype, 'scrollHeight');
       }
     },
   };

--- a/src/components/ui/textarea.test.tsx
+++ b/src/components/ui/textarea.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { Textarea } from './textarea';
+
+function installTextareaHeights(initialHeights: { offsetHeight: number; scrollHeight: number }) {
+  const heights = { ...initialHeights };
+  const offsetHeightDescriptor = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'offsetHeight');
+  const scrollHeightDescriptor = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'scrollHeight');
+
+  Object.defineProperty(HTMLTextAreaElement.prototype, 'offsetHeight', {
+    configurable: true,
+    get: () => heights.offsetHeight,
+  });
+  Object.defineProperty(HTMLTextAreaElement.prototype, 'scrollHeight', {
+    configurable: true,
+    get: () => heights.scrollHeight,
+  });
+
+  return {
+    set(nextHeights: { offsetHeight: number; scrollHeight: number }) {
+      heights.offsetHeight = nextHeights.offsetHeight;
+      heights.scrollHeight = nextHeights.scrollHeight;
+    },
+    restore() {
+      if (offsetHeightDescriptor) {
+        Object.defineProperty(HTMLTextAreaElement.prototype, 'offsetHeight', offsetHeightDescriptor);
+      } else {
+        delete (HTMLTextAreaElement.prototype as HTMLTextAreaElement).offsetHeight;
+      }
+
+      if (scrollHeightDescriptor) {
+        Object.defineProperty(HTMLTextAreaElement.prototype, 'scrollHeight', scrollHeightDescriptor);
+      } else {
+        delete (HTMLTextAreaElement.prototype as HTMLTextAreaElement).scrollHeight;
+      }
+    },
+  };
+}
+
+describe('Textarea', () => {
+  it('preserves the current baseline height before content grows', async () => {
+    const mockHeights = installTextareaHeights({ offsetHeight: 96, scrollHeight: 96 });
+
+    render(<Textarea rows={3} value="" onChange={() => undefined} />);
+    const textarea = screen.getByRole('textbox');
+
+    await waitFor(() => expect(textarea.style.height).toBe('96px'));
+    mockHeights.restore();
+  });
+
+  it('grows to the content height until it reaches the max height', async () => {
+    const mockHeights = installTextareaHeights({ offsetHeight: 80, scrollHeight: 80 });
+
+    const { rerender } = render(<Textarea value="" onChange={() => undefined} />);
+    const textarea = screen.getByRole('textbox');
+
+    mockHeights.set({ offsetHeight: 80, scrollHeight: 180 });
+    rerender(<Textarea value={'line 1\nline 2\nline 3'} onChange={() => undefined} />);
+
+    await waitFor(() => expect(textarea.style.height).toBe('180px'));
+    expect(textarea.style.overflowY).toBe('hidden');
+    mockHeights.restore();
+  });
+
+  it('switches to internal scrolling after the max height is reached', async () => {
+    const mockHeights = installTextareaHeights({ offsetHeight: 80, scrollHeight: 80 });
+
+    const { rerender } = render(
+      <Textarea value="" onChange={() => undefined} maxAutoHeight="120px" />,
+    );
+    const textarea = screen.getByRole('textbox');
+
+    mockHeights.set({ offsetHeight: 80, scrollHeight: 240 });
+    rerender(<Textarea value={'long value'} onChange={() => undefined} maxAutoHeight="120px" />);
+
+    await waitFor(() => expect(textarea.style.height).toBe('120px'));
+    expect(textarea.style.overflowY).toBe('auto');
+    mockHeights.restore();
+  });
+
+  it('resets back to the measured baseline when the controlled value clears', async () => {
+    const mockHeights = installTextareaHeights({ offsetHeight: 80, scrollHeight: 180 });
+
+    const { rerender } = render(<Textarea value={'long value'} onChange={() => undefined} />);
+    const textarea = screen.getByRole('textbox');
+
+    await waitFor(() => expect(textarea.style.height).toBe('180px'));
+
+    mockHeights.set({ offsetHeight: 80, scrollHeight: 80 });
+    rerender(<Textarea value="" onChange={() => undefined} />);
+
+    await waitFor(() => expect(textarea.style.height).toBe('80px'));
+    mockHeights.restore();
+  });
+});

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,23 +1,106 @@
-import * as React from "react"
+import * as React from 'react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
+const DEFAULT_MAX_AUTO_HEIGHT = '40svh';
+
+function setRef<T>(ref: React.ForwardedRef<T>, value: T | null) {
+  if (typeof ref === 'function') {
+    ref(value);
+    return;
+  }
+
+  if (ref) {
+    ref.current = value;
+  }
+}
+
+function resolveAutoHeight(value: number | string) {
+  if (typeof value === 'number') {
+    return value;
+  }
+
+  const trimmedValue = value.trim();
+
+  if (trimmedValue.endsWith('px')) {
+    return Number.parseFloat(trimmedValue);
+  }
+
+  if (trimmedValue.endsWith('svh') || trimmedValue.endsWith('dvh') || trimmedValue.endsWith('lvh') || trimmedValue.endsWith('vh')) {
+    return (window.innerHeight * Number.parseFloat(trimmedValue)) / 100;
+  }
+
+  if (trimmedValue.endsWith('rem')) {
+    const rootFontSize = Number.parseFloat(getComputedStyle(document.documentElement).fontSize) || 16;
+    return rootFontSize * Number.parseFloat(trimmedValue);
+  }
+
+  const parsed = Number.parseFloat(trimmedValue);
+
+  return Number.isFinite(parsed) ? parsed : Number.POSITIVE_INFINITY;
+}
+
+export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
+  autosize?: boolean;
+  maxAutoHeight?: number | string;
+}
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
-  ({ className, ...props }, ref) => {
+  ({ autosize = true, className, maxAutoHeight = DEFAULT_MAX_AUTO_HEIGHT, style, ...props }, forwardedRef) => {
+    const innerRef = React.useRef<HTMLTextAreaElement | null>(null);
+    const baselineHeightRef = React.useRef<number | null>(null);
+
+    const resizeToFit = React.useCallback(() => {
+      const node = innerRef.current;
+
+      if (!node) {
+        return;
+      }
+
+      if (!autosize) {
+        baselineHeightRef.current = null;
+        node.style.removeProperty('height');
+        node.style.removeProperty('overflow-y');
+        return;
+      }
+
+      node.style.height = 'auto';
+
+      const baselineHeight = baselineHeightRef.current ?? node.offsetHeight;
+      baselineHeightRef.current = baselineHeight;
+
+      const resolvedMaxHeight = resolveAutoHeight(maxAutoHeight);
+      const nextHeight = Math.max(baselineHeight, Math.min(node.scrollHeight, resolvedMaxHeight));
+
+      node.style.height = `${nextHeight}px`;
+      node.style.overflowY = node.scrollHeight > resolvedMaxHeight ? 'auto' : 'hidden';
+    }, [autosize, maxAutoHeight]);
+
+    React.useLayoutEffect(() => {
+      baselineHeightRef.current = null;
+      resizeToFit();
+    }, [resizeToFit, className, props.rows]);
+
+    React.useLayoutEffect(() => {
+      resizeToFit();
+    }, [resizeToFit, props.defaultValue, props.value]);
+
     return (
       <textarea
         className={cn(
-          "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
-          className
+          'flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+          className,
         )}
-        ref={ref}
+        ref={(node) => {
+          innerRef.current = node;
+          setRef(forwardedRef, node);
+        }}
+        style={style}
         {...props}
       />
-    )
-  }
-)
-Textarea.displayName = "Textarea"
+    );
+  },
+);
+Textarea.displayName = 'Textarea';
 
-export { Textarea }
+export { Textarea };

--- a/src/pages/ConversationPage.test.tsx
+++ b/src/pages/ConversationPage.test.tsx
@@ -104,8 +104,19 @@ describe('ConversationPage', () => {
     mockSendMutateAsync.mockImplementation(() => new Promise<void>(() => undefined));
   });
 
-  it('clears the composer immediately after send is triggered', async () => {
+  it('renders the composer with a two-line baseline', () => {
+    renderPage();
+
+    expect(screen.getByRole('textbox')).toHaveAttribute('rows', '2');
+  });
+
+  it('clears the composer only after a successful send', async () => {
     const user = userEvent.setup();
+    let resolveSend: (() => void) | undefined;
+
+    mockSendMutateAsync.mockImplementationOnce(() => new Promise<void>((resolve) => {
+      resolveSend = resolve;
+    }));
 
     renderPage();
 
@@ -114,12 +125,35 @@ describe('ConversationPage', () => {
     await user.type(composer, 'hello');
     await user.keyboard('{Enter}');
 
-    await waitFor(() => expect(mockSendMutate).toHaveBeenCalledWith({
+    await waitFor(() => expect(mockSendMutateAsync).toHaveBeenCalledWith({
       participantPubkeys: [RECIPIENT_PUBKEY],
       content: 'hello',
       share: undefined,
     }));
-    expect(composer).toHaveValue('');
+    expect(composer).toHaveValue('hello');
+
+    resolveSend?.();
+    await waitFor(() => expect(composer).toHaveValue(''));
+  });
+
+  it('keeps the composer content when send fails', async () => {
+    const user = userEvent.setup();
+
+    mockSendMutateAsync.mockRejectedValueOnce(new Error('publish failed'));
+
+    renderPage();
+
+    const composer = screen.getByRole('textbox');
+
+    await user.type(composer, 'hello');
+    await user.keyboard('{Enter}');
+
+    await waitFor(() => expect(mockSendMutateAsync).toHaveBeenCalledWith({
+      participantPubkeys: [RECIPIENT_PUBKEY],
+      content: 'hello',
+      share: undefined,
+    }));
+    expect(composer).toHaveValue('hello');
   });
 
   it('renders a sending indicator for optimistic messages', () => {

--- a/src/pages/ConversationPage.tsx
+++ b/src/pages/ConversationPage.tsx
@@ -193,23 +193,26 @@ export function ConversationPage() {
 
   const sharelessPath = conversationId ? getDmConversationPath(peerPubkeys) : '/messages';
 
-  const handleSend = () => {
+  const handleSend = async () => {
     const trimmedDraft = draft.trim();
     if (!peerPubkeys.length || (!trimmedDraft && !share)) {
       return;
     }
 
-    const content = trimmedDraft;
-    setDraft('');
+    try {
+      await sendMessage.mutateAsync({
+        participantPubkeys: peerPubkeys,
+        content: trimmedDraft,
+        share: share ?? undefined,
+      });
 
-    sendMessage.mutate({
-      participantPubkeys: peerPubkeys,
-      content,
-      share: share ?? undefined,
-    });
+      setDraft('');
 
-    if (share) {
-      navigate(sharelessPath, { replace: true });
+      if (share) {
+        navigate(sharelessPath, { replace: true });
+      }
+    } catch {
+      // Mutation error state and toast are handled by the hook.
     }
   };
 
@@ -226,10 +229,10 @@ export function ConversationPage() {
     });
   };
 
-  const handleComposerKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+  const handleComposerKeyDown = async (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (event.key === 'Enter' && !event.shiftKey) {
       event.preventDefault();
-      handleSend();
+      await handleSend();
     }
   };
 
@@ -355,8 +358,8 @@ export function ConversationPage() {
                   onChange={(event) => setDraft(event.target.value)}
                   onKeyDown={handleComposerKeyDown}
                   placeholder={share ? 'Add an optional note...' : 'Write a message...'}
-                  rows={1}
-                  className="min-h-12 rounded-[24px] border-border/80 bg-background/80 px-4 py-3 text-sm"
+                  rows={2}
+                  className="resize-none rounded-[24px] border-border/80 bg-background/80 px-4 py-3 text-sm"
                 />
                 <Button
                   className="h-12 w-12 rounded-full"


### PR DESCRIPTION
## Summary
- add shared textarea autosize behavior with focused component coverage
- make the DM composer start at two lines and grow cleanly on mobile and desktop
- clear the DM draft only after a successful async send and preserve it on failure

## Test Plan
- [x] npx vitest run src/components/ui/textarea.test.tsx
- [x] npx vitest run src/pages/ConversationPage.test.tsx src/components/ui/textarea.test.tsx
- [x] npm run test
