### PR TITLE
refactor(copy): localize Playful Rebel microcopy in all 14 non-EN locales

### DIFF
--- a/src/components/ClassicVinersRow.tsx
+++ b/src/components/ClassicVinersRow.tsx
@@ -2,6 +2,7 @@
 // ABOUTME: Uses static preloaded data for instant rendering, no API calls needed
 
 import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { SmartLink } from '@/components/SmartLink';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Star } from '@phosphor-icons/react';
@@ -64,6 +65,7 @@ function usePreloadAvatars() {
  * No API calls needed - data is from CLASSIC_VINERS constant.
  */
 export function ClassicVinersRow() {
+  const { t } = useTranslation();
   // Preload avatar images
   usePreloadAvatars();
 
@@ -72,7 +74,7 @@ export function ClassicVinersRow() {
       {/* Header */}
       <div className="flex items-center gap-2 mb-3">
         <Star className="h-4 w-4 text-primary" />
-        <h3 className="text-sm font-medium">Classic Viners</h3>
+        <h3 className="text-sm font-medium">{t('classicViners.heading')}</h3>
       </div>
 
       {/* Scrollable row */}

--- a/src/components/EditProfileDialog.tsx
+++ b/src/components/EditProfileDialog.tsx
@@ -1,6 +1,7 @@
 // ABOUTME: Dialog for editing user profile with form fields for metadata
 // ABOUTME: Wraps EditProfileForm in a responsive dialog with close handling
 
+import { useTranslation } from 'react-i18next';
 import {
   Dialog,
   DialogContent,
@@ -16,6 +17,7 @@ interface EditProfileDialogProps {
 }
 
 export function EditProfileDialog({ open, onOpenChange }: EditProfileDialogProps) {
+  const { t } = useTranslation();
   const handleSuccess = () => {
     // Close the dialog after successful profile update
     onOpenChange(false);
@@ -25,9 +27,9 @@ export function EditProfileDialog({ open, onOpenChange }: EditProfileDialogProps
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
-          <DialogTitle>Edit Profile</DialogTitle>
-          <DialogDescription>
-            Update your profile information. Changes will be published to the Nostr network.
+          <DialogTitle>{t('profile.editProfile')}</DialogTitle>
+          <DialogDescription className="sr-only">
+            {t('profile.editProfile')}
           </DialogDescription>
         </DialogHeader>
         <EditProfileForm onSuccess={handleSuccess} />

--- a/src/components/FullscreenVideoItem.tsx
+++ b/src/components/FullscreenVideoItem.tsx
@@ -27,6 +27,7 @@ import { useSubdomainNavigate } from '@/hooks/useSubdomainNavigate';
 import { enhanceAuthorData } from '@/lib/generateProfile';
 import { genUserName } from '@/lib/genUserName';
 import { formatDistanceToNow } from 'date-fns';
+import { useTranslation } from 'react-i18next';
 import { formatClassicVineViewBreakdown, formatCount, formatViewCount } from '@/lib/formatUtils';
 import { getSafeProfileImage } from '@/lib/imageUtils';
 import { useBadges } from '@/hooks/useBadges';
@@ -75,6 +76,7 @@ export function FullscreenVideoItem({
   viewCount = 0,
   trafficSource,
 }: FullscreenVideoItemProps) {
+  const { t } = useTranslation();
   // Subscribe to bandwidth tier changes for adaptive HLS quality
   const _bandwidthTier = useBandwidthTier();
 
@@ -385,7 +387,7 @@ export function FullscreenVideoItem({
               {viewCount > 0 && (
                 <div className="flex items-center gap-1 text-sm text-white/80 drop-shadow-lg mt-1">
                   <Eye className="h-3 w-3" />
-                  <span>{classicViewBreakdown || formatViewCount(viewCount)}</span>
+                  <span>{classicViewBreakdown || formatViewCount(viewCount, t)}</span>
                 </div>
               )}
             </div>

--- a/src/components/ProfileHeader.tsx
+++ b/src/components/ProfileHeader.tsx
@@ -2,6 +2,7 @@
 // ABOUTME: Displays user metadata, social stats, and follow/unfollow functionality
 
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { getDivineNip05Info } from '@/lib/nip05Utils';
 import { Button } from '@/components/ui/button';
@@ -130,6 +131,7 @@ export function ProfileHeader({
   isLoading: _isLoading = false,
   className,
 }: ProfileHeaderProps) {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const subdomainNavigate = useSubdomainNavigate();
   const rssFeedAvailable = useRssFeedAvailable();
@@ -434,12 +436,12 @@ export function ProfileHeader({
               <div className="text-xl sm:text-2xl font-bold text-foreground">
                 {formatNumber(stats.videosCount)}
               </div>
-              <div className="text-xs sm:text-sm text-muted-foreground">Videos</div>
+              <div className="text-xs sm:text-sm text-muted-foreground">{t('profile.stats.videos')}</div>
             </>
           ) : (
             <>
               <Skeleton className="h-6 w-12 mx-auto mb-1" data-testid="stat-skeleton-videos" />
-              <div className="text-xs sm:text-sm text-muted-foreground">Videos</div>
+              <div className="text-xs sm:text-sm text-muted-foreground">{t('profile.stats.videos')}</div>
             </>
           )}
         </div>
@@ -455,12 +457,12 @@ export function ProfileHeader({
               <div className="text-xl sm:text-2xl font-bold text-foreground">
                 {formatNumber(stats.followersCount)}
               </div>
-              <div className="text-xs sm:text-sm text-muted-foreground">Followers</div>
+              <div className="text-xs sm:text-sm text-muted-foreground">{t('profile.stats.followers')}</div>
             </button>
           ) : (
             <>
               <Skeleton className="h-6 w-12 mx-auto mb-1" data-testid="stat-skeleton-followers" />
-              <div className="text-xs sm:text-sm text-muted-foreground">Followers</div>
+              <div className="text-xs sm:text-sm text-muted-foreground">{t('profile.stats.followers')}</div>
             </>
           )}
         </div>
@@ -476,12 +478,12 @@ export function ProfileHeader({
               <div className="text-xl sm:text-2xl font-bold text-foreground">
                 {formatNumber(stats.followingCount)}
               </div>
-              <div className="text-xs sm:text-sm text-muted-foreground">Following</div>
+              <div className="text-xs sm:text-sm text-muted-foreground">{t('profile.stats.following')}</div>
             </button>
           ) : (
             <>
               <Skeleton className="h-6 w-12 mx-auto mb-1" data-testid="stat-skeleton-following" />
-              <div className="text-xs sm:text-sm text-muted-foreground">Following</div>
+              <div className="text-xs sm:text-sm text-muted-foreground">{t('profile.stats.following')}</div>
             </>
           )}
         </div>
@@ -493,12 +495,12 @@ export function ProfileHeader({
               <div className="text-xl sm:text-2xl font-bold text-primary">
                 {formatNumber(stats.totalLoops)}
               </div>
-              <div className="text-xs sm:text-sm text-muted-foreground">Divine Loops</div>
+              <div className="text-xs sm:text-sm text-muted-foreground">{t('profile.stats.divineLoops')}</div>
             </>
           ) : (
             <>
               <Skeleton className="h-6 w-12 mx-auto mb-1" data-testid="stat-skeleton-loops" />
-              <div className="text-xs sm:text-sm text-muted-foreground">Divine Loops</div>
+              <div className="text-xs sm:text-sm text-muted-foreground">{t('profile.stats.divineLoops')}</div>
             </>
           )}
         </div>
@@ -573,7 +575,7 @@ export function ProfileHeader({
       <UserListDialog
         open={userListDialog === 'followers'}
         onOpenChange={(open) => !open && setUserListDialog(null)}
-        title="Followers"
+        title={t('profile.stats.followers')}
         pubkeys={followerPubkeys}
         isLoading={followersQuery.isLoading || followersQuery.isFetchingNextPage}
         hasMore={followersQuery.hasNextPage ?? false}
@@ -582,7 +584,7 @@ export function ProfileHeader({
       <UserListDialog
         open={userListDialog === 'following'}
         onOpenChange={(open) => !open && setUserListDialog(null)}
-        title="Following"
+        title={t('profile.stats.following')}
         pubkeys={followingPubkeys}
         isLoading={followingQuery.isLoading}
       />

--- a/src/components/ProofModeBadge.tsx
+++ b/src/components/ProofModeBadge.tsx
@@ -2,6 +2,7 @@
 // ABOUTME: Shows different icons and colors based on verification level with detailed tooltip
 
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Shield, ShieldCheck, ShieldWarning as ShieldAlert, CheckCircle, Info } from '@phosphor-icons/react';
 import { Badge } from '@/components/ui/badge';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
@@ -20,11 +21,13 @@ interface ProofModeBadgeProps {
 }
 
 export function ProofModeBadge({ level, proofData, className, showDetails = false, size = 'small' }: ProofModeBadgeProps) {
-  const config = getProofModeConfig(level);
+  const { t } = useTranslation();
+  const baseConfig = getProofModeConfig(level);
   const sizeConfig = getSizeConfig(size);
   const [open, setOpen] = useState(false);
 
-  if (!config) return null;
+  if (!baseConfig) return null;
+  const config = { ...baseConfig, label: t('verification.humanMade') };
 
   const Icon = config.icon;
 

--- a/src/components/VideoCard.tsx
+++ b/src/components/VideoCard.tsx
@@ -2,6 +2,7 @@
 // ABOUTME: Shows video player, metadata, author info, and social interactions
 
 import { useState, useCallback, useRef, useMemo, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Heart, Repeat as Repeat2, ChatCircle as MessageCircle, Share, Eye, DotsThreeVertical as MoreVertical, Flag, UserMinus as UserX, Trash as Trash2, SpeakerHigh as Volume2, SpeakerX as VolumeX, Code, Users, ListPlus, DownloadSimple as Download, ArrowsOutSimple as Maximize2, ClosedCaptioning as Captions, PushPin as Pin, PushPinSlash as PinOff } from '@phosphor-icons/react';
 import { nip19 } from 'nostr-tools';
 import { Card, CardContent, type CardAccent } from '@/components/ui/card';
@@ -111,6 +112,7 @@ export function VideoCard({
   trafficSource,
   accent = 'green',
 }: VideoCardProps) {
+  const { t } = useTranslation();
   const authorData = useAuthor(video.pubkey, {
     initialName: video.authorName,
     initialAvatar: video.authorAvatar,
@@ -795,7 +797,7 @@ export function VideoCard({
           {isHorizontal && viewCount > 0 && (
             <SmartLink to={`/video/${video.id}`} ownerPubkey={video.pubkey} className="py-2 mt-auto hover:underline block">
               <span className="block text-sm text-muted-foreground">
-                {classicViewBreakdown || formatViewCount(viewCount)}
+                {classicViewBreakdown || formatViewCount(viewCount, t)}
               </span>
             </SmartLink>
           )}
@@ -807,7 +809,7 @@ export function VideoCard({
                 {viewCount > 0 && (
                   <SmartLink to={`/video/${video.id}`} ownerPubkey={video.pubkey} className="flex items-center gap-1 hover:underline">
                     <Eye className="h-3 w-3" />
-                    <span>{classicViewBreakdown || formatViewCount(viewCount)}</span>
+                    <span>{classicViewBreakdown || formatViewCount(viewCount, t)}</span>
                   </SmartLink>
                 )}
               </div>

--- a/src/components/VideoVerificationDetailsDialog.tsx
+++ b/src/components/VideoVerificationDetailsDialog.tsx
@@ -2,6 +2,7 @@
 // ABOUTME: Uses the same decision helpers as the badge row so the UI stays aligned with mobile badge rules
 
 import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Archive, CheckCircle as CheckCircle2, ArrowSquareOut as ExternalLink, CircleNotch as Loader2, MagnifyingGlass as Search, ShieldCheck, XCircle } from '@phosphor-icons/react';
 import {
   Dialog,
@@ -15,9 +16,10 @@ import { Progress } from '@/components/ui/progress';
 import { useVideoVerification } from '@/hooks/useVideoVerification';
 import {
   type AIDetectionResult,
+  type VerificationSummaryTone,
   getProofChecklist,
-  getVerificationDescription,
-  getVerificationIntroText,
+  getVerificationIntroKey,
+  getVerificationSummary,
   isOriginalVineVideo,
   shouldFetchAiForDetails,
 } from '@/lib/videoVerification';
@@ -35,6 +37,7 @@ export function VideoVerificationDetailsDialog({
   open,
   onOpenChange,
 }: VideoVerificationDetailsDialogProps) {
+  const { t } = useTranslation();
   const { aiResult, isFetching, refetch } = useVideoVerification(video, {
     autoFetchAi: open && shouldFetchAiForDetails(video),
   });
@@ -62,10 +65,10 @@ export function VideoVerificationDetailsDialog({
             ) : (
               <ShieldCheck className="h-5 w-5 text-primary" />
             )}
-            {isOriginalVine ? 'Original Vine Archive' : 'Video Verification'}
+            {isOriginalVine ? t('verification.dialog.titleArchive') : t('verification.dialog.titleVideo')}
           </DialogTitle>
           <DialogDescription className="sr-only">
-            Details about this video&apos;s archive origin, Proofmode data, AI scan status, and hosting source.
+            {t('verification.dialog.description')}
           </DialogDescription>
         </DialogHeader>
 
@@ -86,25 +89,22 @@ export function VideoVerificationDetailsDialog({
 }
 
 function OriginalVineDetails({ video }: { video: ParsedVideoData }) {
+  const { t } = useTranslation();
   return (
     <div className="space-y-4 text-sm">
-      <p className="font-medium">
-        This video is an original Vine recovered from the Internet Archive.
-      </p>
+      <p className="font-medium">{t('verification.dialog.archiveBlurb')}</p>
 
-      <p className="text-muted-foreground">
-        Before Vine shut down in 2017, ArchiveTeam and the Internet Archive preserved millions of Vines. This content is part of that recovery effort.
-      </p>
+      <p className="text-muted-foreground">{t('verification.dialog.archiveContext')}</p>
 
       {typeof video.loopCount === 'number' && video.loopCount > 0 && (
         <p className="text-xs italic text-muted-foreground">
-          Original stats: {video.loopCount.toLocaleString()} loops
+          {t('verification.dialog.originalLoops', { count: video.loopCount.toLocaleString() })}
         </p>
       )}
 
       <ExternalTextLink
         href="https://divine.video/dmca"
-        label="Learn more about the Vine archive preservation"
+        label={t('verification.dialog.archiveLearnMore')}
       />
     </div>
   );
@@ -125,38 +125,38 @@ function VerificationDetails({
   checkedAndEmpty,
   onManualCheck,
 }: VerificationDetailsProps) {
-  const summary = getVerificationDescription(video, aiResult);
+  const { t } = useTranslation();
+  const summary = getVerificationSummary(video, aiResult);
   const checklist = getProofChecklist(video.proofMode);
+  const introKey = getVerificationIntroKey(video, aiResult);
 
   return (
     <div className="space-y-5">
-      <p className="text-sm font-medium">
-        {getVerificationIntroText(video, aiResult)}
-      </p>
+      <p className="text-sm font-medium">{t(introKey)}</p>
 
       <section className="space-y-3">
         <div className="flex items-center gap-2 text-sm font-semibold">
           <ShieldCheck className="h-4 w-4 text-primary" />
-          <span>ProofMode Verification</span>
+          <span>{t('verification.dialog.proofModeSection')}</span>
         </div>
 
         <div className="flex items-start gap-3 rounded-lg border border-border/70 bg-muted/40 p-3">
           <div className={getSummaryToneClass(summary.tone)}>
             <ShieldCheck className="h-4 w-4" />
           </div>
-          <p className="text-sm text-muted-foreground">{summary.text}</p>
+          <p className="text-sm text-muted-foreground">{t(summary.key)}</p>
         </div>
 
         <div className="space-y-2">
           {checklist.map((item) => (
-            <div key={item.label} className="flex items-center gap-2 text-sm">
+            <div key={item.key} className="flex items-center gap-2 text-sm">
               {item.passed ? (
                 <CheckCircle2 className="h-4 w-4 text-green-600" />
               ) : (
                 <XCircle className="h-4 w-4 text-muted-foreground" />
               )}
               <span className={item.passed ? 'text-foreground' : 'text-muted-foreground'}>
-                {item.label}
+                {t(item.key)}
               </span>
             </div>
           ))}
@@ -166,7 +166,7 @@ function VerificationDetails({
       <section className="space-y-3">
         <div className="flex items-center gap-2 text-sm font-semibold">
           <Search className="h-4 w-4 text-primary" />
-          <span>AI Detection</span>
+          <span>{t('verification.dialog.aiDetectionSection')}</span>
         </div>
 
         {aiResult ? (
@@ -177,16 +177,16 @@ function VerificationDetails({
               </span>
               <div className="space-y-1">
                 <p className="text-sm font-medium">
-                  {Math.round(aiResult.score * 100)}% likelihood of being AI-generated
+                  {t('verification.dialog.aiLikelihood', { percent: Math.round(aiResult.score * 100) })}
                 </p>
                 {aiResult.source && (
                   <p className="text-xs text-muted-foreground">
-                    Scanned by: {aiResult.source}
+                    {t('verification.dialog.scannedBy', { source: aiResult.source })}
                   </p>
                 )}
                 {aiResult.isVerified && (
                   <p className="text-xs text-primary">
-                    Verified by human moderator
+                    {t('verification.dialog.verifiedByMod')}
                   </p>
                 )}
               </div>
@@ -196,24 +196,24 @@ function VerificationDetails({
         ) : (
           <div className="space-y-3 rounded-lg border border-border/70 bg-muted/40 p-3">
             <p className="text-sm font-medium text-muted-foreground">
-              AI scan: Not yet scanned
+              {t('verification.dialog.aiNotScanned')}
             </p>
 
             {isFetching ? (
               <div className="flex items-center gap-2 text-sm text-muted-foreground">
                 <Loader2 className="h-4 w-4 animate-spin" />
-                <span>Checking for scan results…</span>
+                <span>{t('verification.dialog.checking')}</span>
               </div>
             ) : checkedAndEmpty ? (
               <p className="text-xs italic text-muted-foreground">
-                No scan results available yet.
+                {t('verification.dialog.noScanResults')}
               </p>
             ) : null}
 
             {!isFetching && (
               <Button type="button" variant="outline" size="sm" onClick={onManualCheck} className="w-full justify-center">
                 <Search className="mr-2 h-4 w-4" />
-                Check if AI-generated
+                {t('verification.dialog.checkAi')}
               </Button>
             )}
           </div>
@@ -221,11 +221,11 @@ function VerificationDetails({
       </section>
 
       <div className="space-y-2 border-t pt-3 text-sm">
-        <InternalTextLink href="/proofmode" label="Learn more about Proofmode verification" />
+        <InternalTextLink href="/proofmode" label={t('verification.dialog.learnMore')} />
         {video.videoUrl && (
           <ExternalTextLink
             href={`https://check.proofmode.org/#${video.videoUrl}`}
-            label="Inspect with ProofCheck Tool"
+            label={t('verification.dialog.inspectTool')}
           />
         )}
       </div>
@@ -233,7 +233,7 @@ function VerificationDetails({
   );
 }
 
-function getSummaryToneClass(tone: 'platinum' | 'gold' | 'silver' | 'bronze' | 'muted') {
+function getSummaryToneClass(tone: VerificationSummaryTone) {
   switch (tone) {
     case 'platinum':
       return 'text-[#E5E4E2]';

--- a/src/components/VineBadge.tsx
+++ b/src/components/VineBadge.tsx
@@ -1,6 +1,7 @@
 // ABOUTME: Badge component for displaying original Vine video indicator
 // ABOUTME: Shows the classic Vine logo for videos migrated from original Vine platform
 
+import { useTranslation } from 'react-i18next';
 import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
 
@@ -10,6 +11,7 @@ interface VineBadgeProps {
 }
 
 export function VineBadge({ className, size = 'small' }: VineBadgeProps) {
+  const { t } = useTranslation();
   const sizeConfig = getSizeConfig(size);
 
   return (
@@ -21,11 +23,11 @@ export function VineBadge({ className, size = 'small' }: VineBadgeProps) {
         sizeConfig.className,
         className
       )}
-      title="Original Vine archive preserved from the Internet Archive"
+      title={t('classicViners.archivedTooltip')}
       style={{ fontFamily: "'Bricolage Grotesque', system-ui, sans-serif" }}
     >
       <VineIcon className={sizeConfig.iconSize} />
-      <span>Archived</span>
+      <span>{t('classicViners.archivedBadge')}</span>
     </Badge>
   );
 }

--- a/src/components/auth/AccountSwitcher.test.tsx
+++ b/src/components/auth/AccountSwitcher.test.tsx
@@ -1,6 +1,7 @@
 import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { initializeI18n } from '@/lib/i18n';
 
 const {
   mockClearLoginCookie,
@@ -76,7 +77,18 @@ vi.mock('./LocalNsecBanner', () => ({
 import { AccountSwitcher } from './AccountSwitcher';
 
 describe('AccountSwitcher', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    const storage = new Map<string, string>();
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: (key: string) => storage.get(key) ?? null,
+        setItem: (key: string, value: string) => storage.set(key, value),
+        removeItem: (key: string) => storage.delete(key),
+        clear: () => storage.clear(),
+      } satisfies Pick<Storage, 'getItem' | 'setItem' | 'removeItem' | 'clear'>,
+    });
+    await initializeI18n({ force: true, languages: ['en-US'] });
     mockClearLoginCookie.mockClear();
     mockClearSession.mockClear();
     mockNavigate.mockClear();

--- a/src/components/auth/AccountSwitcher.tsx
+++ b/src/components/auth/AccountSwitcher.tsx
@@ -1,6 +1,7 @@
 // NOTE: This file is stable and usually should not be modified.
 // It is important that all functionality in this file is preserved, and should only be modified if explicitly requested.
 
+import { useTranslation } from 'react-i18next';
 import { CaretDown as ChevronDown, SignOut as LogOut, User as UserIcon, UserPlus, User, Gear as Settings, LinkSimple as Link2 } from '@phosphor-icons/react';
 import { useNavigate } from 'react-router-dom';
 import { nip19 } from 'nostr-tools';
@@ -29,6 +30,7 @@ interface AccountSwitcherProps {
 }
 
 export function AccountSwitcher({ onAddAccountClick }: AccountSwitcherProps) {
+  const { t } = useTranslation();
   const { logins } = useNostrLogin();
   const { currentUser, otherUsers, setLogin, removeLogin } = useLoggedInAccounts();
   const { clearSession } = useDivineSession();
@@ -80,31 +82,31 @@ export function AccountSwitcher({ onAddAccountClick }: AccountSwitcherProps) {
             className='flex items-center gap-2 cursor-pointer p-2 rounded-md'
           >
             <User className='w-4 h-4' />
-            <span>My Profile</span>
+            <span>{t('accountMenu.myProfile')}</span>
           </DropdownMenuItem>
           <DropdownMenuItem
             onClick={() => navigate('/settings/moderation')}
             className='flex items-center gap-2 cursor-pointer p-2 rounded-md'
           >
             <Settings className='w-4 h-4' />
-            <span>Settings</span>
+            <span>{t('accountMenu.settings')}</span>
           </DropdownMenuItem>
           <DropdownMenuItem
             onClick={() => navigate('/settings/linked-accounts')}
             className='flex items-center gap-2 cursor-pointer p-2 rounded-md'
           >
             <Link2 className='w-4 h-4' />
-            <span>Linked Accounts</span>
+            <span>{t('accountMenu.linkedAccounts')}</span>
           </DropdownMenuItem>
           <DropdownMenuSeparator />
-          <DropdownMenuLabel>Switch Relay</DropdownMenuLabel>
+          <DropdownMenuLabel>{t('accountMenu.switchRelay')}</DropdownMenuLabel>
           <DropdownMenuItem onSelect={(e) => e.preventDefault()} className='p-2'>
             <RelaySelector className='w-full' />
           </DropdownMenuItem>
           {!isJwtCurrentUser ? (
             <>
               <DropdownMenuSeparator />
-              <DropdownMenuLabel>Switch Account</DropdownMenuLabel>
+              <DropdownMenuLabel>{t('accountMenu.switchAccount')}</DropdownMenuLabel>
               {otherUsers.map((user) => (
                 <DropdownMenuItem
                   key={user.id}
@@ -140,7 +142,7 @@ export function AccountSwitcher({ onAddAccountClick }: AccountSwitcherProps) {
               className='flex items-center gap-2 cursor-pointer p-2 rounded-md'
             >
               <UserPlus className='w-4 h-4' />
-              <span>Add another account</span>
+              <span>{t('accountMenu.addAccount')}</span>
             </DropdownMenuItem>
           ) : null}
           <DropdownMenuItem
@@ -148,7 +150,7 @@ export function AccountSwitcher({ onAddAccountClick }: AccountSwitcherProps) {
             className='flex items-center gap-2 cursor-pointer p-2 rounded-md text-red-500'
           >
             <LogOut className='w-4 h-4' />
-            <span>Log out</span>
+            <span>{t('accountMenu.logOut')}</span>
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/src/components/auth/LoginArea.test.tsx
+++ b/src/components/auth/LoginArea.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { initializeI18n } from '@/lib/i18n';
 
 import { LoginArea } from './LoginArea';
 
@@ -24,6 +25,20 @@ vi.mock('./LoginDialog', () => ({
 }));
 
 describe('LoginArea', () => {
+  beforeEach(async () => {
+    const storage = new Map<string, string>();
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: (key: string) => storage.get(key) ?? null,
+        setItem: (key: string, value: string) => storage.set(key, value),
+        removeItem: (key: string) => storage.delete(key),
+        clear: () => storage.clear(),
+      } satisfies Pick<Storage, 'getItem' | 'setItem' | 'removeItem' | 'clear'>,
+    });
+    await initializeI18n({ force: true, languages: ['en-US'] });
+  });
+
   afterEach(() => {
     vi.clearAllMocks();
     sessionStorage.clear();

--- a/src/components/auth/LoginArea.tsx
+++ b/src/components/auth/LoginArea.tsx
@@ -2,6 +2,7 @@
 // It is important that all functionality in this file is preserved, and should only be modified if explicitly requested.
 
 import { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { User } from '@phosphor-icons/react';
 import { Button } from '@/components/ui/button.tsx';
 import LoginDialog from './LoginDialog';
@@ -15,6 +16,7 @@ export interface LoginAreaProps {
 }
 
 export function LoginArea({ className }: LoginAreaProps) {
+  const { t } = useTranslation();
   const { currentUser } = useLoggedInAccounts();
   const { isOpen: globalLoginDialogOpen, closeLoginDialog } = useLoginDialog();
   const [localLoginDialogOpen, setLocalLoginDialogOpen] = useState(false);
@@ -52,7 +54,7 @@ export function LoginArea({ className }: LoginAreaProps) {
           className='flex items-center gap-2 px-4 py-2 font-medium transition-all animate-scale-in'
         >
           <User className='w-4 h-4' />
-          <span className='truncate'>Log in</span>
+          <span className='truncate'>{t('auth.logIn')}</span>
         </Button>
       )}
 

--- a/src/lib/formatUtils.ts
+++ b/src/lib/formatUtils.ts
@@ -1,6 +1,8 @@
 // ABOUTME: Utility functions for formatting numbers, durations, and counts
 // ABOUTME: Provides consistent formatting across the application for social metrics
 
+import type { TFunction } from 'i18next';
+
 /**
  * Format view counts and social interaction counts with K/M notation
  */
@@ -30,10 +32,14 @@ export function formatDuration(seconds: number): string {
 }
 
 /**
- * Format view count with proper pluralization
+ * Format view count with proper pluralization. Pass a translator (`t` from
+ * useTranslation) to localize the unit; falls back to English if omitted.
  */
-export function formatViewCount(count: number): string {
+export function formatViewCount(count: number, t?: TFunction): string {
   const formatted = formatCount(count);
+  if (t) {
+    return t('videoMeta.viewCount', { count, formatted });
+  }
   return count === 1 ? `${formatted} view` : `${formatted} views`;
 }
 

--- a/src/lib/i18n/locales/ar/common.json
+++ b/src/lib/i18n/locales/ar/common.json
@@ -203,5 +203,34 @@
     "heading": "كلاسيكيو Vine",
     "archivedBadge": "مؤرشف",
     "archivedTooltip": "أرشيف Vine الأصلي محفوظ من Internet Archive"
+  },
+  "profile": {
+    "stats": {
+      "videos": "الفيديوهات",
+      "followers": "المتابعون",
+      "following": "يتابع",
+      "divineLoops": "لقطات Divine"
+    },
+    "editProfile": "تحرير الملف الشخصي"
+  },
+  "accountMenu": {
+    "myProfile": "ملفي الشخصي",
+    "settings": "الإعدادات",
+    "linkedAccounts": "الحسابات المرتبطة",
+    "switchRelay": "تبديل الـ Relay",
+    "switchAccount": "تبديل الحساب",
+    "addAccount": "إضافة حساب آخر",
+    "logOut": "تسجيل الخروج"
+  },
+  "trending": {
+    "title": "الرائج",
+    "subtitle": "شاهد ما يتفاعل معه المجتمع"
+  },
+  "searchTabs": {
+    "all": "الكل",
+    "videos": "الفيديوهات",
+    "users": "الأشخاص",
+    "hashtags": "الوسوم",
+    "searching": "جاري البحث..."
   }
 }

--- a/src/lib/i18n/locales/ar/common.json
+++ b/src/lib/i18n/locales/ar/common.json
@@ -198,5 +198,10 @@
       "c2paContentCredentials": "C2PA Content Credentials",
       "proofManifest": "بيان الإثبات"
     }
+  },
+  "classicViners": {
+    "heading": "كلاسيكيو Vine",
+    "archivedBadge": "مؤرشف",
+    "archivedTooltip": "أرشيف Vine الأصلي محفوظ من Internet Archive"
   }
 }

--- a/src/lib/i18n/locales/ar/common.json
+++ b/src/lib/i18n/locales/ar/common.json
@@ -44,19 +44,19 @@
     "yourFeed": "خلاصتك"
   },
   "auth": {
-    "logInOnDivine": "سجل الدخول إلى Divine"
+    "logInOnDivine": "هيا ندخل"
   },
   "home": {
-    "welcomeTitle": "مرحبًا بك في خلاصتك الرئيسية",
-    "welcomeSubtitle": "سجل الدخول لرؤية فيديوهات الأشخاص الذين تتابعهم",
+    "welcomeTitle": "خلاصتك، قواعدك.",
+    "welcomeSubtitle": "سجّل الدخول لمشاهدة لقطات الأشخاص الذين تتابعهم.",
     "title": "الرئيسية",
-    "subtitle": "فيديوهات الأشخاص الذين تتابعهم",
+    "subtitle": "لقطات من الأشخاص الذين تتابعهم.",
     "sortBy": "ترتيب حسب:",
     "updating": "جارٍ التحديث..."
   },
   "discovery": {
     "title": "اكتشف",
-    "subtitle": "استكشف الفيديوهات من الشبكة",
+    "subtitle": "تجوّل في الشبكة. اعثر على ناسك.",
     "categories": "الفئات",
     "forYou": "لك",
     "classic": "كلاسيكي",
@@ -82,14 +82,14 @@
   },
   "comments": {
     "title": "التعليقات",
-    "noCommentsYet": "لا توجد تعليقات بعد",
-    "beFirstToShare": "كن أول من يشارك رأيه",
-    "failedToLoad": "تعذر تحميل التعليقات",
-    "writeAComment": "اكتب تعليقًا...",
+    "noCommentsYet": "لا شيء يُقال بعد.",
+    "beFirstToShare": "كن أول من يبدأ — اكتب تعليقًا.",
+    "failedToLoad": "تعذّر تحميل التعليقات.",
+    "writeAComment": "قل شيئًا...",
     "signInToReply": "سجل الدخول للرد",
     "signInToComment": "سجل الدخول للتعليق",
     "replyingToComment": "الرد على التعليق",
-    "addingToDiscussion": "إضافة إلى النقاش",
+    "addingToDiscussion": "ندخل إلى النقاش",
     "posting": "جارٍ النشر...",
     "reply": "رد",
     "comment": "تعليق"
@@ -97,46 +97,46 @@
   "messages": {
     "badge": "الرسائل",
     "title": "الرسائل المباشرة",
-    "subtitle": "تحدث مع الدعم، وأرسل vines بشكل خاص، أو واصل المحادثة مع الأشخاص الذين تتابعهم.",
-    "searchPlaceholder": "ابحث عن أشخاص لمراسلتهم",
+    "subtitle": "تحدث مع الدعم، أرسل لقطة بشكل خاص، أو واصل المحادثة مع الأشخاص الذين تتابعهم.",
+    "searchPlaceholder": "ابحث عن شخص لمراسلته",
     "newMessage": "رسالة جديدة",
-    "readyToShare": "جاهز للمشاركة بشكل خاص.",
+    "readyToShare": "جاهز للإرسال بشكل خاص.",
     "shareWithTitle": "ستتضمن رسالتك التالية “{{title}}”.",
     "shareWithLink": "ستتضمن رسالتك التالية رابط vine.",
-    "signerUnsupported": "يمكن للموقّع الحالي تسجيل دخولك، لكنه لا يوفّر بعد تشفير NIP-44. انتقل إلى nsec أو bunker أو موقّع آخر يدعم NIP-44 لاستخدام الرسائل المباشرة على الويب.",
+    "signerUnsupported": "يمكن للموقّع الحالي تسجيل دخولك، لكنه لا يتحدث NIP-44 بعد. انتقل إلى nsec أو bunker أو موقّع آخر يدعم NIP-44 لاستخدام الرسائل المباشرة هنا.",
     "supportBadge": "الدعم",
-    "supportSummary": "اسأل عن الأخطاء أو الإشراف أو مشكلات الحساب."
+    "supportSummary": "أخطاء، إشراف، أمور الحساب — نحن نسمعك."
   },
   "support": {
     "title": "الدعم",
-    "subtitle": "هل تحتاج إلى مساعدة؟ نحن هنا لمساعدتك.",
-    "helpCenterTitle": "زيارة مركز مساعدة Divine",
-    "helpCenterDescription": "اعثر على إجابات لأسئلتك حول Divine.",
+    "subtitle": "بحاجة لمساعدة؟ نحن معك.",
+    "helpCenterTitle": "مركز مساعدة Divine",
+    "helpCenterDescription": "إجابات للأسئلة الشائعة.",
     "helpCenterCta": "زيارة مركز المساعدة",
     "messageSupportTitle": "مراسلة الدعم",
-    "messageSupportDescription": "تواصل مباشرة مع صندوق دعم Divine باستخدام رسائل NIP-17 الخاصة.",
+    "messageSupportDescription": "راسلنا مباشرة داخل Divine — مشفّرة بـ NIP-17.",
     "messageSupportCta": "فتح دردشة الدعم",
     "contactTitle": "الاتصال بالدعم",
-    "contactDescription": "أنشئ تذكرة وسنرد عليك في أقرب وقت ممكن.",
+    "contactDescription": "افتح تذكرة وسنرد عليك بأسرع ما يمكن.",
     "contactLink": "الاتصال بالدعم",
     "githubTitle": "مشكلات GitHub",
-    "githubDescription": "أبلغ عن الأخطاء أو اطلب ميزات أو تصفح المشكلات الحالية في مستودعات GitHub الخاصة بنا.",
+    "githubDescription": "أبلغ عن الأخطاء، اطلب ميزات، أو تجوّل في GitHub لدينا.",
     "webAppLabel": "تطبيق الويب:",
     "flutterAppLabel": "تطبيق Flutter ‏(iOS/Android):",
     "communityTitle": "المجتمع",
-    "communityDescription": "انضم إلى نقاشات المجتمع وتواصل مع مستخدمي Divine الآخرين على Nostr.",
-    "communityBody": "تم بناء Divine على Nostr، وهو بروتوكول اجتماعي لامركزي. اعثر علينا في عميل Nostr المفضل لديك."
+    "communityDescription": "تعالَ وانضم لمجتمع Divine على Nostr.",
+    "communityBody": "Divine يعمل على Nostr، البروتوكول الاجتماعي اللامركزي. اعثر علينا في عميل Nostr المفضل لديك."
   },
   "tagPage": {
-    "notFoundTitle": "لم يتم العثور على الوسم",
-    "notFoundDescription": "تعذر العثور على الوسم المطلوب.",
+    "notFoundTitle": "لم يتم العثور على الوسم.",
+    "notFoundDescription": "تعذّر العثور على هذا الوسم.",
     "back": "رجوع",
-    "subtitle": "استعرض الفيديوهات الموسومة بـ #{{tag}}"
+    "subtitle": "لقطات موسومة بـ #{{tag}}"
   },
   "categoriesPage": {
     "title": "الفئات",
-    "subtitle": "تصفح الفيديوهات حسب الموضوع",
-    "emptyState": "لا توجد فئات متاحة حاليا.",
+    "subtitle": "لقطات، مرتّبة حسب المزاج.",
+    "emptyState": "لا توجد فئات قيد الإعداد الآن.",
     "metaTitle": "تصفح الفئات - Divine",
     "metaDescription": "استكشف فئات الفيديو على Divine مثل الكوميديا والموسيقى والرقص والحيوانات والرياضة والطعام والمزيد.",
     "videoCount_zero": "0 فيديو",

--- a/src/lib/i18n/locales/ar/common.json
+++ b/src/lib/i18n/locales/ar/common.json
@@ -44,7 +44,8 @@
     "yourFeed": "خلاصتك"
   },
   "auth": {
-    "logInOnDivine": "هيا ندخل"
+    "logInOnDivine": "هيا ندخل",
+    "logIn": "تسجيل الدخول"
   },
   "home": {
     "welcomeTitle": "خلاصتك، قواعدك.",
@@ -145,5 +146,57 @@
     "videoCount_few": "{{count}} فيديوهات",
     "videoCount_many": "{{count}} فيديو",
     "videoCount_other": "{{count}} فيديو"
+  },
+  "videoMeta": {
+    "viewCount_zero": "لا توجد مشاهدات",
+    "viewCount_one": "مشاهدة واحدة",
+    "viewCount_two": "مشاهدتان",
+    "viewCount_few": "{{formatted}} مشاهدات",
+    "viewCount_many": "{{formatted}} مشاهدة",
+    "viewCount_other": "{{formatted}} مشاهدة"
+  },
+  "verification": {
+    "humanMade": "من صنع البشر",
+    "dialog": {
+      "titleVideo": "التحقق من الفيديو",
+      "titleArchive": "أرشيف Vine الأصلي",
+      "description": "تفاصيل عن أصل الأرشيف وبيانات Proofmode وحالة فحص الذكاء الاصطناعي ومصدر الاستضافة.",
+      "proofModeSection": "تحقق ProofMode",
+      "aiDetectionSection": "كشف الذكاء الاصطناعي",
+      "aiNotScanned": "فحص الذكاء الاصطناعي: لم يُفحص بعد",
+      "checking": "يتم التحقق من نتائج الفحص…",
+      "noScanResults": "لا توجد نتائج فحص متاحة بعد.",
+      "checkAi": "تحقق إذا كان مولّدًا بالذكاء الاصطناعي",
+      "aiLikelihood": "احتمال أن يكون مولّدًا بالذكاء الاصطناعي {{percent}}%",
+      "scannedBy": "تم الفحص بواسطة: {{source}}",
+      "verifiedByMod": "تم التحقق من قبل مشرف بشري",
+      "learnMore": "اعرف المزيد عن تحقق Proofmode",
+      "inspectTool": "افحص بأداة ProofCheck",
+      "archiveBlurb": "هذا الفيديو هو Vine أصلي تم استرجاعه من Internet Archive.",
+      "archiveContext": "قبل إغلاق Vine في 2017، حفظ ArchiveTeam وInternet Archive ملايين من Vine. هذا المحتوى جزء من ذلك الإنقاذ.",
+      "originalLoops": "إحصاءات أصلية: {{count}} لقطة",
+      "archiveLearnMore": "اعرف المزيد عن حفظ أرشيف Vine"
+    },
+    "intro": {
+      "proofMode": "تم التحقق من أصالة هذا الفيديو باستخدام تقنية Proofmode.",
+      "aiHumanDivine": "هذا الفيديو مستضاف على Divine ويشير كشف الذكاء الاصطناعي إلى أنه على الأرجح من صنع البشر، رغم عدم وجود بيانات ProofMode.",
+      "aiHuman": "يشير كشف الذكاء الاصطناعي إلى أن هذا الفيديو على الأرجح من صنع البشر، رغم عدم وجود بيانات ProofMode.",
+      "unverifiedDivine": "هذا الفيديو غير موثّق. مستضاف على Divine لكنه لا يحتوي على بيانات ProofMode بعد.",
+      "unverifiedExternal": "هذا الفيديو غير موثّق ومستضاف خارج Divine. لا يحتوي على بيانات ProofMode."
+    },
+    "summary": {
+      "platinum": "بلاتيني: شهادة عتاد الجهاز، توقيعات تشفيرية، Content Credentials (C2PA)، وفحص الذكاء الاصطناعي يؤكد الأصل البشري.",
+      "gold": "ذهبي: مُلتقط على جهاز حقيقي مع شهادة العتاد، توقيعات تشفيرية، وContent Credentials (C2PA).",
+      "silverProof": "فضي: التوقيعات التشفيرية تُثبت أن هذا الفيديو لم يُعدَّل منذ التسجيل.",
+      "bronze": "برونزي: توقيعات بيانات وصفية أساسية موجودة.",
+      "silverAi": "فضي: فحص الذكاء الاصطناعي يؤكد أن هذا الفيديو على الأرجح من صنع البشر.",
+      "muted": "لا تتوفر بيانات تحقق لهذا الفيديو."
+    },
+    "checklist": {
+      "deviceAttestation": "شهادة الجهاز",
+      "pgpSignature": "توقيع PGP",
+      "c2paContentCredentials": "C2PA Content Credentials",
+      "proofManifest": "بيان الإثبات"
+    }
   }
 }

--- a/src/lib/i18n/locales/de/common.json
+++ b/src/lib/i18n/locales/de/common.json
@@ -44,19 +44,19 @@
     "yourFeed": "Dein Feed"
   },
   "auth": {
-    "logInOnDivine": "Bei Divine anmelden"
+    "logInOnDivine": "Rein da"
   },
   "home": {
-    "welcomeTitle": "Willkommen in deinem Home-Feed",
-    "welcomeSubtitle": "Melde dich an, um Videos von Personen zu sehen, denen du folgst",
+    "welcomeTitle": "Dein Feed, deine Regeln.",
+    "welcomeSubtitle": "Melde dich an und sieh die Loops von Leuten, denen du folgst.",
     "title": "Startseite",
-    "subtitle": "Videos von Personen, denen du folgst",
+    "subtitle": "Loops von Leuten, denen du folgst.",
     "sortBy": "Sortieren nach:",
     "updating": "Wird aktualisiert..."
   },
   "discovery": {
     "title": "Entdecken",
-    "subtitle": "Videos aus dem Netzwerk entdecken",
+    "subtitle": "Streif durchs Netzwerk. Find deine Leute.",
     "categories": "Kategorien",
     "forYou": "Fur dich",
     "classic": "Klassisch",
@@ -82,14 +82,14 @@
   },
   "comments": {
     "title": "Kommentare",
-    "noCommentsYet": "Noch keine Kommentare",
-    "beFirstToShare": "Teile als Erste oder Erster deine Gedanken",
-    "failedToLoad": "Kommentare konnten nicht geladen werden",
-    "writeAComment": "Schreibe einen Kommentar...",
+    "noCommentsYet": "Noch nichts zu sagen.",
+    "beFirstToShare": "Mach den Anfang — schreib was.",
+    "failedToLoad": "Kommentare konnten nicht geladen werden.",
+    "writeAComment": "Sag was...",
     "signInToReply": "Melde dich an, um zu antworten",
     "signInToComment": "Melde dich an, um zu kommentieren",
     "replyingToComment": "Antwort auf Kommentar",
-    "addingToDiscussion": "Zur Diskussion hinzufugen",
+    "addingToDiscussion": "Steig in den Thread ein",
     "posting": "Wird gesendet...",
     "reply": "Antworten",
     "comment": "Kommentieren"
@@ -97,46 +97,46 @@
   "messages": {
     "badge": "Nachrichten",
     "title": "Direktnachrichten",
-    "subtitle": "Sprich mit dem Support, sende Vines privat oder fuhre Unterhaltungen mit Personen fort, denen du folgst.",
-    "searchPlaceholder": "Personen zum Anschreiben finden",
+    "subtitle": "Sprich mit dem Support, schick einen Loop privat oder halt einen Thread mit den Leuten am Laufen, denen du folgst.",
+    "searchPlaceholder": "Jemanden zum Anschreiben finden",
     "newMessage": "Neue Nachricht",
-    "readyToShare": "Bereit zum privaten Teilen.",
+    "readyToShare": "Bereit fur den privaten Versand.",
     "shareWithTitle": "Deine nachste Nachricht enthalt „{{title}}“.",
     "shareWithLink": "Deine nachste Nachricht enthalt einen Vine-Link.",
-    "signerUnsupported": "Dein aktueller Signer kann dich anmelden, bietet aber noch keine NIP-44-Verschlusselung. Wechsle zu einem nsec, bunker oder einem anderen Signer mit NIP-44-Unterstutzung, um Direktnachrichten im Web zu nutzen.",
+    "signerUnsupported": "Dein aktueller Signer kann dich anmelden, spricht aber noch kein NIP-44. Wechsle zu einem nsec, bunker oder einem anderen Signer mit NIP-44-Unterstutzung, um DMs hier zu nutzen.",
     "supportBadge": "Support",
-    "supportSummary": "Frage nach Bugs, Moderation oder Kontoproblemen."
+    "supportSummary": "Bugs, Moderation, Account-Kram — wir horen zu."
   },
   "support": {
     "title": "Support",
-    "subtitle": "Brauchst du Hilfe? Wir sind fur dich da.",
-    "helpCenterTitle": "Divine Hilfe-Center besuchen",
-    "helpCenterDescription": "Finde Antworten auf deine Fragen zu Divine.",
+    "subtitle": "Brauchst du Hilfe? Wir haben dich.",
+    "helpCenterTitle": "Divine Hilfe-Center",
+    "helpCenterDescription": "Antworten auf das, was die meisten fragen.",
     "helpCenterCta": "Hilfe-Center besuchen",
     "messageSupportTitle": "Support anschreiben",
-    "messageSupportDescription": "Erreiche den Support-Posteingang direkt in Divine mit privaten NIP-17-Nachrichten.",
+    "messageSupportDescription": "Schreib uns direkt in Divine — verschlusselt mit NIP-17.",
     "messageSupportCta": "Support-Chat offnen",
     "contactTitle": "Support kontaktieren",
-    "contactDescription": "Erstelle ein Ticket und wir melden uns so schnell wie moglich.",
+    "contactDescription": "Erstelle ein Ticket — wir melden uns so schnell wie moglich.",
     "contactLink": "Support kontaktieren",
     "githubTitle": "GitHub-Issues",
-    "githubDescription": "Melde Fehler, frage Funktionen an oder sieh dir bestehende Issues in unseren GitHub-Repositories an.",
+    "githubDescription": "Melde Bugs, wunsche dir Features oder stober in unserem GitHub.",
     "webAppLabel": "Web-App:",
     "flutterAppLabel": "Flutter-App (iOS/Android):",
     "communityTitle": "Community",
-    "communityDescription": "Beteilige dich an unseren Community-Diskussionen und vernetze dich mit anderen Divine-Nutzern auf Nostr.",
-    "communityBody": "Divine basiert auf Nostr, einem dezentralen sozialen Protokoll. Finde uns in deinem bevorzugten Nostr-Client."
+    "communityDescription": "Komm in die Divine-Community auf Nostr.",
+    "communityBody": "Divine lauft auf Nostr, dem dezentralen sozialen Protokoll. Find uns in deinem Lieblings-Nostr-Client."
   },
   "tagPage": {
-    "notFoundTitle": "Tag nicht gefunden",
-    "notFoundDescription": "Der angeforderte Tag konnte nicht gefunden werden.",
+    "notFoundTitle": "Tag nicht gefunden.",
+    "notFoundDescription": "Diesen Tag gibt's hier nicht.",
     "back": "Zuruck",
-    "subtitle": "Entdecke Videos mit dem Tag #{{tag}}"
+    "subtitle": "Loops mit dem Tag #{{tag}}"
   },
   "categoriesPage": {
     "title": "Kategorien",
-    "subtitle": "Videos nach Thema durchsuchen",
-    "emptyState": "Derzeit sind keine Kategorien verfugbar.",
+    "subtitle": "Loops, sortiert nach Vibe.",
+    "emptyState": "Aktuell brodelt hier keine Kategorie.",
     "metaTitle": "Kategorien entdecken - Divine",
     "metaDescription": "Entdecke Videokategorien auf Divine - Comedy, Musik, Tanz, Tiere, Sport, Essen und mehr.",
     "videoCount_one": "{{count}} Video",

--- a/src/lib/i18n/locales/de/common.json
+++ b/src/lib/i18n/locales/de/common.json
@@ -195,5 +195,34 @@
     "heading": "Klassische Viner",
     "archivedBadge": "Archiviert",
     "archivedTooltip": "Original Vine-Archiv, gerettet aus dem Internet Archive"
+  },
+  "profile": {
+    "stats": {
+      "videos": "Videos",
+      "followers": "Follower",
+      "following": "Folgt",
+      "divineLoops": "Divine Loops"
+    },
+    "editProfile": "Profil bearbeiten"
+  },
+  "accountMenu": {
+    "myProfile": "Mein Profil",
+    "settings": "Einstellungen",
+    "linkedAccounts": "Verknupfte Konten",
+    "switchRelay": "Relay wechseln",
+    "switchAccount": "Konto wechseln",
+    "addAccount": "Weiteres Konto hinzufugen",
+    "logOut": "Abmelden"
+  },
+  "trending": {
+    "title": "Trends",
+    "subtitle": "Sieh, was in der Community gerade angesagt ist"
+  },
+  "searchTabs": {
+    "all": "Alles",
+    "videos": "Videos",
+    "users": "Leute",
+    "hashtags": "Tags",
+    "searching": "Suche laeuft..."
   }
 }

--- a/src/lib/i18n/locales/de/common.json
+++ b/src/lib/i18n/locales/de/common.json
@@ -44,7 +44,8 @@
     "yourFeed": "Dein Feed"
   },
   "auth": {
-    "logInOnDivine": "Rein da"
+    "logInOnDivine": "Rein da",
+    "logIn": "Anmelden"
   },
   "home": {
     "welcomeTitle": "Dein Feed, deine Regeln.",
@@ -141,5 +142,53 @@
     "metaDescription": "Entdecke Videokategorien auf Divine - Comedy, Musik, Tanz, Tiere, Sport, Essen und mehr.",
     "videoCount_one": "{{count}} Video",
     "videoCount_other": "{{count}} Videos"
+  },
+  "videoMeta": {
+    "viewCount_one": "{{formatted}} Aufruf",
+    "viewCount_other": "{{formatted}} Aufrufe"
+  },
+  "verification": {
+    "humanMade": "Von Menschen gemacht",
+    "dialog": {
+      "titleVideo": "Video-Verifizierung",
+      "titleArchive": "Original Vine-Archiv",
+      "description": "Details zur Archivherkunft, Proofmode-Daten, KI-Scan-Status und Hosting-Quelle.",
+      "proofModeSection": "ProofMode-Verifizierung",
+      "aiDetectionSection": "KI-Erkennung",
+      "aiNotScanned": "KI-Scan: noch nicht gescannt",
+      "checking": "Pruefe Scan-Ergebnisse…",
+      "noScanResults": "Noch keine Scan-Ergebnisse verfugbar.",
+      "checkAi": "Prufen, ob KI-generiert",
+      "aiLikelihood": "{{percent}}% Wahrscheinlichkeit, KI-generiert zu sein",
+      "scannedBy": "Gescannt von: {{source}}",
+      "verifiedByMod": "Von menschlichem Moderator bestatigt",
+      "learnMore": "Mehr uber Proofmode-Verifizierung erfahren",
+      "inspectTool": "Mit ProofCheck-Tool prufen",
+      "archiveBlurb": "Dieses Video ist ein Original-Vine, geborgen aus dem Internet Archive.",
+      "archiveContext": "Bevor Vine 2017 abgeschaltet wurde, haben ArchiveTeam und das Internet Archive Millionen von Vines gesichert. Dieser Inhalt ist Teil dieser Rettungsaktion.",
+      "originalLoops": "Originalstats: {{count}} Loops",
+      "archiveLearnMore": "Mehr uber die Vine-Archivierung erfahren"
+    },
+    "intro": {
+      "proofMode": "Die Echtheit dieses Videos ist mit Proofmode-Technologie verifiziert.",
+      "aiHumanDivine": "Dieses Video lauft auf Divine, und die KI-Erkennung deutet auf menschlichen Ursprung hin, obwohl keine ProofMode-Daten anliegen.",
+      "aiHuman": "Die KI-Erkennung deutet darauf hin, dass dieses Video wahrscheinlich von Menschen gemacht ist, auch ohne ProofMode-Daten.",
+      "unverifiedDivine": "Dieses Video ist nicht verifiziert. Es lauft auf Divine, aber es liegen noch keine ProofMode-Daten an.",
+      "unverifiedExternal": "Dieses Video ist nicht verifiziert und wird auserhalb von Divine gehostet. Es enthalt keine ProofMode-Daten."
+    },
+    "summary": {
+      "platinum": "Platin: Geratehardware-Attestierung, kryptografische Signaturen, Content Credentials (C2PA) und KI-Scan bestatigen menschlichen Ursprung.",
+      "gold": "Gold: Auf einem echten Gerat aufgenommen mit Hardware-Attestierung, kryptografischen Signaturen und Content Credentials (C2PA).",
+      "silverProof": "Silber: Kryptografische Signaturen belegen, dass dieses Video seit der Aufnahme nicht verandert wurde.",
+      "bronze": "Bronze: Grundlegende Metadaten-Signaturen vorhanden.",
+      "silverAi": "Silber: KI-Scan bestatigt, dass dieses Video wahrscheinlich von einem Menschen erstellt wurde.",
+      "muted": "Fur dieses Video sind keine Verifizierungsdaten verfugbar."
+    },
+    "checklist": {
+      "deviceAttestation": "Gerate-Attestierung",
+      "pgpSignature": "PGP-Signatur",
+      "c2paContentCredentials": "C2PA Content Credentials",
+      "proofManifest": "Proof-Manifest"
+    }
   }
 }

--- a/src/lib/i18n/locales/de/common.json
+++ b/src/lib/i18n/locales/de/common.json
@@ -190,5 +190,10 @@
       "c2paContentCredentials": "C2PA Content Credentials",
       "proofManifest": "Proof-Manifest"
     }
+  },
+  "classicViners": {
+    "heading": "Klassische Viner",
+    "archivedBadge": "Archiviert",
+    "archivedTooltip": "Original Vine-Archiv, gerettet aus dem Internet Archive"
   }
 }

--- a/src/lib/i18n/locales/en/common.json
+++ b/src/lib/i18n/locales/en/common.json
@@ -190,5 +190,10 @@
       "c2paContentCredentials": "C2PA Content Credentials",
       "proofManifest": "Proof manifest"
     }
+  },
+  "classicViners": {
+    "heading": "Classic Viners",
+    "archivedBadge": "Archived",
+    "archivedTooltip": "Original Vine archive preserved from the Internet Archive"
   }
 }

--- a/src/lib/i18n/locales/en/common.json
+++ b/src/lib/i18n/locales/en/common.json
@@ -195,5 +195,34 @@
     "heading": "Classic Viners",
     "archivedBadge": "Archived",
     "archivedTooltip": "Original Vine archive preserved from the Internet Archive"
+  },
+  "profile": {
+    "stats": {
+      "videos": "Videos",
+      "followers": "Followers",
+      "following": "Following",
+      "divineLoops": "Divine Loops"
+    },
+    "editProfile": "Edit Profile"
+  },
+  "accountMenu": {
+    "myProfile": "My Profile",
+    "settings": "Settings",
+    "linkedAccounts": "Linked Accounts",
+    "switchRelay": "Switch Relay",
+    "switchAccount": "Switch Account",
+    "addAccount": "Add another account",
+    "logOut": "Log out"
+  },
+  "trending": {
+    "title": "Trending",
+    "subtitle": "Discover what's popular in the community"
+  },
+  "searchTabs": {
+    "all": "All",
+    "videos": "Videos",
+    "users": "Users",
+    "hashtags": "Hashtags",
+    "searching": "Searching..."
   }
 }

--- a/src/lib/i18n/locales/en/common.json
+++ b/src/lib/i18n/locales/en/common.json
@@ -44,7 +44,8 @@
     "yourFeed": "Your Feed"
   },
   "auth": {
-    "logInOnDivine": "Jump in"
+    "logInOnDivine": "Jump in",
+    "logIn": "Log in"
   },
   "home": {
     "welcomeTitle": "Your feed, your rules.",
@@ -141,5 +142,53 @@
     "metaDescription": "Explore video categories on Divine - comedy, music, dance, animals, sports, food, and more.",
     "videoCount_one": "{{count}} video",
     "videoCount_other": "{{count}} videos"
+  },
+  "videoMeta": {
+    "viewCount_one": "{{formatted}} view",
+    "viewCount_other": "{{formatted}} views"
+  },
+  "verification": {
+    "humanMade": "Human Made",
+    "dialog": {
+      "titleVideo": "Video Verification",
+      "titleArchive": "Original Vine Archive",
+      "description": "Details about this video's archive origin, Proofmode data, AI scan status, and hosting source.",
+      "proofModeSection": "ProofMode Verification",
+      "aiDetectionSection": "AI Detection",
+      "aiNotScanned": "AI scan: Not yet scanned",
+      "checking": "Checking for scan results…",
+      "noScanResults": "No scan results available yet.",
+      "checkAi": "Check if AI-generated",
+      "aiLikelihood": "{{percent}}% likelihood of being AI-generated",
+      "scannedBy": "Scanned by: {{source}}",
+      "verifiedByMod": "Verified by human moderator",
+      "learnMore": "Learn more about Proofmode verification",
+      "inspectTool": "Inspect with ProofCheck Tool",
+      "archiveBlurb": "This video is an original Vine recovered from the Internet Archive.",
+      "archiveContext": "Before Vine shut down in 2017, ArchiveTeam and the Internet Archive preserved millions of Vines. This content is part of that recovery effort.",
+      "originalLoops": "Original stats: {{count}} loops",
+      "archiveLearnMore": "Learn more about the Vine archive preservation"
+    },
+    "intro": {
+      "proofMode": "This video's authenticity is verified using Proofmode technology.",
+      "aiHumanDivine": "This video is hosted on Divine and AI detection indicates it is likely human-made, even though no ProofMode verification data is attached.",
+      "aiHuman": "AI detection indicates this video is likely human-made, though no ProofMode verification data is attached.",
+      "unverifiedDivine": "This video is unverified. It is hosted on Divine, but no ProofMode verification data is attached yet.",
+      "unverifiedExternal": "This video is unverified and hosted outside Divine. It does not include ProofMode verification data."
+    },
+    "summary": {
+      "platinum": "Platinum: Device hardware attestation, cryptographic signatures, Content Credentials (C2PA), and AI scan confirms human origin.",
+      "gold": "Gold: Captured on a real device with hardware attestation, cryptographic signatures, and Content Credentials (C2PA).",
+      "silverProof": "Silver: Cryptographic signatures prove this video hasn't been altered since recording.",
+      "bronze": "Bronze: Basic metadata signatures are present.",
+      "silverAi": "Silver: AI scan confirms this video is likely human-created.",
+      "muted": "No verification data available for this video."
+    },
+    "checklist": {
+      "deviceAttestation": "Device attestation",
+      "pgpSignature": "PGP signature",
+      "c2paContentCredentials": "C2PA Content Credentials",
+      "proofManifest": "Proof manifest"
+    }
   }
 }

--- a/src/lib/i18n/locales/es/common.json
+++ b/src/lib/i18n/locales/es/common.json
@@ -44,7 +44,8 @@
     "yourFeed": "Tu feed"
   },
   "auth": {
-    "logInOnDivine": "Entra ya"
+    "logInOnDivine": "Entra ya",
+    "logIn": "Iniciar sesion"
   },
   "home": {
     "welcomeTitle": "Tu feed, tus reglas.",
@@ -141,5 +142,53 @@
     "metaDescription": "Explora categorias de video en Divine: comedia, musica, baile, animales, deportes, comida y mas.",
     "videoCount_one": "{{count}} video",
     "videoCount_other": "{{count}} videos"
+  },
+  "videoMeta": {
+    "viewCount_one": "{{formatted}} vista",
+    "viewCount_other": "{{formatted}} vistas"
+  },
+  "verification": {
+    "humanMade": "Hecho por humanos",
+    "dialog": {
+      "titleVideo": "Verificacion de video",
+      "titleArchive": "Archivo original de Vine",
+      "description": "Detalles sobre el origen del archivo, datos de Proofmode, estado del escaneo IA y fuente de alojamiento.",
+      "proofModeSection": "Verificacion ProofMode",
+      "aiDetectionSection": "Deteccion de IA",
+      "aiNotScanned": "Escaneo IA: aun no escaneado",
+      "checking": "Buscando resultados del escaneo…",
+      "noScanResults": "Aun no hay resultados de escaneo.",
+      "checkAi": "Comprobar si es generado por IA",
+      "aiLikelihood": "{{percent}}% de probabilidad de ser generado por IA",
+      "scannedBy": "Escaneado por: {{source}}",
+      "verifiedByMod": "Verificado por moderador humano",
+      "learnMore": "Saber mas sobre la verificacion Proofmode",
+      "inspectTool": "Inspeccionar con ProofCheck",
+      "archiveBlurb": "Este video es un Vine original recuperado del Internet Archive.",
+      "archiveContext": "Antes de que Vine cerrara en 2017, ArchiveTeam y el Internet Archive conservaron millones de Vines. Este contenido forma parte de ese rescate.",
+      "originalLoops": "Estadisticas originales: {{count}} loops",
+      "archiveLearnMore": "Saber mas sobre la preservacion del archivo de Vine"
+    },
+    "intro": {
+      "proofMode": "La autenticidad de este video esta verificada con tecnologia Proofmode.",
+      "aiHumanDivine": "Este video esta alojado en Divine y la deteccion de IA indica que es probablemente humano, aunque no tiene datos de verificacion ProofMode.",
+      "aiHuman": "La deteccion de IA indica que este video es probablemente humano, aunque no tiene datos de verificacion ProofMode.",
+      "unverifiedDivine": "Este video no esta verificado. Esta alojado en Divine, pero todavia no tiene datos de verificacion ProofMode.",
+      "unverifiedExternal": "Este video no esta verificado y se aloja fuera de Divine. No incluye datos de verificacion ProofMode."
+    },
+    "summary": {
+      "platinum": "Platino: Atestacion del hardware del dispositivo, firmas criptograficas, Content Credentials (C2PA) y el escaneo IA confirma origen humano.",
+      "gold": "Oro: Capturado en un dispositivo real con atestacion de hardware, firmas criptograficas y Content Credentials (C2PA).",
+      "silverProof": "Plata: Las firmas criptograficas prueban que este video no se ha alterado desde la grabacion.",
+      "bronze": "Bronce: Firmas basicas de metadatos presentes.",
+      "silverAi": "Plata: El escaneo de IA confirma que este video probablemente fue creado por un humano.",
+      "muted": "No hay datos de verificacion disponibles para este video."
+    },
+    "checklist": {
+      "deviceAttestation": "Atestacion del dispositivo",
+      "pgpSignature": "Firma PGP",
+      "c2paContentCredentials": "Content Credentials C2PA",
+      "proofManifest": "Manifiesto de prueba"
+    }
   }
 }

--- a/src/lib/i18n/locales/es/common.json
+++ b/src/lib/i18n/locales/es/common.json
@@ -44,19 +44,19 @@
     "yourFeed": "Tu feed"
   },
   "auth": {
-    "logInOnDivine": "Inicia sesion en Divine"
+    "logInOnDivine": "Entra ya"
   },
   "home": {
-    "welcomeTitle": "Bienvenido a tu feed principal",
-    "welcomeSubtitle": "Inicia sesion para ver videos de las personas que sigues",
+    "welcomeTitle": "Tu feed, tus reglas.",
+    "welcomeSubtitle": "Inicia sesion para ver loops de la gente que sigues.",
     "title": "Inicio",
-    "subtitle": "Videos de las personas que sigues",
+    "subtitle": "Loops de la gente que sigues.",
     "sortBy": "Ordenar por:",
     "updating": "Actualizando..."
   },
   "discovery": {
     "title": "Descubrir",
-    "subtitle": "Explora videos de la red",
+    "subtitle": "Recorre la red. Encuentra a tu gente.",
     "categories": "Categorias",
     "forYou": "Para ti",
     "classic": "Clasico",
@@ -82,14 +82,14 @@
   },
   "comments": {
     "title": "Comentarios",
-    "noCommentsYet": "Aun no hay comentarios",
-    "beFirstToShare": "Se la primera persona en compartir tu opinion",
-    "failedToLoad": "No se pudieron cargar los comentarios",
-    "writeAComment": "Escribe un comentario...",
+    "noCommentsYet": "Nada que decir aun.",
+    "beFirstToShare": "Empieza tu — deja un comentario.",
+    "failedToLoad": "Los comentarios no cargaron.",
+    "writeAComment": "Di algo...",
     "signInToReply": "Inicia sesion para responder",
     "signInToComment": "Inicia sesion para comentar",
     "replyingToComment": "Respondiendo al comentario",
-    "addingToDiscussion": "Anadiendo a la conversacion",
+    "addingToDiscussion": "Sumandote al hilo",
     "posting": "Publicando...",
     "reply": "Responder",
     "comment": "Comentar"
@@ -97,46 +97,46 @@
   "messages": {
     "badge": "Mensajes",
     "title": "Mensajes directos",
-    "subtitle": "Habla con soporte, envia vines en privado o mantén una conversacion con personas que sigues.",
-    "searchPlaceholder": "Busca personas para escribirles",
+    "subtitle": "Habla con soporte, mete un loop en privado o mantén una conversacion con la gente que sigues.",
+    "searchPlaceholder": "Busca a alguien para escribirle",
     "newMessage": "Nuevo mensaje",
-    "readyToShare": "Listo para compartir en privado.",
+    "readyToShare": "Listo para enviar en privado.",
     "shareWithTitle": "Tu proximo mensaje incluira “{{title}}”.",
     "shareWithLink": "Tu proximo mensaje incluira un enlace de vine.",
-    "signerUnsupported": "Tu firmador actual puede iniciar sesion, pero todavia no expone cifrado NIP-44. Cambia a un nsec, bunker u otro firmador que admita NIP-44 para usar mensajes directos en la web.",
+    "signerUnsupported": "Tu firmador actual puede iniciar sesion, pero todavia no habla NIP-44. Cambia a un nsec, bunker u otro firmador con soporte NIP-44 para usar DMs aqui.",
     "supportBadge": "Soporte",
-    "supportSummary": "Pregunta sobre errores, moderacion o problemas de cuenta."
+    "supportSummary": "Bugs, moderacion, cosas de cuenta — te escuchamos."
   },
   "support": {
     "title": "Soporte",
-    "subtitle": "Necesitas ayuda? Estamos aqui para ayudarte.",
-    "helpCenterTitle": "Visitar el centro de ayuda de Divine",
-    "helpCenterDescription": "Encuentra respuestas a tus preguntas sobre Divine.",
+    "subtitle": "Necesitas una mano? Te tenemos.",
+    "helpCenterTitle": "Centro de ayuda Divine",
+    "helpCenterDescription": "Respuestas a lo que la gente suele preguntar.",
     "helpCenterCta": "Visitar el centro de ayuda",
     "messageSupportTitle": "Mensaje al soporte",
-    "messageSupportDescription": "Contacta con la bandeja de soporte dentro de Divine usando mensajes privados NIP-17.",
+    "messageSupportDescription": "Escribenos directo dentro de Divine — cifrado con NIP-17.",
     "messageSupportCta": "Abrir chat de soporte",
     "contactTitle": "Contactar con soporte",
-    "contactDescription": "Crea un ticket y te responderemos lo antes posible.",
+    "contactDescription": "Abre un ticket y te respondemos lo mas rapido posible.",
     "contactLink": "Contactar con soporte",
     "githubTitle": "Incidencias de GitHub",
-    "githubDescription": "Informa de errores, solicita funciones o revisa incidencias existentes en nuestros repositorios de GitHub.",
+    "githubDescription": "Reporta bugs, pide funciones o curiosea por nuestro GitHub.",
     "webAppLabel": "App web:",
     "flutterAppLabel": "App Flutter (iOS/Android):",
     "communityTitle": "Comunidad",
-    "communityDescription": "Unete a nuestras conversaciones comunitarias y conecta con otros usuarios de Divine en Nostr.",
-    "communityBody": "Divine esta construido sobre Nostr, un protocolo social descentralizado. Encuentranos en tu cliente de Nostr favorito."
+    "communityDescription": "Pasate por la comunidad Divine en Nostr.",
+    "communityBody": "Divine corre sobre Nostr, el protocolo social descentralizado. Encuentranos en tu cliente de Nostr favorito."
   },
   "tagPage": {
-    "notFoundTitle": "Etiqueta no encontrada",
-    "notFoundDescription": "No se pudo encontrar la etiqueta solicitada.",
+    "notFoundTitle": "Etiqueta no encontrada.",
+    "notFoundDescription": "No encontramos esa etiqueta.",
     "back": "Atras",
-    "subtitle": "Explora videos etiquetados con #{{tag}}"
+    "subtitle": "Loops etiquetados con #{{tag}}"
   },
   "categoriesPage": {
     "title": "Categorias",
-    "subtitle": "Explora videos por tema",
-    "emptyState": "No hay categorias disponibles en este momento.",
+    "subtitle": "Loops, ordenados por vibe.",
+    "emptyState": "No hay categorias en marcha ahora mismo.",
     "metaTitle": "Explorar categorias - Divine",
     "metaDescription": "Explora categorias de video en Divine: comedia, musica, baile, animales, deportes, comida y mas.",
     "videoCount_one": "{{count}} video",

--- a/src/lib/i18n/locales/es/common.json
+++ b/src/lib/i18n/locales/es/common.json
@@ -190,5 +190,10 @@
       "c2paContentCredentials": "Content Credentials C2PA",
       "proofManifest": "Manifiesto de prueba"
     }
+  },
+  "classicViners": {
+    "heading": "Viners clasicos",
+    "archivedBadge": "Archivado",
+    "archivedTooltip": "Archivo original de Vine preservado por el Internet Archive"
   }
 }

--- a/src/lib/i18n/locales/es/common.json
+++ b/src/lib/i18n/locales/es/common.json
@@ -195,5 +195,34 @@
     "heading": "Viners clasicos",
     "archivedBadge": "Archivado",
     "archivedTooltip": "Archivo original de Vine preservado por el Internet Archive"
+  },
+  "profile": {
+    "stats": {
+      "videos": "Videos",
+      "followers": "Seguidores",
+      "following": "Siguiendo",
+      "divineLoops": "Loops Divine"
+    },
+    "editProfile": "Editar perfil"
+  },
+  "accountMenu": {
+    "myProfile": "Mi perfil",
+    "settings": "Ajustes",
+    "linkedAccounts": "Cuentas enlazadas",
+    "switchRelay": "Cambiar de relay",
+    "switchAccount": "Cambiar de cuenta",
+    "addAccount": "Anadir otra cuenta",
+    "logOut": "Cerrar sesion"
+  },
+  "trending": {
+    "title": "Tendencias",
+    "subtitle": "Descubre lo que arrasa en la comunidad"
+  },
+  "searchTabs": {
+    "all": "Todo",
+    "videos": "Videos",
+    "users": "Personas",
+    "hashtags": "Etiquetas",
+    "searching": "Buscando..."
   }
 }

--- a/src/lib/i18n/locales/fr/common.json
+++ b/src/lib/i18n/locales/fr/common.json
@@ -44,7 +44,8 @@
     "yourFeed": "Votre flux"
   },
   "auth": {
-    "logInOnDivine": "On y va"
+    "logInOnDivine": "On y va",
+    "logIn": "Se connecter"
   },
   "home": {
     "welcomeTitle": "Votre fil, vos regles.",
@@ -141,5 +142,53 @@
     "metaDescription": "Explorez les categories de videos sur Divine - comedie, musique, danse, animaux, sport, cuisine et plus encore.",
     "videoCount_one": "{{count}} video",
     "videoCount_other": "{{count}} videos"
+  },
+  "videoMeta": {
+    "viewCount_one": "{{formatted}} vue",
+    "viewCount_other": "{{formatted}} vues"
+  },
+  "verification": {
+    "humanMade": "Cree par des humains",
+    "dialog": {
+      "titleVideo": "Verification de la video",
+      "titleArchive": "Archive Vine originale",
+      "description": "Details sur l'origine de l'archive, les donnees Proofmode, le statut du scan IA et la source d'hebergement.",
+      "proofModeSection": "Verification ProofMode",
+      "aiDetectionSection": "Detection IA",
+      "aiNotScanned": "Scan IA : pas encore scanne",
+      "checking": "Recherche des resultats de scan…",
+      "noScanResults": "Aucun resultat de scan disponible pour le moment.",
+      "checkAi": "Verifier si genere par IA",
+      "aiLikelihood": "{{percent}}% de probabilite que ce soit genere par IA",
+      "scannedBy": "Scanne par : {{source}}",
+      "verifiedByMod": "Verifie par un moderateur humain",
+      "learnMore": "En savoir plus sur la verification Proofmode",
+      "inspectTool": "Inspecter avec l'outil ProofCheck",
+      "archiveBlurb": "Cette video est un Vine original recupere depuis l'Internet Archive.",
+      "archiveContext": "Avant la fermeture de Vine en 2017, ArchiveTeam et l'Internet Archive ont sauvegarde des millions de Vines. Ce contenu fait partie de ce travail de preservation.",
+      "originalLoops": "Stats originales : {{count}} loops",
+      "archiveLearnMore": "En savoir plus sur la preservation du Vine archive"
+    },
+    "intro": {
+      "proofMode": "L'authenticite de cette video est verifiee avec la technologie Proofmode.",
+      "aiHumanDivine": "Cette video est hebergee sur Divine et la detection IA indique qu'elle est probablement humaine, meme sans donnees ProofMode.",
+      "aiHuman": "La detection IA indique que cette video est probablement humaine, meme sans donnees ProofMode.",
+      "unverifiedDivine": "Cette video n'est pas verifiee. Elle est hebergee sur Divine, mais aucune donnee ProofMode n'est encore attachee.",
+      "unverifiedExternal": "Cette video n'est pas verifiee et est hebergee en dehors de Divine. Elle n'inclut pas de donnees ProofMode."
+    },
+    "summary": {
+      "platinum": "Platine : Attestation materielle de l'appareil, signatures cryptographiques, Content Credentials (C2PA) et scan IA confirment l'origine humaine.",
+      "gold": "Or : Capture sur un vrai appareil avec attestation materielle, signatures cryptographiques et Content Credentials (C2PA).",
+      "silverProof": "Argent : Les signatures cryptographiques prouvent que cette video n'a pas ete alteree depuis l'enregistrement.",
+      "bronze": "Bronze : Signatures de metadonnees de base presentes.",
+      "silverAi": "Argent : Le scan IA confirme que cette video est probablement creee par un humain.",
+      "muted": "Aucune donnee de verification disponible pour cette video."
+    },
+    "checklist": {
+      "deviceAttestation": "Attestation de l'appareil",
+      "pgpSignature": "Signature PGP",
+      "c2paContentCredentials": "Content Credentials C2PA",
+      "proofManifest": "Manifeste de preuve"
+    }
   }
 }

--- a/src/lib/i18n/locales/fr/common.json
+++ b/src/lib/i18n/locales/fr/common.json
@@ -44,19 +44,19 @@
     "yourFeed": "Votre flux"
   },
   "auth": {
-    "logInOnDivine": "Se connecter a Divine"
+    "logInOnDivine": "On y va"
   },
   "home": {
-    "welcomeTitle": "Bienvenue dans votre fil d'accueil",
-    "welcomeSubtitle": "Connectez-vous pour voir les videos des personnes que vous suivez",
+    "welcomeTitle": "Votre fil, vos regles.",
+    "welcomeSubtitle": "Connectez-vous pour voir les loops des gens que vous suivez.",
     "title": "Accueil",
-    "subtitle": "Videos des personnes que vous suivez",
+    "subtitle": "Loops des gens que vous suivez.",
     "sortBy": "Trier par :",
     "updating": "Mise a jour..."
   },
   "discovery": {
     "title": "Decouvrir",
-    "subtitle": "Explorer les videos du reseau",
+    "subtitle": "Baladez-vous sur le reseau. Trouvez votre crew.",
     "categories": "Categories",
     "forYou": "Pour vous",
     "classic": "Classique",
@@ -82,14 +82,14 @@
   },
   "comments": {
     "title": "Commentaires",
-    "noCommentsYet": "Aucun commentaire pour l'instant",
-    "beFirstToShare": "Soyez la premiere personne a partager votre avis",
-    "failedToLoad": "Impossible de charger les commentaires",
-    "writeAComment": "Ecrire un commentaire...",
+    "noCommentsYet": "Rien a dire pour l'instant.",
+    "beFirstToShare": "Lancez la conversation — laissez un commentaire.",
+    "failedToLoad": "Les commentaires n'ont pas charge.",
+    "writeAComment": "Dites quelque chose...",
     "signInToReply": "Connectez-vous pour repondre",
     "signInToComment": "Connectez-vous pour commenter",
     "replyingToComment": "Reponse au commentaire",
-    "addingToDiscussion": "Ajout a la discussion",
+    "addingToDiscussion": "Vous sautez dans le fil",
     "posting": "Publication...",
     "reply": "Repondre",
     "comment": "Commenter"
@@ -97,46 +97,46 @@
   "messages": {
     "badge": "Messages",
     "title": "Messages directs",
-    "subtitle": "Parlez au support, envoyez des vines en prive ou poursuivez une conversation avec les personnes que vous suivez.",
-    "searchPlaceholder": "Trouver des personnes a contacter",
+    "subtitle": "Parlez au support, glissez un loop en prive ou poursuivez un fil avec les gens que vous suivez.",
+    "searchPlaceholder": "Trouvez quelqu'un a contacter",
     "newMessage": "Nouveau message",
-    "readyToShare": "Pret a partager en prive.",
+    "readyToShare": "Pret a envoyer en prive.",
     "shareWithTitle": "Votre prochain message inclura « {{title}} ».",
     "shareWithLink": "Votre prochain message inclura un lien vine.",
-    "signerUnsupported": "Votre signer actuel peut vous connecter, mais il n'expose pas encore le chiffrement NIP-44. Passez a un nsec, un bunker ou un autre signer compatible NIP-44 pour utiliser les messages directs sur le web.",
+    "signerUnsupported": "Votre signer actuel peut vous connecter, mais il ne parle pas encore NIP-44. Passez a un nsec, un bunker ou un autre signer compatible NIP-44 pour utiliser les DM ici.",
     "supportBadge": "Support",
-    "supportSummary": "Posez des questions sur les bugs, la moderation ou les problemes de compte."
+    "supportSummary": "Bugs, moderation, problemes de compte — on est a l'ecoute."
   },
   "support": {
     "title": "Assistance",
-    "subtitle": "Besoin d'aide ? Nous sommes la pour vous aider.",
-    "helpCenterTitle": "Visiter le centre d'aide Divine",
-    "helpCenterDescription": "Trouvez des reponses a vos questions sur Divine.",
+    "subtitle": "Besoin d'un coup de main ? On s'occupe de vous.",
+    "helpCenterTitle": "Centre d'aide Divine",
+    "helpCenterDescription": "Les reponses aux questions qu'on nous pose le plus.",
     "helpCenterCta": "Visiter le centre d'aide",
     "messageSupportTitle": "Contacter l'assistance",
-    "messageSupportDescription": "Contactez directement la boite de reception du support dans Divine via des messages prives NIP-17.",
+    "messageSupportDescription": "Glissez-nous un message direct dans Divine — chiffre avec NIP-17.",
     "messageSupportCta": "Ouvrir le chat du support",
     "contactTitle": "Contacter l'assistance",
-    "contactDescription": "Creez un ticket et nous vous repondrons des que possible.",
+    "contactDescription": "Ouvrez un ticket et on revient vers vous au plus vite.",
     "contactLink": "Contacter l'assistance",
     "githubTitle": "Tickets GitHub",
-    "githubDescription": "Signalez des bugs, demandez des fonctionnalites ou consultez les tickets existants sur nos depots GitHub.",
+    "githubDescription": "Signalez des bugs, demandez des fonctionnalites ou fouinez sur notre GitHub.",
     "webAppLabel": "App web :",
     "flutterAppLabel": "App Flutter (iOS/Android) :",
     "communityTitle": "Communaute",
-    "communityDescription": "Rejoignez les discussions de la communaute et connectez-vous avec d'autres utilisateurs de Divine sur Nostr.",
-    "communityBody": "Divine est construit sur Nostr, un protocole social decentralise. Retrouvez-nous sur votre client Nostr prefere."
+    "communityDescription": "Venez trainer avec la communaute Divine sur Nostr.",
+    "communityBody": "Divine tourne sur Nostr, le protocole social decentralise. Retrouvez-nous sur votre client Nostr prefere."
   },
   "tagPage": {
-    "notFoundTitle": "Tag introuvable",
-    "notFoundDescription": "Le tag demande est introuvable.",
+    "notFoundTitle": "Tag introuvable.",
+    "notFoundDescription": "On n'a pas trouve ce tag.",
     "back": "Retour",
-    "subtitle": "Explorer les videos taguees avec #{{tag}}"
+    "subtitle": "Loops tagues #{{tag}}"
   },
   "categoriesPage": {
     "title": "Categories",
-    "subtitle": "Parcourir les videos par sujet",
-    "emptyState": "Aucune categorie disponible pour le moment.",
+    "subtitle": "Loops, ranges par vibe.",
+    "emptyState": "Aucune categorie en marche pour le moment.",
     "metaTitle": "Parcourir les categories - Divine",
     "metaDescription": "Explorez les categories de videos sur Divine - comedie, musique, danse, animaux, sport, cuisine et plus encore.",
     "videoCount_one": "{{count}} video",

--- a/src/lib/i18n/locales/fr/common.json
+++ b/src/lib/i18n/locales/fr/common.json
@@ -190,5 +190,10 @@
       "c2paContentCredentials": "Content Credentials C2PA",
       "proofManifest": "Manifeste de preuve"
     }
+  },
+  "classicViners": {
+    "heading": "Viners classiques",
+    "archivedBadge": "Archive",
+    "archivedTooltip": "Archive Vine originale preservee par l'Internet Archive"
   }
 }

--- a/src/lib/i18n/locales/fr/common.json
+++ b/src/lib/i18n/locales/fr/common.json
@@ -195,5 +195,34 @@
     "heading": "Viners classiques",
     "archivedBadge": "Archive",
     "archivedTooltip": "Archive Vine originale preservee par l'Internet Archive"
+  },
+  "profile": {
+    "stats": {
+      "videos": "Videos",
+      "followers": "Abonnes",
+      "following": "Abonnements",
+      "divineLoops": "Loops Divine"
+    },
+    "editProfile": "Modifier le profil"
+  },
+  "accountMenu": {
+    "myProfile": "Mon profil",
+    "settings": "Parametres",
+    "linkedAccounts": "Comptes lies",
+    "switchRelay": "Changer de relay",
+    "switchAccount": "Changer de compte",
+    "addAccount": "Ajouter un autre compte",
+    "logOut": "Se deconnecter"
+  },
+  "trending": {
+    "title": "Tendances",
+    "subtitle": "Voyez ce qui cartonne dans la communaute"
+  },
+  "searchTabs": {
+    "all": "Tout",
+    "videos": "Videos",
+    "users": "Personnes",
+    "hashtags": "Hashtags",
+    "searching": "Recherche..."
   }
 }

--- a/src/lib/i18n/locales/id/common.json
+++ b/src/lib/i18n/locales/id/common.json
@@ -44,19 +44,19 @@
     "yourFeed": "Umpan Anda"
   },
   "auth": {
-    "logInOnDivine": "Masuk ke Divine"
+    "logInOnDivine": "Masuk yuk"
   },
   "home": {
-    "welcomeTitle": "Selamat datang di beranda Anda",
-    "welcomeSubtitle": "Masuk untuk melihat video dari orang yang Anda ikuti",
+    "welcomeTitle": "Feed Anda, aturan Anda.",
+    "welcomeSubtitle": "Masuk untuk melihat loop dari orang yang Anda ikuti.",
     "title": "Beranda",
-    "subtitle": "Video dari orang yang Anda ikuti",
+    "subtitle": "Loop dari orang yang Anda ikuti.",
     "sortBy": "Urutkan berdasarkan:",
     "updating": "Memperbarui..."
   },
   "discovery": {
     "title": "Jelajahi",
-    "subtitle": "Jelajahi video dari jaringan",
+    "subtitle": "Keliling jaringan. Temukan teman seperjalanan.",
     "categories": "Kategori",
     "forYou": "Untuk Anda",
     "classic": "Klasik",
@@ -82,14 +82,14 @@
   },
   "comments": {
     "title": "Komentar",
-    "noCommentsYet": "Belum ada komentar",
-    "beFirstToShare": "Jadilah yang pertama membagikan pendapat Anda",
-    "failedToLoad": "Gagal memuat komentar",
-    "writeAComment": "Tulis komentar...",
+    "noCommentsYet": "Belum ada yang berkomentar.",
+    "beFirstToShare": "Mulai duluan — tulis komentar.",
+    "failedToLoad": "Komentar gagal dimuat.",
+    "writeAComment": "Bilang sesuatu...",
     "signInToReply": "Masuk untuk membalas",
     "signInToComment": "Masuk untuk berkomentar",
     "replyingToComment": "Membalas komentar",
-    "addingToDiscussion": "Menambahkan ke diskusi",
+    "addingToDiscussion": "Ikut nimbrung di thread",
     "posting": "Mengirim...",
     "reply": "Balas",
     "comment": "Komentar"
@@ -97,46 +97,46 @@
   "messages": {
     "badge": "Pesan",
     "title": "Pesan langsung",
-    "subtitle": "Hubungi dukungan, kirim vine secara pribadi, atau lanjutkan percakapan dengan orang yang Anda ikuti.",
-    "searchPlaceholder": "Cari orang untuk dikirimi pesan",
+    "subtitle": "Hubungi dukungan, kirim loop secara pribadi, atau lanjutkan obrolan dengan orang yang Anda ikuti.",
+    "searchPlaceholder": "Cari seseorang untuk dikirimi pesan",
     "newMessage": "Pesan baru",
-    "readyToShare": "Siap dibagikan secara pribadi.",
+    "readyToShare": "Siap dikirim secara pribadi.",
     "shareWithTitle": "Pesan Anda berikutnya akan menyertakan “{{title}}”.",
     "shareWithLink": "Pesan Anda berikutnya akan menyertakan tautan vine.",
-    "signerUnsupported": "Signer Anda saat ini bisa dipakai untuk masuk, tetapi belum mendukung enkripsi NIP-44. Gunakan nsec, bunker, atau signer lain yang mendukung NIP-44 untuk memakai pesan langsung di web.",
+    "signerUnsupported": "Signer Anda saat ini bisa dipakai untuk masuk, tetapi belum berbicara NIP-44. Gunakan nsec, bunker, atau signer lain yang mendukung NIP-44 untuk memakai DM di sini.",
     "supportBadge": "Dukungan",
-    "supportSummary": "Tanyakan tentang bug, moderasi, atau masalah akun."
+    "supportSummary": "Bug, moderasi, urusan akun — kami siap mendengar."
   },
   "support": {
     "title": "Dukungan",
-    "subtitle": "Butuh bantuan? Kami siap membantu Anda.",
-    "helpCenterTitle": "Kunjungi pusat bantuan Divine",
-    "helpCenterDescription": "Temukan jawaban atas pertanyaan Anda tentang Divine.",
+    "subtitle": "Butuh bantuan? Kami siap bantu.",
+    "helpCenterTitle": "Pusat bantuan Divine",
+    "helpCenterDescription": "Jawaban untuk hal yang biasa ditanyakan.",
     "helpCenterCta": "Kunjungi pusat bantuan",
     "messageSupportTitle": "Kirim pesan ke dukungan",
-    "messageSupportDescription": "Hubungi kotak masuk dukungan langsung di Divine menggunakan pesan pribadi NIP-17.",
+    "messageSupportDescription": "Sapa kami langsung di Divine — terenkripsi dengan NIP-17.",
     "messageSupportCta": "Buka chat dukungan",
     "contactTitle": "Hubungi dukungan",
-    "contactDescription": "Buat tiket dan kami akan membalas secepat mungkin.",
+    "contactDescription": "Buat tiket dan kami balas secepat mungkin.",
     "contactLink": "Hubungi dukungan",
     "githubTitle": "Issue GitHub",
-    "githubDescription": "Laporkan bug, minta fitur, atau telusuri issue yang ada di repositori GitHub kami.",
+    "githubDescription": "Laporkan bug, minta fitur, atau intip GitHub kami.",
     "webAppLabel": "Aplikasi web:",
     "flutterAppLabel": "Aplikasi Flutter (iOS/Android):",
     "communityTitle": "Komunitas",
-    "communityDescription": "Bergabunglah dalam diskusi komunitas dan terhubung dengan pengguna Divine lainnya di Nostr.",
-    "communityBody": "Divine dibangun di atas Nostr, protokol sosial yang terdesentralisasi. Temukan kami di klien Nostr favorit Anda."
+    "communityDescription": "Mampir dan nimbrung di komunitas Divine di Nostr.",
+    "communityBody": "Divine berjalan di Nostr, protokol sosial yang terdesentralisasi. Temukan kami di klien Nostr favorit Anda."
   },
   "tagPage": {
-    "notFoundTitle": "Tag tidak ditemukan",
-    "notFoundDescription": "Tag yang diminta tidak dapat ditemukan.",
+    "notFoundTitle": "Tag tidak ditemukan.",
+    "notFoundDescription": "Tidak menemukan tag itu.",
     "back": "Kembali",
-    "subtitle": "Jelajahi video dengan tag #{{tag}}"
+    "subtitle": "Loop dengan tag #{{tag}}"
   },
   "categoriesPage": {
     "title": "Kategori",
-    "subtitle": "Jelajahi video berdasarkan topik",
-    "emptyState": "Belum ada kategori yang tersedia saat ini.",
+    "subtitle": "Loop, ditata sesuai vibe.",
+    "emptyState": "Belum ada kategori yang jalan saat ini.",
     "metaTitle": "Jelajahi kategori - Divine",
     "metaDescription": "Jelajahi kategori video di Divine - komedi, musik, tarian, hewan, olahraga, makanan, dan lainnya.",
     "videoCount_one": "{{count}} video",

--- a/src/lib/i18n/locales/id/common.json
+++ b/src/lib/i18n/locales/id/common.json
@@ -44,7 +44,8 @@
     "yourFeed": "Umpan Anda"
   },
   "auth": {
-    "logInOnDivine": "Masuk yuk"
+    "logInOnDivine": "Masuk yuk",
+    "logIn": "Masuk"
   },
   "home": {
     "welcomeTitle": "Feed Anda, aturan Anda.",
@@ -141,5 +142,53 @@
     "metaDescription": "Jelajahi kategori video di Divine - komedi, musik, tarian, hewan, olahraga, makanan, dan lainnya.",
     "videoCount_one": "{{count}} video",
     "videoCount_other": "{{count}} video"
+  },
+  "videoMeta": {
+    "viewCount_one": "{{formatted}} tontonan",
+    "viewCount_other": "{{formatted}} tontonan"
+  },
+  "verification": {
+    "humanMade": "Buatan manusia",
+    "dialog": {
+      "titleVideo": "Verifikasi video",
+      "titleArchive": "Arsip Vine asli",
+      "description": "Detail tentang asal arsip, data Proofmode, status pemindaian AI, dan sumber hosting.",
+      "proofModeSection": "Verifikasi ProofMode",
+      "aiDetectionSection": "Deteksi AI",
+      "aiNotScanned": "Pemindaian AI: belum dipindai",
+      "checking": "Mencari hasil pemindaian…",
+      "noScanResults": "Belum ada hasil pemindaian.",
+      "checkAi": "Periksa apakah dihasilkan AI",
+      "aiLikelihood": "{{percent}}% kemungkinan dihasilkan AI",
+      "scannedBy": "Dipindai oleh: {{source}}",
+      "verifiedByMod": "Diverifikasi oleh moderator manusia",
+      "learnMore": "Pelajari lebih lanjut tentang verifikasi Proofmode",
+      "inspectTool": "Periksa dengan alat ProofCheck",
+      "archiveBlurb": "Video ini adalah Vine asli yang diselamatkan dari Internet Archive.",
+      "archiveContext": "Sebelum Vine ditutup pada 2017, ArchiveTeam dan Internet Archive menyelamatkan jutaan Vine. Konten ini bagian dari penyelamatan itu.",
+      "originalLoops": "Statistik asli: {{count}} loop",
+      "archiveLearnMore": "Pelajari lebih lanjut tentang pelestarian arsip Vine"
+    },
+    "intro": {
+      "proofMode": "Keaslian video ini diverifikasi dengan teknologi Proofmode.",
+      "aiHumanDivine": "Video ini di-host di Divine dan deteksi AI menunjukkan kemungkinan besar buatan manusia, meski tanpa data ProofMode.",
+      "aiHuman": "Deteksi AI menunjukkan video ini kemungkinan besar buatan manusia, meski tanpa data ProofMode.",
+      "unverifiedDivine": "Video ini belum diverifikasi. Di-host di Divine, tapi belum ada data ProofMode.",
+      "unverifiedExternal": "Video ini belum diverifikasi dan di-host di luar Divine. Tidak menyertakan data ProofMode."
+    },
+    "summary": {
+      "platinum": "Platinum: Atestasi perangkat keras, tanda tangan kriptografis, Content Credentials (C2PA), dan pemindaian AI mengonfirmasi asal manusia.",
+      "gold": "Emas: Diambil di perangkat asli dengan atestasi perangkat keras, tanda tangan kriptografis, dan Content Credentials (C2PA).",
+      "silverProof": "Perak: Tanda tangan kriptografis membuktikan video ini tidak diubah sejak perekaman.",
+      "bronze": "Perunggu: Tanda tangan metadata dasar tersedia.",
+      "silverAi": "Perak: Pemindaian AI mengonfirmasi video ini kemungkinan besar dibuat manusia.",
+      "muted": "Tidak ada data verifikasi untuk video ini."
+    },
+    "checklist": {
+      "deviceAttestation": "Atestasi perangkat",
+      "pgpSignature": "Tanda tangan PGP",
+      "c2paContentCredentials": "Content Credentials C2PA",
+      "proofManifest": "Manifes bukti"
+    }
   }
 }

--- a/src/lib/i18n/locales/id/common.json
+++ b/src/lib/i18n/locales/id/common.json
@@ -190,5 +190,10 @@
       "c2paContentCredentials": "Content Credentials C2PA",
       "proofManifest": "Manifes bukti"
     }
+  },
+  "classicViners": {
+    "heading": "Viner klasik",
+    "archivedBadge": "Diarsipkan",
+    "archivedTooltip": "Arsip Vine asli yang dilestarikan oleh Internet Archive"
   }
 }

--- a/src/lib/i18n/locales/id/common.json
+++ b/src/lib/i18n/locales/id/common.json
@@ -195,5 +195,34 @@
     "heading": "Viner klasik",
     "archivedBadge": "Diarsipkan",
     "archivedTooltip": "Arsip Vine asli yang dilestarikan oleh Internet Archive"
+  },
+  "profile": {
+    "stats": {
+      "videos": "Video",
+      "followers": "Pengikut",
+      "following": "Mengikuti",
+      "divineLoops": "Loop Divine"
+    },
+    "editProfile": "Edit profil"
+  },
+  "accountMenu": {
+    "myProfile": "Profil saya",
+    "settings": "Pengaturan",
+    "linkedAccounts": "Akun terhubung",
+    "switchRelay": "Ganti relay",
+    "switchAccount": "Ganti akun",
+    "addAccount": "Tambah akun lain",
+    "logOut": "Keluar"
+  },
+  "trending": {
+    "title": "Sedang tren",
+    "subtitle": "Lihat apa yang lagi rame di komunitas"
+  },
+  "searchTabs": {
+    "all": "Semua",
+    "videos": "Video",
+    "users": "Orang",
+    "hashtags": "Tagar",
+    "searching": "Mencari..."
   }
 }

--- a/src/lib/i18n/locales/it/common.json
+++ b/src/lib/i18n/locales/it/common.json
@@ -44,7 +44,8 @@
     "yourFeed": "Il tuo feed"
   },
   "auth": {
-    "logInOnDivine": "Entra"
+    "logInOnDivine": "Entra",
+    "logIn": "Accedi"
   },
   "home": {
     "welcomeTitle": "Il tuo feed, le tue regole.",
@@ -141,5 +142,53 @@
     "metaDescription": "Esplora le categorie video su Divine - commedia, musica, danza, animali, sport, cibo e altro.",
     "videoCount_one": "{{count}} video",
     "videoCount_other": "{{count}} video"
+  },
+  "videoMeta": {
+    "viewCount_one": "{{formatted}} visualizzazione",
+    "viewCount_other": "{{formatted}} visualizzazioni"
+  },
+  "verification": {
+    "humanMade": "Creato da umani",
+    "dialog": {
+      "titleVideo": "Verifica video",
+      "titleArchive": "Archivio Vine originale",
+      "description": "Dettagli sull'origine dell'archivio, dati Proofmode, stato della scansione IA e fonte di hosting.",
+      "proofModeSection": "Verifica ProofMode",
+      "aiDetectionSection": "Rilevamento IA",
+      "aiNotScanned": "Scansione IA: non ancora effettuata",
+      "checking": "Cerco risultati della scansione…",
+      "noScanResults": "Nessun risultato di scansione disponibile al momento.",
+      "checkAi": "Controlla se generato da IA",
+      "aiLikelihood": "{{percent}}% di probabilita che sia generato da IA",
+      "scannedBy": "Scansionato da: {{source}}",
+      "verifiedByMod": "Verificato da un moderatore umano",
+      "learnMore": "Scopri di piu sulla verifica Proofmode",
+      "inspectTool": "Ispeziona con lo strumento ProofCheck",
+      "archiveBlurb": "Questo video e un Vine originale recuperato dall'Internet Archive.",
+      "archiveContext": "Prima della chiusura di Vine nel 2017, ArchiveTeam e l'Internet Archive hanno preservato milioni di Vines. Questo contenuto fa parte di quel salvataggio.",
+      "originalLoops": "Statistiche originali: {{count}} loop",
+      "archiveLearnMore": "Scopri di piu sulla preservazione dell'archivio Vine"
+    },
+    "intro": {
+      "proofMode": "L'autenticita di questo video e verificata con la tecnologia Proofmode.",
+      "aiHumanDivine": "Questo video e ospitato su Divine e il rilevamento IA indica che e probabilmente umano, anche senza dati ProofMode allegati.",
+      "aiHuman": "Il rilevamento IA indica che questo video e probabilmente umano, anche senza dati ProofMode allegati.",
+      "unverifiedDivine": "Questo video non e verificato. E ospitato su Divine, ma non ha ancora dati ProofMode allegati.",
+      "unverifiedExternal": "Questo video non e verificato ed e ospitato fuori da Divine. Non include dati ProofMode."
+    },
+    "summary": {
+      "platinum": "Platino: Attestazione hardware del dispositivo, firme crittografiche, Content Credentials (C2PA) e la scansione IA confermano l'origine umana.",
+      "gold": "Oro: Catturato su un dispositivo reale con attestazione hardware, firme crittografiche e Content Credentials (C2PA).",
+      "silverProof": "Argento: Le firme crittografiche provano che questo video non e stato alterato dalla registrazione.",
+      "bronze": "Bronzo: Firme di metadati di base presenti.",
+      "silverAi": "Argento: La scansione IA conferma che questo video e probabilmente creato da un umano.",
+      "muted": "Nessun dato di verifica disponibile per questo video."
+    },
+    "checklist": {
+      "deviceAttestation": "Attestazione del dispositivo",
+      "pgpSignature": "Firma PGP",
+      "c2paContentCredentials": "Content Credentials C2PA",
+      "proofManifest": "Manifesto di prova"
+    }
   }
 }

--- a/src/lib/i18n/locales/it/common.json
+++ b/src/lib/i18n/locales/it/common.json
@@ -44,19 +44,19 @@
     "yourFeed": "Il tuo feed"
   },
   "auth": {
-    "logInOnDivine": "Accedi a Divine"
+    "logInOnDivine": "Entra"
   },
   "home": {
-    "welcomeTitle": "Benvenuto nel tuo feed principale",
-    "welcomeSubtitle": "Accedi per vedere i video delle persone che segui",
+    "welcomeTitle": "Il tuo feed, le tue regole.",
+    "welcomeSubtitle": "Accedi per vedere i loop delle persone che segui.",
     "title": "Home",
-    "subtitle": "Video delle persone che segui",
+    "subtitle": "Loop delle persone che segui.",
     "sortBy": "Ordina per:",
     "updating": "Aggiornamento..."
   },
   "discovery": {
     "title": "Scopri",
-    "subtitle": "Esplora i video della rete",
+    "subtitle": "Gira per la rete. Trova la tua gente.",
     "categories": "Categorie",
     "forYou": "Per te",
     "classic": "Classico",
@@ -82,14 +82,14 @@
   },
   "comments": {
     "title": "Commenti",
-    "noCommentsYet": "Nessun commento per ora",
-    "beFirstToShare": "Sii la prima persona a condividere la tua opinione",
-    "failedToLoad": "Impossibile caricare i commenti",
-    "writeAComment": "Scrivi un commento...",
+    "noCommentsYet": "Niente da dire per ora.",
+    "beFirstToShare": "Inizia tu — lascia un commento.",
+    "failedToLoad": "I commenti non si sono caricati.",
+    "writeAComment": "Di' qualcosa...",
     "signInToReply": "Accedi per rispondere",
     "signInToComment": "Accedi per commentare",
     "replyingToComment": "Risposta al commento",
-    "addingToDiscussion": "Aggiunta alla discussione",
+    "addingToDiscussion": "Ti unisci al thread",
     "posting": "Pubblicazione...",
     "reply": "Rispondi",
     "comment": "Commenta"
@@ -97,46 +97,46 @@
   "messages": {
     "badge": "Messaggi",
     "title": "Messaggi diretti",
-    "subtitle": "Parla con il supporto, invia vines in privato o continua una conversazione con le persone che segui.",
-    "searchPlaceholder": "Trova persone a cui scrivere",
+    "subtitle": "Parla con il supporto, manda un loop in privato o continua una conversazione con le persone che segui.",
+    "searchPlaceholder": "Trova qualcuno a cui scrivere",
     "newMessage": "Nuovo messaggio",
-    "readyToShare": "Pronto per la condivisione privata.",
+    "readyToShare": "Pronto per l'invio privato.",
     "shareWithTitle": "Il tuo prossimo messaggio includera “{{title}}”.",
     "shareWithLink": "Il tuo prossimo messaggio includera un link vine.",
-    "signerUnsupported": "Il tuo signer attuale puo autenticarti, ma non espone ancora la crittografia NIP-44. Passa a un nsec, bunker o altro signer con supporto NIP-44 per usare i messaggi diretti sul web.",
+    "signerUnsupported": "Il tuo signer attuale puo autenticarti, ma non parla ancora NIP-44. Passa a un nsec, bunker o altro signer con supporto NIP-44 per usare i DM qui.",
     "supportBadge": "Supporto",
-    "supportSummary": "Chiedi informazioni su bug, moderazione o problemi dell'account."
+    "supportSummary": "Bug, moderazione, cose dell'account — siamo qui ad ascoltarti."
   },
   "support": {
     "title": "Supporto",
-    "subtitle": "Hai bisogno di aiuto? Siamo qui per aiutarti.",
-    "helpCenterTitle": "Visita il centro assistenza Divine",
-    "helpCenterDescription": "Trova risposte alle tue domande su Divine.",
+    "subtitle": "Hai bisogno di una mano? Ci pensiamo noi.",
+    "helpCenterTitle": "Centro assistenza Divine",
+    "helpCenterDescription": "Risposte alle cose che ci chiedono di solito.",
     "helpCenterCta": "Visita il centro assistenza",
     "messageSupportTitle": "Invia un messaggio al supporto",
-    "messageSupportDescription": "Contatta direttamente la casella di supporto dentro Divine usando messaggi privati NIP-17.",
+    "messageSupportDescription": "Scrivici direttamente dentro Divine — cifrato con NIP-17.",
     "messageSupportCta": "Apri la chat di supporto",
     "contactTitle": "Contatta il supporto",
-    "contactDescription": "Apri un ticket e ti risponderemo il prima possibile.",
+    "contactDescription": "Apri un ticket e ti rispondiamo il prima possibile.",
     "contactLink": "Contatta il supporto",
     "githubTitle": "Issue di GitHub",
-    "githubDescription": "Segnala bug, richiedi funzionalita o consulta le issue esistenti nei nostri repository GitHub.",
+    "githubDescription": "Segnala bug, chiedi funzionalita o curiosa nel nostro GitHub.",
     "webAppLabel": "App web:",
     "flutterAppLabel": "App Flutter (iOS/Android):",
     "communityTitle": "Comunita",
-    "communityDescription": "Partecipa alle discussioni della comunita e connettiti con altri utenti Divine su Nostr.",
-    "communityBody": "Divine e costruito su Nostr, un protocollo sociale decentralizzato. Trovaci nel tuo client Nostr preferito."
+    "communityDescription": "Vieni a stare con la community di Divine su Nostr.",
+    "communityBody": "Divine gira su Nostr, il protocollo sociale decentralizzato. Trovaci nel tuo client Nostr preferito."
   },
   "tagPage": {
-    "notFoundTitle": "Tag non trovata",
-    "notFoundDescription": "Impossibile trovare la tag richiesta.",
+    "notFoundTitle": "Tag non trovata.",
+    "notFoundDescription": "Non abbiamo trovato questa tag.",
     "back": "Indietro",
-    "subtitle": "Esplora i video con il tag #{{tag}}"
+    "subtitle": "Loop con il tag #{{tag}}"
   },
   "categoriesPage": {
     "title": "Categorie",
-    "subtitle": "Esplora i video per argomento",
-    "emptyState": "Nessuna categoria disponibile in questo momento.",
+    "subtitle": "Loop, ordinati per vibe.",
+    "emptyState": "Nessuna categoria in pentola adesso.",
     "metaTitle": "Esplora le categorie - Divine",
     "metaDescription": "Esplora le categorie video su Divine - commedia, musica, danza, animali, sport, cibo e altro.",
     "videoCount_one": "{{count}} video",

--- a/src/lib/i18n/locales/it/common.json
+++ b/src/lib/i18n/locales/it/common.json
@@ -190,5 +190,10 @@
       "c2paContentCredentials": "Content Credentials C2PA",
       "proofManifest": "Manifesto di prova"
     }
+  },
+  "classicViners": {
+    "heading": "Viner classici",
+    "archivedBadge": "Archiviato",
+    "archivedTooltip": "Archivio Vine originale preservato dall'Internet Archive"
   }
 }

--- a/src/lib/i18n/locales/it/common.json
+++ b/src/lib/i18n/locales/it/common.json
@@ -195,5 +195,34 @@
     "heading": "Viner classici",
     "archivedBadge": "Archiviato",
     "archivedTooltip": "Archivio Vine originale preservato dall'Internet Archive"
+  },
+  "profile": {
+    "stats": {
+      "videos": "Video",
+      "followers": "Follower",
+      "following": "Seguiti",
+      "divineLoops": "Loop Divine"
+    },
+    "editProfile": "Modifica profilo"
+  },
+  "accountMenu": {
+    "myProfile": "Il mio profilo",
+    "settings": "Impostazioni",
+    "linkedAccounts": "Account collegati",
+    "switchRelay": "Cambia relay",
+    "switchAccount": "Cambia account",
+    "addAccount": "Aggiungi un altro account",
+    "logOut": "Esci"
+  },
+  "trending": {
+    "title": "Tendenze",
+    "subtitle": "Scopri cosa spacca nella community"
+  },
+  "searchTabs": {
+    "all": "Tutto",
+    "videos": "Video",
+    "users": "Persone",
+    "hashtags": "Hashtag",
+    "searching": "Ricerca in corso..."
   }
 }

--- a/src/lib/i18n/locales/ja/common.json
+++ b/src/lib/i18n/locales/ja/common.json
@@ -44,7 +44,8 @@
     "yourFeed": "あなたのフィード"
   },
   "auth": {
-    "logInOnDivine": "とびこむ"
+    "logInOnDivine": "とびこむ",
+    "logIn": "ログイン"
   },
   "home": {
     "welcomeTitle": "あなたのフィード、あなたのルール。",
@@ -141,5 +142,53 @@
     "metaDescription": "Divine でコメディ、音楽、ダンス、動物、スポーツ、食べ物などの動画カテゴリを探そう。",
     "videoCount_one": "{{count}}本の動画",
     "videoCount_other": "{{count}}本の動画"
+  },
+  "videoMeta": {
+    "viewCount_one": "{{formatted}}回再生",
+    "viewCount_other": "{{formatted}}回再生"
+  },
+  "verification": {
+    "humanMade": "人が作成",
+    "dialog": {
+      "titleVideo": "動画の認証",
+      "titleArchive": "オリジナル Vine アーカイブ",
+      "description": "アーカイブの出所、Proofmode データ、AI スキャンの状態、ホスティング元の詳細。",
+      "proofModeSection": "ProofMode 認証",
+      "aiDetectionSection": "AI 検出",
+      "aiNotScanned": "AI スキャン: 未スキャン",
+      "checking": "スキャン結果を確認中…",
+      "noScanResults": "まだスキャン結果はありません。",
+      "checkAi": "AI 生成かどうかチェック",
+      "aiLikelihood": "AI 生成の可能性 {{percent}}%",
+      "scannedBy": "スキャン元: {{source}}",
+      "verifiedByMod": "人間のモデレーターが確認",
+      "learnMore": "Proofmode 認証についてもっと知る",
+      "inspectTool": "ProofCheck ツールで検査",
+      "archiveBlurb": "この動画は Internet Archive から救出されたオリジナルの Vine です。",
+      "archiveContext": "2017 年に Vine が停止する前、ArchiveTeam と Internet Archive は数百万本の Vine を保存しました。このコンテンツはその救出活動の一部です。",
+      "originalLoops": "元の統計: {{count}} ループ",
+      "archiveLearnMore": "Vine アーカイブの保存についてもっと知る"
+    },
+    "intro": {
+      "proofMode": "この動画の信頼性は Proofmode 技術で認証されています。",
+      "aiHumanDivine": "この動画は Divine でホストされており、ProofMode データはありませんが、AI 検出では人が作った可能性が高いとされています。",
+      "aiHuman": "AI 検出では、ProofMode データはなくとも、この動画は人が作った可能性が高いとされています。",
+      "unverifiedDivine": "この動画は未認証です。Divine でホストされていますが、まだ ProofMode データがありません。",
+      "unverifiedExternal": "この動画は未認証で、Divine 外でホストされています。ProofMode データはありません。"
+    },
+    "summary": {
+      "platinum": "プラチナ: デバイスのハードウェア認証、暗号署名、Content Credentials (C2PA)、AI スキャンが人間由来を確認しました。",
+      "gold": "ゴールド: 実機で撮影され、ハードウェア認証、暗号署名、Content Credentials (C2PA) を備えています。",
+      "silverProof": "シルバー: 暗号署名により、この動画は記録以来改変されていないことが証明されています。",
+      "bronze": "ブロンズ: 基本的なメタデータ署名があります。",
+      "silverAi": "シルバー: AI スキャンが、この動画は人が作成した可能性が高いと確認しました。",
+      "muted": "この動画には認証データがありません。"
+    },
+    "checklist": {
+      "deviceAttestation": "デバイス認証",
+      "pgpSignature": "PGP 署名",
+      "c2paContentCredentials": "C2PA Content Credentials",
+      "proofManifest": "証明マニフェスト"
+    }
   }
 }

--- a/src/lib/i18n/locales/ja/common.json
+++ b/src/lib/i18n/locales/ja/common.json
@@ -190,5 +190,10 @@
       "c2paContentCredentials": "C2PA Content Credentials",
       "proofManifest": "証明マニフェスト"
     }
+  },
+  "classicViners": {
+    "heading": "クラシック Viner",
+    "archivedBadge": "アーカイブ",
+    "archivedTooltip": "Internet Archive で保存されたオリジナルの Vine アーカイブ"
   }
 }

--- a/src/lib/i18n/locales/ja/common.json
+++ b/src/lib/i18n/locales/ja/common.json
@@ -44,19 +44,19 @@
     "yourFeed": "あなたのフィード"
   },
   "auth": {
-    "logInOnDivine": "Divine にログイン"
+    "logInOnDivine": "とびこむ"
   },
   "home": {
-    "welcomeTitle": "ホームフィードへようこそ",
-    "welcomeSubtitle": "フォローしている人の動画を見るにはログインしてください",
+    "welcomeTitle": "あなたのフィード、あなたのルール。",
+    "welcomeSubtitle": "ログインしてフォロー中の人のループを見よう。",
     "title": "ホーム",
-    "subtitle": "フォローしている人の動画",
+    "subtitle": "フォロー中の人のループ。",
     "sortBy": "並び替え:",
     "updating": "更新中..."
   },
   "discovery": {
     "title": "発見",
-    "subtitle": "ネットワーク上の動画を探す",
+    "subtitle": "ネットワークをぶらり。仲間を見つけよう。",
     "categories": "カテゴリ",
     "forYou": "あなた向け",
     "classic": "クラシック",
@@ -82,14 +82,14 @@
   },
   "comments": {
     "title": "コメント",
-    "noCommentsYet": "まだコメントはありません",
-    "beFirstToShare": "最初に感想を共有しましょう",
-    "failedToLoad": "コメントを読み込めませんでした",
-    "writeAComment": "コメントを書く...",
+    "noCommentsYet": "まだ何も語られていません。",
+    "beFirstToShare": "最初の一人になろう — コメントしよう。",
+    "failedToLoad": "コメントが読み込めませんでした。",
+    "writeAComment": "なにか言ってみよう...",
     "signInToReply": "返信するにはログインしてください",
     "signInToComment": "コメントするにはログインしてください",
     "replyingToComment": "コメントに返信中",
-    "addingToDiscussion": "会話に追加しています",
+    "addingToDiscussion": "スレッドにとびこむ",
     "posting": "投稿中...",
     "reply": "返信",
     "comment": "コメント"
@@ -97,46 +97,46 @@
   "messages": {
     "badge": "メッセージ",
     "title": "ダイレクトメッセージ",
-    "subtitle": "サポートに相談したり、vine を非公開で送ったり、フォロー中の人との会話を続けたりできます。",
+    "subtitle": "サポートに相談したり、ループをこっそり送ったり、フォロー中の人とのスレッドを続けたりできます。",
     "searchPlaceholder": "メッセージを送る相手を探す",
     "newMessage": "新しいメッセージ",
-    "readyToShare": "非公開で共有する準備ができました。",
+    "readyToShare": "プライベートで送る準備ができました。",
     "shareWithTitle": "次のメッセージには「{{title}}」が含まれます。",
     "shareWithLink": "次のメッセージには vine のリンクが含まれます。",
-    "signerUnsupported": "現在の signer ではログインできますが、まだ NIP-44 暗号化に対応していません。Web でダイレクトメッセージを使うには、NIP-44 に対応した nsec、bunker、または別の signer に切り替えてください。",
+    "signerUnsupported": "現在の signer ではログインできますが、まだ NIP-44 を話せません。ここで DM を使うには、NIP-44 対応の nsec、bunker、または別の signer に切り替えてください。",
     "supportBadge": "サポート",
-    "supportSummary": "不具合、モデレーション、またはアカウントの問題について相談できます。"
+    "supportSummary": "不具合、モデレーション、アカウントのこと — 聞いてます。"
   },
   "support": {
     "title": "サポート",
-    "subtitle": "お困りですか。私たちがサポートします。",
-    "helpCenterTitle": "Divine ヘルプセンターを開く",
-    "helpCenterDescription": "Divine に関する質問の答えを見つけてください。",
+    "subtitle": "助けが必要？まかせて。",
+    "helpCenterTitle": "Divine ヘルプセンター",
+    "helpCenterDescription": "よく聞かれる質問の答えはこちら。",
     "helpCenterCta": "ヘルプセンターを開く",
     "messageSupportTitle": "サポートにメッセージ",
-    "messageSupportDescription": "NIP-17 のプライベートメッセージで Divine 内のサポート受信箱に直接連絡できます。",
+    "messageSupportDescription": "Divine の中で直接 DM を送れます — NIP-17 で暗号化。",
     "messageSupportCta": "サポートチャットを開く",
     "contactTitle": "サポートに連絡",
-    "contactDescription": "チケットを作成してください。できるだけ早く返信します。",
+    "contactDescription": "チケットを作成してください。できる限り早く返信します。",
     "contactLink": "サポートに連絡",
     "githubTitle": "GitHub Issues",
-    "githubDescription": "バグ報告、機能リクエスト、または GitHub リポジトリの既存 issue を確認できます。",
+    "githubDescription": "バグ報告、機能リクエスト、または GitHub をのぞいてみてください。",
     "webAppLabel": "Web アプリ:",
     "flutterAppLabel": "Flutter アプリ (iOS/Android):",
     "communityTitle": "コミュニティ",
-    "communityDescription": "コミュニティの会話に参加し、Nostr 上の他の Divine ユーザーとつながりましょう。",
-    "communityBody": "Divine は分散型ソーシャルプロトコル Nostr 上に構築されています。お気に入りの Nostr クライアントで見つけてください。"
+    "communityDescription": "Nostr 上の Divine コミュニティに遊びにきてください。",
+    "communityBody": "Divine は分散型ソーシャルプロトコル Nostr の上で動いています。お気に入りの Nostr クライアントで見つけてください。"
   },
   "tagPage": {
-    "notFoundTitle": "タグが見つかりません",
-    "notFoundDescription": "指定されたタグは見つかりませんでした。",
+    "notFoundTitle": "タグが見つかりません。",
+    "notFoundDescription": "そのタグは見つかりませんでした。",
     "back": "戻る",
-    "subtitle": "#{{tag}} のタグが付いた動画を探す"
+    "subtitle": "#{{tag}} のタグが付いたループ"
   },
   "categoriesPage": {
     "title": "カテゴリ",
-    "subtitle": "テーマごとに動画を探す",
-    "emptyState": "現在利用できるカテゴリはありません。",
+    "subtitle": "ループ、ノリで仕分け。",
+    "emptyState": "今のところカテゴリは仕込み中です。",
     "metaTitle": "カテゴリを探す - Divine",
     "metaDescription": "Divine でコメディ、音楽、ダンス、動物、スポーツ、食べ物などの動画カテゴリを探そう。",
     "videoCount_one": "{{count}}本の動画",

--- a/src/lib/i18n/locales/ja/common.json
+++ b/src/lib/i18n/locales/ja/common.json
@@ -195,5 +195,34 @@
     "heading": "クラシック Viner",
     "archivedBadge": "アーカイブ",
     "archivedTooltip": "Internet Archive で保存されたオリジナルの Vine アーカイブ"
+  },
+  "profile": {
+    "stats": {
+      "videos": "動画",
+      "followers": "フォロワー",
+      "following": "フォロー中",
+      "divineLoops": "Divine ループ"
+    },
+    "editProfile": "プロフィールを編集"
+  },
+  "accountMenu": {
+    "myProfile": "マイプロフィール",
+    "settings": "設定",
+    "linkedAccounts": "連携アカウント",
+    "switchRelay": "リレーを切り替え",
+    "switchAccount": "アカウントを切り替え",
+    "addAccount": "別のアカウントを追加",
+    "logOut": "ログアウト"
+  },
+  "trending": {
+    "title": "トレンド",
+    "subtitle": "コミュニティで盛り上がっているものをチェック"
+  },
+  "searchTabs": {
+    "all": "すべて",
+    "videos": "動画",
+    "users": "ユーザー",
+    "hashtags": "ハッシュタグ",
+    "searching": "検索中..."
   }
 }

--- a/src/lib/i18n/locales/ko/common.json
+++ b/src/lib/i18n/locales/ko/common.json
@@ -190,5 +190,10 @@
       "c2paContentCredentials": "C2PA Content Credentials",
       "proofManifest": "증명 매니페스트"
     }
+  },
+  "classicViners": {
+    "heading": "클래식 Viner",
+    "archivedBadge": "아카이브됨",
+    "archivedTooltip": "Internet Archive에서 보존된 오리지널 Vine 아카이브"
   }
 }

