### PR TITLE
refactor(ui): brand offset shadow on active tabs

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -41,7 +41,7 @@ function NavItem({ icon, label, onClick, isActive }: NavItemProps) {
       className={cn(
         "group flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-[15px] transition-all duration-150",
         isActive
-          ? "bg-primary text-primary-foreground font-medium"
+          ? "bg-primary text-primary-foreground font-medium brand-offset-shadow-sm-dark"
           : "text-muted-foreground font-normal hover:bg-muted hover:text-foreground hover:font-medium"
       )}
     >
@@ -219,7 +219,7 @@ export function AppSidebar({ className }: { className?: string }) {
                       className={cn(
                         "flex w-full items-center gap-3 rounded-lg px-3 py-2 text-[14px] transition-all duration-150",
                         isCategoryActive(cat.name)
-                          ? "bg-primary text-primary-foreground font-medium"
+                          ? "bg-primary text-primary-foreground font-medium brand-offset-shadow-sm-dark"
                           : "text-muted-foreground hover:bg-muted hover:text-foreground"
                       )}
                     >

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -27,7 +27,11 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-full px-4 py-2 text-sm font-medium ring-offset-background transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:shadow-md hover:brightness-110",
+      // Active tab picks up the brand offset shadow (solid 3px dark-green)
+      // instead of the generic blurred shadow-md. Matches the house style
+      // established by brand-sticker / brand-card without going full sticker
+      // weight, which would over-read on a tab bar.
+      "inline-flex items-center justify-center whitespace-nowrap rounded-full px-4 py-2 text-sm font-medium ring-offset-background transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:brand-offset-shadow-sm-dark hover:brightness-110",
       className
     )}
     {...props}

--- a/src/pages/CategoryPage.tsx
+++ b/src/pages/CategoryPage.tsx
@@ -12,6 +12,7 @@ import { VideoFeed } from '@/components/VideoFeed';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { cn } from '@/lib/utils';
 import type { SortMode } from '@/types/nostr';
 import { EXTENDED_SORT_MODES as SORT_MODES } from '@/lib/constants/sortModes';
 import { getCategoryConfig } from '@/lib/constants/categories';
@@ -120,7 +121,7 @@ export function CategoryPage() {
                 variant={viewMode === 'feed' ? 'default' : 'ghost'}
                 size="sm"
                 onClick={() => setViewMode('feed')}
-                className="text-xs"
+                className={cn('text-xs', viewMode === 'feed' && 'brand-offset-shadow-sm-dark')}
                 aria-pressed={viewMode === 'feed'}
               >
                 <List className="h-4 w-4 mr-1" />
@@ -130,7 +131,7 @@ export function CategoryPage() {
                 variant={viewMode === 'grid' ? 'default' : 'ghost'}
                 size="sm"
                 onClick={() => setViewMode('grid')}
-                className="text-xs"
+                className={cn('text-xs', viewMode === 'grid' && 'brand-offset-shadow-sm-dark')}
                 aria-pressed={viewMode === 'grid'}
               >
                 <Grid3X3 className="h-4 w-4 mr-1" />

--- a/src/pages/HashtagPage.tsx
+++ b/src/pages/HashtagPage.tsx
@@ -12,6 +12,7 @@ import { VideoFeed } from '@/components/VideoFeed';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { cn } from '@/lib/utils';
 import type { SortMode } from '@/types/nostr';
 import { EXTENDED_SORT_MODES as SORT_MODES } from '@/lib/constants/sortModes';
 
@@ -113,7 +114,7 @@ export function HashtagPage() {
                 variant={viewMode === 'feed' ? 'default' : 'ghost'}
                 size="sm"
                 onClick={() => setViewMode('feed')}
-                className="text-xs"
+                className={cn('text-xs', viewMode === 'feed' && 'brand-offset-shadow-sm-dark')}
                 role="button"
                 aria-pressed={viewMode === 'feed'}
               >
@@ -124,7 +125,7 @@ export function HashtagPage() {
                 variant={viewMode === 'grid' ? 'default' : 'ghost'}
                 size="sm"
                 onClick={() => setViewMode('grid')}
-                className="text-xs"
+                className={cn('text-xs', viewMode === 'grid' && 'brand-offset-shadow-sm-dark')}
                 role="button"
                 aria-pressed={viewMode === 'grid'}
               >


### PR DESCRIPTION
## Summary

One-commit polish. Stacks on #253.

Active tabs (shadcn `<TabsTrigger>`) used Tailwind's generic blurred `shadow-md`. Swap for `brand-offset-shadow-sm-dark` — a 3px solid dark-green offset — so the tab bar picks up the house visual language established by `brand-sticker` buttons and `brand-card` surfaces.

**Intentionally NOT using the full `brand-sticker` treatment.** A tab bar's active state should read as *selected*, not *hero CTA*. The small (3px) offset is tab-appropriate.

### Before
```tsx
data-[state=active]:shadow-md
```
Generic blurred soft shadow.

### After
```tsx
data-[state=active]:brand-offset-shadow-sm-dark
```
Solid 3px offset dark-green, same shadow language as the rest of the refresh.

## Test plan

- [x] `npx vitest run` — 560 passed
- [x] `npx tsc` — clean
- [ ] Manual QA: click between For You / Classic / Hot / New / Tags on `/discovery`. Active tab should have a small chunky offset shadow matching the house style. Focus ring still visible on keyboard focus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)