### PR TITLE
fix: replace dead relay.nostr.band with working relays

### DIFF
--- a/docs/relay-configuration-refactor.md
+++ b/docs/relay-configuration-refactor.md
@@ -93,14 +93,19 @@ Used for kind 0 (profile) and kind 3 (contact lists):
 - wss://relay.primal.net
 
 ### Search Relay
-- **wss://relay.nostr.band** - NIP-50 search with large profile index
+- **wss://relay.divine.video** - NIP-50 search via Divine infrastructure
+
+### NIP-05 Search Relays
+Fanned out in parallel when resolving a subdomain's NIP-05:
+- wss://relay.primal.net
+- wss://relay.damus.io
+- wss://purplepag.es
 
 ### UI Preset Relays
 Available in relay picker:
 - wss://relay.divine.video (Divine)
 - wss://divine.diy (divine.diy)
 - wss://relay.ditto.pub (Ditto)
-- wss://relay.nostr.band (Nostr.Band)
 - wss://relay.damus.io (Damus)
 - wss://relay.primal.net (Primal)
 

--- a/public/embed-viewer.js
+++ b/public/embed-viewer.js
@@ -57,7 +57,7 @@
         'wss://relay.divine.video',
         'wss://relay.damus.io',
         'wss://nos.lol',
-        'wss://relay.nostr.band',
+        'wss://relay.primal.net',
         'wss://cache2.primal.net/v1'
     ];
     const RELAY_TIMEOUT = 8000;