--- a/src/lib/i18n/locales/ko/common.json
+++ b/src/lib/i18n/locales/ko/common.json
@@ -195,5 +195,34 @@
     "heading": "클래식 Viner",
     "archivedBadge": "아카이브됨",
     "archivedTooltip": "Internet Archive에서 보존된 오리지널 Vine 아카이브"
+  },
+  "profile": {
+    "stats": {
+      "videos": "동영상",
+      "followers": "팔로워",
+      "following": "팔로잉",
+      "divineLoops": "Divine 루프"
+    },
+    "editProfile": "프로필 편집"
+  },
+  "accountMenu": {
+    "myProfile": "내 프로필",
+    "settings": "설정",
+    "linkedAccounts": "연결된 계정",
+    "switchRelay": "릴레이 전환",
+    "switchAccount": "계정 전환",
+    "addAccount": "다른 계정 추가",
+    "logOut": "로그아웃"
+  },
+  "trending": {
+    "title": "인기",
+    "subtitle": "커뮤니티에서 뜨는 걸 확인하세요"
+  },
+  "searchTabs": {
+    "all": "전체",
+    "videos": "동영상",
+    "users": "사람",
+    "hashtags": "해시태그",
+    "searching": "검색 중..."
   }
 }

--- a/src/lib/i18n/locales/ko/common.json
+++ b/src/lib/i18n/locales/ko/common.json
@@ -44,19 +44,19 @@
     "yourFeed": "내 피드"
   },
   "auth": {
-    "logInOnDivine": "Divine에 로그인"
+    "logInOnDivine": "들어가자"
   },
   "home": {
-    "welcomeTitle": "홈 피드에 오신 것을 환영합니다",
-    "welcomeSubtitle": "팔로우한 사람들의 동영상을 보려면 로그인하세요",
+    "welcomeTitle": "당신의 피드, 당신의 규칙.",
+    "welcomeSubtitle": "팔로우한 사람들의 루프를 보려면 로그인하세요.",
     "title": "홈",
-    "subtitle": "팔로우한 사람들의 동영상",
+    "subtitle": "팔로우한 사람들의 루프.",
     "sortBy": "정렬 기준:",
     "updating": "업데이트 중..."
   },
   "discovery": {
     "title": "탐색",
-    "subtitle": "네트워크의 동영상을 둘러보세요",
+    "subtitle": "네트워크를 거닐어보세요. 당신의 사람들을 찾아요.",
     "categories": "카테고리",
     "forYou": "추천",
     "classic": "클래식",
@@ -82,14 +82,14 @@
   },
   "comments": {
     "title": "댓글",
-    "noCommentsYet": "아직 댓글이 없습니다",
-    "beFirstToShare": "가장 먼저 의견을 남겨보세요",
-    "failedToLoad": "댓글을 불러오지 못했습니다",
-    "writeAComment": "댓글 쓰기...",
+    "noCommentsYet": "아직 할 말이 없네요.",
+    "beFirstToShare": "먼저 시작해보세요 — 댓글을 남겨보세요.",
+    "failedToLoad": "댓글이 안 불러와졌어요.",
+    "writeAComment": "한마디 남겨보세요...",
     "signInToReply": "답글을 쓰려면 로그인하세요",
     "signInToComment": "댓글을 쓰려면 로그인하세요",
     "replyingToComment": "댓글에 답글 작성 중",
-    "addingToDiscussion": "대화에 추가하는 중",
+    "addingToDiscussion": "스레드에 뛰어드는 중",
     "posting": "게시 중...",
     "reply": "답글",
     "comment": "댓글"
@@ -97,46 +97,46 @@
   "messages": {
     "badge": "메시지",
     "title": "다이렉트 메시지",
-    "subtitle": "지원팀과 대화하고, vine을 비공개로 보내거나, 팔로우한 사람들과 대화를 이어가세요.",
+    "subtitle": "지원팀과 대화하고, 루프를 비공개로 보내거나, 팔로우한 사람들과 대화를 이어가세요.",
     "searchPlaceholder": "메시지를 보낼 사람 찾기",
     "newMessage": "새 메시지",
-    "readyToShare": "비공개로 공유할 준비가 되었습니다.",
+    "readyToShare": "비공개로 보낼 준비 완료.",
     "shareWithTitle": "다음 메시지에는 “{{title}}”가 포함됩니다.",
     "shareWithLink": "다음 메시지에는 vine 링크가 포함됩니다.",
-    "signerUnsupported": "현재 signer로 로그인할 수는 있지만 아직 NIP-44 암호화를 제공하지 않습니다. 웹에서 다이렉트 메시지를 사용하려면 NIP-44를 지원하는 nsec, bunker 또는 다른 signer로 전환하세요.",
+    "signerUnsupported": "현재 signer로 로그인할 수는 있지만 아직 NIP-44를 사용할 수 없어요. 여기서 DM을 사용하려면 NIP-44를 지원하는 nsec, bunker 또는 다른 signer로 전환하세요.",
     "supportBadge": "지원",
-    "supportSummary": "버그, 모더레이션 또는 계정 문제에 대해 문의하세요."
+    "supportSummary": "버그, 모더레이션, 계정 문제 — 듣고 있어요."
   },
   "support": {
     "title": "지원",
-    "subtitle": "도움이 필요하신가요? 저희가 도와드리겠습니다.",
-    "helpCenterTitle": "Divine 도움말 센터 방문",
-    "helpCenterDescription": "Divine 에 대한 질문의 답을 찾아보세요.",
+    "subtitle": "도움이 필요하신가요? 저희가 챙길게요.",
+    "helpCenterTitle": "Divine 도움말 센터",
+    "helpCenterDescription": "사람들이 자주 묻는 것들의 답변.",
     "helpCenterCta": "도움말 센터 방문",
     "messageSupportTitle": "지원팀에 메시지 보내기",
-    "messageSupportDescription": "NIP-17 개인 메시지로 Divine 안의 지원 수신함에 직접 연락하세요.",
+    "messageSupportDescription": "Divine 안에서 바로 DM 주세요 — NIP-17로 암호화됩니다.",
     "messageSupportCta": "지원 채팅 열기",
     "contactTitle": "지원팀에 문의",
-    "contactDescription": "티켓을 만들면 가능한 한 빨리 답변드리겠습니다.",
+    "contactDescription": "티켓을 만들면 가능한 한 빨리 답변드릴게요.",
     "contactLink": "지원팀에 문의",
     "githubTitle": "GitHub 이슈",
-    "githubDescription": "버그를 신고하거나 기능을 요청하거나 GitHub 저장소의 기존 이슈를 살펴보세요.",
+    "githubDescription": "버그를 신고하거나 기능을 요청하거나 GitHub을 둘러보세요.",
     "webAppLabel": "웹 앱:",
     "flutterAppLabel": "Flutter 앱 (iOS/Android):",
     "communityTitle": "커뮤니티",
-    "communityDescription": "커뮤니티 대화에 참여하고 Nostr 의 다른 Divine 사용자와 연결하세요.",
-    "communityBody": "Divine 은 탈중앙화 소셜 프로토콜인 Nostr 위에 구축되었습니다. 즐겨 사용하는 Nostr 클라이언트에서 저희를 찾아보세요."
+    "communityDescription": "Nostr의 Divine 커뮤니티에 놀러오세요.",
+    "communityBody": "Divine 은 탈중앙화 소셜 프로토콜인 Nostr 위에서 돌아갑니다. 즐겨 사용하는 Nostr 클라이언트에서 저희를 찾아보세요."
   },
   "tagPage": {
-    "notFoundTitle": "태그를 찾을 수 없습니다",
-    "notFoundDescription": "요청한 태그를 찾을 수 없습니다.",
+    "notFoundTitle": "태그를 찾을 수 없습니다.",
+    "notFoundDescription": "해당 태그를 찾지 못했어요.",
     "back": "뒤로",
-    "subtitle": "#{{tag}} 태그가 붙은 동영상을 둘러보세요"
+    "subtitle": "#{{tag}} 태그가 붙은 루프"
   },
   "categoriesPage": {
     "title": "카테고리",
-    "subtitle": "주제별로 동영상을 둘러보세요",
-    "emptyState": "현재 사용할 수 있는 카테고리가 없습니다.",
+    "subtitle": "루프, 분위기별로 정리.",
+    "emptyState": "지금은 준비 중인 카테고리가 없어요.",
     "metaTitle": "카테고리 둘러보기 - Divine",
     "metaDescription": "Divine 에서 코미디, 음악, 댄스, 동물, 스포츠, 음식 등 다양한 동영상 카테고리를 둘러보세요.",
     "videoCount_one": "동영상 {{count}}개",

--- a/src/lib/i18n/locales/ko/common.json
+++ b/src/lib/i18n/locales/ko/common.json
@@ -44,7 +44,8 @@
     "yourFeed": "내 피드"
   },
   "auth": {
-    "logInOnDivine": "들어가자"
+    "logInOnDivine": "들어가자",
+    "logIn": "로그인"
   },
   "home": {
     "welcomeTitle": "당신의 피드, 당신의 규칙.",
@@ -141,5 +142,53 @@
     "metaDescription": "Divine 에서 코미디, 음악, 댄스, 동물, 스포츠, 음식 등 다양한 동영상 카테고리를 둘러보세요.",
     "videoCount_one": "동영상 {{count}}개",
     "videoCount_other": "동영상 {{count}}개"
+  },
+  "videoMeta": {
+    "viewCount_one": "조회수 {{formatted}}회",
+    "viewCount_other": "조회수 {{formatted}}회"
+  },
+  "verification": {
+    "humanMade": "사람이 만든 콘텐츠",
+    "dialog": {
+      "titleVideo": "동영상 인증",
+      "titleArchive": "오리지널 Vine 아카이브",
+      "description": "아카이브 출처, Proofmode 데이터, AI 스캔 상태, 호스팅 출처에 대한 세부 정보.",
+      "proofModeSection": "ProofMode 인증",
+      "aiDetectionSection": "AI 탐지",
+      "aiNotScanned": "AI 스캔: 아직 스캔되지 않음",
+      "checking": "스캔 결과를 확인하는 중…",
+      "noScanResults": "아직 스캔 결과가 없습니다.",
+      "checkAi": "AI 생성 여부 확인",
+      "aiLikelihood": "AI 생성 가능성 {{percent}}%",
+      "scannedBy": "스캔자: {{source}}",
+      "verifiedByMod": "사람 모더레이터가 확인",
+      "learnMore": "Proofmode 인증에 대해 더 알아보기",
+      "inspectTool": "ProofCheck 도구로 검사",
+      "archiveBlurb": "이 동영상은 Internet Archive에서 구해낸 오리지널 Vine입니다.",
+      "archiveContext": "2017년 Vine 종료 전, ArchiveTeam과 Internet Archive가 수백만 개의 Vine을 보존했습니다. 이 콘텐츠는 그 구출 작업의 일부입니다.",
+      "originalLoops": "오리지널 통계: {{count}} 루프",
+      "archiveLearnMore": "Vine 아카이브 보존에 대해 더 알아보기"
+    },
+    "intro": {
+      "proofMode": "이 동영상의 진위는 Proofmode 기술로 인증되었습니다.",
+      "aiHumanDivine": "이 동영상은 Divine에서 호스팅되며, ProofMode 데이터가 없어도 AI 탐지로 사람이 만든 것일 가능성이 높다고 표시됩니다.",
+      "aiHuman": "ProofMode 데이터가 없더라도 AI 탐지에서 이 동영상은 사람이 만든 것일 가능성이 높다고 표시됩니다.",
+      "unverifiedDivine": "이 동영상은 인증되지 않았습니다. Divine에서 호스팅되지만, 아직 ProofMode 데이터가 없습니다.",
+      "unverifiedExternal": "이 동영상은 인증되지 않았고 Divine 외부에서 호스팅됩니다. ProofMode 데이터를 포함하지 않습니다."
+    },
+    "summary": {
+      "platinum": "플래티넘: 디바이스 하드웨어 증명, 암호화 서명, Content Credentials (C2PA), AI 스캔이 사람 출처를 확인합니다.",
+      "gold": "골드: 실제 기기에서 하드웨어 증명, 암호화 서명, Content Credentials (C2PA)와 함께 촬영.",
+      "silverProof": "실버: 암호화 서명이 이 동영상이 녹화 이후 변경되지 않았음을 증명합니다.",
+      "bronze": "브론즈: 기본 메타데이터 서명이 있습니다.",
+      "silverAi": "실버: AI 스캔으로 이 동영상이 사람이 만든 것일 가능성이 높다고 확인되었습니다.",
+      "muted": "이 동영상에 대한 인증 데이터가 없습니다."
+    },
+    "checklist": {
+      "deviceAttestation": "디바이스 증명",
+      "pgpSignature": "PGP 서명",
+      "c2paContentCredentials": "C2PA Content Credentials",
+      "proofManifest": "증명 매니페스트"
+    }
   }
 }

