### PR TITLE
Fix notifications NIP-98 auth

### DIFF
--- a/src/config/api.test.ts
+++ b/src/config/api.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   clearFunnelcakeApiModeOverride,
   getFunnelcakeApiModeOverride,
+  resolveNotificationsBaseUrl,
   resolveFunnelcakeBaseUrl,
   setFunnelcakeApiModeOverride,
 } from './api';
@@ -62,6 +63,52 @@ describe('resolveFunnelcakeBaseUrl', () => {
       hostname: 'divine.video',
       mode: 'staging',
     })).toBe('https://api.staging.divine.video');
+  });
+});
+
+describe('resolveNotificationsBaseUrl', () => {
+  it('uses the staging relay host in auto mode on staging.divine.video', () => {
+    expect(resolveNotificationsBaseUrl({
+      hostname: 'staging.divine.video',
+      mode: 'auto',
+    })).toBe('https://relay.staging.divine.video');
+  });
+
+  it('uses the production relay host in auto mode on divine.video', () => {
+    expect(resolveNotificationsBaseUrl({
+      hostname: 'divine.video',
+      mode: 'auto',
+    })).toBe('https://relay.divine.video');
+  });
+
+  it('maps the production Funnelcake API host to the relay host for unknown hosts', () => {
+    expect(resolveNotificationsBaseUrl({
+      hostname: 'preview.divine-web.pages.dev',
+      mode: 'auto',
+      envBaseUrl: 'https://api.divine.video',
+    })).toBe('https://relay.divine.video');
+  });
+
+  it('preserves custom environment hosts for unknown hosts', () => {
+    expect(resolveNotificationsBaseUrl({
+      hostname: 'localhost',
+      mode: 'auto',
+      envBaseUrl: 'https://api.preview.divine.video',
+    })).toBe('https://api.preview.divine.video');
+  });
+
+  it('forces the production relay host when production mode is selected', () => {
+    expect(resolveNotificationsBaseUrl({
+      hostname: 'staging.divine.video',
+      mode: 'production',
+    })).toBe('https://relay.divine.video');
+  });
+
+  it('forces the staging relay host when staging mode is selected', () => {
+    expect(resolveNotificationsBaseUrl({
+      hostname: 'divine.video',
+      mode: 'staging',
+    })).toBe('https://relay.staging.divine.video');
   });
 });
 

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -3,6 +3,8 @@
 
 export const FUNNELCAKE_PRODUCTION_API_URL = 'https://api.divine.video';
 export const FUNNELCAKE_STAGING_API_URL = 'https://api.staging.divine.video';
+export const NOTIFICATIONS_PRODUCTION_API_URL = 'https://relay.divine.video';
+export const NOTIFICATIONS_STAGING_API_URL = 'https://relay.staging.divine.video';
 export const FUNNELCAKE_API_MODE_OVERRIDE_KEY = 'divine_dev_funnelcake_api_mode';
 
 export type FunnelcakeApiMode = 'auto' | 'production' | 'staging';
@@ -52,6 +54,29 @@ function resolveAutoFunnelcakeBaseUrl(hostname: string, envBaseUrl?: string): st
   return FUNNELCAKE_PRODUCTION_API_URL;
 }
 
