### PR TITLE
feat: Phase 5 — landing rebuild + remove layout gradients

### DIFF
--- a/src/components/ClassicVinersRow.tsx
+++ b/src/components/ClassicVinersRow.tsx
@@ -77,10 +77,6 @@ export function ClassicVinersRow() {
 
       {/* Scrollable row */}
       <div className="relative group">
-        {/* Scroll hint gradients */}
-        <div className="absolute left-0 top-0 bottom-0 w-8 bg-gradient-to-r from-background to-transparent z-10 pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity" />
-        <div className="absolute right-0 top-0 bottom-0 w-8 bg-gradient-to-l from-background to-transparent z-10 pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity" />
-
         {/* Scrollable container */}
         <div className="flex gap-3 overflow-x-auto pb-2 scrollbar-hide -mx-1 px-1">
           {CLASSIC_VINERS.map((viner) => (

--- a/src/components/HashtagExplorer.tsx
+++ b/src/components/HashtagExplorer.tsx
@@ -80,10 +80,10 @@ function HashtagCard({ stat }: { stat: HashtagStats }) {
                     loading="lazy"
                   />
                 )}
-                <div className="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent pointer-events-none" />
+                <div className="absolute inset-x-0 bottom-0 h-1/2 bg-brand-dark-green/60 pointer-events-none" />
               </>
             ) : (
-              <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-primary/10 to-primary/5">
+              <div className="w-full h-full flex items-center justify-center bg-primary/10">
                 <Hash className="h-12 w-12 text-primary/30" />
               </div>
             )}

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -84,7 +84,7 @@ export function LandingPage() {
             {/* Playful sticker badge */}
             <div className="flex justify-center">
               <span
-                className="inline-block brand-tilt-neg-3 rounded-full border-2 border-brand-off-white bg-brand-yellow px-4 py-1.5 text-xs font-bold uppercase tracking-wide text-brand-dark-green brand-offset-shadow-sm-dark"
+                className="inline-block brand-tilt-neg-3 rounded-full border-2 border-brand-off-white bg-brand-yellow px-4 py-1.5 text-xs font-bold tracking-wide text-brand-dark-green brand-offset-shadow-sm-dark"
               >
                 No slop. All human.
               </span>

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -1,8 +1,11 @@
-// ABOUTME: Landing page component shown to logged-out users
-// ABOUTME: Displays the Divine Video brand message
+// ABOUTME: Landing page for logged-out visitors — manifesto-first, brand-aligned
+// ABOUTME: Hero + pillars + mailing list + screenshot tour. No layout gradients.
 
-import { Card, CardContent } from "@/components/ui/card";
 import { Link } from "react-router-dom";
+import { useRef } from "react";
+import Autoplay from "embla-carousel-autoplay";
+
+import { Button } from "@/components/ui/button";
 import {
   Carousel,
   CarouselContent,
@@ -10,31 +13,36 @@ import {
   CarouselNext,
   CarouselPrevious,
 } from "@/components/ui/carousel";
-import Autoplay from "embla-carousel-autoplay";
-import { useRef } from "react";
 import { HubSpotSignup } from "@/components/HubSpotSignup";
+import { AuthenticDemo } from "@/components/landing/AuthenticDemo";
+import { VerifiedDemo } from "@/components/landing/VerifiedDemo";
+import { DecentralizedDemo } from "@/components/landing/DecentralizedDemo";
+
+const SCREENSHOTS: Array<{ src: string; alt: string }> = [
+  { src: "/screenshots/iPad 13 inch-0.avif", alt: "Divine video feed" },
+  { src: "/screenshots/iPad 13 inch-1.avif", alt: "Divine profile view" },
+  { src: "/screenshots/iPad 13 inch-2.avif", alt: "Divine hashtags" },
+  { src: "/screenshots/iPad 13 inch-3.avif", alt: "Divine discovery" },
+  { src: "/screenshots/iPad 13 inch-4.avif", alt: "Divine trending" },
+  { src: "/screenshots/iPad 13 inch-5.avif", alt: "Divine lists" },
+  { src: "/screenshots/iPad 13 inch-6.avif", alt: "Divine search" },
+];
 
 export function LandingPage() {
-  const plugin = useRef(
-    Autoplay({ delay: 3000, stopOnInteraction: true })
+  const autoplay = useRef(
+    Autoplay({ delay: 3200, stopOnInteraction: true })
   );
 
   return (
-    <div className="flex flex-col min-h-screen">
-      {/* Navigation */}
-      <nav className="fixed top-0 left-0 right-0 z-50 bg-white/95 dark:bg-gray-900/95 backdrop-blur-sm border-b border-gray-200 dark:border-gray-800">
+    <div className="flex flex-col min-h-screen bg-brand-off-white">
+      {/* Nav */}
+      <nav className="fixed top-0 left-0 right-0 z-50 bg-brand-off-white/95 dark:bg-brand-dark-green/95 backdrop-blur-sm border-b-2 border-brand-dark-green/10">
         <div className="container mx-auto px-4">
           <div className="flex items-center justify-between h-16">
-            {/* Logo */}
-            <Link to="/">
-              <img
-                src="/divine-logo.svg"
-                alt="Divine"
-                className="h-5"
-              />
+            <Link to="/" aria-label="Divine home">
+              <img src="/divine-logo.svg" alt="Divine" className="h-5" />
             </Link>
 
-            {/* Navigation Links */}
             <div className="flex items-center gap-4 md:gap-8">
               <a
                 href="https://about.divine.video/"
@@ -61,195 +69,184 @@ export function LandingPage() {
                 <span className="md:hidden">News</span>
                 <span className="hidden md:inline">In the News</span>
               </a>
-              <Link
-                to="/discovery"
-                className="ml-2 md:ml-4 inline-flex items-center gap-1 md:gap-1.5 px-3 py-1.5 md:px-4 md:py-2 text-xs md:text-sm font-semibold bg-primary text-white rounded-full hover:brightness-110 transition-colors whitespace-nowrap"
-              >
-                Try it
-                <svg className="w-3 h-3 md:w-4 md:h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
-                </svg>
-              </Link>
+              <Button asChild variant="sticker" size="sm">
+                <Link to="/discovery">Try it</Link>
+              </Button>
             </div>
           </div>
         </div>
       </nav>
 
-      <div className="flex-1 flex items-center justify-center bg-gradient-to-br from-brand-green to-brand-green dark:from-brand-green dark:to-brand-dark-green p-4 pt-20 relative overflow-hidden">
-        {/* Decorative curved line */}
-        <svg
-          className="absolute inset-0 w-full h-full pointer-events-none"
-          viewBox="0 0 1000 1000"
-          preserveAspectRatio="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M -50,200 Q 250,100 500,300 T 1050,400"
-            stroke="white"
-            strokeWidth="8"
-            fill="none"
-            opacity="0.4"
-            strokeLinecap="round"
-          />
-          <path
-            d="M -50,600 Q 250,500 500,700 T 1050,800"
-            stroke="white"
-            strokeWidth="6"
-            fill="none"
-            opacity="0.3"
-            strokeLinecap="round"
-          />
-        </svg>
-
-        <div className="max-w-2xl w-full space-y-6 relative z-10">
-        <Card className="w-full shadow-2xl bg-white dark:bg-gray-900">
-          <CardContent className="pt-8 pb-8 px-8 text-center space-y-6">
-            {/* Elevator Pitch */}
-            <div className="space-y-4">
-              <div className="flex flex-col items-center justify-center gap-3">
-                <img
-                  src="/divine_icon_transparent.avif"
-                  alt="Divine logo"
-                  className="w-16 h-16 md:w-20 md:h-20"
-                />
-                <img
-                  src="/divine-logo.svg"
-                  alt="Divine"
-                  className="h-12 md:h-16"
-                />
-              </div>
-              <p className="text-xl md:text-2xl font-semibold text-foreground">
-                Short-form looping videos. Authentic moments. Human creativity.
-              </p>
+      {/* Hero — dark green on off-white, no gradient */}
+      <section className="relative overflow-hidden bg-brand-dark-green text-brand-off-white pt-28 pb-20 md:pt-36 md:pb-28">
+        <div className="container mx-auto px-4">
+          <div className="mx-auto max-w-4xl text-center space-y-8">
+            {/* Playful sticker badge */}
+            <div className="flex justify-center">
+              <span
+                className="inline-block brand-tilt-neg-3 rounded-full border-2 border-brand-off-white bg-brand-yellow px-4 py-1.5 text-xs font-bold uppercase tracking-wide text-brand-dark-green brand-offset-shadow-sm-dark"
+              >
+                No slop. All human.
+              </span>
             </div>
 
-            {/* Mailing List Signup */}
-            <div className="pt-4">
-              <div className="hs-form-landing bg-card border border-border rounded-lg p-6 shadow-sm max-w-[600px] w-full mx-auto">
-                <h4 className="text-base font-semibold text-primary text-center mb-2">
-                  Divine Inspiration
-                </h4>
-                <p className="text-sm text-foreground text-center mb-6 leading-5">
-                  The Divine beta is currently full. If you'd like to hear our news and be among the first to hear when the Divine app goes live, sign up here.
-                </p>
-                <HubSpotSignup />
-              </div>
-            </div>
+            {/* Manifesto headline */}
+            <h1 className="font-display text-5xl md:text-7xl lg:text-8xl font-extrabold leading-[0.95] tracking-tight text-brand-off-white">
+              Creative power belongs in human hands.
+            </h1>
 
-            {/* Screenshot Carousel */}
-            <Link to="/discovery" className="block py-6 relative cursor-pointer">
-              <Carousel
-                className="w-full mx-auto"
-                opts={{
-                  align: "center",
-                  loop: true,
-                  dragFree: true,
-                  watchDrag: true,
-                }}
-                plugins={[plugin.current]}
-                onMouseEnter={plugin.current.stop}
-                onMouseLeave={plugin.current.reset}
-              >
-                <CarouselContent className="-ml-2 md:-ml-4">
-                  <CarouselItem className="pl-2 md:pl-4 basis-4/5 md:basis-3/4">
-                    <div className="p-1">
-                      <img
-                        src="/screenshots/iPad 13 inch-0.avif"
-                        alt="Divine Video feed screenshot"
-                        className="w-full h-auto rounded-lg shadow-lg"
-                      />
-                    </div>
-                  </CarouselItem>
-                  <CarouselItem className="pl-2 md:pl-4 basis-4/5 md:basis-3/4">
-                    <div className="p-1">
-                      <img
-                        src="/screenshots/iPad 13 inch-1.avif"
-                        alt="Divine Video profile screenshot"
-                        className="w-full h-auto rounded-lg shadow-lg"
-                      />
-                    </div>
-                  </CarouselItem>
-                  <CarouselItem className="pl-2 md:pl-4 basis-4/5 md:basis-3/4">
-                    <div className="p-1">
-                      <img
-                        src="/screenshots/iPad 13 inch-2.avif"
-                        alt="Divine Video hashtags screenshot"
-                        className="w-full h-auto rounded-lg shadow-lg"
-                      />
-                    </div>
-                  </CarouselItem>
-                  <CarouselItem className="pl-2 md:pl-4 basis-4/5 md:basis-3/4">
-                    <div className="p-1">
-                      <img
-                        src="/screenshots/iPad 13 inch-3.avif"
-                        alt="Divine Video discovery screenshot"
-                        className="w-full h-auto rounded-lg shadow-lg"
-                      />
-                    </div>
-                  </CarouselItem>
-                  <CarouselItem className="pl-2 md:pl-4 basis-4/5 md:basis-3/4">
-                    <div className="p-1">
-                      <img
-                        src="/screenshots/iPad 13 inch-4.avif"
-                        alt="Divine Video trending screenshot"
-                        className="w-full h-auto rounded-lg shadow-lg"
-                      />
-                    </div>
-                  </CarouselItem>
-                  <CarouselItem className="pl-2 md:pl-4 basis-4/5 md:basis-3/4">
-                    <div className="p-1">
-                      <img
-                        src="/screenshots/iPad 13 inch-5.avif"
-                        alt="Divine Video lists screenshot"
-                        className="w-full h-auto rounded-lg shadow-lg"
-                      />
-                    </div>
-                  </CarouselItem>
-                  <CarouselItem className="pl-2 md:pl-4 basis-4/5 md:basis-3/4">
-                    <div className="p-1">
-                      <img
-                        src="/screenshots/iPad 13 inch-6.avif"
-                        alt="Divine Video search screenshot"
-                        className="w-full h-auto rounded-lg shadow-lg"
-                      />
-                    </div>
-                  </CarouselItem>
-                </CarouselContent>
-                <CarouselPrevious className="left-2" />
-                <CarouselNext className="right-2" />
-              </Carousel>
-              {/* Fade effects on sides */}
-              <div className="absolute inset-y-0 left-0 w-16 bg-gradient-to-r from-white dark:from-background to-transparent pointer-events-none z-10" />
-              <div className="absolute inset-y-0 right-0 w-16 bg-gradient-to-l from-white dark:from-background to-transparent pointer-events-none z-10" />
-            </Link>
-
-            {/* Description */}
-            <p className="text-base md:text-lg text-muted-foreground max-w-xl mx-auto">
-              Experience the raw, unfiltered creativity of real people sharing genuine moments in 6-second loops. Built on decentralized technology, owned by no one, controlled by everyone.{" "}
-              <a
-                href="https://techcrunch.com/2025/11/12/jack-dorsey-funds-divine-a-vine-reboot-that-includes-vines-video-archive/"
-                className="text-primary hover:underline"
-              >
-                Learn more
-              </a>
+            <p className="mx-auto max-w-2xl text-lg md:text-xl text-brand-off-white/85 leading-relaxed">
+              Divine is bringing back the six-second videos that shaped internet
+              culture — on a protocol where creators own what they make and you
+              choose what you see.
             </p>
 
-            {/* Action Button */}
-            <div className="pt-4">
-              <Link
-                to="/discovery"
-                className="inline-flex items-center justify-center gap-2 px-8 py-4 text-base font-semibold bg-white dark:bg-gray-800 text-primary border-2 border-primary rounded-full shadow-lg hover:shadow-xl hover:scale-105 transition-all duration-200 active:scale-95"
+            <div className="flex flex-col sm:flex-row items-center justify-center gap-4 pt-2">
+              <Button asChild variant="sticker" size="lg" className="text-base">
+                <Link to="/discovery">Start joy scrolling</Link>
+              </Button>
+              <Button
+                asChild
+                variant="outline"
+                size="lg"
+                className="text-base bg-transparent border-brand-off-white text-brand-off-white hover:bg-brand-off-white hover:text-brand-dark-green hover:border-brand-off-white"
               >
-                Try it on the web
-                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
-                </svg>
-              </Link>
+                <Link to="/faq">Read the manifesto</Link>
+              </Button>
             </div>
-          </CardContent>
-        </Card>
+          </div>
         </div>
-      </div>
+      </section>
+
+      {/* Pillars — what Divine stands for */}
+      <section className="bg-brand-off-white text-brand-dark-green py-20 md:py-28">
+        <div className="container mx-auto px-4">
+          <div className="mx-auto max-w-3xl text-center mb-12 md:mb-16">
+            <h2 className="font-display text-4xl md:text-5xl font-extrabold tracking-tight">
+              Your playground for human creativity.
+            </h2>
+            <p className="mt-4 text-base md:text-lg text-brand-dark-green/75">
+              Weird, wonderful, technicolor glory — seeing, sharing, and making
+              six seconds at a time. Built by a band of thoughtful rascals who
+              saw a better way.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6 md:gap-8 max-w-6xl mx-auto">
+            <AuthenticDemo />
+            <VerifiedDemo />
+            <DecentralizedDemo />
+          </div>
+        </div>
+      </section>
+
+      {/* Screenshot tour — solid off-white, no gradient fades */}
+      <section className="bg-brand-light-green text-brand-dark-green py-16 md:py-20">
+        <div className="container mx-auto px-4">
+          <div className="mx-auto max-w-3xl text-center mb-10">
+            <h2 className="font-display text-3xl md:text-4xl font-extrabold tracking-tight">
+              Joy scrolling &gt; doom scrolling.
+            </h2>
+            <p className="mt-3 text-base text-brand-dark-green/75">
+              Peek at what's inside. Trade keyboard wars for six-second bursts
+              of brilliance.
+            </p>
+          </div>
+
+          <Link
+            to="/discovery"
+            className="block max-w-5xl mx-auto rounded-[22px] border-2 border-brand-dark-green bg-brand-off-white p-4 md:p-6 brand-offset-shadow-dark hover:translate-x-[-2px] hover:translate-y-[-2px] transition-transform"
+            aria-label="Open Divine"
+          >
+            <Carousel
+              className="w-full"
+              opts={{
+                align: "center",
+                loop: true,
+                dragFree: true,
+                watchDrag: true,
+              }}
+              plugins={[autoplay.current]}
+              onMouseEnter={autoplay.current.stop}
+              onMouseLeave={autoplay.current.reset}
+            >
+              <CarouselContent className="-ml-2 md:-ml-4">
+                {SCREENSHOTS.map(({ src, alt }) => (
+                  <CarouselItem
+                    key={src}
+                    className="pl-2 md:pl-4 basis-4/5 md:basis-3/4"
+                  >
+                    <div className="p-1">
+                      <img
+                        src={src}
+                        alt={alt}
+                        className="w-full h-auto rounded-lg border-2 border-brand-dark-green/15"
+                        loading="lazy"
+                      />
+                    </div>
+                  </CarouselItem>
+                ))}
+              </CarouselContent>
+              <CarouselPrevious className="left-2" />
+              <CarouselNext className="right-2" />
+            </Carousel>
+          </Link>
+        </div>
+      </section>
+
+      {/* Mailing list + final CTA */}
+      <section className="bg-brand-dark-green text-brand-off-white py-20 md:py-24">
+        <div className="container mx-auto px-4">
+          <div className="mx-auto max-w-3xl text-center space-y-8">
+            <div className="flex justify-center">
+              <img
+                src="/divine_icon_transparent.avif"
+                alt=""
+                aria-hidden="true"
+                className="w-20 h-20 md:w-24 md:h-24"
+              />
+            </div>
+
+            <h2 className="font-display text-3xl md:text-5xl font-extrabold tracking-tight">
+              Join the movement to brighten the internet.
+            </h2>
+
+            <p className="text-base md:text-lg text-brand-off-white/80">
+              The Divine beta is currently full. Drop your email and we'll
+              holler when the doors open — no spam, no slop.
+            </p>
+
+            <div className="hs-form-landing mx-auto max-w-xl rounded-[22px] border-2 border-brand-off-white/20 bg-brand-off-white p-6 md:p-8 text-brand-dark-green">
+              <h3 className="text-base font-semibold text-primary text-center mb-2">
+                Divine Inspiration
+              </h3>
+              <p className="text-sm text-center mb-6 leading-5 text-brand-dark-green/80">
+                Be among the first to hear when the Divine app goes live.
+              </p>
+              <HubSpotSignup />
+            </div>
+
+            <div className="pt-2">
+              <Button asChild variant="sticker" size="lg" className="text-base">
+                <Link to="/discovery">Jump into the web app</Link>
+              </Button>
+            </div>
+
+            <p className="text-xs text-brand-off-white/60 pt-4">
+              Built on Nostr.{" "}
+              <a
+                href="https://techcrunch.com/2025/11/12/jack-dorsey-funds-divine-a-vine-reboot-that-includes-vines-video-archive/"
+                className="underline hover:text-brand-off-white"
+                target="_blank"
+                rel="noreferrer noopener"
+              >
+                Read the backstory
+              </a>
+              .
+            </p>
+          </div>
+        </div>
+      </section>
     </div>
   );
 }

--- a/src/components/VideoFeed.tsx
+++ b/src/components/VideoFeed.tsx
@@ -293,7 +293,7 @@ export function VideoFeed({
                   <div className="h-3 w-16 bg-muted rounded animate-pulse" />
                 </div>
               </div>
-              <div className="aspect-square w-full bg-gradient-to-br from-brand-light-green to-brand-light-green dark:from-brand-dark-green dark:to-brand-dark-green flex items-center justify-center">
+              <div className="aspect-square w-full bg-brand-light-green dark:bg-brand-dark-green flex items-center justify-center">
                 <div className="relative w-12 h-12">
                   <div className="absolute inset-0 border-4 border-brand-light-green dark:border-brand-dark-green rounded-full" />
                   <div className="absolute inset-0 border-4 border-transparent border-t-primary rounded-full animate-spin" />

--- a/src/components/VideoGrid.tsx
+++ b/src/components/VideoGrid.tsx
@@ -220,7 +220,7 @@ export function VideoGrid({ videos, loading = false, className, navigationContex
               {/* Metadata Overlay */}
               {isHovered && (video.content || video.hashtags.length > 0) && (
                 <div
-                  className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/80 to-transparent p-4 text-white"
+                  className="absolute inset-x-0 bottom-0 bg-brand-dark-green/85 p-4 text-brand-off-white"
                   data-testid={`metadata-overlay-${video.id}`}
                 >
                   {video.content && video.content.trim() && (

--- a/src/pages/ConversationPage.tsx
+++ b/src/pages/ConversationPage.tsx
@@ -199,7 +199,7 @@ export function ConversationPage() {
 
   if (!conversationId || !peerPubkeys.length) {
     return (
-      <div className="min-h-full bg-[radial-gradient(circle_at_top,_hsl(var(--primary)/0.12),_transparent_42%),linear-gradient(180deg,hsl(var(--background)),hsl(var(--background)))]">
+      <div className="min-h-full bg-brand-off-white dark:bg-brand-dark-green">
         <main className="container py-6">
           <div className="mx-auto max-w-3xl rounded-[32px] border border-border/80 bg-card/80 px-6 py-12 text-center shadow-sm backdrop-blur-sm">
             <p className="text-lg font-semibold text-foreground">Conversation not found</p>
@@ -215,7 +215,7 @@ export function ConversationPage() {
 
   if (!canUseDirectMessages) {
     return (
-      <div className="min-h-full bg-[radial-gradient(circle_at_top,_hsl(var(--primary)/0.12),_transparent_42%),linear-gradient(180deg,hsl(var(--background)),hsl(var(--background)))]">
+      <div className="min-h-full bg-brand-off-white dark:bg-brand-dark-green">
         <main className="container py-6">
           <div className="mx-auto max-w-3xl rounded-[32px] border border-border/80 bg-card/80 px-6 py-12 text-center shadow-sm backdrop-blur-sm">
             <p className="text-lg font-semibold text-foreground">Direct messages are unavailable</p>
@@ -232,7 +232,7 @@ export function ConversationPage() {
   }
 
   return (
-    <div className="min-h-full bg-[radial-gradient(circle_at_top,_hsl(var(--primary)/0.14),_transparent_42%),linear-gradient(180deg,hsl(var(--background)),hsl(var(--background)))]">
+    <div className="min-h-full bg-brand-off-white dark:bg-brand-dark-green">
       <main className="container py-6">
         <div className="mx-auto flex max-w-3xl flex-col gap-4">
           <section className="rounded-[32px] border border-border/80 bg-card/80 px-4 py-4 shadow-[0_24px_60px_rgba(39,197,139,0.08)] backdrop-blur-sm">

--- a/src/pages/MessagesPage.tsx
+++ b/src/pages/MessagesPage.tsx
@@ -189,7 +189,7 @@ export function MessagesPage() {
   const searchResults = searchUsersQuery.data || [];
 
   return (
-    <div className="min-h-full bg-[radial-gradient(circle_at_top,_hsl(var(--primary)/0.14),_transparent_42%),linear-gradient(180deg,hsl(var(--background)),hsl(var(--background)))]">
+    <div className="min-h-full bg-brand-off-white dark:bg-brand-dark-green">
       <main className="container py-6">
         <div className="mx-auto max-w-4xl space-y-5">
           <section className="overflow-hidden rounded-[32px] border border-border/70 bg-card/80 px-5 py-6 shadow-[0_24px_60px_rgba(39,197,139,0.08)] backdrop-blur-sm">

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -20,19 +20,19 @@ const NotFound = () => {
   }, [location.pathname]);
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-purple-100 via-pink-100 to-teal-100 dark:from-purple-950 dark:via-pink-950 dark:to-teal-950">
+    <div className="min-h-screen flex items-center justify-center bg-brand-off-white dark:bg-brand-dark-green">
       <div className="text-center px-4 max-w-2xl mx-auto">
         {/* Divine Image */}
         <div className="mb-8 flex justify-center">
           <img
             src="/divine_gun.avif"
             alt="Divine"
-            className="w-64 h-auto rounded-2xl shadow-2xl transform hover:scale-105 transition-transform duration-300 border-4 border-primary"
+            className="w-64 h-auto rounded-2xl brand-offset-shadow-pink transform hover:scale-105 transition-transform duration-300 border-4 border-primary"
           />
         </div>
 
         {/* 404 Text */}
-        <h1 className="text-8xl md:text-9xl font-bold mb-4 bg-gradient-to-r from-purple-600 via-pink-600 to-teal-600 bg-clip-text text-transparent animate-pulse">
+        <h1 className="text-8xl md:text-9xl font-bold mb-4 text-brand-dark-green dark:text-brand-off-white animate-pulse">
           404
         </h1>
 

--- a/tests/brand/no-gradients.test.ts
+++ b/tests/brand/no-gradients.test.ts
@@ -28,9 +28,11 @@ const ALLOWLIST: RegExp[] = [
   /src\/components\/landing\/DecentralizedDemo\.tsx$/,
 ];
 
-// TODO(phase-5): re-enable once LandingPage, MessagesPage, ConversationPage, NotFound.tsx,
-// VideoGrid, VideoFeed, HashtagExplorer, and ClassicVinersRow are de-gradiented.
-describe.skip('brand rule: no gradients on layout surfaces', () => {
+// Phase 5: enforced. LandingPage, MessagesPage, ConversationPage, NotFound.tsx,
+// VideoGrid, VideoFeed, HashtagExplorer, and ClassicVinersRow are now de-gradiented.
+// Any new layout-surface gradient must either (a) be removed or (b) be justified
+// as genuine illustration/imagery and added to ALLOWLIST with a code comment.
+describe('brand rule: no gradients on layout surfaces', () => {
   it('src/ has no gradient classes or CSS gradients outside the illustration allowlist', () => {
     const files = walk('src');
     const violations: string[] = [];


### PR DESCRIPTION
## Summary

Fifth PR of the brand refresh. **Stacks on #251 (Phase 3).** Merge order: #245 → #246 → #247 → #248 → #251 → #252 → #253 (#253 is Phase 4, which stacks on this).

Implemented by an isolated worktree agent running in parallel with the Phase 4 microcopy agent. Clean rebase — no conflicts because file territories were carved disjoint.

### Commits (10)

**Layout gradient removal (7 files, one commit each):**
- `fix: remove layout gradient from NotFound.tsx` — swapped purple/pink/teal page gradient + gradient-clip 404 text for flat brand colors; image gets `brand-offset-shadow-pink` for visual interest
- `fix: remove layout gradient from MessagesPage.tsx` — flat `bg-brand-off-white dark:bg-brand-dark-green`
- `fix: remove layout gradient from ConversationPage.tsx` — flattened 3 radial+linear backgrounds (main + two fallback states)
- `fix: remove layout gradient from VideoGrid.tsx` — hover metadata overlay now solid `bg-brand-dark-green/85`
- `fix: remove layout gradient from VideoFeed.tsx` — skeleton placeholder flat (the gradient went from/to identical colors anyway)
- `fix: remove layout gradient from HashtagExplorer.tsx` — thumbnail overlay now a solid half-height band
- `fix: remove layout gradient from ClassicVinersRow.tsx` — dropped hover scroll-hint edge-fade gradients

**Landing rebuild:**
- `feat: rebuild LandingPage around brand manifesto (no gradients)` — 4 flat sections, no layout gradients
- `fix: drop uppercase class on landing sticker badge` — the no-uppercase guardrail caught this on first pass; agent self-corrected. The Phase 1 guardrail is earning its keep.

**Guardrail enablement:**
- `test: enable no-gradients guardrail` — un-skips the last remaining skipped test. **Suite now has 0 skips.**

### Landing page design

Four flat sections:
1. **Hero** (Dark Green bg): manifesto headline \"Creative power belongs in human hands.\", rotated yellow sticker badge \"No slop. All human.\", single-sentence subhead, primary sticker CTA \"Start joy scrolling\" → /discovery, outline \"Read the manifesto\" → /faq.
2. **Pillars** (Off White bg): reuses the 3 allowlisted demo components (AuthenticDemo, VerifiedDemo, DecentralizedDemo).
3. **Screenshot tour** (Light Green bg): existing carousel wrapped in a `brand-offset-shadow-dark` card.
4. **Final CTA** (Dark Green bg): mailing list + sticker button.

All visual energy comes from `brand-offset-shadow-*`, `brand-tilt-neg-3`, and the `brand-sticker` button utility — no layout gradients anywhere.

### Gradient final state

```
$ grep -rnE 'bg-gradient-|linear-gradient\(|radial-gradient\(' src/
```
Only 5 hits, all in the illustration allowlist:
- `src/components/ui/avatar.tsx` — 3D avatar shading
- `src/components/landing/{Verified,Decentralized}Demo.tsx` — illustration
- `src/components/BadgeImage.tsx` — badge imagery
- `src/components/BadgeDetailModal.tsx` — badge hero

## Test plan

- [x] `npx vitest run` — 560 passed, 0 skipped
- [x] `npx tsc -p tsconfig.app.json --noEmit` — clean
- [x] `npm run build` — succeeds
- [x] `no-gradients` guardrail passes (was skipped, now enforced)
- [ ] Manual QA: visit `/`, `/404`, `/messages`, `/messages/x` (invalid convo), `/search`, any hashtag page, any profile. Confirm no visible gradients on layout surfaces.
- [ ] Manual QA: the new landing page at `/` looks manifesto-first. Sticker CTA lifts on hover.

## Concerns / follow-ups

1. **Dropped elements** on landing: the \"Short-form looping videos. Authentic moments. Human creativity.\" elevator pitch line; the standalone TechCrunch anchor became a \"Read the backstory\" footer link. Manifesto headline + subhead carry the elevator-pitch role now.
2. **Rainbow 404 text** replaced with solid brand ink. Animation (pulse) retained.
3. **ClassicVinersRow** scroll-hint edge-fades dropped outright — a solid fade would misrepresent the affordance.
4. Kept external marketing links (`about.divine.video/*`) since downstream may rely on them.

## What's next

- **Phase 4** (#253): microcopy rewrite — stacks on this one.
- **Phase 6**: a11y + docs — final phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code) in parallel via isolated worktree