--- a/src/lib/i18n/locales/nl/common.json
+++ b/src/lib/i18n/locales/nl/common.json
@@ -190,5 +190,10 @@
       "c2paContentCredentials": "C2PA Content Credentials",
       "proofManifest": "Bewijsmanifest"
     }
+  },
+  "classicViners": {
+    "heading": "Klassieke Viners",
+    "archivedBadge": "Gearchiveerd",
+    "archivedTooltip": "Origineel Vine-archief bewaard door het Internet Archive"
   }
 }

--- a/src/lib/i18n/locales/nl/common.json
+++ b/src/lib/i18n/locales/nl/common.json
@@ -44,19 +44,19 @@
     "yourFeed": "Jouw feed"
   },
   "auth": {
-    "logInOnDivine": "Inloggen op Divine"
+    "logInOnDivine": "Spring erin"
   },
   "home": {
-    "welcomeTitle": "Welkom bij je homefeed",
-    "welcomeSubtitle": "Log in om video's te zien van mensen die je volgt",
+    "welcomeTitle": "Jouw feed, jouw regels.",
+    "welcomeSubtitle": "Log in om loops te zien van mensen die je volgt.",
     "title": "Home",
-    "subtitle": "Video's van mensen die je volgt",
+    "subtitle": "Loops van mensen die je volgt.",
     "sortBy": "Sorteren op:",
     "updating": "Bezig met bijwerken..."
   },
   "discovery": {
     "title": "Ontdekken",
-    "subtitle": "Verken video's uit het netwerk",
+    "subtitle": "Dwaal door het netwerk. Vind je mensen.",
     "categories": "Categorieen",
     "forYou": "Voor jou",
     "classic": "Klassiek",
@@ -82,14 +82,14 @@
   },
   "comments": {
     "title": "Reacties",
-    "noCommentsYet": "Nog geen reacties",
-    "beFirstToShare": "Wees de eerste om je mening te delen",
-    "failedToLoad": "Reacties konden niet worden geladen",
-    "writeAComment": "Schrijf een reactie...",
+    "noCommentsYet": "Nog niks te zeggen.",
+    "beFirstToShare": "Begin jij maar — laat een reactie achter.",
+    "failedToLoad": "Reacties zijn niet geladen.",
+    "writeAComment": "Zeg iets...",
     "signInToReply": "Log in om te antwoorden",
     "signInToComment": "Log in om te reageren",
     "replyingToComment": "Reageren op reactie",
-    "addingToDiscussion": "Toevoegen aan de discussie",
+    "addingToDiscussion": "Springt in de thread",
     "posting": "Plaatsen...",
     "reply": "Antwoorden",
     "comment": "Reageren"
@@ -97,46 +97,46 @@
   "messages": {
     "badge": "Berichten",
     "title": "Directe berichten",
-    "subtitle": "Praat met support, stuur vines prive of houd een gesprek gaande met mensen die je volgt.",
-    "searchPlaceholder": "Zoek mensen om een bericht te sturen",
+    "subtitle": "Praat met support, schuif een loop privé door of houd een thread gaande met de mensen die je volgt.",
+    "searchPlaceholder": "Vind iemand om te berichten",
     "newMessage": "Nieuw bericht",
-    "readyToShare": "Klaar om prive te delen.",
+    "readyToShare": "Klaar om privé te versturen.",
     "shareWithTitle": "Je volgende bericht bevat “{{title}}”.",
     "shareWithLink": "Je volgende bericht bevat een vine-link.",
-    "signerUnsupported": "Je huidige signer kan je laten inloggen, maar ondersteunt nog geen NIP-44-versleuteling. Schakel over naar een nsec, bunker of andere signer met NIP-44-ondersteuning om directe berichten op het web te gebruiken.",
+    "signerUnsupported": "Je huidige signer kan je laten inloggen, maar spreekt nog geen NIP-44. Schakel over naar een nsec, bunker of andere signer met NIP-44-ondersteuning om hier DM's te gebruiken.",
     "supportBadge": "Support",
-    "supportSummary": "Vraag naar bugs, moderatie of accountproblemen."
+    "supportSummary": "Bugs, moderatie, accountgedoe — we luisteren."
   },
   "support": {
     "title": "Support",
-    "subtitle": "Hulp nodig? We staan klaar om je te helpen.",
-    "helpCenterTitle": "Bezoek het Divine-helpcentrum",
-    "helpCenterDescription": "Vind antwoorden op je vragen over Divine.",
+    "subtitle": "Hulp nodig? We hebben je.",
+    "helpCenterTitle": "Divine-helpcentrum",
+    "helpCenterDescription": "Antwoorden op wat mensen meestal vragen.",
     "helpCenterCta": "Bezoek het helpcentrum",
     "messageSupportTitle": "Bericht naar support",
-    "messageSupportDescription": "Neem rechtstreeks contact op met de supportinbox in Divine via prive-NIP-17-berichten.",
+    "messageSupportDescription": "Schuif ons een DM in Divine — versleuteld met NIP-17.",
     "messageSupportCta": "Open supportchat",
     "contactTitle": "Contact opnemen met support",
-    "contactDescription": "Maak een ticket aan en we reageren zo snel mogelijk.",
+    "contactDescription": "Maak een ticket aan en we reageren zo snel als we kunnen.",
     "contactLink": "Contact opnemen met support",
     "githubTitle": "GitHub-issues",
-    "githubDescription": "Meld bugs, vraag functies aan of bekijk bestaande issues in onze GitHub-repositories.",
+    "githubDescription": "Meld bugs, vraag functies aan of snuffel rond op onze GitHub.",
     "webAppLabel": "Webapp:",
     "flutterAppLabel": "Flutter-app (iOS/Android):",
     "communityTitle": "Community",
-    "communityDescription": "Doe mee aan onze communitygesprekken en maak contact met andere Divine-gebruikers op Nostr.",
-    "communityBody": "Divine is gebouwd op Nostr, een gedecentraliseerd sociaal protocol. Vind ons in je favoriete Nostr-client."
+    "communityDescription": "Kom hangen bij de Divine-community op Nostr.",
+    "communityBody": "Divine draait op Nostr, het gedecentraliseerde sociale protocol. Vind ons in je favoriete Nostr-client."
   },
   "tagPage": {
-    "notFoundTitle": "Tag niet gevonden",
-    "notFoundDescription": "De gevraagde tag kon niet worden gevonden.",
+    "notFoundTitle": "Tag niet gevonden.",
+    "notFoundDescription": "Die tag konden we niet vinden.",
     "back": "Terug",
-    "subtitle": "Bekijk video's met tag #{{tag}}"
+    "subtitle": "Loops met tag #{{tag}}"
   },
   "categoriesPage": {
     "title": "Categorieen",
-    "subtitle": "Bekijk videos per onderwerp",
-    "emptyState": "Er zijn momenteel geen categorieen beschikbaar.",
+    "subtitle": "Loops, gesorteerd op vibe.",
+    "emptyState": "Nu staan er geen categorieen op het vuur.",
     "metaTitle": "Categorieen bekijken - Divine",
     "metaDescription": "Ontdek videocategorieen op Divine - komedie, muziek, dans, dieren, sport, eten en meer.",
     "videoCount_one": "{{count}} video",

--- a/src/lib/i18n/locales/nl/common.json
+++ b/src/lib/i18n/locales/nl/common.json
@@ -195,5 +195,34 @@
     "heading": "Klassieke Viners",
     "archivedBadge": "Gearchiveerd",
     "archivedTooltip": "Origineel Vine-archief bewaard door het Internet Archive"
+  },
+  "profile": {
+    "stats": {
+      "videos": "Video's",
+      "followers": "Volgers",
+      "following": "Volgend",
+      "divineLoops": "Divine Loops"
+    },
+    "editProfile": "Profiel bewerken"
+  },
+  "accountMenu": {
+    "myProfile": "Mijn profiel",
+    "settings": "Instellingen",
+    "linkedAccounts": "Gekoppelde accounts",
+    "switchRelay": "Relay wisselen",
+    "switchAccount": "Account wisselen",
+    "addAccount": "Nog een account toevoegen",
+    "logOut": "Uitloggen"
+  },
+  "trending": {
+    "title": "Trending",
+    "subtitle": "Zie wat er speelt in de community"
+  },
+  "searchTabs": {
+    "all": "Alles",
+    "videos": "Video's",
+    "users": "Mensen",
+    "hashtags": "Hashtags",
+    "searching": "Zoeken..."
   }
 }

