### PR TITLE
feat: add notification category tabs

### DIFF
--- a/docs/superpowers/plans/2026-04-17-notifications-categories-read-state.md
+++ b/docs/superpowers/plans/2026-04-17-notifications-categories-read-state.md
@@ -1,0 +1,270 @@
+# Notifications Categories And Read State Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add server-backed notification category tabs, preserve implicit mark-all-read on page open, and keep the first loaded `All` view visually split into `New` and `Earlier`.
+
+**Architecture:** Extend the notification client and hook layer to accept server-side filters, then update the notifications page to drive those filters through tabs and local sectioning state. Keep the backend as the source of truth for unread status, but snapshot the first page’s unread IDs locally so the page can still show what was new when it opened.
+
+**Tech Stack:** React 18, TypeScript, TanStack Query, Vitest, Testing Library, Tailwind, shared `Tabs` UI primitives
+
+---
+
+## File Map
+
+- Modify: `src/types/notification.ts`
+- Modify: `src/lib/funnelcakeClient.ts`
+- Modify: `src/lib/funnelcakeClient.test.ts`
+- Create: `src/hooks/useNotifications.test.ts`
+- Modify: `src/hooks/useNotifications.ts`
+- Create: `src/pages/NotificationsPage.test.tsx`
+- Modify: `src/pages/NotificationsPage.tsx`
+- Modify: `src/pages/ConversationPage.tsx`
+
+## Chunk 1: Filterable Notification Data Layer
+
+### Task 1: Add notification filter types
+
+**Files:**
+- Modify: `src/types/notification.ts`
+- Test: `src/hooks/useNotifications.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+expectTypeOf<NotificationCategory>().toEqualTypeOf<
+  'all' | 'unread' | 'likes' | 'comments' | 'follows' | 'reposts' | 'zaps'
+>();
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vitest run src/hooks/useNotifications.test.ts`
+Expected: FAIL because the notification filter types do not exist yet
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add `NotificationCategory` plus a small filter interface in `src/types/notification.ts` that hook and page code can share.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `vitest run src/hooks/useNotifications.test.ts`
+Expected: PASS for the new type usage
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/types/notification.ts src/hooks/useNotifications.test.ts
+git commit -m "test: add notification filter types"
+```
+
+### Task 2: Forward notification filters to the REST client
+
+**Files:**
+- Modify: `src/lib/funnelcakeClient.ts:1196-1280`
+- Modify: `src/lib/funnelcakeClient.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+it('passes types and unread_only when fetching notifications', async () => {
+  await fetchNotifications(API_URL, TEST_PUBKEY, signer, {
+    limit: 30,
+    before: 'cursor-1',
+    unreadOnly: true,
+    types: ['like', 'follow'],
+  });
+
+  expect(global.fetch).toHaveBeenCalledWith(
+    expect.stringContaining('types=like%2Cfollow'),
+    expect.objectContaining({ headers: expect.any(Object) }),
+  );
+  expect(global.fetch).toHaveBeenCalledWith(
+    expect.stringContaining('unread_only=true'),
+    expect.any(Object),
+  );
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vitest run src/lib/funnelcakeClient.test.ts`
+Expected: FAIL because `fetchNotifications` ignores `types` and `unreadOnly`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Extend the `fetchNotifications` options object to include `types` and `unreadOnly`, then include them in the authenticated request params using the backend’s expected query names.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `vitest run src/lib/funnelcakeClient.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/funnelcakeClient.ts src/lib/funnelcakeClient.test.ts
+git commit -m "test: cover notification filter params"
+```
+
+### Task 3: Make `useNotifications` filter-aware
+
+**Files:**
+- Create: `src/hooks/useNotifications.test.ts`
+- Modify: `src/hooks/useNotifications.ts`
+- Modify: `src/types/notification.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+it('uses category-specific query keys and request filters', async () => {
+  renderHook(() => useNotifications({ category: 'likes' }), { wrapper });
+
+  await waitFor(() => {
+    expect(fetchNotifications).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      expect.any(Object),
+      expect.objectContaining({ types: ['like'], unreadOnly: false }),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vitest run src/hooks/useNotifications.test.ts`
+Expected: FAIL because the hook does not accept category filters
+
+- [ ] **Step 3: Write minimal implementation**
+
+Update `useNotifications` to accept a filter object, derive backend params from category, and include the filter in the query key. Keep `useUnreadNotificationCount` and `useMarkNotificationsRead` behavior unchanged except for shared typing if needed.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `vitest run src/hooks/useNotifications.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hooks/useNotifications.ts src/hooks/useNotifications.test.ts src/types/notification.ts
+git commit -m "test: add filtered notifications hook"
+```
+
+## Chunk 2: Notifications Page Tabs And Sectioning
+
+### Task 4: Add notifications page tests for tabs and implicit read behavior
+
+**Files:**
+- Create: `src/pages/NotificationsPage.test.tsx`
+- Modify: `src/pages/NotificationsPage.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+it('marks all notifications read once and keeps initial unread rows in a New section', async () => {
+  renderPage();
+
+  expect(await screen.findByText('New')).toBeInTheDocument();
+  expect(screen.getByText('Earlier')).toBeInTheDocument();
+
+  await waitFor(() => {
+    expect(mockMarkReadMutate).toHaveBeenCalledWith(undefined);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vitest run src/pages/NotificationsPage.test.tsx`
+Expected: FAIL because the page has no sections and marks specific IDs instead of "all"
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create a page test that mocks the notification hooks and verifies:
+- the tab list renders
+- the default `All` tab sections rows into `New` and `Earlier`
+- the page only triggers mark-all-read once for the initial `All` load
+- switching to another tab requests that filtered dataset
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `vitest run src/pages/NotificationsPage.test.tsx`
+Expected: PASS after the page implementation lands
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pages/NotificationsPage.test.tsx src/pages/NotificationsPage.tsx
+git commit -m "test: cover notifications page tabs"
+```
+
+### Task 5: Implement tabs, sectioning, and filtered empty states
+
+**Files:**
+- Modify: `src/pages/NotificationsPage.tsx`
+- Test: `src/pages/NotificationsPage.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+it('shows a category-specific empty state for Likes', async () => {
+  mockUseNotificationsState.notifications = [];
+  renderPage({ category: 'likes' });
+  expect(await screen.findByText(/No like notifications yet/i)).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vitest run src/pages/NotificationsPage.test.tsx`
+Expected: FAIL because the page only has one generic empty state
+
+- [ ] **Step 3: Write minimal implementation**
+
+Use the shared `Tabs` components, track the selected category in page state, call `useNotifications({ category })`, derive `newNotifications` from the initial unread snapshot for `All`, and add category-aware empty copy.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `vitest run src/pages/NotificationsPage.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pages/NotificationsPage.tsx src/pages/NotificationsPage.test.tsx
+git commit -m "feat: add notification category tabs"
+```
+
+## Chunk 3: Verification And Baseline Cleanup
+
+### Task 6: Remove the pre-existing lint blocker from `ConversationPage`
+
+**Files:**
+- Modify: `src/pages/ConversationPage.tsx:1-20`
+
+- [ ] **Step 1: Write the failing test**
+
+No new test. This is a baseline cleanup required because `origin/main` currently fails lint on an unused import.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test`
+Expected: FAIL with `Loader2 is defined but never used`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Remove the unused `Loader2` import from `src/pages/ConversationPage.tsx` and avoid any behavioral changes.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test`
+Expected: PASS for lint, the new notification tests, and the full build
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pages/ConversationPage.tsx src/pages/NotificationsPage.tsx src/pages/NotificationsPage.test.tsx src/hooks/useNotifications.ts src/hooks/useNotifications.test.ts src/lib/funnelcakeClient.ts src/lib/funnelcakeClient.test.ts src/types/notification.ts
+git commit -m "feat: add notification category tabs and read-state sections"
+```

--- a/docs/superpowers/specs/2026-04-17-notifications-categories-read-state-design.md
+++ b/docs/superpowers/specs/2026-04-17-notifications-categories-read-state-design.md
@@ -1,0 +1,85 @@
+# Notifications Categories And Read State Design
+
+## Summary
+
+Add notification category tabs to the notifications page, keep the existing newest-first ordering, and make read state implicit when the user opens the page. The page should still show which items were unread when the page first loaded by splitting the initial result into `New` and `Earlier` sections.
+
+## Goals
+
+- Let users break notifications out by category without changing routes.
+- Preserve the current "open notifications means I read them" mental model.
+- Keep unread badges accurate across the header, sidebar, and bottom nav.
+- Avoid client-side filtering that breaks pagination semantics.
+
+## Non-Goals
+
+- No manual sort controls beyond the existing reverse-chronological order.
+- No explicit `Mark all read` button.
+- No per-row read tracking based on clicks or visibility.
+
+## Categories
+
+The UI will expose these tabs:
+
+- `All`
+- `Unread`
+- `Likes`
+- `Comments`
+- `Follows`
+- `Reposts`
+- `Zaps`
+
+These map directly to backend notification filters. `Unread` uses the backend `unread_only` flag. The type-specific tabs use backend `types` values. `All` applies no filter.
+
+## Page Behavior
+
+`NotificationsPage` remains a single route and a single infinite list. A tab switch resets pagination and fetches a fresh server-filtered stream for that tab.
+
+When the `All` tab first loads, the page captures which notifications were unread at arrival time, then immediately sends a mark-all-read mutation without notification IDs. That preserves the user’s requested implicit behavior while still letting the rendered page label those initially unread rows under `New`.
+
+After the mark-all-read mutation succeeds, global unread badges should clear because the unread-count query is already invalidated by the mutation hook. Subsequent pages fetched in the same session should render as read unless the backend returns newer unread items later.
+
+## Data Flow
+
+`useNotifications` will accept a filter object with:
+
+- `category`
+- derived `types`
+- derived `unreadOnly`
+
+That filter becomes part of the React Query key so each tab gets its own cache entry. `fetchNotifications` will pass `types` and `unread_only` to the REST API. Pagination continues to use the backend cursor unchanged.
+
+`useMarkNotificationsRead` keeps its optimistic cache behavior, but the notifications page will call it with no IDs to represent "mark all." For the active `All` query, the page will also maintain a local set of initially unread IDs so the UI can keep showing `New` vs `Earlier` after the optimistic cache flips those rows to `isRead: true`.
+
+## UI Structure
+
+The page header stays the same, followed by a tab bar using the existing shared `Tabs` components.
+
+List presentation:
+
+- `All`: show `New` and `Earlier` sections when both exist
+- `Unread`: show a flat list because everything returned is new by definition
+- Type tabs: show a flat list, but keep unread row styling if the backend still reports unread items before the implicit mark-all-read completes
+
+Empty states should reflect the selected tab instead of always using the generic message.
+
+## Error Handling
+
+- Tab changes keep using the existing error state pattern.
+- If the mark-all-read mutation fails, the list still renders and the unread badges will resync on the next refetch.
+- The UI should not block on mark-all-read completion.
+
+## Testing
+
+Add coverage for:
+
+- query filters being forwarded to the notification client
+- unread-only and type-specific request params
+- `NotificationsPage` rendering category tabs
+- `All` tab splitting the first page into `New` and `Earlier`
+- implicit mark-all-read firing once on initial `All` load
+- tab changes resetting to the correct filtered results
+
+## Implementation Notes
+
+`origin/main` currently fails `npm run test` because of an unused `Loader2` import in `src/pages/ConversationPage.tsx`. Remove that import as a minimal cleanup in this branch so full verification remains meaningful.

--- a/src/hooks/useNotifications.test.ts
+++ b/src/hooks/useNotifications.test.ts
@@ -4,26 +4,31 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useNotifications, useUnreadNotificationCount } from './useNotifications';
-import {
-  fetchNotifications,
-  fetchUnreadCount,
-} from '@/lib/funnelcakeClient';
 
-vi.mock('@/config/api', () => ({
-  getFunnelcakeBaseUrl: vi.fn(() => 'https://api.divine.video'),
-  getNotificationsBaseUrl: vi.fn(() => 'https://relay.divine.video'),
+const { mockFetchNotifications, mockFetchUnreadCount } = vi.hoisted(() => ({
+  mockFetchNotifications: vi.fn(),
+  mockFetchUnreadCount: vi.fn(),
 }));
 
 vi.mock('@/hooks/useCurrentUser', () => ({
-  useCurrentUser: vi.fn(() => ({
+  useCurrentUser: () => ({
     user: { pubkey: 'a'.repeat(64) },
-    signer: { signEvent: vi.fn() },
-  })),
+    signer: { signEvent: vi.fn(), getPublicKey: vi.fn() },
+  }),
+}));
+
+vi.mock('@/config/api', () => ({
+  getFunnelcakeBaseUrl: () => 'https://api.divine.video',
+  getNotificationsBaseUrl: () => 'https://relay.divine.video',
+}));
+
+vi.mock('@/lib/debug', () => ({
+  debugLog: vi.fn(),
 }));
 
 vi.mock('@/lib/funnelcakeClient', () => ({
-  fetchNotifications: vi.fn(),
-  fetchUnreadCount: vi.fn(),
+  fetchNotifications: mockFetchNotifications,
+  fetchUnreadCount: mockFetchUnreadCount,
   markNotificationsRead: vi.fn(),
 }));
 
@@ -39,36 +44,45 @@ function createWrapper() {
     },
   });
 
-  return ({ children }: { children: React.ReactNode }) =>
-    React.createElement(QueryClientProvider, { client: queryClient }, children);
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children);
+  };
 }
 
 describe('useNotifications', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-  });
-
-  it('uses the notifications relay base URL for the list query', async () => {
-    vi.mocked(fetchNotifications).mockResolvedValue({
+    mockFetchNotifications.mockResolvedValue({
       notifications: [],
       unreadCount: 0,
       hasMore: false,
     });
+    mockFetchUnreadCount.mockResolvedValue(0);
+  });
 
-    renderHook(() => useNotifications(), { wrapper: createWrapper() });
+  it('uses the notifications relay base URL for the list query and category filters', async () => {
+    renderHook(() => useNotifications({ category: 'likes' }), {
+      wrapper: createWrapper(),
+    });
 
     await waitFor(() => {
-      expect(fetchNotifications).toHaveBeenCalledWith(
+      expect(mockFetchNotifications).toHaveBeenCalledWith(
         'https://relay.divine.video',
         'a'.repeat(64),
         expect.any(Object),
-        expect.objectContaining({ limit: 30 }),
+        expect.objectContaining({
+          limit: 30,
+          before: undefined,
+          types: ['like'],
+          unreadOnly: false,
+          signal: expect.any(AbortSignal),
+        }),
       );
     });
   });
 
   it('uses the notifications relay base URL for unread count polling', async () => {
-    vi.mocked(fetchUnreadCount).mockResolvedValue(7);
+    mockFetchUnreadCount.mockResolvedValue(7);
 
     const { result } = renderHook(() => useUnreadNotificationCount(), {
       wrapper: createWrapper(),
@@ -78,7 +92,7 @@ describe('useNotifications', () => {
       expect(result.current.data).toBe(7);
     });
 
-    expect(fetchUnreadCount).toHaveBeenCalledWith(
+    expect(mockFetchUnreadCount).toHaveBeenCalledWith(
       'https://relay.divine.video',
       'a'.repeat(64),
       expect.any(Object),

--- a/src/hooks/useNotifications.test.ts
+++ b/src/hooks/useNotifications.test.ts
@@ -60,7 +60,7 @@ describe('useNotifications', () => {
     mockFetchUnreadCount.mockResolvedValue(0);
   });
 
-  it('uses the notifications relay base URL for the list query and category filters', async () => {
+  it('maps the likes category to the backend reaction filter on the notifications relay', async () => {
     renderHook(() => useNotifications({ category: 'likes' }), {
       wrapper: createWrapper(),
     });
@@ -73,7 +73,28 @@ describe('useNotifications', () => {
         expect.objectContaining({
           limit: 30,
           before: undefined,
-          types: ['like'],
+          types: ['reaction'],
+          unreadOnly: false,
+          signal: expect.any(AbortSignal),
+        }),
+      );
+    });
+  });
+
+  it('maps the comments category to the backend reply filter on the notifications relay', async () => {
+    renderHook(() => useNotifications({ category: 'comments' }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(mockFetchNotifications).toHaveBeenCalledWith(
+        'https://relay.divine.video',
+        'a'.repeat(64),
+        expect.any(Object),
+        expect.objectContaining({
+          limit: 30,
+          before: undefined,
+          types: ['reply'],
           unreadOnly: false,
           signal: expect.any(AbortSignal),
         }),

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -6,21 +6,37 @@ import { getNotificationsBaseUrl } from '@/config/api';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { fetchNotifications, fetchUnreadCount, markNotificationsRead } from '@/lib/funnelcakeClient';
 import { debugLog } from '@/lib/debug';
-import type { NotificationsResponse } from '@/types/notification';
+import type { NotificationCategory, NotificationFilters, NotificationType, NotificationsResponse } from '@/types/notification';
 
 const NOTIFICATIONS_PAGE_SIZE = 30;
+
+const CATEGORY_TYPES: Partial<Record<NotificationCategory, NotificationType[]>> = {
+  likes: ['like'],
+  comments: ['comment'],
+  follows: ['follow'],
+  reposts: ['repost'],
+  zaps: ['zap'],
+};
+
+function resolveNotificationQueryFilters(category: NotificationCategory) {
+  return {
+    unreadOnly: category === 'unread',
+    types: CATEGORY_TYPES[category],
+  };
+}
 
 /**
  * Infinite query for paginated notifications list.
  * Fetches pages of notifications with cursor-based pagination.
  */
-export function useNotifications() {
+export function useNotifications(filters: NotificationFilters = { category: 'all' }) {
   const { user, signer } = useCurrentUser();
   const pubkey = user?.pubkey;
   const apiUrl = getNotificationsBaseUrl();
+  const { unreadOnly, types } = resolveNotificationQueryFilters(filters.category);
 
   return useInfiniteQuery<NotificationsResponse, Error>({
-    queryKey: ['notifications', pubkey],
+    queryKey: ['notifications', pubkey, filters.category],
 
     queryFn: async ({ pageParam, signal }) => {
       if (!pubkey || !signer) {
@@ -32,6 +48,8 @@ export function useNotifications() {
       return fetchNotifications(apiUrl, pubkey, signer, {
         limit: NOTIFICATIONS_PAGE_SIZE,
         before: pageParam as string | undefined,
+        unreadOnly,
+        types,
         signal,
       });
     },

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -6,13 +6,13 @@ import { getNotificationsBaseUrl } from '@/config/api';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { fetchNotifications, fetchUnreadCount, markNotificationsRead } from '@/lib/funnelcakeClient';
 import { debugLog } from '@/lib/debug';
-import type { NotificationCategory, NotificationFilters, NotificationType, NotificationsResponse } from '@/types/notification';
+import type { NotificationApiType, NotificationCategory, NotificationFilters, NotificationsResponse } from '@/types/notification';
 
 const NOTIFICATIONS_PAGE_SIZE = 30;
 
-const CATEGORY_TYPES: Partial<Record<NotificationCategory, NotificationType[]>> = {
-  likes: ['like'],
-  comments: ['comment'],
+const CATEGORY_TYPES: Partial<Record<NotificationCategory, NotificationApiType[]>> = {
+  likes: ['reaction'],
+  comments: ['reply'],
   follows: ['follow'],
   reposts: ['repost'],
   zaps: ['zap'],

--- a/src/lib/funnelcakeClient.test.ts
+++ b/src/lib/funnelcakeClient.test.ts
@@ -32,6 +32,7 @@ describe('funnelcakeClient', () => {
   let searchProfiles: typeof import('./funnelcakeClient').searchProfiles;
   let fetchRecommendations: typeof import('./funnelcakeClient').fetchRecommendations;
   let markNotificationsRead: typeof import('./funnelcakeClient').markNotificationsRead;
+  let fetchNotifications: typeof import('./funnelcakeClient').fetchNotifications;
 
   beforeEach(async () => {
     vi.resetModules();
@@ -47,6 +48,7 @@ describe('funnelcakeClient', () => {
     searchProfiles = client.searchProfiles;
     fetchRecommendations = client.fetchRecommendations;
     markNotificationsRead = client.markNotificationsRead;
+    fetchNotifications = client.fetchNotifications;
   });
 
   afterEach(() => {
@@ -494,6 +496,48 @@ describe('funnelcakeClient', () => {
       expect(init).toEqual(expect.objectContaining({
         signal: expect.any(AbortSignal),
       }));
+    });
+  });
+
+  describe('fetchNotifications', () => {
+    it('forwards notification type and unread filters to the backend', async () => {
+      const signer = {
+        signEvent: vi.fn().mockResolvedValue({
+          id: 'event-id',
+          sig: 'sig',
+          pubkey: TEST_PUBKEY,
+          kind: 27235,
+          created_at: 1_700_000_000,
+          content: '',
+          tags: [],
+        }),
+        getPublicKey: vi.fn().mockResolvedValue(TEST_PUBKEY),
+      };
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          notifications: [],
+          unread_count: 2,
+          has_more: false,
+        }),
+      });
+
+      await fetchNotifications(API_URL, TEST_PUBKEY, signer as never, {
+        limit: 30,
+        before: 'cursor-1',
+        unreadOnly: true,
+        types: ['like', 'follow'],
+      });
+
+      const [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      const requestUrl = new URL(url as string);
+
+      expect(requestUrl.pathname).toBe(`/api/users/${TEST_PUBKEY}/notifications`);
+      expect(requestUrl.searchParams.get('limit')).toBe('30');
+      expect(requestUrl.searchParams.get('before')).toBe('cursor-1');
+      expect(requestUrl.searchParams.get('unread_only')).toBe('true');
+      expect(requestUrl.searchParams.get('types')).toBe('like,follow');
     });
   });
 });

--- a/src/lib/funnelcakeClient.ts
+++ b/src/lib/funnelcakeClient.ts
@@ -1201,6 +1201,8 @@ export async function fetchNotifications(
   options?: {
     limit?: number;
     before?: string;
+    types?: string[];
+    unreadOnly?: boolean;
     signal?: AbortSignal;
   },
 ): Promise<NotificationsResponse> {
@@ -1209,6 +1211,8 @@ export async function fetchNotifications(
   const params: Record<string, string | number | boolean | undefined> = {
     limit: options?.limit ?? 50,
     before: options?.before,
+    types: options?.types?.length ? options.types.join(',') : undefined,
+    unread_only: options?.unreadOnly ? true : undefined,
   };
 
   const raw = await authenticatedNotificationRequest<RawNotificationsApiResponse>(

--- a/src/pages/ConversationPage.tsx
+++ b/src/pages/ConversationPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { ArrowLeft, ArrowUp, LinkSimple as Link2, CircleNotch as Loader2, X } from '@phosphor-icons/react';
+import { ArrowLeft, ArrowUp, LinkSimple as Link2, X } from '@phosphor-icons/react';
 import { Link, useLocation, useParams } from 'react-router-dom';
 
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';

--- a/src/pages/NotificationsPage.test.tsx
+++ b/src/pages/NotificationsPage.test.tsx
@@ -1,0 +1,118 @@
+import userEvent from '@testing-library/user-event';
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Notification } from '@/types/notification';
+import NotificationsPage from './NotificationsPage';
+
+const { mockMarkReadMutate, mockUseNotifications } = vi.hoisted(() => ({
+  mockMarkReadMutate: vi.fn(),
+  mockUseNotifications: vi.fn(),
+}));
+
+vi.mock('@/hooks/useNotifications', () => ({
+  useNotifications: (filters?: { category?: string }) => mockUseNotifications(filters),
+  useMarkNotificationsRead: () => ({
+    mutate: mockMarkReadMutate,
+  }),
+}));
+
+vi.mock('@/components/NotificationItem', () => ({
+  NotificationItem: ({ notification }: { notification: Notification }) => (
+    <div>{notification.id}</div>
+  ),
+}));
+
+vi.mock('@/components/ui/skeleton', () => ({
+  Skeleton: () => <div>loading</div>,
+}));
+
+function buildNotification(overrides: Partial<Notification>): Notification {
+  return {
+    id: 'notification-1',
+    type: 'like',
+    actorPubkey: 'a'.repeat(64),
+    timestamp: 1_700_000_000,
+    isRead: true,
+    sourceEventId: 'b'.repeat(64),
+    sourceKind: 7,
+    ...overrides,
+  };
+}
+
+describe('NotificationsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockUseNotifications.mockImplementation((filters?: { category?: string }) => {
+      const category = filters?.category ?? 'all';
+
+      if (category === 'likes') {
+        return {
+          data: {
+            pages: [
+              {
+                notifications: [
+                  buildNotification({ id: 'like-1', type: 'like', isRead: true }),
+                ],
+              },
+            ],
+          },
+          isLoading: false,
+          isError: false,
+          error: null,
+          fetchNextPage: vi.fn(),
+          hasNextPage: false,
+          isFetchingNextPage: false,
+        };
+      }
+
+      return {
+        data: {
+          pages: [
+            {
+              notifications: [
+                buildNotification({ id: 'new-1', isRead: false }),
+                buildNotification({ id: 'earlier-1', type: 'follow', isRead: true }),
+              ],
+            },
+          ],
+        },
+        isLoading: false,
+        isError: false,
+        error: null,
+        fetchNextPage: vi.fn(),
+        hasNextPage: false,
+        isFetchingNextPage: false,
+      };
+    });
+  });
+
+  it('shows New and Earlier sections and marks all read on open', async () => {
+    render(<NotificationsPage />);
+
+    expect(screen.getByRole('heading', { name: 'Notifications' })).toBeInTheDocument();
+    expect(screen.getByText('All')).toBeInTheDocument();
+    expect(screen.getByText('Likes')).toBeInTheDocument();
+    expect(await screen.findByText('New')).toBeInTheDocument();
+    expect(screen.getByText('Earlier')).toBeInTheDocument();
+    expect(screen.getByText('new-1')).toBeInTheDocument();
+    expect(screen.getByText('earlier-1')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(mockMarkReadMutate).toHaveBeenCalledWith(undefined);
+    });
+  });
+
+  it('switches to a category tab and shows the filtered notification list', async () => {
+    const user = userEvent.setup();
+
+    render(<NotificationsPage />);
+
+    await user.click(screen.getByRole('tab', { name: 'Likes' }));
+
+    expect(await screen.findByText('like-1')).toBeInTheDocument();
+    expect(screen.queryByText('new-1')).not.toBeInTheDocument();
+    expect(screen.queryByText('Earlier')).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/NotificationsPage.tsx
+++ b/src/pages/NotificationsPage.tsx
@@ -1,14 +1,60 @@
 // ABOUTME: Notifications page showing social interactions (likes, comments, follows, reposts, zaps)
 // ABOUTME: Simple list with infinite scroll, marks all as read on page open
 
-import { useEffect, useRef, useCallback, useMemo } from 'react';
+import { useEffect, useRef, useCallback, useMemo, useState } from 'react';
 import { Bell } from '@phosphor-icons/react';
 import { useNotifications, useMarkNotificationsRead } from '@/hooks/useNotifications';
 import { NotificationItem } from '@/components/NotificationItem';
 import { Skeleton } from '@/components/ui/skeleton';
-import type { Notification } from '@/types/notification';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import type { Notification, NotificationCategory } from '@/types/notification';
+
+const NOTIFICATION_TABS: Array<{ value: NotificationCategory; label: string }> = [
+  { value: 'all', label: 'All' },
+  { value: 'unread', label: 'Unread' },
+  { value: 'likes', label: 'Likes' },
+  { value: 'comments', label: 'Comments' },
+  { value: 'follows', label: 'Follows' },
+  { value: 'reposts', label: 'Reposts' },
+  { value: 'zaps', label: 'Zaps' },
+];
+
+const EMPTY_STATE_COPY: Record<
+  NotificationCategory,
+  { title: string; description: string }
+> = {
+  all: {
+    title: 'All quiet. Nothing to flag.',
+    description: 'When people react to your stuff, it lands right here.',
+  },
+  unread: {
+    title: 'You are all caught up.',
+    description: 'New activity will show up here first.',
+  },
+  likes: {
+    title: 'No like notifications yet.',
+    description: 'When someone likes one of your videos, it will show up here.',
+  },
+  comments: {
+    title: 'No comment notifications yet.',
+    description: 'Replies and comments on your videos will show up here.',
+  },
+  follows: {
+    title: 'No follow notifications yet.',
+    description: 'New followers will show up here.',
+  },
+  reposts: {
+    title: 'No repost notifications yet.',
+    description: 'Reposts of your videos will show up here.',
+  },
+  zaps: {
+    title: 'No zap notifications yet.',
+    description: 'Zaps on your videos will show up here.',
+  },
+};
 
 export default function NotificationsPage() {
+  const [category, setCategory] = useState<NotificationCategory>('all');
   const {
     data,
     isLoading,
@@ -17,10 +63,11 @@ export default function NotificationsPage() {
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
-  } = useNotifications();
+  } = useNotifications({ category });
 
   const markRead = useMarkNotificationsRead();
-  const hasMarkedRead = useRef(false);
+  const hasCapturedInitialUnread = useRef(false);
+  const [initialUnreadIds, setInitialUnreadIds] = useState<Set<string>>(() => new Set());
 
   // Flatten all pages into a single array of notifications
   const notifications: Notification[] = useMemo(
@@ -28,17 +75,43 @@ export default function NotificationsPage() {
     [data?.pages],
   );
 
-  // Mark all as read on page open (once, when first page loads)
+  const newNotifications = useMemo(
+    () => notifications.filter((notification) => initialUnreadIds.has(notification.id)),
+    [notifications, initialUnreadIds],
+  );
+
+  const earlierNotifications = useMemo(
+    () => notifications.filter((notification) => !initialUnreadIds.has(notification.id)),
+    [notifications, initialUnreadIds],
+  );
+
+  // Mark all as read on page open (once, when first page loads).
+  // Keep a snapshot of initially unread rows so the list can still show
+  // what was new when the user arrived, even after optimistic updates flip
+  // everything to read in the cache.
   useEffect(() => {
-    if (hasMarkedRead.current) return;
+    if (category !== 'all') return;
+    if (hasCapturedInitialUnread.current) return;
     if (notifications.length === 0) return;
 
     const unreadIds = notifications.filter((n) => !n.isRead).map((n) => n.id);
-    if (unreadIds.length > 0) {
-      hasMarkedRead.current = true;
-      markRead.mutate(unreadIds);
-    }
-  }, [notifications, markRead]);
+    hasCapturedInitialUnread.current = true;
+
+    if (unreadIds.length === 0) return;
+
+    setInitialUnreadIds(new Set(unreadIds));
+    markRead.mutate(undefined);
+  }, [category, notifications, markRead]);
+
+  const emptyState = EMPTY_STATE_COPY[category];
+
+  const renderNotifications = (items: Notification[]) => (
+    <div className="divide-y divide-border">
+      {items.map((notification) => (
+        <NotificationItem key={notification.id} notification={notification} />
+      ))}
+    </div>
+  );
 
   // Infinite scroll observer
   const observerRef = useRef<IntersectionObserver | null>(null);
@@ -71,6 +144,16 @@ export default function NotificationsPage() {
         </h1>
       </div>
 
+      <Tabs value={category} onValueChange={(value) => setCategory(value as NotificationCategory)}>
+        <TabsList className="mb-6 flex w-full justify-start overflow-x-auto">
+          {NOTIFICATION_TABS.map((tab) => (
+            <TabsTrigger key={tab.value} value={tab.value}>
+              {tab.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+      </Tabs>
+
       {/* Loading skeleton */}
       {isLoading && (
         <div className="space-y-4">
@@ -100,20 +183,35 @@ export default function NotificationsPage() {
       {!isLoading && !isError && notifications.length === 0 && (
         <div className="text-center py-16">
           <Bell className="h-12 w-12 mx-auto mb-4 text-muted-foreground" />
-          <p className="text-lg font-medium mb-1">All quiet. Nothing to flag.</p>
-          <p className="text-sm text-muted-foreground">
-            When people react to your stuff, it lands right here.
-          </p>
+          <p className="text-lg font-medium mb-1">{emptyState.title}</p>
+          <p className="text-sm text-muted-foreground">{emptyState.description}</p>
         </div>
       )}
 
       {/* Notification list */}
       {notifications.length > 0 && (
-        <div className="divide-y divide-border">
-          {notifications.map((notification) => (
-            <NotificationItem key={notification.id} notification={notification} />
-          ))}
-        </div>
+        category === 'all' && initialUnreadIds.size > 0 ? (
+          <div className="space-y-6">
+            {newNotifications.length > 0 && (
+              <section>
+                <h2 className="mb-3 text-sm font-semibold tracking-wide text-muted-foreground">
+                  New
+                </h2>
+                {renderNotifications(newNotifications)}
+              </section>
+            )}
+            {earlierNotifications.length > 0 && (
+              <section>
+                <h2 className="mb-3 text-sm font-semibold tracking-wide text-muted-foreground">
+                  Earlier
+                </h2>
+                {renderNotifications(earlierNotifications)}
+              </section>
+            )}
+          </div>
+        ) : (
+          renderNotifications(notifications)
+        )
       )}
 
       {/* Infinite scroll sentinel */}

--- a/src/types/notification.ts
+++ b/src/types/notification.ts
@@ -4,6 +4,9 @@
 /** Notification types supported by the app */
 export type NotificationType = 'like' | 'comment' | 'follow' | 'repost' | 'zap';
 
+/** Raw notification types accepted by the backend filter API */
+export type NotificationApiType = 'reaction' | 'reply' | 'follow' | 'repost' | 'zap' | 'mention';
+
 /** Notification tabs supported by the notifications page */
 export type NotificationCategory =
   | 'all'

--- a/src/types/notification.ts
+++ b/src/types/notification.ts
@@ -4,6 +4,21 @@
 /** Notification types supported by the app */
 export type NotificationType = 'like' | 'comment' | 'follow' | 'repost' | 'zap';
 
+/** Notification tabs supported by the notifications page */
+export type NotificationCategory =
+  | 'all'
+  | 'unread'
+  | 'likes'
+  | 'comments'
+  | 'follows'
+  | 'reposts'
+  | 'zaps';
+
+/** Filters used when fetching notifications */
+export interface NotificationFilters {
+  category: NotificationCategory;
+}
+
 /** A single notification in app format */
 export interface Notification {
   id: string;


### PR DESCRIPTION
## Summary
- add server-backed notification category tabs for all, unread, likes, comments, follows, reposts, and zaps
- preserve implicit mark-all-read on notifications open while keeping the initial all-feed split into New and Earlier sections
- add notification client and hook coverage for filter params, plus page tests for tab switching and read-state grouping

## Test Plan
- [x] npm run test