### PR TITLE
Fix DM identity handling

### DIFF
--- a/src/pages/ConversationPage.test.tsx
+++ b/src/pages/ConversationPage.test.tsx
@@ -11,12 +11,15 @@ const RECIPIENT_PUBKEY = 'b'.repeat(64);
 const CONVERSATION_ID = encodeConversationId([RECIPIENT_PUBKEY]);
 
 const {
+  currentUserPubkey,
+  mockAuthorMap,
   directMessageState,
   mockNavigate,
   mockMarkConversationRead,
   mockSendMutate,
   mockSendMutateAsync,
 } = vi.hoisted(() => ({
+  currentUserPubkey: 'a'.repeat(64),
   directMessageState: {
     messages: [] as DmMessage[],
     latestMessageAt: 0,
@@ -29,6 +32,15 @@ const {
   mockMarkConversationRead: vi.fn(),
   mockSendMutate: vi.fn(),
   mockSendMutateAsync: vi.fn(),
+  mockAuthorMap: {
+    ['b'.repeat(64)]: {
+      metadata: {
+        display_name: 'Inbox Friend',
+        name: 'inboxfriend',
+        picture: 'https://example.com/friend.png',
+      },
+    },
+  } as Record<string, { metadata: { display_name?: string; name?: string; picture?: string; nip05?: string } }>,
 }));
 
 vi.mock('@/hooks/useDirectMessages', () => ({
@@ -50,20 +62,18 @@ vi.mock('@/hooks/useDirectMessages', () => ({
 
 vi.mock('@/hooks/useBatchedAuthors', () => ({
   useBatchedAuthors: () => ({
-    data: {
-      [RECIPIENT_PUBKEY]: {
-        metadata: {
-          display_name: 'Inbox Friend',
-          name: 'inboxfriend',
-          picture: 'https://example.com/friend.png',
-        },
-      },
-    },
+    data: mockAuthorMap,
   }),
 }));
 
 vi.mock('@/hooks/useSubdomainNavigate', () => ({
   useSubdomainNavigate: () => mockNavigate,
+}));
+
+vi.mock('@/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({
+    user: { pubkey: currentUserPubkey },
+  }),
 }));
 
 function buildMessage(overrides: Partial<DmMessage> = {}): DmMessage {
@@ -94,6 +104,13 @@ function renderPage() {
 describe('ConversationPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockAuthorMap[RECIPIENT_PUBKEY] = {
+      metadata: {
+        display_name: 'Inbox Friend',
+        name: 'inboxfriend',
+        picture: 'https://example.com/friend.png',
+      },
+    };
     directMessageState.messages = [];
     directMessageState.latestMessageAt = 0;
     directMessageState.lastReadAt = 0;
@@ -120,6 +137,20 @@ describe('ConversationPage', () => {
       share: undefined,
     }));
     expect(composer).toHaveValue('');
+  });
+
+  it('prefers nip05 in the header subtitle when it is available', () => {
+    mockAuthorMap[RECIPIENT_PUBKEY] = {
+      metadata: {
+        display_name: 'Rabble',
+        nip05: '_@rabble.divine.video',
+      },
+    };
+
+    renderPage();
+
+    expect(screen.getByRole('heading', { name: 'Rabble' })).toBeInTheDocument();
+    expect(screen.getByText('@rabble.divine.video')).toBeInTheDocument();
   });
 
   it('renders a sending indicator for optimistic messages', () => {

--- a/src/pages/ConversationPage.tsx
+++ b/src/pages/ConversationPage.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/lib/dm';
 import { genUserName } from '@/lib/genUserName';
 import { getSafeProfileImage } from '@/lib/imageUtils';
+import { getDivineNip05Info } from '@/lib/nip05Utils';
 import { formatRelativeTime } from '@/lib/notificationTransform';
 import { cn } from '@/lib/utils';
 
@@ -31,6 +32,27 @@ function getDisplayName(pubkey: string, metadata?: { display_name?: string; name
   }
 
   return metadata?.display_name || metadata?.name || genUserName(pubkey);
+}
+
+function getConversationSubtitle(
+  pubkey: string,
+  metadata?: { name?: string; nip05?: string },
+) {
+  if (pubkey === DIVINE_SUPPORT_PUBKEY) {
+    return 'Private support chat';
+  }
+
+  const nip05 = metadata?.nip05?.trim();
+  if (nip05) {
+    const divineInfo = getDivineNip05Info(nip05);
+    if (divineInfo) {
+      return divineInfo.displayName;
+    }
+
+    return nip05.startsWith('_@') ? `@${nip05.slice(2)}` : `@${nip05}`;
+  }
+
+  return `@${metadata?.name || genUserName(pubkey)}`;
 }
 
 function MessageBubble({
@@ -184,11 +206,7 @@ export function ConversationPage() {
     ? peerNames[0]
     : `${peerNames.length} people`;
   const subtitle = peerNames.length === 1
-    ? (
-        peerPubkeys[0] === DIVINE_SUPPORT_PUBKEY
-          ? 'Private support chat'
-          : `@${authorMap[peerPubkeys[0]]?.metadata?.name || genUserName(peerPubkeys[0])}`
-      )
+    ? getConversationSubtitle(peerPubkeys[0], authorMap[peerPubkeys[0]]?.metadata)
     : peerNames.join(', ');
 
   const sharelessPath = conversationId ? getDmConversationPath(peerPubkeys) : '/messages';

--- a/src/pages/MessagesPage.test.tsx
+++ b/src/pages/MessagesPage.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { LOCALE_STORAGE_KEY } from '@/lib/i18n/config';
@@ -7,7 +8,16 @@ import { initializeI18n } from '@/lib/i18n';
 import MessagesPage from './MessagesPage';
 import type { DmConversation } from '@/lib/dm';
 
-const { mockNavigate, mockConversations, mockAuthorMap } = vi.hoisted(() => ({
+const {
+  currentUserPubkey,
+  otherUserPubkey,
+  mockNavigate,
+  mockConversations,
+  mockAuthorMap,
+  mockSearchResults,
+} = vi.hoisted(() => ({
+  currentUserPubkey: 'a'.repeat(64),
+  otherUserPubkey: 'c'.repeat(64),
   mockNavigate: vi.fn(),
   mockConversations: [
     {
@@ -40,7 +50,29 @@ const { mockNavigate, mockConversations, mockAuthorMap } = vi.hoisted(() => ({
         picture: 'https://example.com/friend.png',
       },
     },
+    ['a'.repeat(64)]: {
+      metadata: {
+        display_name: 'Rabble',
+        name: 'rabble',
+        nip05: '_@rabble.divine.video',
+      },
+    },
+    ['c'.repeat(64)]: {
+      metadata: {
+        display_name: 'Alice',
+        name: 'alice',
+      },
+    },
   },
+  mockSearchResults: [] as Array<{
+    pubkey: string;
+    metadata?: {
+      display_name?: string;
+      name?: string;
+      picture?: string;
+      nip05?: string;
+    };
+  }>,
 }));
 
 vi.mock('@/hooks/useDirectMessages', () => ({
@@ -50,11 +82,15 @@ vi.mock('@/hooks/useDirectMessages', () => ({
 }));
 
 vi.mock('@/hooks/useSearchUsers', () => ({
-  useSearchUsers: () => ({ data: [], isLoading: false }),
+  useSearchUsers: () => ({ data: mockSearchResults, isLoading: false }),
 }));
 
 vi.mock('@/hooks/useBatchedAuthors', () => ({
   useBatchedAuthors: () => ({ data: mockAuthorMap }),
+}));
+
+vi.mock('@/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({ user: { pubkey: currentUserPubkey } }),
 }));
 
 vi.mock('@/hooks/useSubdomainNavigate', () => ({
@@ -71,6 +107,7 @@ function renderPage() {
 
 describe('MessagesPage', () => {
   beforeEach(async () => {
+    mockSearchResults.length = 0;
     mockConversations[0].lastMessage = {
       conversationId: 'conversation-1',
       wrapId: 'wrap-1',
@@ -143,5 +180,34 @@ describe('MessagesPage', () => {
     renderPage();
 
     expect(screen.getByText(/failed to send: this one failed/i)).toBeInTheDocument();
+  });
+
+  it('filters the current user out of compose search results', async () => {
+    const user = userEvent.setup();
+
+    mockSearchResults.push(
+      {
+        pubkey: currentUserPubkey,
+        metadata: {
+          display_name: 'Rabble',
+          name: 'rabble',
+          nip05: '_@rabble.divine.video',
+        },
+      },
+      {
+        pubkey: otherUserPubkey,
+        metadata: {
+          display_name: 'Alice',
+          name: 'alice',
+        },
+      },
+    );
+
+    renderPage();
+
+    await user.type(screen.getByRole('textbox'), 'a');
+
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.queryByText('Rabble')).not.toBeInTheDocument();
   });
 });

--- a/src/pages/MessagesPage.tsx
+++ b/src/pages/MessagesPage.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useBatchedAuthors } from '@/hooks/useBatchedAuthors';
+import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { useDmCapability, useDmConversations, useParsedDmShare } from '@/hooks/useDirectMessages';
 import { useSearchUsers } from '@/hooks/useSearchUsers';
 import { useSubdomainNavigate } from '@/hooks/useSubdomainNavigate';
@@ -170,6 +171,7 @@ export function MessagesPage() {
   const navigate = useSubdomainNavigate();
   const location = useLocation();
   const { t } = useTranslation();
+  const { user } = useCurrentUser();
   const { canUseDirectMessages } = useDmCapability();
   const conversationsQuery = useDmConversations();
   const share = useParsedDmShare(location.search);
@@ -200,7 +202,7 @@ export function MessagesPage() {
   const supportDisplayName = getDisplayName(DIVINE_SUPPORT_PUBKEY, supportMetadata);
   const supportPicture = getSafeProfileImage(supportMetadata?.picture) || '/user-avatar.png';
 
-  const searchResults = searchUsersQuery.data || [];
+  const searchResults = (searchUsersQuery.data || []).filter((result) => result.pubkey !== user?.pubkey);
 
   return (
     <div className="min-h-full bg-[radial-gradient(circle_at_top,_hsl(var(--primary)/0.14),_transparent_42%),linear-gradient(180deg,hsl(var(--background)),hsl(var(--background)))]">


### PR DESCRIPTION
## Summary
- filter the signed-in user out of DM compose search results so self-DMs are not opened
- prefer NIP-05 in the DM header subtitle instead of falling back to generated usernames
- add focused page tests for DM search identity filtering and DM header NIP-05 display

## Test Plan
- [x] npx vitest run src/pages/MessagesPage.test.tsx src/pages/ConversationPage.test.tsx
- [x] npm run test