--- a/src/lib/i18n/locales/nl/common.json
+++ b/src/lib/i18n/locales/nl/common.json
@@ -44,7 +44,8 @@
     "yourFeed": "Jouw feed"
   },
   "auth": {
-    "logInOnDivine": "Spring erin"
+    "logInOnDivine": "Spring erin",
+    "logIn": "Inloggen"
   },
   "home": {
     "welcomeTitle": "Jouw feed, jouw regels.",
@@ -141,5 +142,53 @@
     "metaDescription": "Ontdek videocategorieen op Divine - komedie, muziek, dans, dieren, sport, eten en meer.",
     "videoCount_one": "{{count}} video",
     "videoCount_other": "{{count}} videos"
+  },
+  "videoMeta": {
+    "viewCount_one": "{{formatted}} weergave",
+    "viewCount_other": "{{formatted}} weergaven"
+  },
+  "verification": {
+    "humanMade": "Door mensen gemaakt",
+    "dialog": {
+      "titleVideo": "Videoverificatie",
+      "titleArchive": "Origineel Vine-archief",
+      "description": "Details over de archiefoorsprong, Proofmode-data, AI-scanstatus en hostingbron.",
+      "proofModeSection": "ProofMode-verificatie",
+      "aiDetectionSection": "AI-detectie",
+      "aiNotScanned": "AI-scan: nog niet gescand",
+      "checking": "Scanresultaten zoeken…",
+      "noScanResults": "Nog geen scanresultaten beschikbaar.",
+      "checkAi": "Controleer of door AI gegenereerd",
+      "aiLikelihood": "{{percent}}% kans dat dit door AI is gegenereerd",
+      "scannedBy": "Gescand door: {{source}}",
+      "verifiedByMod": "Geverifieerd door menselijke moderator",
+      "learnMore": "Meer over Proofmode-verificatie",
+      "inspectTool": "Inspecteren met ProofCheck",
+      "archiveBlurb": "Deze video is een originele Vine, gered uit het Internet Archive.",
+      "archiveContext": "Voordat Vine in 2017 sloot, hebben ArchiveTeam en het Internet Archive miljoenen Vines bewaard. Deze content is onderdeel van die reddingsoperatie.",
+      "originalLoops": "Originele stats: {{count}} loops",
+      "archiveLearnMore": "Meer over het behoud van het Vine-archief"
+    },
+    "intro": {
+      "proofMode": "De echtheid van deze video is geverifieerd met Proofmode-technologie.",
+      "aiHumanDivine": "Deze video staat op Divine en de AI-detectie geeft aan dat het waarschijnlijk door mensen is gemaakt, ook zonder ProofMode-data.",
+      "aiHuman": "De AI-detectie geeft aan dat deze video waarschijnlijk door mensen is gemaakt, ook zonder ProofMode-data.",
+      "unverifiedDivine": "Deze video is niet geverifieerd. Hij staat op Divine, maar er zijn nog geen ProofMode-data aan gekoppeld.",
+      "unverifiedExternal": "Deze video is niet geverifieerd en wordt buiten Divine gehost. Hij bevat geen ProofMode-data."
+    },
+    "summary": {
+      "platinum": "Platina: Hardware-attestatie van het apparaat, cryptografische handtekeningen, Content Credentials (C2PA) en AI-scan bevestigen menselijke oorsprong.",
+      "gold": "Goud: Opgenomen op een echt apparaat met hardware-attestatie, cryptografische handtekeningen en Content Credentials (C2PA).",
+      "silverProof": "Zilver: Cryptografische handtekeningen bewijzen dat deze video sinds de opname niet is gewijzigd.",
+      "bronze": "Brons: Basis metadata-handtekeningen aanwezig.",
+      "silverAi": "Zilver: AI-scan bevestigt dat deze video waarschijnlijk door een mens is gemaakt.",
+      "muted": "Geen verificatiegegevens beschikbaar voor deze video."
+    },
+    "checklist": {
+      "deviceAttestation": "Apparaat-attestatie",
+      "pgpSignature": "PGP-handtekening",
+      "c2paContentCredentials": "C2PA Content Credentials",
+      "proofManifest": "Bewijsmanifest"
+    }
   }
 }