--- a/src/config/relays.ts
+++ b/src/config/relays.ts
@@ -31,15 +31,40 @@ export const PRIMARY_RELAY: RelayConfig = {
 
 /**
  * Relay optimized for user search (NIP-50)
- * - Large index of kind 0 (profile) events
- * - Used exclusively for user search functionality
+ * - Used for kind 0 (profile) and general NIP-50 search
  */
 export const SEARCH_RELAY: RelayConfig = {
-  url: 'wss://relay.nostr.band',
-  name: 'Nostr.Band',
-  capabilities: { nip50: true },
+  url: 'wss://relay.divine.video',
+  name: 'Divine',
+  capabilities: { nip50: true, funnelcake: true },
   purpose: 'search',
 };
+
+/**
+ * Relays queried when resolving a subdomain's NIP-05 via NIP-50.
+ * Fanned out in parallel; first profile with a matching NIP-05 wins.
+ * Chosen for broad kind 0 / NIP-05 coverage across public infrastructure.
+ */
+export const NIP05_SEARCH_RELAYS: RelayConfig[] = [
+  {
+    url: 'wss://relay.primal.net',
+    name: 'Primal',
+    capabilities: { nip50: true, nip05: true },
+    purpose: 'search',
+  },
+  {
+    url: 'wss://relay.damus.io',
+    name: 'Damus',
+    capabilities: { nip50: true, nip05: true },
+    purpose: 'search',
+  },
+  {
+    url: 'wss://purplepag.es',
+    name: 'Purple Pages',
+    capabilities: { nip50: true, nip05: true },
+    purpose: 'search',
+  },
+];
 
 /**
  * Relays used for profile metadata (kind 0) and contact lists (kind 3)
@@ -93,11 +118,6 @@ export const PRESET_RELAYS: RelayConfig[] = [
   {
     url: 'wss://relay.ditto.pub',
     name: 'Ditto',
-  },
-  {
-    url: 'wss://relay.nostr.band',
-    name: 'Nostr.Band',
-    capabilities: { nip50: true },
   },
   {
     url: 'wss://relay.damus.io',

--- a/src/hooks/useResolveSubdomainPubkey.test.ts
+++ b/src/hooks/useResolveSubdomainPubkey.test.ts
@@ -28,7 +28,11 @@ vi.mock('@/hooks/useSubdomainUser', () => ({
 
 // Mock relay config
 vi.mock('@/config/relays', () => ({
-  SEARCH_RELAY: { url: 'wss://relay.nostr.band', name: 'Nostr.Band' },
+  NIP05_SEARCH_RELAYS: [
+    { url: 'wss://relay.primal.net', name: 'Primal' },
+    { url: 'wss://relay.damus.io', name: 'Damus' },
+    { url: 'wss://purplepag.es', name: 'Purple Pages' },
+  ],
 }));
 
 function createWrapper() {
@@ -122,7 +126,7 @@ describe('useResolveSubdomainPubkey', () => {
       nip05Stale: true,
     });
 
-    mockQuery.mockResolvedValueOnce([
+    mockQuery.mockResolvedValue([
       {
         pubkey: 'unrelated' + 'c'.repeat(55),
         content: JSON.stringify({ nip05: '_@other.divine.video' }),
@@ -155,7 +159,7 @@ describe('useResolveSubdomainPubkey', () => {
       nip05Stale: true,
     });
 
-    mockQuery.mockResolvedValueOnce([
+    mockQuery.mockResolvedValue([
       {
         pubkey: 'unrelated' + 'c'.repeat(55),
         content: JSON.stringify({ nip05: '_@other.divine.video' }),
@@ -183,7 +187,7 @@ describe('useResolveSubdomainPubkey', () => {
       nip05Stale: true,
     });
 
-    mockQuery.mockRejectedValueOnce(new Error('Relay connection failed'));
+    mockQuery.mockRejectedValue(new Error('Relay connection failed'));
 
     const { result } = renderHook(() => useResolveSubdomainPubkey(), {
       wrapper: createWrapper(),
@@ -206,7 +210,7 @@ describe('useResolveSubdomainPubkey', () => {
       nip05Stale: true,
     });
 
-    mockQuery.mockResolvedValueOnce([
+    mockQuery.mockResolvedValue([
       {
         pubkey: 'bad' + 'd'.repeat(61),
         content: 'not json at all',

--- a/src/hooks/useResolveSubdomainPubkey.ts
+++ b/src/hooks/useResolveSubdomainPubkey.ts
@@ -1,11 +1,11 @@
 // ABOUTME: Resolves the correct pubkey for a subdomain when the KV store mapping is stale
-// ABOUTME: Searches relay.nostr.band via NIP-50 to find the profile whose NIP-05 matches the subdomain
+// ABOUTME: Fans out a NIP-50 search across NIP05_SEARCH_RELAYS to find the profile whose NIP-05 matches the subdomain
 
 import { useQuery } from '@tanstack/react-query';
 import { NRelay1 } from '@nostrify/nostrify';
 import { nip19 } from 'nostr-tools';
 import { getSubdomainUser } from '@/hooks/useSubdomainUser';
-import { SEARCH_RELAY } from '@/config/relays';
+import { NIP05_SEARCH_RELAYS } from '@/config/relays';
 
 interface ResolvedPubkey {
   /** The pubkey to use (either resolved or original fallback) */
@@ -29,39 +29,34 @@ export function isNip05MatchForSubdomain(nip05: string, subdomain: string, apexD
   return lower === `_@${subLower}.${apexDomain}` || lower === `${subLower}@${apexDomain}`;
 }
 
-/**
- * Search for the correct pubkey when the subdomain's KV mapping is stale.
- * Connects to relay.nostr.band, does a NIP-50 search for profiles mentioning
- * the subdomain, and finds the one whose NIP-05 matches.
- */
-async function searchForCorrectPubkey(subdomain: string, apexDomain: string): Promise<string | null> {
-  const searchTerm = `${subdomain}.${apexDomain}`;
+async function searchRelayForMatch(
+  relayUrl: string,
+  subdomain: string,
+  apexDomain: string,
+  searchTerm: string,
+  signal: AbortSignal,
+): Promise<string | null> {
   let relay: NRelay1 | null = null;
-
   try {
-    relay = new NRelay1(SEARCH_RELAY.url);
-
+    relay = new NRelay1(relayUrl);
     const events = await relay.query(
       [{ kinds: [0], search: searchTerm, limit: 20 }],
-      { signal: AbortSignal.timeout(10000) },
+      { signal },
     );
-
     for (const event of events) {
       try {
         const metadata = JSON.parse(event.content);
         if (metadata.nip05 && isNip05MatchForSubdomain(metadata.nip05, subdomain, apexDomain)) {
-          console.log(`[useResolveSubdomainPubkey] Found correct pubkey: ${event.pubkey} via NIP-05: ${metadata.nip05}`);
+          console.log(`[useResolveSubdomainPubkey] Found correct pubkey via ${relayUrl}: ${event.pubkey} (NIP-05: ${metadata.nip05})`);
           return event.pubkey;
         }
       } catch {
         // Skip events with invalid JSON content
       }
     }
-
-    console.log(`[useResolveSubdomainPubkey] No matching NIP-05 found for ${searchTerm}`);
     return null;
   } catch (err) {
-    console.error('[useResolveSubdomainPubkey] Search failed:', err);
+    console.warn(`[useResolveSubdomainPubkey] Relay ${relayUrl} search failed:`, err);
     return null;
   } finally {
     try {
@@ -73,12 +68,37 @@ async function searchForCorrectPubkey(subdomain: string, apexDomain: string): Pr
 }
 
 /**
+ * Search for the correct pubkey when the subdomain's KV mapping is stale.
+ * Fans out a NIP-50 search across NIP05_SEARCH_RELAYS in parallel.
+ * Returns the first profile whose NIP-05 matches the subdomain.
+ */
+async function searchForCorrectPubkey(subdomain: string, apexDomain: string): Promise<string | null> {
+  const searchTerm = `${subdomain}.${apexDomain}`;
+  const signal = AbortSignal.timeout(10000);
+
+  const results = await Promise.allSettled(
+    NIP05_SEARCH_RELAYS.map(r =>
+      searchRelayForMatch(r.url, subdomain, apexDomain, searchTerm, signal),
+    ),
+  );
+
+  for (const result of results) {
+    if (result.status === 'fulfilled' && result.value) {
+      return result.value;
+    }
+  }
+
+  console.log(`[useResolveSubdomainPubkey] No matching NIP-05 found for ${searchTerm}`);
+  return null;
+}
+
+/**
  * Hook to resolve the correct pubkey for a subdomain profile when the
  * edge worker detects a NIP-05 mismatch (stale KV store mapping).
  *
  * When nip05Stale is false, returns the original pubkey immediately with no relay queries.
- * When nip05Stale is true, searches relay.nostr.band for the profile whose NIP-05
- * matches this subdomain, and returns the resolved pubkey.
+ * When nip05Stale is true, fans out a NIP-50 search across NIP05_SEARCH_RELAYS to find
+ * the profile whose NIP-05 matches this subdomain, and returns the resolved pubkey.
  */
 export function useResolveSubdomainPubkey(): ResolvedPubkey {
   const subdomainUser = getSubdomainUser();

--- a/src/lib/relayCapabilities.ts
+++ b/src/lib/relayCapabilities.ts
@@ -75,7 +75,6 @@ export function getOptimisticRelayCapabilities(relayUrl: string): RelayCapabilit
       });
 
     case 'relay.ditto.pub':
-    case 'relay.nostr.band':
     case 'relay.nostr.wine':
     case 'relay.openvine.co':
     case 'relay2.openvine.co':


### PR DESCRIPTION
## Summary
- `relay.nostr.band` is offline — confirmed by 5s TCP timeout on `https://relay.nostr.band`, which was surfacing as WebSocket connection failures in the browser console
- Swap `SEARCH_RELAY` to `wss://relay.divine.video` (already has NIP-50 + Funnelcake capabilities)
- Introduce a dedicated `NIP05_SEARCH_RELAYS` fan-out for subdomain NIP-05 resolution: Primal, Damus, Purple Pages (all verified reachable). `useResolveSubdomainPubkey` now queries all three in parallel with `Promise.allSettled` and returns the first profile whose NIP-05 matches — a single dead relay no longer breaks resolution
- Remove `relay.nostr.band` from the preset picker, `public/embed-viewer.js` relay list, `relayCapabilities.ts` optimistic hints, and `docs/relay-configuration-refactor.md`

## Test plan
- [x] `npx vitest run src/hooks/useResolveSubdomainPubkey.test.ts` — 12/12 pass
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: load a subdomain profile and confirm NIP-05 resolution still works when the KV mapping is stale
- [ ] Manual: verify relay picker no longer lists nostr.band

🤖 Generated with [Claude Code](https://claude.com/claude-code)