+function mapNotificationsBaseUrl(baseUrl: string): string {
+  switch (baseUrl) {
+    case FUNNELCAKE_PRODUCTION_API_URL:
+      return NOTIFICATIONS_PRODUCTION_API_URL;
+    case FUNNELCAKE_STAGING_API_URL:
+      return NOTIFICATIONS_STAGING_API_URL;
+    default:
+      return baseUrl;
+  }
+}
+
+function resolveAutoNotificationsBaseUrl(hostname: string, envBaseUrl?: string): string {
+  if (hostname === 'staging.divine.video' || hostname.endsWith('.staging.divine.video')) {
+    return NOTIFICATIONS_STAGING_API_URL;
+  }
+
+  if (envBaseUrl && hostname !== 'divine.video' && hostname !== 'www.divine.video') {
+    return mapNotificationsBaseUrl(envBaseUrl);
+  }
+
+  return NOTIFICATIONS_PRODUCTION_API_URL;
+}
+
 export function resolveFunnelcakeBaseUrl(options: ResolveFunnelcakeBaseUrlOptions = {}): string {
   const mode = options.mode ?? 'auto';
   const hostname = options.hostname ?? getCurrentHostname();
@@ -65,6 +90,24 @@ export function resolveFunnelcakeBaseUrl(options: ResolveFunnelcakeBaseUrlOption
     case 'auto':
     default:
       return resolveAutoFunnelcakeBaseUrl(hostname, envBaseUrl);
+  }
+}
+
+export function resolveNotificationsBaseUrl(
+  options: ResolveFunnelcakeBaseUrlOptions = {},
+): string {
+  const mode = options.mode ?? 'auto';
+  const hostname = options.hostname ?? getCurrentHostname();
+  const envBaseUrl = options.envBaseUrl;
+
+  switch (mode) {
+    case 'production':
+      return NOTIFICATIONS_PRODUCTION_API_URL;
+    case 'staging':
+      return NOTIFICATIONS_STAGING_API_URL;
+    case 'auto':
+    default:
+      return resolveAutoNotificationsBaseUrl(hostname, envBaseUrl);
   }
 }
 