--- a/src/lib/i18n/locales/pl/common.json
+++ b/src/lib/i18n/locales/pl/common.json
@@ -44,19 +44,19 @@
     "yourFeed": "Twoj kanal"
   },
   "auth": {
-    "logInOnDivine": "Zaloguj sie do Divine"
+    "logInOnDivine": "Wskakuj"
   },
   "home": {
-    "welcomeTitle": "Witaj w swoim glownym kanale",
-    "welcomeSubtitle": "Zaloguj sie, aby zobaczyc filmy osob, ktore obserwujesz",
+    "welcomeTitle": "Twoj feed, twoje zasady.",
+    "welcomeSubtitle": "Zaloguj sie, zeby ogladac loopy ludzi, ktorych obserwujesz.",
     "title": "Strona glowna",
-    "subtitle": "Filmy osob, ktore obserwujesz",
+    "subtitle": "Loopy ludzi, ktorych obserwujesz.",
     "sortBy": "Sortuj wedlug:",
     "updating": "Aktualizacja..."
   },
   "discovery": {
     "title": "Odkrywaj",
-    "subtitle": "Odkrywaj filmy z sieci",
+    "subtitle": "Powlocz sie po sieci. Znajdz swoich ludzi.",
     "categories": "Kategorie",
     "forYou": "Dla ciebie",
     "classic": "Klasyczne",
@@ -82,14 +82,14 @@
   },
   "comments": {
     "title": "Komentarze",
-    "noCommentsYet": "Brak komentarzy",
-    "beFirstToShare": "Badz pierwsza osoba, ktora podzieli sie swoja opinia",
-    "failedToLoad": "Nie udalo sie zaladowac komentarzy",
-    "writeAComment": "Napisz komentarz...",
+    "noCommentsYet": "Nic do powiedzenia jeszcze.",
+    "beFirstToShare": "Zacznij pierwszy — zostaw komentarz.",
+    "failedToLoad": "Komentarze sie nie zaladowaly.",
+    "writeAComment": "Powiedz cos...",
     "signInToReply": "Zaloguj sie, aby odpowiedziec",
     "signInToComment": "Zaloguj sie, aby skomentowac",
     "replyingToComment": "Odpowiadanie na komentarz",
-    "addingToDiscussion": "Dodawanie do dyskusji",
+    "addingToDiscussion": "Wskakujesz w watek",
     "posting": "Publikowanie...",
     "reply": "Odpowiedz",
     "comment": "Komentarz"
@@ -97,46 +97,46 @@
   "messages": {
     "badge": "Wiadomosci",
     "title": "Wiadomosci bezposrednie",
-    "subtitle": "Porozmawiaj z supportem, wyslij vines prywatnie albo kontynuuj rozmowe z osobami, ktore obserwujesz.",
-    "searchPlaceholder": "Znajdz osoby, do ktorych chcesz napisac",
+    "subtitle": "Pogadaj z supportem, podrzuc loop prywatnie albo kontynuuj watek z osobami, ktore obserwujesz.",
+    "searchPlaceholder": "Znajdz kogos, do kogo napiszesz",
     "newMessage": "Nowa wiadomosc",
-    "readyToShare": "Gotowe do prywatnego udostepnienia.",
+    "readyToShare": "Gotowe do prywatnej wysylki.",
     "shareWithTitle": "Twoja nastepna wiadomosc bedzie zawierac “{{title}}”.",
     "shareWithLink": "Twoja nastepna wiadomosc bedzie zawierac link do vine.",
-    "signerUnsupported": "Twoj obecny signer pozwala sie zalogowac, ale nie udostepnia jeszcze szyfrowania NIP-44. Przelacz sie na nsec, bunker lub inny signer obslugujacy NIP-44, aby korzystac z wiadomosci bezposrednich w sieci.",
+    "signerUnsupported": "Twoj obecny signer pozwala sie zalogowac, ale nie mowi jeszcze NIP-44. Przelacz sie na nsec, bunker lub inny signer obslugujacy NIP-44, zeby uzywac tu DM-ow.",
     "supportBadge": "Wsparcie",
-    "supportSummary": "Zapytaj o bledy, moderacje lub problemy z kontem."
+    "supportSummary": "Bugi, moderacja, sprawy konta — sluchamy."
   },
   "support": {
     "title": "Wsparcie",
-    "subtitle": "Potrzebujesz pomocy? Jestesmy tutaj, aby pomoc.",
-    "helpCenterTitle": "Odwiedz centrum pomocy Divine",
-    "helpCenterDescription": "Znajdz odpowiedzi na swoje pytania o Divine.",
+    "subtitle": "Potrzebujesz pomocy? Mamy cie.",
+    "helpCenterTitle": "Centrum pomocy Divine",
+    "helpCenterDescription": "Odpowiedzi na to, o co zwykle pytaja.",
     "helpCenterCta": "Odwiedz centrum pomocy",
     "messageSupportTitle": "Napisz do wsparcia",
-    "messageSupportDescription": "Skontaktuj sie bezposrednio ze skrzynka wsparcia w Divine za pomoca prywatnych wiadomosci NIP-17.",
+    "messageSupportDescription": "Napisz do nas DM bezposrednio w Divine — szyfrowane przez NIP-17.",
     "messageSupportCta": "Otworz czat wsparcia",
     "contactTitle": "Skontaktuj sie ze wsparciem",
-    "contactDescription": "Utworz zgloszenie, a odpowiemy tak szybko, jak to mozliwe.",
+    "contactDescription": "Otworz zgloszenie, a odpowiemy najszybciej, jak sie da.",
     "contactLink": "Skontaktuj sie ze wsparciem",
     "githubTitle": "Zgloszenia GitHub",
-    "githubDescription": "Zglaszaj bledy, pros o funkcje lub przegladaj istniejace zgloszenia w naszych repozytoriach GitHub.",
+    "githubDescription": "Zglos bugi, popros o funkcje albo poszperaj po naszym GitHubie.",
     "webAppLabel": "Aplikacja webowa:",
     "flutterAppLabel": "Aplikacja Flutter (iOS/Android):",
     "communityTitle": "Spolecznosc",
-    "communityDescription": "Dolacz do dyskusji spolecznosci i polacz sie z innymi uzytkownikami Divine na Nostr.",
-    "communityBody": "Divine jest zbudowane na Nostr, zdecentralizowanym protokole spolecznosciowym. Znajdz nas w swoim ulubionym kliencie Nostr."
+    "communityDescription": "Wpadnij do spolecznosci Divine na Nostr.",
+    "communityBody": "Divine dziala na Nostr, zdecentralizowanym protokole spolecznosciowym. Znajdz nas w swoim ulubionym kliencie Nostr."
   },
   "tagPage": {
-    "notFoundTitle": "Nie znaleziono tagu",
-    "notFoundDescription": "Nie mozna znalezc podanego tagu.",
+    "notFoundTitle": "Nie znaleziono tagu.",
+    "notFoundDescription": "Nie znalezlismy tego tagu.",
     "back": "Wroc",
-    "subtitle": "Przegladaj filmy oznaczone tagiem #{{tag}}"
+    "subtitle": "Loopy z tagiem #{{tag}}"
   },
   "categoriesPage": {
     "title": "Kategorie",
-    "subtitle": "Przegladaj filmy wedlug tematu",
-    "emptyState": "Obecnie brak dostepnych kategorii.",
+    "subtitle": "Loopy, ulozone wedlug klimatu.",
+    "emptyState": "Aktualnie zadne kategorie sie nie gotuja.",
     "metaTitle": "Przegladaj kategorie - Divine",
     "metaDescription": "Przegladaj kategorie wideo w Divine - komedia, muzyka, taniec, zwierzeta, sport, jedzenie i wiecej.",
     "videoCount_one": "{{count}} film",

--- a/src/lib/i18n/locales/pl/common.json
+++ b/src/lib/i18n/locales/pl/common.json
@@ -194,5 +194,10 @@
       "c2paContentCredentials": "Content Credentials C2PA",
       "proofManifest": "Manifest dowodu"
     }
+  },
+  "classicViners": {
+    "heading": "Klasyczni Vinerzy",
+    "archivedBadge": "Zarchiwizowane",
+    "archivedTooltip": "Oryginalne archiwum Vine zachowane przez Internet Archive"
   }
 }

