### PR TITLE
[codex] Restore route scroll positions

### DIFF
--- a/src/components/ScrollToTop.test.tsx
+++ b/src/components/ScrollToTop.test.tsx
@@ -1,0 +1,65 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { Link, MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ScrollToTop } from './ScrollToTop';
+
+function TestApp() {
+  return (
+    <MemoryRouter initialEntries={['/feed']}>
+      <ScrollToTop />
+      <Routes>
+        <Route
+          path="/feed"
+          element={
+            <div>
+              <h1>Feed</h1>
+              <Link to="/details">Details</Link>
+            </div>
+          }
+        />
+        <Route
+          path="/details"
+          element={
+            <div>
+              <h1>Details</h1>
+              <Link to="/feed">Feed</Link>
+            </div>
+          }
+        />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('ScrollToTop', () => {
+  let scrollY = 0;
+
+  beforeEach(() => {
+    scrollY = 0;
+    Object.defineProperty(window, 'scrollY', {
+      configurable: true,
+      get: () => scrollY,
+    });
+    vi.mocked(window.scrollTo).mockImplementation((_x, y) => {
+      scrollY = Number(y);
+    });
+  });
+
+  it('restores the saved scroll position when returning to a route', () => {
+    render(<TestApp />);
+
+    expect(window.scrollTo).toHaveBeenLastCalledWith(0, 0);
+
+    scrollY = 420;
+    fireEvent.click(screen.getByRole('link', { name: 'Details' }));
+
+    expect(screen.getByRole('heading', { name: 'Details' })).toBeInTheDocument();
+    expect(window.scrollTo).toHaveBeenLastCalledWith(0, 0);
+
+    scrollY = 125;
+    fireEvent.click(screen.getByRole('link', { name: 'Feed' }));
+
+    expect(screen.getByRole('heading', { name: 'Feed' })).toBeInTheDocument();
+    expect(window.scrollTo).toHaveBeenLastCalledWith(0, 420);
+  });
+});

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -1,10 +1,41 @@
-import { useEffect } from 'react';
+import { useEffect, useLayoutEffect, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
 
+const scrollPositions = new Map<string, number>();
+
+function getScrollKey(pathname: string, search: string) {
+  return `${pathname}${search}`;
+}
+
 export function ScrollToTop() {
-  const { pathname, hash } = useLocation();
+  const { pathname, search, hash } = useLocation();
+  const scrollKey = getScrollKey(pathname, search);
+  const timeoutRef = useRef<number | null>(null);
 
   useEffect(() => {
+    if ('scrollRestoration' in window.history) {
+      const previousRestoration = window.history.scrollRestoration;
+      window.history.scrollRestoration = 'manual';
+
+      return () => {
+        window.history.scrollRestoration = previousRestoration;
+      };
+    }
+  }, []);
+
+  useEffect(() => {
+    const saveCurrentPosition = () => {
+      scrollPositions.set(scrollKey, window.scrollY);
+    };
+
+    window.addEventListener('pagehide', saveCurrentPosition);
+
+    return () => {
+      window.removeEventListener('pagehide', saveCurrentPosition);
+    };
+  }, [scrollKey]);
+
+  useLayoutEffect(() => {
     if (hash) {
       // If there's a hash, scroll to that element after a short delay
       // to allow the page content to render
@@ -20,14 +51,24 @@ export function ScrollToTop() {
       scrollToHash();
 
       // Also try after a delay to handle slow-loading content
-      const timeoutId = setTimeout(scrollToHash, 100);
+      timeoutRef.current = window.setTimeout(scrollToHash, 100);
 
-      return () => clearTimeout(timeoutId);
-    } else {
-      // No hash, scroll to top
-      window.scrollTo(0, 0);
+      return () => {
+        scrollPositions.set(scrollKey, window.scrollY);
+        if (timeoutRef.current !== null) {
+          window.clearTimeout(timeoutRef.current);
+          timeoutRef.current = null;
+        }
+      };
     }
-  }, [pathname, hash]);
+
+    const savedPosition = scrollPositions.get(scrollKey) ?? 0;
+    window.scrollTo(0, savedPosition);
+
+    return () => {
+      scrollPositions.set(scrollKey, window.scrollY);
+    };
+  }, [scrollKey, hash]);
 
   return null;
 }


### PR DESCRIPTION
## Summary
- Restore saved scroll positions when returning to previously visited routes
- Keep new routes starting at the top when no saved position exists
- Preserve existing hash-link scrolling behavior
- Add a regression test covering route scroll restoration

## Root Cause
`ScrollToTop` was calling `window.scrollTo(0, 0)` on every pathname change. That made normal screen changes discard the user's previous feed/list position, even though the like/comment code paths themselves do not remount the feed.

## Issue
Fixes #61

## Validation
- `npx vitest run src/components/ScrollToTop.test.tsx`
- `npm test`
- Manual dev-server verification that returning to a previous screen restores its scroll position