@@ -90,6 +133,14 @@ export function clearFunnelcakeApiModeOverride(): void {
 
 export function getFunnelcakeBaseUrl(): string {
   return resolveFunnelcakeBaseUrl({
+    mode: getFunnelcakeApiModeOverride(),
+    hostname: getCurrentHostname(),
+    envBaseUrl: import.meta.env.VITE_FUNNELCAKE_API_URL,
+  });
+}
+
+export function getNotificationsBaseUrl(): string {
+  return resolveNotificationsBaseUrl({
     mode: getFunnelcakeApiModeOverride(),
     hostname: getCurrentHostname(),
     envBaseUrl: import.meta.env.VITE_FUNNELCAKE_API_URL,

--- a/src/hooks/useNotifications.test.ts
+++ b/src/hooks/useNotifications.test.ts
@@ -1,0 +1,88 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useNotifications, useUnreadNotificationCount } from './useNotifications';
+import {
+  fetchNotifications,
+  fetchUnreadCount,
+} from '@/lib/funnelcakeClient';
+
+vi.mock('@/config/api', () => ({
+  getFunnelcakeBaseUrl: vi.fn(() => 'https://api.divine.video'),
+  getNotificationsBaseUrl: vi.fn(() => 'https://relay.divine.video'),
+}));
+
+vi.mock('@/hooks/useCurrentUser', () => ({
+  useCurrentUser: vi.fn(() => ({
+    user: { pubkey: 'a'.repeat(64) },
+    signer: { signEvent: vi.fn() },
+  })),
+}));
+
+vi.mock('@/lib/funnelcakeClient', () => ({
+  fetchNotifications: vi.fn(),
+  fetchUnreadCount: vi.fn(),
+  markNotificationsRead: vi.fn(),
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+  });
+
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+describe('useNotifications', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses the notifications relay base URL for the list query', async () => {
+    vi.mocked(fetchNotifications).mockResolvedValue({
+      notifications: [],
+      unreadCount: 0,
+      hasMore: false,
+    });
+
+    renderHook(() => useNotifications(), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(fetchNotifications).toHaveBeenCalledWith(
+        'https://relay.divine.video',
+        'a'.repeat(64),
+        expect.any(Object),
+        expect.objectContaining({ limit: 30 }),
+      );
+    });
+  });
+
+  it('uses the notifications relay base URL for unread count polling', async () => {
+    vi.mocked(fetchUnreadCount).mockResolvedValue(7);
+
+    const { result } = renderHook(() => useUnreadNotificationCount(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toBe(7);
+    });
+
+    expect(fetchUnreadCount).toHaveBeenCalledWith(
+      'https://relay.divine.video',
+      'a'.repeat(64),
+      expect.any(Object),
+      expect.any(AbortSignal),
+    );
+  });
+});

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -2,7 +2,7 @@
 // ABOUTME: Provides infinite scroll, unread count polling, and mark-as-read
 
 import { useInfiniteQuery, useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { getFunnelcakeBaseUrl } from '@/config/api';
+import { getNotificationsBaseUrl } from '@/config/api';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { fetchNotifications, fetchUnreadCount, markNotificationsRead } from '@/lib/funnelcakeClient';
 import { debugLog } from '@/lib/debug';
@@ -17,7 +17,7 @@ const NOTIFICATIONS_PAGE_SIZE = 30;
 export function useNotifications() {
   const { user, signer } = useCurrentUser();
   const pubkey = user?.pubkey;
-  const apiUrl = getFunnelcakeBaseUrl();
+  const apiUrl = getNotificationsBaseUrl();
 
   return useInfiniteQuery<NotificationsResponse, Error>({
     queryKey: ['notifications', pubkey],
@@ -58,7 +58,7 @@ export function useNotifications() {
 export function useUnreadNotificationCount() {
   const { user, signer } = useCurrentUser();
   const pubkey = user?.pubkey;
-  const apiUrl = getFunnelcakeBaseUrl();
+  const apiUrl = getNotificationsBaseUrl();
 
   return useQuery<number, Error>({
     queryKey: ['notifications-unread-count', pubkey],
@@ -86,7 +86,7 @@ export function useUnreadNotificationCount() {
 export function useMarkNotificationsRead() {
   const { user, signer } = useCurrentUser();
   const pubkey = user?.pubkey;
-  const apiUrl = getFunnelcakeBaseUrl();
+  const apiUrl = getNotificationsBaseUrl();
   const queryClient = useQueryClient();
 
   return useMutation({

--- a/src/lib/funnelcakeClient.test.ts
+++ b/src/lib/funnelcakeClient.test.ts
@@ -2,6 +2,8 @@
 // ABOUTME: Tests HTTP communication layer in isolation from hooks and transforms
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { NostrSigner } from '@nostrify/nostrify';
+import { createNip98AuthHeader } from './nip98Auth';
 
 // We need to mock the health module before importing the client
 vi.mock('./funnelcakeHealth', () => ({
@@ -15,8 +17,13 @@ vi.mock('./debug', () => ({
   debugError: vi.fn(),
 }));
 
+vi.mock('./nip98Auth', () => ({
+  createNip98AuthHeader: vi.fn(),
+}));
+
 const API_URL = 'https://api.divine.video';
 const TEST_PUBKEY = 'a'.repeat(64);
+const TEST_SIGNER = { signEvent: vi.fn() } as unknown as NostrSigner;
 
 describe('funnelcakeClient', () => {
   let fetchUserProfile: typeof import('./funnelcakeClient').fetchUserProfile;
@@ -24,11 +31,13 @@ describe('funnelcakeClient', () => {
   let fetchBulkVideoStats: typeof import('./funnelcakeClient').fetchBulkVideoStats;
   let searchProfiles: typeof import('./funnelcakeClient').searchProfiles;
   let fetchRecommendations: typeof import('./funnelcakeClient').fetchRecommendations;
+  let markNotificationsRead: typeof import('./funnelcakeClient').markNotificationsRead;
 
   beforeEach(async () => {
     vi.resetModules();
     // Mock fetch globally
     global.fetch = vi.fn();
+    vi.mocked(createNip98AuthHeader).mockReset().mockResolvedValue('Nostr signed-auth');
 
     // Import after mocking
     const client = await import('./funnelcakeClient');
@@ -37,6 +46,7 @@ describe('funnelcakeClient', () => {
     fetchBulkVideoStats = client.fetchBulkVideoStats;
     searchProfiles = client.searchProfiles;
     fetchRecommendations = client.fetchRecommendations;
+    markNotificationsRead = client.markNotificationsRead;
   });
 
   afterEach(() => {
@@ -324,6 +334,44 @@ describe('funnelcakeClient', () => {
 
       expect(result.stats).toEqual([]);
       expect(result.missing).toContain(eventIds[0]);
+    });
+  });
+
+  describe('notification auth requests', () => {
+    it('signs mark-as-read requests with the exact serialized JSON body', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ success: true, marked_count: 1 }),
+      });
+
+      const result = await markNotificationsRead(
+        API_URL,
+        TEST_PUBKEY,
+        TEST_SIGNER,
+        ['event-1'],
+      );
+
+      expect(result).toEqual({ success: true, markedCount: 1 });
+
+      const expectedBody = JSON.stringify({ notification_ids: ['event-1'] });
+      expect(createNip98AuthHeader).toHaveBeenCalledWith(
+        TEST_SIGNER,
+        `${API_URL}/api/users/${TEST_PUBKEY}/notifications/read`,
+        'POST',
+        expectedBody,
+      );
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${API_URL}/api/users/${TEST_PUBKEY}/notifications/read`,
+        expect.objectContaining({
+          method: 'POST',
+          body: expectedBody,
+          headers: expect.objectContaining({
+            'Authorization': 'Nostr signed-auth',
+            'Content-Type': 'application/json',
+          }),
+        }),
+      );
     });
   });
 

--- a/src/lib/funnelcakeClient.ts
+++ b/src/lib/funnelcakeClient.ts
@@ -1151,8 +1151,9 @@ async function authenticatedNotificationRequest<T>(
   const { method = 'GET', params = {}, body, signal } = options;
   const url = buildUrl(apiUrl, endpoint, params);
   const timeout = API_CONFIG.funnelcake.timeout;
+  const serializedBody = body === undefined ? undefined : JSON.stringify(body);
 
-  const authHeader = await createNip98AuthHeader(signer, url, method);
+  const authHeader = await createNip98AuthHeader(signer, url, method, serializedBody);
   if (!authHeader) {
     throw new FunnelcakeApiError('Failed to create NIP-98 auth header', null);
   }
@@ -1168,9 +1169,9 @@ async function authenticatedNotificationRequest<T>(
     headers: {
       'Accept': 'application/json',
       'Authorization': authHeader,
-      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...(serializedBody !== undefined ? { 'Content-Type': 'application/json' } : {}),
     },
-    ...(body ? { body: JSON.stringify(body) } : {}),
+    ...(serializedBody !== undefined ? { body: serializedBody } : {}),
   };
 
   debugLog(`[FunnelcakeClient] Auth request: ${method} ${url}`);

--- a/src/lib/nip98Auth.test.ts
+++ b/src/lib/nip98Auth.test.ts
@@ -1,0 +1,70 @@
+import { createHash } from 'node:crypto';
+import type { NostrSigner } from '@nostrify/nostrify';
+import { describe, expect, it, vi } from 'vitest';
+
+import { createNip98AuthHeader } from './nip98Auth';
+
+const TEST_PUBKEY = 'a'.repeat(64);
+const TEST_ID = 'b'.repeat(64);
+const TEST_SIG = 'c'.repeat(128);
+
+function decodeHeader(header: string) {
+  const encoded = header.replace(/^Nostr /, '');
+  return JSON.parse(Buffer.from(encoded, 'base64').toString('utf8'));
+}
+
+describe('createNip98AuthHeader', () => {
+  it('omits the payload tag for GET requests without a body', async () => {
+    const signer = {
+      signEvent: vi.fn(async (event) => ({
+        ...event,
+        pubkey: TEST_PUBKEY,
+        id: TEST_ID,
+        sig: TEST_SIG,
+      })),
+    } as unknown as NostrSigner;
+
+    const header = await createNip98AuthHeader(
+      signer,
+      'https://relay.divine.video/api/users/pubkey/notifications?limit=1',
+      'GET',
+    );
+
+    expect(header).toBeTruthy();
+
+    const event = decodeHeader(header!);
+    expect(event.tags).toContainEqual([
+      'u',
+      'https://relay.divine.video/api/users/pubkey/notifications?limit=1',
+    ]);
+    expect(event.tags).toContainEqual(['method', 'GET']);
+    expect(event.tags.some((tag: string[]) => tag[0] === 'payload')).toBe(false);
+  });
+
+  it('includes a payload hash for POST requests with a body', async () => {
+    const signer = {
+      signEvent: vi.fn(async (event) => ({
+        ...event,
+        pubkey: TEST_PUBKEY,
+        id: TEST_ID,
+        sig: TEST_SIG,
+      })),
+    } as unknown as NostrSigner;
+    const body = JSON.stringify({ notification_ids: ['event-1'] });
+
+    const header = await createNip98AuthHeader(
+      signer,
+      'https://relay.divine.video/api/users/pubkey/notifications/read',
+      'POST',
+      body,
+    );
+
+    expect(header).toBeTruthy();
+
+    const event = decodeHeader(header!);
+    expect(event.tags).toContainEqual([
+      'payload',
+      createHash('sha256').update(body).digest('hex'),
+    ]);
+  });
+});

--- a/src/lib/nip98Auth.ts
+++ b/src/lib/nip98Auth.ts
@@ -1,33 +1,65 @@
 // ABOUTME: Shared NIP-98 HTTP authentication utility
 // ABOUTME: Creates signed authorization headers for authenticated API calls
 
-import { NIP98 } from '@nostrify/nostrify';
 import type { NostrSigner } from '@nostrify/nostrify';
 import { debugLog, debugError } from './debug';
+
+const METHODS_WITH_PAYLOAD = new Set(['POST', 'PUT', 'PATCH']);
+
+function normalizeUrl(url: string): string {
+  const fragmentIndex = url.indexOf('#');
+  return fragmentIndex === -1 ? url : url.slice(0, fragmentIndex);
+}
+
+async function sha256Hex(body: string): Promise<string> {
+  const bytes = new TextEncoder().encode(body);
+  const digest = await crypto.subtle.digest('SHA-256', bytes);
+
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
 
 /**
  * Create a NIP-98 authorization header for an authenticated HTTP request.
  *
- * Signs a kind 27235 event with the target URL and method, then base64-encodes
- * it for use as `Authorization: Nostr <base64>`.
+ * Signs a kind 27235 event with the target URL, method, and optional payload
+ * hash, then base64-encodes it for use as `Authorization: Nostr <base64>`.
  *
  * @param signer - Nostr signer capable of signing events
  * @param url - The full URL being requested
  * @param method - HTTP method (GET, POST, etc.)
+ * @param body - Exact serialized request body, when present
  * @returns The full Authorization header value, or null on failure
  */
 export async function createNip98AuthHeader(
   signer: NostrSigner,
   url: string,
   method: string = 'GET',
+  body?: string,
 ): Promise<string | null> {
   try {
-    const request = new Request(url, { method });
-    const template = await NIP98.template(request);
+    const normalizedMethod = method.toUpperCase();
+    const normalizedUrl = normalizeUrl(url);
+    const tags: string[][] = [
+      ['u', normalizedUrl],
+      ['method', normalizedMethod],
+    ];
+
+    if (body !== undefined && METHODS_WITH_PAYLOAD.has(normalizedMethod)) {
+      tags.push(['payload', await sha256Hex(body)]);
+    }
+
+    const template = {
+      kind: 27235,
+      content: '',
+      tags,
+      created_at: Math.floor(Date.now() / 1000),
+    };
     const signedEvent = await signer.signEvent(template);
     const encoded = btoa(JSON.stringify(signedEvent));
 
-    debugLog(`[nip98Auth] Created auth header for ${method} ${url}`);
+    debugLog(`[nip98Auth] Created auth header for ${normalizedMethod} ${normalizedUrl}`);
     return `Nostr ${encoded}`;
   } catch (error) {
     debugError('[nip98Auth] Failed to generate auth header:', error);


### PR DESCRIPTION
## Summary
- route notifications to the relay-backed host instead of the cached Funnelcake API host so signed NIP-98 URLs match backend verification
- include the exact serialized JSON body in notification POST auth headers so mark-as-read requests sign the required payload hash
- add regression coverage for notification base URL resolution, hook wiring, and NIP-98 payload signing

## Test Plan
- [x] npm run test