--- a/src/lib/i18n/locales/pl/common.json
+++ b/src/lib/i18n/locales/pl/common.json
@@ -199,5 +199,34 @@
     "heading": "Klasyczni Vinerzy",
     "archivedBadge": "Zarchiwizowane",
     "archivedTooltip": "Oryginalne archiwum Vine zachowane przez Internet Archive"
+  },
+  "profile": {
+    "stats": {
+      "videos": "Filmy",
+      "followers": "Obserwujacy",
+      "following": "Obserwowani",
+      "divineLoops": "Loopy Divine"
+    },
+    "editProfile": "Edytuj profil"
+  },
+  "accountMenu": {
+    "myProfile": "Moj profil",
+    "settings": "Ustawienia",
+    "linkedAccounts": "Polaczone konta",
+    "switchRelay": "Zmien relay",
+    "switchAccount": "Zmien konto",
+    "addAccount": "Dodaj kolejne konto",
+    "logOut": "Wyloguj"
+  },
+  "trending": {
+    "title": "Na czasie",
+    "subtitle": "Zobacz, co wymiata w spolecznosci"
+  },
+  "searchTabs": {
+    "all": "Wszystko",
+    "videos": "Filmy",
+    "users": "Ludzie",
+    "hashtags": "Tagi",
+    "searching": "Szukam..."
   }
 }

--- a/src/lib/i18n/locales/pl/common.json
+++ b/src/lib/i18n/locales/pl/common.json
@@ -44,7 +44,8 @@
     "yourFeed": "Twoj kanal"
   },
   "auth": {
-    "logInOnDivine": "Wskakuj"
+    "logInOnDivine": "Wskakuj",
+    "logIn": "Zaloguj sie"
   },
   "home": {
     "welcomeTitle": "Twoj feed, twoje zasady.",
@@ -143,5 +144,55 @@
     "videoCount_few": "{{count}} filmy",
     "videoCount_many": "{{count}} filmow",
     "videoCount_other": "{{count}} filmu"
+  },
+  "videoMeta": {
+    "viewCount_one": "{{formatted}} wyswietlenie",
+    "viewCount_few": "{{formatted}} wyswietlenia",
+    "viewCount_many": "{{formatted}} wyswietlen",
+    "viewCount_other": "{{formatted}} wyswietlenia"
+  },
+  "verification": {
+    "humanMade": "Stworzone przez ludzi",
+    "dialog": {
+      "titleVideo": "Weryfikacja wideo",
+      "titleArchive": "Oryginalne archiwum Vine",
+      "description": "Szczegoly o pochodzeniu archiwum, danych Proofmode, statusie skanowania AI i zrodle hostingu.",
+      "proofModeSection": "Weryfikacja ProofMode",
+      "aiDetectionSection": "Wykrywanie AI",
+      "aiNotScanned": "Skan AI: jeszcze nie zeskanowano",
+      "checking": "Szukam wynikow skanu…",
+      "noScanResults": "Brak dostepnych wynikow skanu.",
+      "checkAi": "Sprawdz, czy wygenerowane przez AI",
+      "aiLikelihood": "{{percent}}% prawdopodobienstwa, ze wygenerowane przez AI",
+      "scannedBy": "Zeskanowane przez: {{source}}",
+      "verifiedByMod": "Zweryfikowane przez ludzkiego moderatora",
+      "learnMore": "Dowiedz sie wiecej o weryfikacji Proofmode",
+      "inspectTool": "Sprawdz narzedziem ProofCheck",
+      "archiveBlurb": "To wideo jest oryginalnym Vine ocalonym z Internet Archive.",
+      "archiveContext": "Zanim Vine zamknieto w 2017, ArchiveTeam i Internet Archive zachowali miliony Vine. Ten material jest czescia tej akcji ratunkowej.",
+      "originalLoops": "Oryginalne statystyki: {{count}} loopow",
+      "archiveLearnMore": "Dowiedz sie wiecej o zachowaniu archiwum Vine"
+    },
+    "intro": {
+      "proofMode": "Autentycznosc tego wideo jest zweryfikowana technologia Proofmode.",
+      "aiHumanDivine": "To wideo jest hostowane na Divine, a wykrywanie AI sugeruje, ze prawdopodobnie zrobil je czlowiek, nawet bez danych ProofMode.",
+      "aiHuman": "Wykrywanie AI sugeruje, ze to wideo prawdopodobnie zrobil czlowiek, nawet bez danych ProofMode.",
+      "unverifiedDivine": "To wideo nie jest zweryfikowane. Jest hostowane na Divine, ale nie ma jeszcze danych ProofMode.",
+      "unverifiedExternal": "To wideo nie jest zweryfikowane i hostowane jest poza Divine. Nie zawiera danych ProofMode."
+    },
+    "summary": {
+      "platinum": "Platyna: Atestacja sprzetu, podpisy kryptograficzne, Content Credentials (C2PA) i skan AI potwierdzaja ludzkie pochodzenie.",
+      "gold": "Zloto: Nagrane na prawdziwym urzadzeniu z atestacja sprzetu, podpisami kryptograficznymi i Content Credentials (C2PA).",
+      "silverProof": "Srebro: Podpisy kryptograficzne dowodza, ze wideo nie bylo modyfikowane od nagrania.",
+      "bronze": "Braz: Obecne podstawowe podpisy metadanych.",
+      "silverAi": "Srebro: Skan AI potwierdza, ze wideo zostalo prawdopodobnie stworzone przez czlowieka.",
+      "muted": "Brak danych weryfikacyjnych dla tego wideo."
+    },
+    "checklist": {
+      "deviceAttestation": "Atestacja urzadzenia",
+      "pgpSignature": "Podpis PGP",
+      "c2paContentCredentials": "Content Credentials C2PA",
+      "proofManifest": "Manifest dowodu"
+    }
   }
 }

--- a/src/lib/i18n/locales/pt/common.json
+++ b/src/lib/i18n/locales/pt/common.json
@@ -44,7 +44,8 @@
     "yourFeed": "Seu feed"
   },
   "auth": {
-    "logInOnDivine": "Bora entrar"
+    "logInOnDivine": "Bora entrar",
+    "logIn": "Entrar"
   },
   "home": {
     "welcomeTitle": "Seu feed, suas regras.",
@@ -141,5 +142,53 @@
     "metaDescription": "Explore categorias de videos na Divine - comedia, musica, danca, animais, esportes, comida e mais.",
     "videoCount_one": "{{count}} video",
     "videoCount_other": "{{count}} videos"
+  },
+  "videoMeta": {
+    "viewCount_one": "{{formatted}} visualizacao",
+    "viewCount_other": "{{formatted}} visualizacoes"
+  },
+  "verification": {
+    "humanMade": "Feito por humanos",
+    "dialog": {
+      "titleVideo": "Verificacao de video",
+      "titleArchive": "Arquivo original do Vine",
+      "description": "Detalhes sobre a origem do arquivo, dados Proofmode, status do escaneamento de IA e fonte de hospedagem.",
+      "proofModeSection": "Verificacao ProofMode",
+      "aiDetectionSection": "Deteccao de IA",
+      "aiNotScanned": "Escaneamento de IA: ainda nao escaneado",
+      "checking": "Procurando resultados do escaneamento…",
+      "noScanResults": "Nenhum resultado de escaneamento disponivel ainda.",
+      "checkAi": "Verificar se foi gerado por IA",
+      "aiLikelihood": "{{percent}}% de probabilidade de ser gerado por IA",
+      "scannedBy": "Escaneado por: {{source}}",
+      "verifiedByMod": "Verificado por moderador humano",
+      "learnMore": "Saiba mais sobre a verificacao Proofmode",
+      "inspectTool": "Inspecionar com a ferramenta ProofCheck",
+      "archiveBlurb": "Este video e um Vine original recuperado do Internet Archive.",
+      "archiveContext": "Antes do Vine fechar em 2017, o ArchiveTeam e o Internet Archive preservaram milhoes de Vines. Este conteudo faz parte desse resgate.",
+      "originalLoops": "Estatisticas originais: {{count}} loops",
+      "archiveLearnMore": "Saiba mais sobre a preservacao do arquivo do Vine"
+    },
+    "intro": {
+      "proofMode": "A autenticidade deste video e verificada com a tecnologia Proofmode.",
+      "aiHumanDivine": "Este video esta hospedado na Divine e a deteccao de IA indica que provavelmente e humano, mesmo sem dados ProofMode anexados.",
+      "aiHuman": "A deteccao de IA indica que este video provavelmente e humano, mesmo sem dados ProofMode anexados.",
+      "unverifiedDivine": "Este video nao esta verificado. Esta hospedado na Divine, mas ainda nao tem dados ProofMode.",
+      "unverifiedExternal": "Este video nao esta verificado e esta hospedado fora da Divine. Nao inclui dados ProofMode."
+    },
+    "summary": {
+      "platinum": "Platina: Atestacao de hardware do dispositivo, assinaturas criptograficas, Content Credentials (C2PA) e o escaneamento de IA confirmam origem humana.",
+      "gold": "Ouro: Capturado em um dispositivo real com atestacao de hardware, assinaturas criptograficas e Content Credentials (C2PA).",
+      "silverProof": "Prata: Assinaturas criptograficas provam que este video nao foi alterado desde a gravacao.",
+      "bronze": "Bronze: Assinaturas basicas de metadados presentes.",
+      "silverAi": "Prata: O escaneamento de IA confirma que este video provavelmente foi criado por um humano.",
+      "muted": "Nenhum dado de verificacao disponivel para este video."
+    },
+    "checklist": {
+      "deviceAttestation": "Atestacao do dispositivo",
+      "pgpSignature": "Assinatura PGP",
+      "c2paContentCredentials": "Content Credentials C2PA",
+      "proofManifest": "Manifesto de prova"
+    }
   }
 }

--- a/src/lib/i18n/locales/pt/common.json
+++ b/src/lib/i18n/locales/pt/common.json
@@ -44,19 +44,19 @@
     "yourFeed": "Seu feed"
   },
   "auth": {
-    "logInOnDivine": "Entrar na Divine"
+    "logInOnDivine": "Bora entrar"
   },
   "home": {
-    "welcomeTitle": "Bem-vindo ao seu feed inicial",
-    "welcomeSubtitle": "Entre para ver videos das pessoas que voce segue",
+    "welcomeTitle": "Seu feed, suas regras.",
+    "welcomeSubtitle": "Entre para ver os loops de quem voce segue.",
     "title": "Inicio",
-    "subtitle": "Videos das pessoas que voce segue",
+    "subtitle": "Loops de quem voce segue.",
     "sortBy": "Ordenar por:",
     "updating": "Atualizando..."
   },
   "discovery": {
     "title": "Descobrir",
-    "subtitle": "Explore videos da rede",
+    "subtitle": "Passeie pela rede. Encontre a sua galera.",
     "categories": "Categorias",
     "forYou": "Para voce",
     "classic": "Classico",
@@ -82,14 +82,14 @@
   },
   "comments": {
     "title": "Comentarios",
-    "noCommentsYet": "Ainda nao ha comentarios",
-    "beFirstToShare": "Seja a primeira pessoa a compartilhar sua opiniao",
-    "failedToLoad": "Nao foi possivel carregar os comentarios",
-    "writeAComment": "Escreva um comentario...",
+    "noCommentsYet": "Nada para dizer por enquanto.",
+    "beFirstToShare": "Comece voce — deixe um comentario.",
+    "failedToLoad": "Os comentarios nao carregaram.",
+    "writeAComment": "Diga algo...",
     "signInToReply": "Entre para responder",
     "signInToComment": "Entre para comentar",
     "replyingToComment": "Respondendo ao comentario",
-    "addingToDiscussion": "Adicionando a conversa",
+    "addingToDiscussion": "Entrando na conversa",
     "posting": "Publicando...",
     "reply": "Responder",
     "comment": "Comentar"
@@ -97,46 +97,46 @@
   "messages": {
     "badge": "Mensagens",
     "title": "Mensagens diretas",
-    "subtitle": "Fale com o suporte, envie vines em privado ou mantenha uma conversa com as pessoas que voce segue.",
-    "searchPlaceholder": "Encontre pessoas para enviar mensagem",
+    "subtitle": "Fale com o suporte, mande um loop em privado ou mantenha a conversa com quem voce segue.",
+    "searchPlaceholder": "Encontre alguem para conversar",
     "newMessage": "Nova mensagem",
-    "readyToShare": "Pronto para compartilhar em privado.",
+    "readyToShare": "Pronto para mandar em privado.",
     "shareWithTitle": "Sua proxima mensagem incluira “{{title}}”.",
     "shareWithLink": "Sua proxima mensagem incluira um link de vine.",
-    "signerUnsupported": "Seu signer atual permite login, mas ainda nao oferece criptografia NIP-44. Troque para um nsec, bunker ou outro signer com suporte a NIP-44 para usar mensagens diretas na web.",
+    "signerUnsupported": "Seu signer atual permite login, mas ainda nao fala NIP-44. Troque para um nsec, bunker ou outro signer com suporte a NIP-44 para usar DMs aqui.",
     "supportBadge": "Suporte",
-    "supportSummary": "Pergunte sobre bugs, moderacao ou problemas de conta."
+    "supportSummary": "Bugs, moderacao, coisas de conta — estamos ouvindo."
   },
   "support": {
     "title": "Suporte",
-    "subtitle": "Precisa de ajuda? Estamos aqui para ajudar voce.",
-    "helpCenterTitle": "Visitar a central de ajuda da Divine",
-    "helpCenterDescription": "Encontre respostas para suas perguntas sobre a Divine.",
+    "subtitle": "Precisa de uma mao? Pode contar com a gente.",
+    "helpCenterTitle": "Central de ajuda da Divine",
+    "helpCenterDescription": "Respostas para o que a galera mais pergunta.",
     "helpCenterCta": "Visitar a central de ajuda",
     "messageSupportTitle": "Enviar mensagem ao suporte",
-    "messageSupportDescription": "Fale diretamente com a caixa de suporte dentro da Divine usando mensagens privadas NIP-17.",
+    "messageSupportDescription": "Mande uma DM direto dentro da Divine — criptografado com NIP-17.",
     "messageSupportCta": "Abrir chat de suporte",
     "contactTitle": "Entrar em contato com o suporte",
-    "contactDescription": "Abra um ticket e responderemos o mais rapido possivel.",
+    "contactDescription": "Abra um ticket e respondemos o mais rapido possivel.",
     "contactLink": "Entrar em contato com o suporte",
     "githubTitle": "Issues do GitHub",
-    "githubDescription": "Reporte bugs, solicite recursos ou veja issues existentes em nossos repositorios do GitHub.",
+    "githubDescription": "Reporte bugs, peca recursos ou de uma fucada no nosso GitHub.",
     "webAppLabel": "App web:",
     "flutterAppLabel": "App Flutter (iOS/Android):",
     "communityTitle": "Comunidade",
-    "communityDescription": "Participe das discussoes da comunidade e conecte-se com outros usuarios da Divine no Nostr.",
-    "communityBody": "A Divine e construida sobre o Nostr, um protocolo social descentralizado. Encontre-nos no seu cliente Nostr favorito."
+    "communityDescription": "Vem trocar ideia com a comunidade Divine no Nostr.",
+    "communityBody": "A Divine roda no Nostr, o protocolo social descentralizado. Encontre-nos no seu cliente Nostr favorito."
   },
   "tagPage": {
-    "notFoundTitle": "Tag nao encontrada",
-    "notFoundDescription": "Nao foi possivel encontrar a tag solicitada.",
+    "notFoundTitle": "Tag nao encontrada.",
+    "notFoundDescription": "Nao achamos essa tag.",
     "back": "Voltar",
-    "subtitle": "Explore videos marcados com #{{tag}}"
+    "subtitle": "Loops marcados com #{{tag}}"
   },
   "categoriesPage": {
     "title": "Categorias",
-    "subtitle": "Explore videos por tema",
-    "emptyState": "Nenhuma categoria disponivel no momento.",
+    "subtitle": "Loops, organizados por vibe.",
+    "emptyState": "Nenhuma categoria rolando agora.",
     "metaTitle": "Explorar categorias - Divine",
     "metaDescription": "Explore categorias de videos na Divine - comedia, musica, danca, animais, esportes, comida e mais.",
     "videoCount_one": "{{count}} video",

--- a/src/lib/i18n/locales/pt/common.json
+++ b/src/lib/i18n/locales/pt/common.json
@@ -195,5 +195,34 @@
     "heading": "Viners classicos",
     "archivedBadge": "Arquivado",
     "archivedTooltip": "Arquivo original do Vine preservado pelo Internet Archive"
+  },
+  "profile": {
+    "stats": {
+      "videos": "Videos",
+      "followers": "Seguidores",
+      "following": "Seguindo",
+      "divineLoops": "Loops Divine"
+    },
+    "editProfile": "Editar perfil"
+  },
+  "accountMenu": {
+    "myProfile": "Meu perfil",
+    "settings": "Configuracoes",
+    "linkedAccounts": "Contas conectadas",
+    "switchRelay": "Trocar de relay",
+    "switchAccount": "Trocar de conta",
+    "addAccount": "Adicionar outra conta",
+    "logOut": "Sair"
+  },
+  "trending": {
+    "title": "Em alta",
+    "subtitle": "Veja o que esta bombando na comunidade"
+  },
+  "searchTabs": {
+    "all": "Tudo",
+    "videos": "Videos",
+    "users": "Pessoas",
+    "hashtags": "Hashtags",
+    "searching": "Pesquisando..."
   }
 }

--- a/src/lib/i18n/locales/pt/common.json
+++ b/src/lib/i18n/locales/pt/common.json
@@ -190,5 +190,10 @@
       "c2paContentCredentials": "Content Credentials C2PA",
       "proofManifest": "Manifesto de prova"
     }
+  },
+  "classicViners": {
+    "heading": "Viners classicos",
+    "archivedBadge": "Arquivado",
+    "archivedTooltip": "Arquivo original do Vine preservado pelo Internet Archive"
   }
 }

--- a/src/lib/i18n/locales/ro/common.json
+++ b/src/lib/i18n/locales/ro/common.json
@@ -44,7 +44,8 @@
     "yourFeed": "Fluxul tau"
   },
   "auth": {
-    "logInOnDivine": "Hai inauntru"
+    "logInOnDivine": "Hai inauntru",
+    "logIn": "Conecteaza-te"
   },
   "home": {
     "welcomeTitle": "Fluxul tau, regulile tale.",
@@ -142,5 +143,54 @@
     "videoCount_one": "{{count}} videoclip",
     "videoCount_few": "{{count}} videoclipuri",
     "videoCount_other": "{{count}} de videoclipuri"
+  },
+  "videoMeta": {
+    "viewCount_one": "{{formatted}} vizualizare",
+    "viewCount_few": "{{formatted}} vizualizari",
+    "viewCount_other": "{{formatted}} de vizualizari"
+  },
+  "verification": {
+    "humanMade": "Creat de oameni",
+    "dialog": {
+      "titleVideo": "Verificare video",
+      "titleArchive": "Arhiva Vine originala",
+      "description": "Detalii despre originea arhivei, datele Proofmode, statusul scanarii AI si sursa de hosting.",
+      "proofModeSection": "Verificare ProofMode",
+      "aiDetectionSection": "Detectie AI",
+      "aiNotScanned": "Scanare AI: inca nu a fost scanata",
+      "checking": "Caut rezultatele scanarii…",
+      "noScanResults": "Inca nu sunt rezultate de scanare disponibile.",
+      "checkAi": "Verifica daca e generat de AI",
+      "aiLikelihood": "{{percent}}% probabilitate sa fie generat de AI",
+      "scannedBy": "Scanat de: {{source}}",
+      "verifiedByMod": "Verificat de un moderator uman",
+      "learnMore": "Afla mai multe despre verificarea Proofmode",
+      "inspectTool": "Inspecteaza cu instrumentul ProofCheck",
+      "archiveBlurb": "Acest video este un Vine original recuperat de pe Internet Archive.",
+      "archiveContext": "Inainte ca Vine sa se inchida in 2017, ArchiveTeam si Internet Archive au pastrat milioane de Vines. Acest continut face parte din acea operatiune de salvare.",
+      "originalLoops": "Statistici originale: {{count}} loop-uri",
+      "archiveLearnMore": "Afla mai multe despre pastrarea arhivei Vine"
+    },
+    "intro": {
+      "proofMode": "Autenticitatea acestui video este verificata cu tehnologia Proofmode.",
+      "aiHumanDivine": "Acest video este gazduit pe Divine si detectia AI indica ca este probabil uman, chiar daca nu are date ProofMode.",
+      "aiHuman": "Detectia AI indica ca acest video este probabil uman, chiar daca nu are date ProofMode.",
+      "unverifiedDivine": "Acest video nu este verificat. E gazduit pe Divine, dar inca nu are date ProofMode atasate.",
+      "unverifiedExternal": "Acest video nu este verificat si este gazduit in afara Divine. Nu include date ProofMode."
+    },
+    "summary": {
+      "platinum": "Platina: Atestare hardware a dispozitivului, semnaturi criptografice, Content Credentials (C2PA) si scanarea AI confirma originea umana.",
+      "gold": "Aur: Filmat pe un dispozitiv real cu atestare hardware, semnaturi criptografice si Content Credentials (C2PA).",
+      "silverProof": "Argint: Semnaturile criptografice dovedesc ca acest video nu a fost modificat de la inregistrare.",
+      "bronze": "Bronz: Semnaturi de metadate de baza prezente.",
+      "silverAi": "Argint: Scanarea AI confirma ca acest video este probabil creat de un om.",
+      "muted": "Nu sunt date de verificare disponibile pentru acest video."
+    },
+    "checklist": {
+      "deviceAttestation": "Atestare a dispozitivului",
+      "pgpSignature": "Semnatura PGP",
+      "c2paContentCredentials": "Content Credentials C2PA",
+      "proofManifest": "Manifest al dovezii"
+    }
   }
 }

--- a/src/lib/i18n/locales/ro/common.json
+++ b/src/lib/i18n/locales/ro/common.json
@@ -44,19 +44,19 @@
     "yourFeed": "Fluxul tau"
   },
   "auth": {
-    "logInOnDivine": "Conecteaza-te la Divine"
+    "logInOnDivine": "Hai inauntru"
   },
   "home": {
-    "welcomeTitle": "Bine ai venit in fluxul tau principal",
-    "welcomeSubtitle": "Conecteaza-te pentru a vedea videoclipuri de la persoanele pe care le urmaresti",
+    "welcomeTitle": "Fluxul tau, regulile tale.",
+    "welcomeSubtitle": "Conecteaza-te ca sa vezi loop-urile celor pe care ii urmaresti.",
     "title": "Acasa",
-    "subtitle": "Videoclipuri de la persoanele pe care le urmaresti",
+    "subtitle": "Loop-uri de la cei pe care ii urmaresti.",
     "sortBy": "Sorteaza dupa:",
     "updating": "Se actualizeaza..."
   },
   "discovery": {
     "title": "Descopera",
-    "subtitle": "Exploreaza videoclipuri din retea",
+    "subtitle": "Hoinareste prin retea. Gaseste-ti gasca.",
     "categories": "Categorii",
     "forYou": "Pentru tine",
     "classic": "Clasic",
@@ -82,14 +82,14 @@
   },
   "comments": {
     "title": "Comentarii",
-    "noCommentsYet": "Nu exista comentarii inca",
-    "beFirstToShare": "Fii prima persoana care isi impartaseste gandurile",
-    "failedToLoad": "Comentariile nu au putut fi incarcate",
-    "writeAComment": "Scrie un comentariu...",
+    "noCommentsYet": "Nimic de spus deocamdata.",
+    "beFirstToShare": "Da-i drumul tu — lasa un comentariu.",
+    "failedToLoad": "Comentariile nu s-au incarcat.",
+    "writeAComment": "Spune ceva...",
     "signInToReply": "Conecteaza-te pentru a raspunde",
     "signInToComment": "Conecteaza-te pentru a comenta",
     "replyingToComment": "Raspunzi la comentariu",
-    "addingToDiscussion": "Adaugare la discutie",
+    "addingToDiscussion": "Sari in fir",
     "posting": "Se publica...",
     "reply": "Raspunde",
     "comment": "Comenteaza"
@@ -97,46 +97,46 @@
   "messages": {
     "badge": "Mesaje",
     "title": "Mesaje directe",
-    "subtitle": "Vorbeste cu suportul, trimite vines in privat sau continua o conversatie cu persoanele pe care le urmaresti.",
-    "searchPlaceholder": "Gaseste persoane carora sa le scrii",
+    "subtitle": "Vorbeste cu suportul, trimite un loop in privat sau continua o conversatie cu cei pe care ii urmaresti.",
+    "searchPlaceholder": "Gaseste pe cineva caruia sa-i scrii",
     "newMessage": "Mesaj nou",
-    "readyToShare": "Gata de partajare privata.",
+    "readyToShare": "Gata de trimis in privat.",
     "shareWithTitle": "Urmatorul tau mesaj va include “{{title}}”.",
     "shareWithLink": "Urmatorul tau mesaj va include un link vine.",
-    "signerUnsupported": "Signerul tau actual te poate autentifica, dar nu ofera inca criptare NIP-44. Treci la un nsec, bunker sau alt signer care suporta NIP-44 pentru a folosi mesaje directe pe web.",
+    "signerUnsupported": "Signerul tau actual te poate autentifica, dar nu vorbeste inca NIP-44. Treci la un nsec, bunker sau alt signer care suporta NIP-44 ca sa folosesti DM-uri aici.",
     "supportBadge": "Suport",
-    "supportSummary": "Intreaba despre buguri, moderare sau probleme de cont."
+    "supportSummary": "Bug-uri, moderare, treburi de cont — te ascultam."
   },
   "support": {
     "title": "Suport",
-    "subtitle": "Ai nevoie de ajutor? Suntem aici sa te ajutam.",
-    "helpCenterTitle": "Viziteaza centrul de ajutor Divine",
-    "helpCenterDescription": "Gaseste raspunsuri la intrebarile tale despre Divine.",
+    "subtitle": "Ai nevoie de o mana de ajutor? Te-am prins.",
+    "helpCenterTitle": "Centrul de ajutor Divine",
+    "helpCenterDescription": "Raspunsuri la ce intreaba lumea de obicei.",
     "helpCenterCta": "Viziteaza centrul de ajutor",
     "messageSupportTitle": "Trimite mesaj catre suport",
-    "messageSupportDescription": "Contacteaza direct inboxul de suport din Divine folosind mesaje private NIP-17.",
+    "messageSupportDescription": "Trimite-ne un DM direct in Divine — criptat cu NIP-17.",
     "messageSupportCta": "Deschide chatul de suport",
     "contactTitle": "Contacteaza suportul",
-    "contactDescription": "Creeaza un tichet si iti vom raspunde cat mai curand posibil.",
+    "contactDescription": "Deschide un tichet si revenim cat de repede putem.",
     "contactLink": "Contacteaza suportul",
     "githubTitle": "Issue-uri GitHub",
-    "githubDescription": "Raporteaza buguri, cere functii noi sau rasfoieste issue-urile existente din depozitele noastre GitHub.",
+    "githubDescription": "Raporteaza bug-uri, cere functii noi sau scotoceste pe GitHub-ul nostru.",
     "webAppLabel": "Aplicatie web:",
     "flutterAppLabel": "Aplicatie Flutter (iOS/Android):",
     "communityTitle": "Comunitate",
-    "communityDescription": "Alatura-te discutiilor comunitatii si conecteaza-te cu alti utilizatori Divine pe Nostr.",
-    "communityBody": "Divine este construit pe Nostr, un protocol social descentralizat. Gaseste-ne in clientul tau Nostr preferat."
+    "communityDescription": "Vino sa stai cu comunitatea Divine pe Nostr.",
+    "communityBody": "Divine ruleaza pe Nostr, protocolul social descentralizat. Gaseste-ne in clientul tau Nostr preferat."
   },
   "tagPage": {
-    "notFoundTitle": "Eticheta nu a fost gasita",
-    "notFoundDescription": "Eticheta solicitata nu a putut fi gasita.",
+    "notFoundTitle": "Eticheta nu a fost gasita.",
+    "notFoundDescription": "Nu am gasit eticheta asta.",
     "back": "Inapoi",
-    "subtitle": "Exploreaza videoclipuri etichetate cu #{{tag}}"
+    "subtitle": "Loop-uri etichetate #{{tag}}"
   },
   "categoriesPage": {
     "title": "Categorii",
-    "subtitle": "Exploreaza videoclipuri dupa subiect",
-    "emptyState": "Nu exista categorii disponibile acum.",
+    "subtitle": "Loop-uri, sortate dupa vibe.",
+    "emptyState": "Nicio categorie nu fierbe acum.",
     "metaTitle": "Rasfoieste categoriile - Divine",
     "metaDescription": "Exploreaza categoriile video de pe Divine - comedie, muzica, dans, animale, sport, mancare si multe altele.",
     "videoCount_one": "{{count}} videoclip",

--- a/src/lib/i18n/locales/ro/common.json
+++ b/src/lib/i18n/locales/ro/common.json
@@ -197,5 +197,34 @@
     "heading": "Vineri clasici",
     "archivedBadge": "Arhivat",
     "archivedTooltip": "Arhiva Vine originala pastrata de Internet Archive"
+  },
+  "profile": {
+    "stats": {
+      "videos": "Videoclipuri",
+      "followers": "Urmaritori",
+      "following": "Urmaresti",
+      "divineLoops": "Loop-uri Divine"
+    },
+    "editProfile": "Editeaza profilul"
+  },
+  "accountMenu": {
+    "myProfile": "Profilul meu",
+    "settings": "Setari",
+    "linkedAccounts": "Conturi conectate",
+    "switchRelay": "Schimba relay-ul",
+    "switchAccount": "Schimba contul",
+    "addAccount": "Adauga alt cont",
+    "logOut": "Deconectare"
+  },
+  "trending": {
+    "title": "In tendinte",
+    "subtitle": "Vezi ce face valuri in comunitate"
+  },
+  "searchTabs": {
+    "all": "Tot",
+    "videos": "Videoclipuri",
+    "users": "Persoane",
+    "hashtags": "Etichete",
+    "searching": "Se cauta..."
   }
 }

--- a/src/lib/i18n/locales/ro/common.json
+++ b/src/lib/i18n/locales/ro/common.json
@@ -192,5 +192,10 @@
       "c2paContentCredentials": "Content Credentials C2PA",
       "proofManifest": "Manifest al dovezii"
     }
+  },
+  "classicViners": {
+    "heading": "Vineri clasici",
+    "archivedBadge": "Arhivat",
+    "archivedTooltip": "Arhiva Vine originala pastrata de Internet Archive"
   }
 }

--- a/src/lib/i18n/locales/sv/common.json
+++ b/src/lib/i18n/locales/sv/common.json
@@ -44,19 +44,19 @@
     "yourFeed": "Ditt flode"
   },
   "auth": {
-    "logInOnDivine": "Logga in pa Divine"
+    "logInOnDivine": "Hoppa in"
   },
   "home": {
-    "welcomeTitle": "Valkommen till ditt hemmaflode",
-    "welcomeSubtitle": "Logga in for att se videor fran personer du foljer",
+    "welcomeTitle": "Ditt flode, dina regler.",
+    "welcomeSubtitle": "Logga in for att se loopar fran personer du foljer.",
     "title": "Hem",
-    "subtitle": "Videor fran personer du foljer",
+    "subtitle": "Loopar fran personer du foljer.",
     "sortBy": "Sortera efter:",
     "updating": "Uppdaterar..."
   },
   "discovery": {
     "title": "Utforska",
-    "subtitle": "Utforska videor fran natverket",
+    "subtitle": "Stroya runt i natverket. Hitta ditt folk.",
     "categories": "Kategorier",
     "forYou": "For dig",
     "classic": "Klassiskt",
@@ -82,14 +82,14 @@
   },
   "comments": {
     "title": "Kommentarer",
-    "noCommentsYet": "Inga kommentarer an",
-    "beFirstToShare": "Bli den forsta som delar dina tankar",
-    "failedToLoad": "Det gick inte att ladda kommentarer",
-    "writeAComment": "Skriv en kommentar...",
+    "noCommentsYet": "Inget att saga an.",
+    "beFirstToShare": "Borja du — slang in en kommentar.",
+    "failedToLoad": "Kommentarerna laddade inte.",
+    "writeAComment": "Saga nagot...",
     "signInToReply": "Logga in for att svara",
     "signInToComment": "Logga in for att kommentera",
     "replyingToComment": "Svara pa kommentar",
-    "addingToDiscussion": "Lagger till i diskussionen",
+    "addingToDiscussion": "Hoppar in i traden",
     "posting": "Publicerar...",
     "reply": "Svara",
     "comment": "Kommentera"
@@ -97,46 +97,46 @@
   "messages": {
     "badge": "Meddelanden",
     "title": "Direktmeddelanden",
-    "subtitle": "Prata med support, skicka vines privat eller hall igang en trad med personer du foljer.",
-    "searchPlaceholder": "Hitta personer att skicka meddelanden till",
+    "subtitle": "Prata med supporten, slang in en loop privat eller hall igang en trad med personer du foljer.",
+    "searchPlaceholder": "Hitta nagon att skicka meddelande till",
     "newMessage": "Nytt meddelande",
-    "readyToShare": "Redo att dela privat.",
+    "readyToShare": "Redo att skicka privat.",
     "shareWithTitle": "Ditt nasta meddelande kommer att innehalla “{{title}}”.",
     "shareWithLink": "Ditt nasta meddelande kommer att innehalla en vine-lank.",
-    "signerUnsupported": "Din nuvarande signer kan logga in dig, men den exponerar inte NIP-44-kryptering an. Byt till en nsec, bunker eller annan signer som stodjer NIP-44 for att anvanda direktmeddelanden pa webben.",
+    "signerUnsupported": "Din nuvarande signer kan logga in dig, men talar inte NIP-44 an. Byt till en nsec, bunker eller annan signer som stodjer NIP-44 for att anvanda DM har.",
     "supportBadge": "Support",
-    "supportSummary": "Fraga om buggar, moderering eller kontoproblem."
+    "supportSummary": "Buggar, moderering, kontogrejer — vi lyssnar."
   },
   "support": {
     "title": "Support",
-    "subtitle": "Behöver du hjälp? Vi finns här för att hjälpa dig.",
-    "helpCenterTitle": "Besök Divines hjälpcenter",
-    "helpCenterDescription": "Hitta svar på dina frågor om Divine.",
-    "helpCenterCta": "Besök hjälpcentret",
+    "subtitle": "Behover du en hand? Vi har dig.",
+    "helpCenterTitle": "Divines hjalpcenter",
+    "helpCenterDescription": "Svar pa det folk brukar fraga om.",
+    "helpCenterCta": "Besok hjalpcentret",
     "messageSupportTitle": "Meddela supporten",
-    "messageSupportDescription": "Kontakta supportinkorgen direkt i Divine med privata NIP-17-meddelanden.",
-    "messageSupportCta": "Öppna supportchatten",
+    "messageSupportDescription": "Slang oss en DM direkt i Divine — krypterat med NIP-17.",
+    "messageSupportCta": "Oppna supportchatten",
     "contactTitle": "Kontakta supporten",
-    "contactDescription": "Skapa ett ärende så återkommer vi så snart som möjligt.",
+    "contactDescription": "Oppna ett arende sa hor vi av oss sa fort vi kan.",
     "contactLink": "Kontakta supporten",
-    "githubTitle": "GitHub-ärenden",
-    "githubDescription": "Rapportera buggar, önska funktioner eller bläddra bland befintliga ärenden i våra GitHub-repositorier.",
+    "githubTitle": "GitHub-arenden",
+    "githubDescription": "Rapportera buggar, onska funktioner eller pilla runt pa var GitHub.",
     "webAppLabel": "Webbapp:",
     "flutterAppLabel": "Flutter-app (iOS/Android):",
     "communityTitle": "Gemenskap",
-    "communityDescription": "Delta i våra gemenskapsdiskussioner och få kontakt med andra Divine-användare på Nostr.",
-    "communityBody": "Divine är byggt på Nostr, ett decentraliserat socialt protokoll. Hitta oss i din favoritklient för Nostr."
+    "communityDescription": "Hang med Divine-gemenskapen pa Nostr.",
+    "communityBody": "Divine kor pa Nostr, det decentraliserade sociala protokollet. Hitta oss i din favoritklient for Nostr."
   },
   "tagPage": {
-    "notFoundTitle": "Tagg hittades inte",
-    "notFoundDescription": "Den begarda taggen kunde inte hittas.",
+    "notFoundTitle": "Tagg hittades inte.",
+    "notFoundDescription": "Vi hittade inte den taggen.",
     "back": "Tillbaka",
-    "subtitle": "Utforska videor med taggen #{{tag}}"
+    "subtitle": "Loopar med taggen #{{tag}}"
   },
   "categoriesPage": {
     "title": "Kategorier",
-    "subtitle": "Utforska videor efter amne",
-    "emptyState": "Inga kategorier ar tillgangliga just nu.",
+    "subtitle": "Loopar, sorterade efter vibe.",
+    "emptyState": "Inga kategorier puttrar just nu.",
     "metaTitle": "Utforska kategorier - Divine",
     "metaDescription": "Utforska videokategorier pa Divine - komedi, musik, dans, djur, sport, mat och mer.",
     "videoCount_one": "{{count}} video",

--- a/src/lib/i18n/locales/sv/common.json
+++ b/src/lib/i18n/locales/sv/common.json
@@ -190,5 +190,10 @@
       "c2paContentCredentials": "C2PA Content Credentials",
       "proofManifest": "Bevismanifest"
     }
+  },
+  "classicViners": {
+    "heading": "Klassiska Viners",
+    "archivedBadge": "Arkiverad",
+    "archivedTooltip": "Original Vine-arkiv bevarat av Internet Archive"
   }
 }

--- a/src/lib/i18n/locales/sv/common.json
+++ b/src/lib/i18n/locales/sv/common.json
@@ -44,7 +44,8 @@
     "yourFeed": "Ditt flode"
   },
   "auth": {
-    "logInOnDivine": "Hoppa in"
+    "logInOnDivine": "Hoppa in",
+    "logIn": "Logga in"
   },
   "home": {
     "welcomeTitle": "Ditt flode, dina regler.",
@@ -141,5 +142,53 @@
     "metaDescription": "Utforska videokategorier pa Divine - komedi, musik, dans, djur, sport, mat och mer.",
     "videoCount_one": "{{count}} video",
     "videoCount_other": "{{count}} videor"
+  },
+  "videoMeta": {
+    "viewCount_one": "{{formatted}} visning",
+    "viewCount_other": "{{formatted}} visningar"
+  },
+  "verification": {
+    "humanMade": "Skapad av manniskor",
+    "dialog": {
+      "titleVideo": "Videoverifiering",
+      "titleArchive": "Original Vine-arkiv",
+      "description": "Information om arkivets ursprung, Proofmode-data, AI-scanstatus och hostingkalla.",
+      "proofModeSection": "ProofMode-verifiering",
+      "aiDetectionSection": "AI-detektion",
+      "aiNotScanned": "AI-scan: ej scannad an",
+      "checking": "Soker scanresultat…",
+      "noScanResults": "Inga scanresultat tillgangliga an.",
+      "checkAi": "Kontrollera om AI-genererad",
+      "aiLikelihood": "{{percent}}% sannolikhet att vara AI-genererad",
+      "scannedBy": "Scannad av: {{source}}",
+      "verifiedByMod": "Verifierad av manskliga moderator",
+      "learnMore": "Las mer om Proofmode-verifiering",
+      "inspectTool": "Granska med ProofCheck-verktyget",
+      "archiveBlurb": "Den har videon ar en original-Vine raddad fran Internet Archive.",
+      "archiveContext": "Innan Vine stangde 2017 raddade ArchiveTeam och Internet Archive miljoner Vines. Detta innehall ar en del av den raddningsinsatsen.",
+      "originalLoops": "Original-stats: {{count}} loopar",
+      "archiveLearnMore": "Las mer om Vine-arkivet"
+    },
+    "intro": {
+      "proofMode": "Den har videons akthet ar verifierad med Proofmode-teknik.",
+      "aiHumanDivine": "Den har videon ligger pa Divine och AI-detektionen tyder pa att den troligen ar gjord av manniskor, aven utan ProofMode-data.",
+      "aiHuman": "AI-detektionen tyder pa att den har videon troligen ar gjord av manniskor, aven utan ProofMode-data.",
+      "unverifiedDivine": "Den har videon ar inte verifierad. Den ligger pa Divine, men har annu inga ProofMode-data.",
+      "unverifiedExternal": "Den har videon ar inte verifierad och hostas utanfor Divine. Den innehaller inga ProofMode-data."
+    },
+    "summary": {
+      "platinum": "Platina: Hardvaruattest fran enheten, kryptografiska signaturer, Content Credentials (C2PA) och AI-scan bekraftar manskligt ursprung.",
+      "gold": "Guld: Inspelat pa en riktig enhet med hardvaruattest, kryptografiska signaturer och Content Credentials (C2PA).",
+      "silverProof": "Silver: Kryptografiska signaturer bevisar att videon inte har andrats sedan inspelningen.",
+      "bronze": "Brons: Grundlaggande metadata-signaturer finns.",
+      "silverAi": "Silver: AI-scan bekraftar att videon troligen ar skapad av en manniska.",
+      "muted": "Ingen verifieringsdata tillganglig for den har videon."
+    },
+    "checklist": {
+      "deviceAttestation": "Enhetsattest",
+      "pgpSignature": "PGP-signatur",
+      "c2paContentCredentials": "C2PA Content Credentials",
+      "proofManifest": "Bevismanifest"
+    }
   }
 }

--- a/src/lib/i18n/locales/sv/common.json
+++ b/src/lib/i18n/locales/sv/common.json
@@ -195,5 +195,34 @@
     "heading": "Klassiska Viners",
     "archivedBadge": "Arkiverad",
     "archivedTooltip": "Original Vine-arkiv bevarat av Internet Archive"
+  },
+  "profile": {
+    "stats": {
+      "videos": "Videor",
+      "followers": "Foljare",
+      "following": "Foljer",
+      "divineLoops": "Divine Loops"
+    },
+    "editProfile": "Redigera profil"
+  },
+  "accountMenu": {
+    "myProfile": "Min profil",
+    "settings": "Installningar",
+    "linkedAccounts": "Lankade konton",
+    "switchRelay": "Byt relay",
+    "switchAccount": "Byt konto",
+    "addAccount": "Lagg till ett annat konto",
+    "logOut": "Logga ut"
+  },
+  "trending": {
+    "title": "Trendande",
+    "subtitle": "Se vad som rors i gemenskapen"
+  },
+  "searchTabs": {
+    "all": "Alla",
+    "videos": "Videor",
+    "users": "Personer",
+    "hashtags": "Taggar",
+    "searching": "Soker..."
   }
 }

--- a/src/lib/i18n/locales/tr/common.json
+++ b/src/lib/i18n/locales/tr/common.json
@@ -190,5 +190,10 @@
       "c2paContentCredentials": "C2PA Content Credentials",
       "proofManifest": "Kanit manifestosu"
     }
+  },
+  "classicViners": {
+    "heading": "Klasik Vinerlar",
+    "archivedBadge": "Arsivlenmis",
+    "archivedTooltip": "Internet Archive tarafindan korunan orijinal Vine arsivi"
   }
 }

--- a/src/lib/i18n/locales/tr/common.json
+++ b/src/lib/i18n/locales/tr/common.json
@@ -44,7 +44,8 @@
     "yourFeed": "Akisin"
   },
   "auth": {
-    "logInOnDivine": "Atla iceri"
+    "logInOnDivine": "Atla iceri",
+    "logIn": "Giris yap"
   },
   "home": {
     "welcomeTitle": "Senin akisin, senin kurallarin.",
@@ -141,5 +142,53 @@
     "metaDescription": "Divine uzerinde komedi, muzik, dans, hayvanlar, spor, yemek ve daha fazlasini kesfet.",
     "videoCount_one": "{{count}} video",
     "videoCount_other": "{{count}} video"
+  },
+  "videoMeta": {
+    "viewCount_one": "{{formatted}} goruntuleme",
+    "viewCount_other": "{{formatted}} goruntuleme"
+  },
+  "verification": {
+    "humanMade": "Insan yapimi",
+    "dialog": {
+      "titleVideo": "Video dogrulama",
+      "titleArchive": "Orijinal Vine arsivi",
+      "description": "Arsiv kaynagi, Proofmode verisi, AI tarama durumu ve hosting kaynagi hakkinda detaylar.",
+      "proofModeSection": "ProofMode dogrulamasi",
+      "aiDetectionSection": "AI tespiti",
+      "aiNotScanned": "AI taramasi: henuz taranmadi",
+      "checking": "Tarama sonuclari aranıyor…",
+      "noScanResults": "Henuz tarama sonucu yok.",
+      "checkAi": "AI tarafindan uretildi mi diye kontrol et",
+      "aiLikelihood": "%{{percent}} AI tarafindan uretilmis olma ihtimali",
+      "scannedBy": "Tarayan: {{source}}",
+      "verifiedByMod": "Insan moderator tarafindan dogrulandi",
+      "learnMore": "Proofmode dogrulamasi hakkinda daha fazla bilgi",
+      "inspectTool": "ProofCheck arac ile incele",
+      "archiveBlurb": "Bu video, Internet Archive uzerinden kurtarilmis orijinal bir Vine.",
+      "archiveContext": "Vine 2017'de kapanmadan once, ArchiveTeam ve Internet Archive milyonlarca Vine'i sakladi. Bu icerik o kurtarma calismasinin bir parcasi.",
+      "originalLoops": "Orijinal istatistikler: {{count}} loop",
+      "archiveLearnMore": "Vine arsivinin korunmasi hakkinda daha fazla bilgi"
+    },
+    "intro": {
+      "proofMode": "Bu videonun gercekligi Proofmode teknolojisiyle dogrulandi.",
+      "aiHumanDivine": "Bu video Divine uzerinde barindiriliyor ve AI tespiti, ProofMode verisi olmamasina ragmen muhtemelen insan yapimi oldugunu gosteriyor.",
+      "aiHuman": "AI tespiti, ProofMode verisi olmamasina ragmen bu videonun muhtemelen insan yapimi oldugunu gosteriyor.",
+      "unverifiedDivine": "Bu video dogrulanmadi. Divine uzerinde barindiriliyor, ama henuz ProofMode verisi yok.",
+      "unverifiedExternal": "Bu video dogrulanmadi ve Divine disinda barindiriliyor. ProofMode verisi icermiyor."
+    },
+    "summary": {
+      "platinum": "Platin: Cihaz donanim onayi, kriptografik imzalar, Content Credentials (C2PA) ve AI taramasi insan kaynagini dogruluyor.",
+      "gold": "Altin: Gercek bir cihazda donanim onayi, kriptografik imzalar ve Content Credentials (C2PA) ile cekildi.",
+      "silverProof": "Gumus: Kriptografik imzalar bu videonun kayittan beri degistirilmedigini kanitliyor.",
+      "bronze": "Bronz: Temel meta veri imzalari mevcut.",
+      "silverAi": "Gumus: AI taramasi bu videonun muhtemelen bir insan tarafindan olusturuldugunu dogruluyor.",
+      "muted": "Bu video icin dogrulama verisi yok."
+    },
+    "checklist": {
+      "deviceAttestation": "Cihaz onayi",
+      "pgpSignature": "PGP imzasi",
+      "c2paContentCredentials": "C2PA Content Credentials",
+      "proofManifest": "Kanit manifestosu"
+    }
   }
 }

--- a/src/lib/i18n/locales/tr/common.json
+++ b/src/lib/i18n/locales/tr/common.json
@@ -44,19 +44,19 @@
     "yourFeed": "Akisin"
   },
   "auth": {
-    "logInOnDivine": "Divine'da giris yap"
+    "logInOnDivine": "Atla iceri"
   },
   "home": {
-    "welcomeTitle": "Ana akisina hos geldin",
-    "welcomeSubtitle": "Takip ettigin kisilerin videolarini gormek icin giris yap",
+    "welcomeTitle": "Senin akisin, senin kurallarin.",
+    "welcomeSubtitle": "Takip ettigin kisilerin loop'larini gormek icin giris yap.",
     "title": "Ana sayfa",
-    "subtitle": "Takip ettigin kisilerin videolari",
+    "subtitle": "Takip ettigin kisilerin loop'lari.",
     "sortBy": "Siralama:",
     "updating": "Guncelleniyor..."
   },
   "discovery": {
     "title": "Kesfet",
-    "subtitle": "Agdaki videolari kesfet",
+    "subtitle": "Agda dolas. Kendi insanlarini bul.",
     "categories": "Kategoriler",
     "forYou": "Senin icin",
     "classic": "Klasik",
@@ -82,14 +82,14 @@
   },
   "comments": {
     "title": "Yorumlar",
-    "noCommentsYet": "Henuz yorum yok",
-    "beFirstToShare": "Dusuncelerini ilk paylasan sen ol",
-    "failedToLoad": "Yorumlar yuklenemedi",
-    "writeAComment": "Bir yorum yaz...",
+    "noCommentsYet": "Henuz soylenecek bir sey yok.",
+    "beFirstToShare": "Sen baslat — bir yorum birak.",
+    "failedToLoad": "Yorumlar yuklenemedi.",
+    "writeAComment": "Bir sey soyle...",
     "signInToReply": "Yanıt vermek icin giris yap",
     "signInToComment": "Yorum yapmak icin giris yap",
     "replyingToComment": "Yoruma yanıt veriliyor",
-    "addingToDiscussion": "Tartismaya ekleniyor",
+    "addingToDiscussion": "Konuya atliyorsun",
     "posting": "Gonderiliyor...",
     "reply": "Yanıtla",
     "comment": "Yorum yap"
@@ -97,46 +97,46 @@
   "messages": {
     "badge": "Mesajlar",
     "title": "Dogrudan mesajlar",
-    "subtitle": "Destekle konus, vine'lari ozel olarak gonder veya takip ettigin kisilerle konusmayi surdur.",
-    "searchPlaceholder": "Mesaj gonderecek kisi bul",
+    "subtitle": "Destekle konus, bir loop'u ozel olarak gonder veya takip ettigin kisilerle sohbeti surdur.",
+    "searchPlaceholder": "Mesaj gonderecek birini bul",
     "newMessage": "Yeni mesaj",
-    "readyToShare": "Ozel olarak paylasmaya hazir.",
+    "readyToShare": "Ozel olarak gondermeye hazir.",
     "shareWithTitle": "Bir sonraki mesajin “{{title}}” icerecek.",
     "shareWithLink": "Bir sonraki mesajin bir vine baglantisi icerecek.",
-    "signerUnsupported": "Mevcut imzalayicin giris yapmana izin veriyor, ancak henuz NIP-44 sifrelemesini desteklemiyor. Web'de dogrudan mesaj kullanmak icin NIP-44 destekleyen bir nsec, bunker veya baska bir imzalayiciya gec.",
+    "signerUnsupported": "Mevcut imzalayicin giris yapmana izin veriyor, ancak henuz NIP-44 konusmuyor. Burada DM kullanmak icin NIP-44 destekleyen bir nsec, bunker veya baska bir imzalayiciya gec.",
     "supportBadge": "Destek",
-    "supportSummary": "Hatalar, moderasyon veya hesap sorunlari hakkinda sor."
+    "supportSummary": "Hatalar, moderasyon, hesap meseleleri — dinliyoruz."
   },
   "support": {
     "title": "Destek",
-    "subtitle": "Yardima mi ihtiyacin var? Yardim etmek icin buradayiz.",
-    "helpCenterTitle": "Divine Yardim Merkezini ziyaret et",
-    "helpCenterDescription": "Divine hakkindaki sorularina yanit bul.",
+    "subtitle": "Yardim mi lazim? Sirtin yere gelmez.",
+    "helpCenterTitle": "Divine Yardim Merkezi",
+    "helpCenterDescription": "Sik sorulan seylerin yanitlari.",
     "helpCenterCta": "Yardim merkezini ziyaret et",
     "messageSupportTitle": "Destege mesaj gonder",
-    "messageSupportDescription": "Ozel NIP-17 mesajlariyla Divine icindeki destek kutusuna dogrudan ulas.",
+    "messageSupportDescription": "Divine icinden bize direkt DM at — NIP-17 ile sifreli.",
     "messageSupportCta": "Destek sohbetini ac",
     "contactTitle": "Destekle iletisime gec",
-    "contactDescription": "Bir destek talebi olustur, en kisa surede geri donelim.",
+    "contactDescription": "Bir destek talebi olustur, en hizli sekilde donus yapalim.",
     "contactLink": "Destekle iletisime gec",
     "githubTitle": "GitHub sorunlari",
-    "githubDescription": "Hata bildir, ozellik iste veya GitHub depolarimizdaki mevcut sorunlari incele.",
+    "githubDescription": "Hata bildir, ozellik iste veya GitHub'imizda sage sola bak.",
     "webAppLabel": "Web uygulamasi:",
     "flutterAppLabel": "Flutter uygulamasi (iOS/Android):",
     "communityTitle": "Topluluk",
-    "communityDescription": "Topluluk tartismalarimiza katil ve Nostr uzerindeki diger Divine kullanicilariyla baglan.",
-    "communityBody": "Divine, merkezi olmayan bir sosyal protokol olan Nostr uzerine kuruludur. Bizi sevdigin Nostr istemcisinde bul."
+    "communityDescription": "Nostr'daki Divine toplulugunda takil.",
+    "communityBody": "Divine, merkezi olmayan sosyal protokol Nostr uzerinde calisir. Bizi sevdigin Nostr istemcisinde bul."
   },
   "tagPage": {
-    "notFoundTitle": "Etiket bulunamadi",
-    "notFoundDescription": "Istenen etiket bulunamadi.",
+    "notFoundTitle": "Etiket bulunamadi.",
+    "notFoundDescription": "Bu etiketi bulamadik.",
     "back": "Geri",
-    "subtitle": "#{{tag}} etiketiyle isaretlenmis videolari kesfet"
+    "subtitle": "#{{tag}} etiketli loop'lar"
   },
   "categoriesPage": {
     "title": "Kategoriler",
-    "subtitle": "Videolari konuya gore kesfet",
-    "emptyState": "Su anda hic kategori yok.",
+    "subtitle": "Loop'lar, vibe'a gore siralandi.",
+    "emptyState": "Su an firinda kategori yok.",
     "metaTitle": "Kategorilere goz at - Divine",
     "metaDescription": "Divine uzerinde komedi, muzik, dans, hayvanlar, spor, yemek ve daha fazlasini kesfet.",
     "videoCount_one": "{{count}} video",

--- a/src/lib/i18n/locales/tr/common.json
+++ b/src/lib/i18n/locales/tr/common.json
@@ -195,5 +195,34 @@
     "heading": "Klasik Vinerlar",
     "archivedBadge": "Arsivlenmis",
     "archivedTooltip": "Internet Archive tarafindan korunan orijinal Vine arsivi"
+  },
+  "profile": {
+    "stats": {
+      "videos": "Videolar",
+      "followers": "Takipci",
+      "following": "Takip",
+      "divineLoops": "Divine Loop"
+    },
+    "editProfile": "Profili duzenle"
+  },
+  "accountMenu": {
+    "myProfile": "Profilim",
+    "settings": "Ayarlar",
+    "linkedAccounts": "Bagli hesaplar",
+    "switchRelay": "Relay degistir",
+    "switchAccount": "Hesap degistir",
+    "addAccount": "Baska bir hesap ekle",
+    "logOut": "Cikis yap"
+  },
+  "trending": {
+    "title": "Gundemde",
+    "subtitle": "Toplulukta neler donuyor bir bak"
+  },
+  "searchTabs": {
+    "all": "Hepsi",
+    "videos": "Videolar",
+    "users": "Insanlar",
+    "hashtags": "Etiketler",
+    "searching": "Aranıyor..."
   }
 }

--- a/src/lib/videoVerification.ts
+++ b/src/lib/videoVerification.ts
@@ -154,83 +154,83 @@ export function resolveVideoVerificationBadge(
   return { kind: 'not_divine_hosted' };
 }
 
-export function getVerificationIntroText(
+export type VerificationIntroKey =
+  | 'verification.intro.proofMode'
+  | 'verification.intro.aiHumanDivine'
+  | 'verification.intro.aiHuman'
+  | 'verification.intro.unverifiedDivine'
+  | 'verification.intro.unverifiedExternal';
+
+export function getVerificationIntroKey(
   video: Pick<VerificationVideo, 'proofMode' | 'videoUrl'>,
   aiResult?: AIDetectionResult | null,
-): string {
+): VerificationIntroKey {
   if (hasProofMode(video.proofMode)) {
-    return "This video's authenticity is verified using Proofmode technology.";
+    return 'verification.intro.proofMode';
   }
 
   if (aiResult != null && aiResult.score < 0.5) {
-    if (isDivineHostedVideo(video.videoUrl)) {
-      return 'This video is hosted on Divine and AI detection indicates it is likely human-made, even though no ProofMode verification data is attached.';
-    }
-
-    return 'AI detection indicates this video is likely human-made, though no ProofMode verification data is attached.';
+    return isDivineHostedVideo(video.videoUrl)
+      ? 'verification.intro.aiHumanDivine'
+      : 'verification.intro.aiHuman';
   }
 
-  if (isDivineHostedVideo(video.videoUrl)) {
-    return 'This video is unverified. It is hosted on Divine, but no ProofMode verification data is attached yet.';
-  }
-
-  return 'This video is unverified and hosted outside Divine. It does not include ProofMode verification data.';
+  return isDivineHostedVideo(video.videoUrl)
+    ? 'verification.intro.unverifiedDivine'
+    : 'verification.intro.unverifiedExternal';
 }
 
-export function getVerificationDescription(
+export type VerificationSummaryTone = 'platinum' | 'gold' | 'silver' | 'bronze' | 'muted';
+export type VerificationSummaryKey =
+  | 'verification.summary.platinum'
+  | 'verification.summary.gold'
+  | 'verification.summary.silverProof'
+  | 'verification.summary.bronze'
+  | 'verification.summary.silverAi'
+  | 'verification.summary.muted';
+
+export function getVerificationSummary(
   video: Pick<VerificationVideo, 'proofMode'>,
   aiResult?: AIDetectionResult | null,
-): { tone: 'platinum' | 'gold' | 'silver' | 'bronze' | 'muted'; text: string } {
+): { tone: VerificationSummaryTone; key: VerificationSummaryKey } {
   const baseLevel = getBaseProofLevel(video.proofMode);
   const hasHumanAIScan = aiResult != null && aiResult.score < 0.5;
 
   if (baseLevel === 'verified_mobile' && hasHumanAIScan) {
-    return {
-      tone: 'platinum',
-      text: 'Platinum: Device hardware attestation, cryptographic signatures, Content Credentials (C2PA), and AI scan confirms human origin.',
-    };
+    return { tone: 'platinum', key: 'verification.summary.platinum' };
   }
 
   if (baseLevel === 'verified_mobile') {
-    return {
-      tone: 'gold',
-      text: 'Gold: Captured on a real device with hardware attestation, cryptographic signatures, and Content Credentials (C2PA).',
-    };
+    return { tone: 'gold', key: 'verification.summary.gold' };
   }
 
   if (baseLevel === 'verified_web') {
-    return {
-      tone: 'silver',
-      text: "Silver: Cryptographic signatures prove this video hasn't been altered since recording.",
-    };
+    return { tone: 'silver', key: 'verification.summary.silverProof' };
   }
 
   if (baseLevel === 'basic_proof') {
-    return {
-      tone: 'bronze',
-      text: 'Bronze: Basic metadata signatures are present.',
-    };
+    return { tone: 'bronze', key: 'verification.summary.bronze' };
   }
 
   if (hasHumanAIScan) {
-    return {
-      tone: 'silver',
-      text: 'Silver: AI scan confirms this video is likely human-created.',
-    };
+    return { tone: 'silver', key: 'verification.summary.silverAi' };
   }
 
-  return {
-    tone: 'muted',
-    text: 'No verification data available for this video.',
-  };
+  return { tone: 'muted', key: 'verification.summary.muted' };
 }
 
-export function getProofChecklist(proofMode?: ProofModeData): Array<{ label: string; passed: boolean }> {
+export type ProofChecklistKey =
+  | 'verification.checklist.deviceAttestation'
+  | 'verification.checklist.pgpSignature'
+  | 'verification.checklist.c2paContentCredentials'
+  | 'verification.checklist.proofManifest';
+
+export function getProofChecklist(proofMode?: ProofModeData): Array<{ key: ProofChecklistKey; passed: boolean }> {
   return [
-    { label: 'Device attestation', passed: !!proofMode?.deviceAttestation },
-    { label: 'PGP signature', passed: !!proofMode?.pgpFingerprint },
-    { label: 'C2PA Content Credentials', passed: !!proofMode?.c2paManifestId },
-    { label: 'Proof manifest', passed: !!proofMode?.manifest },
+    { key: 'verification.checklist.deviceAttestation', passed: !!proofMode?.deviceAttestation },
+    { key: 'verification.checklist.pgpSignature', passed: !!proofMode?.pgpFingerprint },
+    { key: 'verification.checklist.c2paContentCredentials', passed: !!proofMode?.c2paManifestId },
+    { key: 'verification.checklist.proofManifest', passed: !!proofMode?.manifest },
   ];
 }
 

--- a/src/pages/CategoriesIndexPage.test.tsx
+++ b/src/pages/CategoriesIndexPage.test.tsx
@@ -53,8 +53,8 @@ describe('CategoriesIndexPage', () => {
     );
 
     expect(screen.getByRole('heading', { name: 'Categorias' })).toBeInTheDocument();
-    expect(screen.getByText('Explora videos por tema')).toBeInTheDocument();
-    expect(screen.getByText('No hay categorias disponibles en este momento.')).toBeInTheDocument();
+    expect(screen.getByText('Loops, ordenados por vibe.')).toBeInTheDocument();
+    expect(screen.getByText('No hay categorias en marcha ahora mismo.')).toBeInTheDocument();
   });
 
   it('renders translated category labels from the shared category map', () => {

--- a/src/pages/DiscoveryPage.test.tsx
+++ b/src/pages/DiscoveryPage.test.tsx
@@ -80,7 +80,7 @@ describe('DiscoveryPage', () => {
     );
 
     expect(screen.getByRole('heading', { name: 'Descubrir' })).toBeInTheDocument();
-    expect(screen.getByText('Explora videos de la red')).toBeInTheDocument();
+    expect(screen.getByText('Recorre la red. Encuentra a tu gente.')).toBeInTheDocument();
     expect(screen.getByText('Clasico')).toBeInTheDocument();
     expect(screen.getByText('Musica')).toBeInTheDocument();
   });

--- a/src/pages/HomePage.test.tsx
+++ b/src/pages/HomePage.test.tsx
@@ -45,7 +45,7 @@ describe('HomePage', () => {
   it('renders the logged-out home prompt in the active locale', () => {
     render(<HomePage />);
 
-    expect(screen.getByRole('heading', { name: 'Bienvenido a tu feed principal' })).toBeInTheDocument();
-    expect(screen.getByText('Inicia sesion para ver videos de las personas que sigues')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Tu feed, tus reglas.' })).toBeInTheDocument();
+    expect(screen.getByText('Inicia sesion para ver loops de la gente que sigues.')).toBeInTheDocument();
   });
 });

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -2,6 +2,7 @@
 // ABOUTME: Supports searching videos, users, hashtags with NIP-50 full-text search
 
 import { useState, useEffect, useRef, useMemo, type ClipboardEvent } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useSearchParams } from 'react-router-dom';
 import { useNostr } from '@nostrify/react';
 import { useSubdomainNavigate } from '@/hooks/useSubdomainNavigate';
@@ -42,6 +43,7 @@ import {
 type SearchFilter = 'all' | 'videos' | 'users' | 'hashtags';
 
 export function SearchPage() {
+  const { t } = useTranslation();
   const [searchParams, setSearchParams] = useSearchParams();
   const { nostr } = useNostr();
   const navigate = useSubdomainNavigate();
@@ -376,19 +378,19 @@ export function SearchPage() {
           <TabsList className="grid w-full max-w-md mx-auto grid-cols-4 mb-6">
             <TabsTrigger value="all" className="gap-2">
               <Search className="h-4 w-4 flex-shrink-0" />
-              <span className="hidden sm:inline">All</span>
+              <span className="hidden sm:inline">{t('searchTabs.all')}</span>
             </TabsTrigger>
             <TabsTrigger value="videos" className="gap-2">
               <Video className="h-4 w-4 flex-shrink-0" />
-              <span className="hidden sm:inline">Videos</span>
+              <span className="hidden sm:inline">{t('searchTabs.videos')}</span>
             </TabsTrigger>
             <TabsTrigger value="users" className="gap-2">
               <Users className="h-4 w-4 flex-shrink-0" />
-              <span className="hidden sm:inline">Users</span>
+              <span className="hidden sm:inline">{t('searchTabs.users')}</span>
             </TabsTrigger>
             <TabsTrigger value="hashtags" className="gap-2">
               <Hash className="h-4 w-4 flex-shrink-0" />
-              <span className="hidden sm:inline">Hashtags</span>
+              <span className="hidden sm:inline">{t('searchTabs.hashtags')}</span>
             </TabsTrigger>
           </TabsList>
 
@@ -396,7 +398,7 @@ export function SearchPage() {
           {searchQuery.trim() && (
             <div className="text-center mb-4">
               {isLoading ? (
-                <p className="text-muted-foreground">Searching...</p>
+                <p className="text-muted-foreground">{t('searchTabs.searching')}</p>
               ) : error ? (
                 <p className="text-destructive">Search error occurred</p>
               ) : getResultsCount() === 0 ? (

--- a/src/pages/Support.test.tsx
+++ b/src/pages/Support.test.tsx
@@ -51,8 +51,8 @@ describe('Support page', () => {
     );
 
     expect(screen.getByRole('heading', { name: 'Soporte' })).toBeInTheDocument();
-    expect(screen.getByText('Necesitas ayuda? Estamos aqui para ayudarte.')).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'Visitar el centro de ayuda de Divine' })).toBeInTheDocument();
+    expect(screen.getByText('Necesitas una mano? Te tenemos.')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Centro de ayuda Divine' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Contactar con soporte' })).toBeInTheDocument();
   });
 });

--- a/src/pages/TagPage.test.tsx
+++ b/src/pages/TagPage.test.tsx
@@ -36,8 +36,8 @@ describe('TagPage', () => {
       </MemoryRouter>,
     );
 
-    expect(screen.getByRole('heading', { name: 'Etiqueta no encontrada' })).toBeInTheDocument();
-    expect(screen.getByText('No se pudo encontrar la etiqueta solicitada.')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Etiqueta no encontrada.' })).toBeInTheDocument();
+    expect(screen.getByText('No encontramos esa etiqueta.')).toBeInTheDocument();
   });
 
   it('renders the tag header copy in spanish', () => {
@@ -50,6 +50,6 @@ describe('TagPage', () => {
     );
 
     expect(screen.getByRole('button', { name: 'Atras' })).toBeInTheDocument();
-    expect(screen.getByText('Explora videos etiquetados con #funny')).toBeInTheDocument();
+    expect(screen.getByText('Loops etiquetados con #funny')).toBeInTheDocument();
   });
 });

--- a/src/pages/TrendingPage.tsx
+++ b/src/pages/TrendingPage.tsx
@@ -2,6 +2,7 @@
 // ABOUTME: Supports NIP-50 search modes: hot, top, rising, controversial
 
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Rss } from '@phosphor-icons/react';
 import { useHead } from '@unhead/react';
 import { VideoFeed } from '@/components/VideoFeed';
@@ -11,6 +12,7 @@ import type { SortMode } from '@/types/nostr';
 import { EXTENDED_SORT_MODES as SORT_MODES } from '@/lib/constants/sortModes';
 
 export function TrendingPage() {
+  const { t } = useTranslation();
   const [sortMode, setSortMode] = useState<SortMode>('hot');
 
   // RSS auto-discovery link for feed readers (only if feed endpoints exist)
@@ -32,9 +34,9 @@ export function TrendingPage() {
         <header className="mb-6 space-y-4">
           <div className="flex items-center justify-between">
             <div>
-              <h1 className="text-2xl font-bold">Trending</h1>
+              <h1 className="text-2xl font-bold">{t('trending.title')}</h1>
               <p className="text-muted-foreground">
-                Discover what's popular in the community
+                {t('trending.subtitle')}
               </p>
             </div>
             {rssFeedAvailable && (


### PR DESCRIPTION
## Summary

PR #253 (Phase 4 microcopy rewrite) intentionally only updated `en/common.json` and flagged "Non-English locales are now stale" as a follow-up. This PR addresses that follow-up.

The same 28 EN keys touched by #253 are now ported to all 14 non-EN locales — adapted per language so each reads native, not literal:

- `ar, de, es, fr, id, it, ja, ko, nl, pl, pt, ro, sv, tr`

### Voice translation, not literal

Each language's playful equivalents were chosen to capture the Divine voice:

| EN | DE | ES | FR | JA |
|---|---|---|---|---|
| "Jump in" | "Rein da" | "Entra ya" | "On y va" | "とびこむ" |
| "Your feed, your rules." | "Dein Feed, deine Regeln." | "Tu feed, tus reglas." | "Votre fil, vos regles." | "あなたのフィード、あなたのルール。" |
| "Loops, sorted by vibe." | "Loops, sortiert nach Vibe." | "Loops, ordenados por vibe." | "Loops, ranges par vibe." | "ループ、ノリで仕分け。" |
| "Nothing to say yet." | "Noch nichts zu sagen." | "Nada que decir aun." | "Rien a dire pour l'instant." | "まだ何も語られていません。" |

### What was kept

- Existing per-locale diacritic conventions (most files transliterate; Arabic/CJK keep full marks)
- Existing formality registers (FR `vous`, ID `Anda`, others informal)
- Plural-rule keys for ar/pl/ro (zero/few/many)
- Untouched keys (~75% of each file)

### Test fixes

5 Spanish-locale test files asserted the old EN-translated literal strings; updated to the new copy. No production behavior change.

- `src/pages/HomePage.test.tsx`
- `src/pages/DiscoveryPage.test.tsx`
- `src/pages/CategoriesIndexPage.test.tsx`
- `src/pages/TagPage.test.tsx`
- `src/pages/Support.test.tsx`

## Test plan

- [x] `npx vitest run` — **560 passed, 0 failed**
- [x] `npx tsc -p tsconfig.app.json --noEmit` — clean
- [x] `npm run build` — succeeds
- [x] JSON validity verified for all 14 locales
- [x] Key parity verified: no missing keys vs `en/common.json`
- [ ] Manual QA: switch language to each locale and skim home, discovery, comments, support, tag/category empty states

## Stack

Stacks on `feature/brand-refresh-phase4` (PR #253). Merge after #253.

## What's not covered

- Other Phase 4 territories that touched component literals (toasts, EditProfileForm placeholders, etc.) are not internationalized — they live as English literals in components. Out of scope for this follow-up; would need a separate i18n-extraction pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)