### PR TITLE
feat: let anonymous viewers pass the age gate via ephemeral signer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -292,7 +292,7 @@ Funnelcake profile response is nested:
 - When a blob SHA-256 is known (NIP-71 `imeta` `x`, i.e. `videoData.sha256`), the picker returns a Blossom/BUD-01 kind 24242 header.
 - Otherwise it returns a NIP-98 kind 27235 header for the URL. HLS segments stay NIP-98 (segment URLs carry no blob hash).
 - `divine-blossom` accepts both on viewer GETs; never invent a third protocol in the picker.
-- Logged-out viewers on age-gated content see `AgeVerificationOverlay` in "Sign in to view" mode, wired to `useLoginDialog().openLoginDialog()` — they must log in before the age-verification / header-generation path runs.
+- Logged-out viewers can still pass the age gate: `AgeVerificationOverlay` shows the "I'm 18 or older" button to everyone, and `getAuthHeader` falls back to a device-scoped ephemeral signer (`src/lib/ephemeralSigner.ts`) — generated lazily, persisted in `localStorage` with the same 30-day TTL as the verification flag, wiped by `revokeVerification()`. The ephemeral signer is scoped to media auth only; view events (kind 22236) and other identity-bearing flows still require a real user signer.
 
 ---
 

--- a/src/components/AgeVerificationOverlay.test.tsx
+++ b/src/components/AgeVerificationOverlay.test.tsx
@@ -1,13 +1,8 @@
-// ABOUTME: Tests that AgeVerificationOverlay shows a Sign In CTA to logged-out viewers
-// ABOUTME: and preserves the existing "I'm 18 or older" flow for logged-in viewers
+// ABOUTME: Tests that AgeVerificationOverlay lets both logged-in and anonymous viewers
+// ABOUTME: pass the age gate via the shared "I'm 18 or older" confirm flow.
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-
-const openLoginDialog = vi.fn();
-vi.mock('@/contexts/LoginDialogContext', () => ({
-  useLoginDialog: () => ({ openLoginDialog, closeLoginDialog: vi.fn(), isOpen: false }),
-}));
 
 const confirmAdult = vi.fn();
 const isVerifiedRef = { current: false };
@@ -22,47 +17,29 @@ vi.mock('@/hooks/useAdultVerification', () => ({
   }),
 }));
 
-const useCurrentUserMock = vi.fn();
-vi.mock('@/hooks/useCurrentUser', () => ({
-  useCurrentUser: () => useCurrentUserMock(),
-}));
-
 import { AgeVerificationOverlay } from '@/components/AgeVerificationOverlay';
 
 describe('AgeVerificationOverlay', () => {
   beforeEach(() => {
-    openLoginDialog.mockClear();
     confirmAdult.mockClear();
-    useCurrentUserMock.mockReset();
     isVerifiedRef.current = false;
   });
 
-  it('shows "Sign in to view this content" heading when no user is logged in', () => {
-    useCurrentUserMock.mockReturnValue({ user: null, signer: null });
-    render(<AgeVerificationOverlay onVerified={vi.fn()} />);
-
-    expect(screen.getByText(/sign in to view this content/i)).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /18 or older/i })).toBeNull();
-  });
-
-  it('renders a Sign In button that opens the login dialog', () => {
-    useCurrentUserMock.mockReturnValue({ user: null, signer: null });
-    render(<AgeVerificationOverlay onVerified={vi.fn()} />);
-
-    const signInButton = screen.getByRole('button', { name: /sign in/i });
-    fireEvent.click(signInButton);
-    expect(openLoginDialog).toHaveBeenCalledTimes(1);
-  });
-
-  it('keeps the existing "I\'m 18 or older" flow when a user IS logged in', () => {
-    useCurrentUserMock.mockReturnValue({
-      user: { pubkey: 'pub' },
-      signer: { signEvent: vi.fn(), getPublicKey: vi.fn() },
-    });
+  it('shows the "I\'m 18 or older" button to anonymous viewers', () => {
     const onVerified = vi.fn();
     render(<AgeVerificationOverlay onVerified={onVerified} />);
 
-    expect(screen.queryByText(/sign in to view this content/i)).toBeNull();
+    const confirmButton = screen.getByRole('button', { name: /18 or older/i });
+    fireEvent.click(confirmButton);
+
+    expect(confirmAdult).toHaveBeenCalledTimes(1);
+    expect(onVerified).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the existing "I\'m 18 or older" flow when a user IS logged in', () => {
+    const onVerified = vi.fn();
+    render(<AgeVerificationOverlay onVerified={onVerified} />);
+
     const confirmButton = screen.getByRole('button', { name: /18 or older/i });
     fireEvent.click(confirmButton);
     expect(confirmAdult).toHaveBeenCalledTimes(1);
@@ -71,10 +48,6 @@ describe('AgeVerificationOverlay', () => {
 
   it('renders nothing when isVerified is true (preserves existing early-return)', () => {
     isVerifiedRef.current = true;
-    useCurrentUserMock.mockReturnValue({
-      user: { pubkey: 'pub' },
-      signer: { signEvent: vi.fn(), getPublicKey: vi.fn() },
-    });
     const { container } = render(<AgeVerificationOverlay onVerified={vi.fn()} />);
     expect(container.firstChild).toBeNull();
   });

--- a/src/components/AgeVerificationOverlay.test.tsx
+++ b/src/components/AgeVerificationOverlay.test.tsx
@@ -1,14 +1,9 @@
-// ABOUTME: Tests that AgeVerificationOverlay shows a Sign In CTA to logged-out viewers
-// ABOUTME: and preserves the existing "I'm 18 or older" flow for logged-in viewers
+// ABOUTME: Tests that AgeVerificationOverlay lets both logged-in and anonymous viewers
+// ABOUTME: pass the age gate via the shared "I'm 18 or older" confirm flow.
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { initializeI18n } from '@/lib/i18n';
-
-const openLoginDialog = vi.fn();
-vi.mock('@/contexts/LoginDialogContext', () => ({
-  useLoginDialog: () => ({ openLoginDialog, closeLoginDialog: vi.fn(), isOpen: false }),
-}));
 
 const confirmAdult = vi.fn();
 const isVerifiedRef = { current: false };
@@ -21,11 +16,6 @@ vi.mock('@/hooks/useAdultVerification', () => ({
     revokeVerification: vi.fn(),
     getAuthHeader: vi.fn(),
   }),
-}));
-
-const useCurrentUserMock = vi.fn();
-vi.mock('@/hooks/useCurrentUser', () => ({
-  useCurrentUser: () => useCurrentUserMock(),
 }));
 
 import { AgeVerificationOverlay } from '@/components/AgeVerificationOverlay';
@@ -43,38 +33,25 @@ describe('AgeVerificationOverlay', () => {
       } satisfies Pick<Storage, 'getItem' | 'setItem' | 'removeItem' | 'clear'>,
     });
     await initializeI18n({ force: true, languages: ['en-US'] });
-    openLoginDialog.mockClear();
     confirmAdult.mockClear();
-    useCurrentUserMock.mockReset();
     isVerifiedRef.current = false;
   });
 
-  it('shows "Sign in to view this content" heading when no user is logged in', () => {
-    useCurrentUserMock.mockReturnValue({ user: null, signer: null });
-    render(<AgeVerificationOverlay onVerified={vi.fn()} />);
-
-    expect(screen.getByText(/sign in to view this content/i)).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /18 or older/i })).toBeNull();
-  });
-
-  it('renders a Sign In button that opens the login dialog', () => {
-    useCurrentUserMock.mockReturnValue({ user: null, signer: null });
-    render(<AgeVerificationOverlay onVerified={vi.fn()} />);
-
-    const signInButton = screen.getByRole('button', { name: /sign in/i });
-    fireEvent.click(signInButton);
-    expect(openLoginDialog).toHaveBeenCalledTimes(1);
-  });
-
-  it('keeps the existing "I\'m 18 or older" flow when a user IS logged in', () => {
-    useCurrentUserMock.mockReturnValue({
-      user: { pubkey: 'pub' },
-      signer: { signEvent: vi.fn(), getPublicKey: vi.fn() },
-    });
+  it('shows the "I\'m 18 or older" button to anonymous viewers', () => {
     const onVerified = vi.fn();
     render(<AgeVerificationOverlay onVerified={onVerified} />);
 
-    expect(screen.queryByText(/sign in to view this content/i)).toBeNull();
+    const confirmButton = screen.getByRole('button', { name: /18 or older/i });
+    fireEvent.click(confirmButton);
+
+    expect(confirmAdult).toHaveBeenCalledTimes(1);
+    expect(onVerified).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the existing "I\'m 18 or older" flow when a user IS logged in', () => {
+    const onVerified = vi.fn();
+    render(<AgeVerificationOverlay onVerified={onVerified} />);
+
     const confirmButton = screen.getByRole('button', { name: /18 or older/i });
     fireEvent.click(confirmButton);
     expect(confirmAdult).toHaveBeenCalledTimes(1);
@@ -83,10 +60,6 @@ describe('AgeVerificationOverlay', () => {
 
   it('renders nothing when isVerified is true (preserves existing early-return)', () => {
     isVerifiedRef.current = true;
-    useCurrentUserMock.mockReturnValue({
-      user: { pubkey: 'pub' },
-      signer: { signEvent: vi.fn(), getPublicKey: vi.fn() },
-    });
     const { container } = render(<AgeVerificationOverlay onVerified={vi.fn()} />);
     expect(container.firstChild).toBeNull();
   });

--- a/src/components/AgeVerificationOverlay.tsx
+++ b/src/components/AgeVerificationOverlay.tsx
@@ -31,12 +31,18 @@ export function AgeVerificationOverlay({
 
     isConfirmingRef.current = true;
     setIsConfirming(true);
-    confirmAdult();
+    try {
+      confirmAdult();
 
-    // Call onVerified synchronously with guard to prevent multiple calls
-    if (!hasCalledOnVerified.current) {
-      hasCalledOnVerified.current = true;
-      onVerified();
+      // Call onVerified synchronously with guard to prevent multiple calls
+      if (!hasCalledOnVerified.current) {
+        hasCalledOnVerified.current = true;
+        onVerified();
+      }
+    } finally {
+      // Always release the lock so a throw doesn't permanently disable the button
+      isConfirmingRef.current = false;
+      setIsConfirming(false);
     }
   };
 

--- a/src/components/AgeVerificationOverlay.tsx
+++ b/src/components/AgeVerificationOverlay.tsx
@@ -5,8 +5,6 @@ import { useState, useEffect, useRef } from 'react';
 import { Button } from '@/components/ui/button';
 import { Warning as AlertTriangle, ShieldCheck } from '@phosphor-icons/react';
 import { useAdultVerification } from '@/hooks/useAdultVerification';
-import { useCurrentUser } from '@/hooks/useCurrentUser';
-import { useLoginDialog } from '@/contexts/LoginDialogContext';
 import { cn } from '@/lib/utils';
 
 interface AgeVerificationOverlayProps {
@@ -23,8 +21,6 @@ export function AgeVerificationOverlay({
   blurhash: _blurhash,
 }: AgeVerificationOverlayProps) {
   const { confirmAdult, isVerified } = useAdultVerification();
-  const { user } = useCurrentUser();
-  const { openLoginDialog } = useLoginDialog();
   const [isConfirming, setIsConfirming] = useState(false);
   const hasCalledOnVerified = useRef(false);
   const isConfirmingRef = useRef(false);
@@ -32,11 +28,11 @@ export function AgeVerificationOverlay({
   const handleConfirm = () => {
     // Prevent double-clicks
     if (isConfirmingRef.current) return;
-    
+
     isConfirmingRef.current = true;
     setIsConfirming(true);
     confirmAdult();
-    
+
     // Call onVerified synchronously with guard to prevent multiple calls
     if (!hasCalledOnVerified.current) {
       hasCalledOnVerified.current = true;
@@ -76,55 +72,36 @@ export function AgeVerificationOverlay({
 
       <div className="relative z-10 flex flex-col items-center gap-4 p-6 text-center max-w-sm">
         <div className="w-16 h-16 rounded-full bg-yellow-500/20 flex items-center justify-center">
-          {user ? (
-            <AlertTriangle className="w-8 h-8 text-yellow-500" />
-          ) : (
-            <ShieldCheck className="w-8 h-8 text-yellow-500" />
-          )}
+          <AlertTriangle className="w-8 h-8 text-yellow-500" />
         </div>
 
-        {user ? (
-          <>
-            <div className="space-y-2">
-              <h3 className="text-lg font-semibold text-white">Age-Restricted Content</h3>
-              <p className="text-sm text-gray-300">
-                This content may not be appropriate for all audiences.
-              </p>
-            </div>
-            <Button
-              onClick={handleConfirm}
-              disabled={isConfirming}
-              className="gap-2 bg-white text-black hover:bg-gray-200 touch-manipulation"
-            >
-              {isConfirming ? (
-                <>Verifying...</>
-              ) : (
-                <>
-                  <ShieldCheck className="w-4 h-4" />
-                  I'm 18 or older
-                </>
-              )}
-            </Button>
-            <p className="text-xs text-gray-500 max-w-xs">
-              Your choice will be remembered for 30 days
-            </p>
-          </>
-        ) : (
-          <>
-            <div className="space-y-2">
-              <h3 className="text-lg font-semibold text-white">Sign in to view this content</h3>
-              <p className="text-sm text-gray-300">
-                This content is age-restricted. Sign in so we can confirm your age and load the video.
-              </p>
-            </div>
-            <Button
-              onClick={openLoginDialog}
-              className="gap-2 bg-white text-black hover:bg-gray-200 touch-manipulation"
-            >
-              Sign in
-            </Button>
-          </>
-        )}
+        <div className="space-y-2">
+          <h3 className="text-lg font-semibold text-white">
+            Age-Restricted Content
+          </h3>
+          <p className="text-sm text-gray-300">
+            This content may not be appropriate for all audiences.
+          </p>
+        </div>
+
+        <Button
+          onClick={handleConfirm}
+          disabled={isConfirming}
+          className="gap-2 bg-white text-black hover:bg-gray-200 touch-manipulation"
+        >
+          {isConfirming ? (
+            <>Verifying...</>
+          ) : (
+            <>
+              <ShieldCheck className="w-4 h-4" />
+              I'm 18 or older
+            </>
+          )}
+        </Button>
+
+        <p className="text-xs text-gray-500 max-w-xs">
+          Your choice will be remembered for 30 days
+        </p>
       </div>
     </div>
   );

--- a/src/components/AgeVerificationOverlay.tsx
+++ b/src/components/AgeVerificationOverlay.tsx
@@ -33,12 +33,18 @@ export function AgeVerificationOverlay({
 
     isConfirmingRef.current = true;
     setIsConfirming(true);
-    confirmAdult();
+    try {
+      confirmAdult();
 
-    // Call onVerified synchronously with guard to prevent multiple calls
-    if (!hasCalledOnVerified.current) {
-      hasCalledOnVerified.current = true;
-      onVerified();
+      // Call onVerified synchronously with guard to prevent multiple calls
+      if (!hasCalledOnVerified.current) {
+        hasCalledOnVerified.current = true;
+        onVerified();
+      }
+    } finally {
+      // Always release the lock so a throw doesn't permanently disable the button
+      isConfirmingRef.current = false;
+      setIsConfirming(false);
     }
   };
 

--- a/src/components/AgeVerificationOverlay.tsx
+++ b/src/components/AgeVerificationOverlay.tsx
@@ -6,8 +6,6 @@ import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { Warning as AlertTriangle, ShieldCheck } from '@phosphor-icons/react';
 import { useAdultVerification } from '@/hooks/useAdultVerification';
-import { useCurrentUser } from '@/hooks/useCurrentUser';
-import { useLoginDialog } from '@/contexts/LoginDialogContext';
 import { cn } from '@/lib/utils';
 
 interface AgeVerificationOverlayProps {
@@ -25,8 +23,6 @@ export function AgeVerificationOverlay({
 }: AgeVerificationOverlayProps) {
   const { t } = useTranslation();
   const { confirmAdult, isVerified } = useAdultVerification();
-  const { user } = useCurrentUser();
-  const { openLoginDialog } = useLoginDialog();
   const [isConfirming, setIsConfirming] = useState(false);
   const hasCalledOnVerified = useRef(false);
   const isConfirmingRef = useRef(false);
@@ -34,11 +30,11 @@ export function AgeVerificationOverlay({
   const handleConfirm = () => {
     // Prevent double-clicks
     if (isConfirmingRef.current) return;
-    
+
     isConfirmingRef.current = true;
     setIsConfirming(true);
     confirmAdult();
-    
+
     // Call onVerified synchronously with guard to prevent multiple calls
     if (!hasCalledOnVerified.current) {
       hasCalledOnVerified.current = true;
@@ -78,55 +74,34 @@ export function AgeVerificationOverlay({
 
       <div className="relative z-10 flex flex-col items-center gap-4 p-6 text-center max-w-sm">
         <div className="w-16 h-16 rounded-full bg-yellow-500/20 flex items-center justify-center">
-          {user ? (
-            <AlertTriangle className="w-8 h-8 text-yellow-500" />
-          ) : (
-            <ShieldCheck className="w-8 h-8 text-yellow-500" />
-          )}
+          <AlertTriangle className="w-8 h-8 text-yellow-500" />
         </div>
 
-        {user ? (
-          <>
-            <div className="space-y-2">
-              <h3 className="text-lg font-semibold text-white">{t('ageVerificationOverlay.restrictedHeading')}</h3>
-              <p className="text-sm text-gray-300">
-                {t('ageVerificationOverlay.restrictedBody')}
-              </p>
-            </div>
-            <Button
-              onClick={handleConfirm}
-              disabled={isConfirming}
-              className="gap-2 bg-white text-black hover:bg-gray-200 touch-manipulation"
-            >
-              {isConfirming ? (
-                <>{t('ageVerificationOverlay.verifying')}</>
-              ) : (
-                <>
-                  <ShieldCheck className="w-4 h-4" />
-                  {t('ageVerificationOverlay.confirmButton')}
-                </>
-              )}
-            </Button>
-            <p className="text-xs text-gray-500 max-w-xs">
-              {t('ageVerificationOverlay.rememberNote')}
-            </p>
-          </>
-        ) : (
-          <>
-            <div className="space-y-2">
-              <h3 className="text-lg font-semibold text-white">{t('ageVerificationOverlay.signInHeading')}</h3>
-              <p className="text-sm text-gray-300">
-                {t('ageVerificationOverlay.signInBody')}
-              </p>
-            </div>
-            <Button
-              onClick={openLoginDialog}
-              className="gap-2 bg-white text-black hover:bg-gray-200 touch-manipulation"
-            >
-              {t('ageVerificationOverlay.signInButton')}
-            </Button>
-          </>
-        )}
+        <div className="space-y-2">
+          <h3 className="text-lg font-semibold text-white">{t('ageVerificationOverlay.restrictedHeading')}</h3>
+          <p className="text-sm text-gray-300">
+            {t('ageVerificationOverlay.restrictedBody')}
+          </p>
+        </div>
+
+        <Button
+          onClick={handleConfirm}
+          disabled={isConfirming}
+          className="gap-2 bg-white text-black hover:bg-gray-200 touch-manipulation"
+        >
+          {isConfirming ? (
+            <>{t('ageVerificationOverlay.verifying')}</>
+          ) : (
+            <>
+              <ShieldCheck className="w-4 h-4" />
+              {t('ageVerificationOverlay.confirmButton')}
+            </>
+          )}
+        </Button>
+
+        <p className="text-xs text-gray-500 max-w-xs">
+          {t('ageVerificationOverlay.rememberNote')}
+        </p>
       </div>
     </div>
   );

--- a/src/components/FullscreenFeed.tsx
+++ b/src/components/FullscreenFeed.tsx
@@ -33,6 +33,7 @@ function FullscreenVideoWithMetrics({
   isActive,
   onBack,
   onEnded,
+  onUnavailable,
   loopPlayback = true,
 }: {
   video: ParsedVideoData;
@@ -40,6 +41,7 @@ function FullscreenVideoWithMetrics({
   isActive: boolean;
   onBack: () => void;
   onEnded?: () => void;
+  onUnavailable?: () => void;
   loopPlayback?: boolean;
 }) {
   const { user } = useCurrentUser();
@@ -153,6 +155,7 @@ function FullscreenVideoWithMetrics({
       commentCount={(video.commentCount ?? 0) + (socialMetrics.data?.commentCount ?? 0)}
       viewCount={divineViewCount + (video.loopCount ?? 0)}
       onEnded={onEnded}
+      onUnavailable={onUnavailable}
       loopPlayback={loopPlayback}
       playbackId={`fullscreen:${video.id}`}
     />
@@ -265,6 +268,23 @@ export function FullscreenFeed({
     }
   }, [autoAdvance, awaitingNextPage, currentIndex, hasMore, onLoadMore, scrollToIndex, videos.length]);
 
+  // Always advance when the currently-active video becomes unavailable (404/410),
+  // independent of autoAdvance — the user can't do anything with a dead card.
+  const handleUnavailable = useCallback((itemIndex: number) => {
+    if (itemIndex !== currentIndex) return; // ignore preload failures off-screen
+
+    if (currentIndex < videos.length - 1) {
+      setCurrentIndex(index => Math.min(index + 1, videos.length - 1));
+      scrollToIndex(currentIndex + 1);
+      return;
+    }
+
+    if (hasMore && onLoadMore && !awaitingNextPage) {
+      setAwaitingNextPage(true);
+      onLoadMore();
+    }
+  }, [awaitingNextPage, currentIndex, hasMore, onLoadMore, scrollToIndex, videos.length]);
+
   // Handle keyboard navigation
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -311,6 +331,7 @@ export function FullscreenFeed({
             isActive={index === currentIndex}
             onBack={onClose}
             onEnded={handleAdvance}
+            onUnavailable={() => handleUnavailable(index)}
             loopPlayback={!autoAdvance}
           />
         ))}

--- a/src/components/FullscreenFeed.tsx
+++ b/src/components/FullscreenFeed.tsx
@@ -34,6 +34,7 @@ function FullscreenVideoWithMetrics({
   isActive,
   onBack,
   onEnded,
+  onUnavailable,
   loopPlayback = true,
 }: {
   video: ParsedVideoData;
@@ -41,6 +42,7 @@ function FullscreenVideoWithMetrics({
   isActive: boolean;
   onBack: () => void;
   onEnded?: () => void;
+  onUnavailable?: () => void;
   loopPlayback?: boolean;
 }) {
   const { t } = useTranslation();
@@ -155,6 +157,7 @@ function FullscreenVideoWithMetrics({
       commentCount={(video.commentCount ?? 0) + (socialMetrics.data?.commentCount ?? 0)}
       viewCount={divineViewCount + (video.loopCount ?? 0)}
       onEnded={onEnded}
+      onUnavailable={onUnavailable}
       loopPlayback={loopPlayback}
       playbackId={`fullscreen:${video.id}`}
     />
@@ -267,6 +270,23 @@ export function FullscreenFeed({
     }
   }, [autoAdvance, awaitingNextPage, currentIndex, hasMore, onLoadMore, scrollToIndex, videos.length]);
 
+  // Always advance when the currently-active video becomes unavailable (404/410),
+  // independent of autoAdvance — the user can't do anything with a dead card.
+  const handleUnavailable = useCallback((itemIndex: number) => {
+    if (itemIndex !== currentIndex) return; // ignore preload failures off-screen
+
+    if (currentIndex < videos.length - 1) {
+      setCurrentIndex(index => Math.min(index + 1, videos.length - 1));
+      scrollToIndex(currentIndex + 1);
+      return;
+    }
+
+    if (hasMore && onLoadMore && !awaitingNextPage) {
+      setAwaitingNextPage(true);
+      onLoadMore();
+    }
+  }, [awaitingNextPage, currentIndex, hasMore, onLoadMore, scrollToIndex, videos.length]);
+
   // Handle keyboard navigation
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -313,6 +333,7 @@ export function FullscreenFeed({
             isActive={index === currentIndex}
             onBack={onClose}
             onEnded={handleAdvance}
+            onUnavailable={() => handleUnavailable(index)}
             loopPlayback={!autoAdvance}
           />
         ))}

--- a/src/components/FullscreenVideoItem.tsx
+++ b/src/components/FullscreenVideoItem.tsx
@@ -49,6 +49,7 @@ interface FullscreenVideoItemProps {
   trafficSource?: ViewTrafficSource;
   onBack: () => void;
   onEnded?: () => void;
+  onUnavailable?: () => void;
   loopPlayback?: boolean;
   onLike: () => void;
   onRepost: () => void;
@@ -68,6 +69,7 @@ export function FullscreenVideoItem({
   playbackId,
   onBack,
   onEnded,
+  onUnavailable,
   loopPlayback = true,
   onLike,
   onRepost,
@@ -248,7 +250,10 @@ export function FullscreenVideoItem({
             poster={video.thumbnailUrl}
             blurhash={video.blurhash}
             className="w-full h-full object-contain"
-            onError={() => setVideoError(true)}
+            onError={() => {
+              setVideoError(true);
+              onUnavailable?.();
+            }}
             onEnded={onEnded}
             loopPlayback={loopPlayback}
             onSwipeRight={handleSwipeRight}

--- a/src/components/FullscreenVideoItem.tsx
+++ b/src/components/FullscreenVideoItem.tsx
@@ -50,6 +50,7 @@ interface FullscreenVideoItemProps {
   trafficSource?: ViewTrafficSource;
   onBack: () => void;
   onEnded?: () => void;
+  onUnavailable?: () => void;
   loopPlayback?: boolean;
   onLike: () => void;
   onRepost: () => void;
@@ -69,6 +70,7 @@ export function FullscreenVideoItem({
   playbackId,
   onBack,
   onEnded,
+  onUnavailable,
   loopPlayback = true,
   onLike,
   onRepost,
@@ -252,7 +254,10 @@ export function FullscreenVideoItem({
             poster={video.thumbnailUrl}
             blurhash={video.blurhash}
             className="w-full h-full object-contain"
-            onError={() => setVideoError(true)}
+            onError={() => {
+              setVideoError(true);
+              onUnavailable?.();
+            }}
             onEnded={onEnded}
             loopPlayback={loopPlayback}
             onSwipeRight={handleSwipeRight}

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -151,11 +151,15 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
     const registerVideoRef = useRef(registerVideo);
     const unregisterVideoRef = useRef(unregisterVideo);
     const globalMutedRef = useRef(globalMuted);
+    // onError is often passed as a fresh inline arrow from the parent; route through a ref
+    // so state-triggered re-renders (like counts, mute, etc.) don't churn the source-loading effect.
+    const onErrorRef = useRef(onError);
 
     // Keep refs updated with latest values
     registerVideoRef.current = registerVideo;
     unregisterVideoRef.current = unregisterVideo;
     globalMutedRef.current = globalMuted;
+    onErrorRef.current = onError;
 
     // Get responsive layout class
     const getLayoutClass = useCallback(() => {
@@ -585,9 +589,9 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
         debugError(`[VideoPlayer ${videoId}] All URLs failed, no more fallbacks`);
         setIsLoading(false);
         setHasError(true);
-        onError?.();
+        onErrorRef.current?.();
       }
-    }, [videoId, currentUrlIndex, allUrls, hlsUrl, triedHls, onError]);
+    }, [videoId, currentUrlIndex, allUrls, hlsUrl, triedHls]);
 
     const handleEnded = () => {
       verboseLog(
@@ -748,7 +752,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
             debugError(`[VideoPlayer ${videoId}] Preflight: direct blob unavailable (${status})`);
             setIsUnavailable(true);
             setIsLoading(false);
-            onError?.();
+            onErrorRef.current?.();
             return false;
           }
           if (!authorized && (status === 401 || status === 403) && !isAdultVerified) {
@@ -894,7 +898,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
                     debugError(`[VideoPlayer ${videoId}] MP4 fetch: blob unavailable (${response.status})`);
                     setIsUnavailable(true);
                     setIsLoading(false);
-                    onError?.();
+                    onErrorRef.current?.();
                   } else if (response.status === 401 || response.status === 403) {
                     debugError(`[VideoPlayer ${videoId}] Auth failed even with NIP-98 (${response.status})`);
                     if (isAdultVerified) {
@@ -945,7 +949,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
         }
       };
 
-    }, [hlsUrl, currentUrlIndex, allUrls, videoId, requiresAuth, isUnavailable, isAdultVerified, authRetryCount, getAuthHeader, videoData?.sha256, onError]); // React to HLS URL, fallback, and auth changes
+    }, [hlsUrl, currentUrlIndex, allUrls, videoId, requiresAuth, isUnavailable, isAdultVerified, authRetryCount, getAuthHeader, videoData?.sha256]); // React to HLS URL, fallback, and auth changes — onError goes via ref
 
     // Cleanup on unmount
     useEffect(() => {

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -721,12 +721,6 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
 
       // Skip if the blob is gone (404/410) — don't keep retrying
       if (isUnavailable) {
-        verboseLog(`[VideoPlayer ${videoId}] Skipping source setup - unavailable`);
-        return;
-      }
-
-      // Skip if blob is gone (404/410) — don't keep retrying
-      if (isUnavailable) {
         verboseLog(`[VideoPlayer ${videoId}] Skipping source setup - unavailable (404/410)`);
         return;
       }

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -120,6 +120,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
     const [hasError, setHasError] = useState(false);
     const [requiresAuth, setRequiresAuth] = useState(false);
     const [authDeniedAfterVerification, setAuthDeniedAfterVerification] = useState(false);
+    const [isUnavailable, setIsUnavailable] = useState(false); // Terminal: blob gone (404/410) — don't retry, skip in feeds
     const [authCheckPending, setAuthCheckPending] = useState(true); // Start true, set false after check completes
     const [authRetryCount, setAuthRetryCount] = useState(0);
     const [currentUrlIndex, setCurrentUrlIndex] = useState(0);
@@ -718,6 +719,18 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
         return;
       }
 
+      // Skip if the blob is gone (404/410) — don't keep retrying
+      if (isUnavailable) {
+        verboseLog(`[VideoPlayer ${videoId}] Skipping source setup - unavailable`);
+        return;
+      }
+
+      // Skip if blob is gone (404/410) — don't keep retrying
+      if (isUnavailable) {
+        verboseLog(`[VideoPlayer ${videoId}] Skipping source setup - unavailable (404/410)`);
+        return;
+      }
+
       // Cleanup previous HLS instance
       if (hlsRef.current) {
         verboseLog(`[VideoPlayer ${videoId}] Destroying previous HLS instance`);
@@ -728,17 +741,26 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
       // Preflight auth check for HLS URL
       const checkAuth = async () => {
         const urlToCheck = hlsUrl || allUrls[currentUrlIndex];
-        if (urlToCheck && !isAdultVerified) {
-          const { authorized, status } = await checkMediaAuth(urlToCheck);
+        if (urlToCheck) {
+          const result = await checkMediaAuth(urlToCheck);
+          const { authorized, status } = result ?? { authorized: true, status: 0 };
           setAuthCheckPending(false);
-          if (!authorized && (status === 401 || status === 403)) {
+          // Terminal: blob is gone. Don't retry, tell the parent to skip.
+          if (status === 404 || status === 410) {
+            debugError(`[VideoPlayer ${videoId}] Preflight check: blob unavailable (${status})`);
+            setIsUnavailable(true);
+            setIsLoading(false);
+            onError?.();
+            return false;
+          }
+          if (!authorized && (status === 401 || status === 403) && !isAdultVerified) {
             verboseLog(`[VideoPlayer ${videoId}] Preflight check: auth required (${status})`);
             setRequiresAuth(true);
             setIsLoading(false);
             return false;
           }
         } else {
-          // Already verified or no URL to check
+          // No URL to check
           setAuthCheckPending(false);
         }
         return true;
@@ -789,6 +811,16 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
 
         hls.on(Hls.Events.ERROR, (event, data) => {
           debugError(`[VideoPlayer ${videoId}] HLS error:`, data);
+
+          // Terminal: blob gone
+          if (data.response && (data.response.code === 404 || data.response.code === 410)) {
+            debugError(`[VideoPlayer ${videoId}] HLS blob unavailable (${data.response.code})`);
+            setIsUnavailable(true);
+            setIsLoading(false);
+            hls.destroy();
+            onError?.();
+            return;
+          }
 
           // Check for 401/403 auth errors
           if (data.response && (data.response.code === 401 || data.response.code === 403)) {
@@ -866,6 +898,11 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
                     video.onloadeddata = () => {
                       verboseLog(`[VideoPlayer ${videoId}] MP4 blob loaded successfully`);
                     };
+                  } else if (response.status === 404 || response.status === 410) {
+                    debugError(`[VideoPlayer ${videoId}] MP4 fetch: blob unavailable (${response.status})`);
+                    setIsUnavailable(true);
+                    setIsLoading(false);
+                    onError?.();
                   } else if (response.status === 401 || response.status === 403) {
                     debugError(`[VideoPlayer ${videoId}] Auth failed even with NIP-98 (${response.status})`);
                     if (isAdultVerified) {
@@ -916,7 +953,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
         }
       };
 
-    }, [hlsUrl, currentUrlIndex, allUrls, videoId, requiresAuth, isAdultVerified, authRetryCount, getAuthHeader, videoData?.sha256]); // React to HLS URL, fallback, and auth changes
+    }, [hlsUrl, currentUrlIndex, allUrls, videoId, requiresAuth, isUnavailable, isAdultVerified, authRetryCount, getAuthHeader, videoData?.sha256, onError]); // React to HLS URL, fallback, and auth changes
 
     // Cleanup on unmount
     useEffect(() => {
@@ -1040,7 +1077,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
         )}
 
         {/* Loading state - show loading animation over blurhash, only on initial load */}
-        {isLoading && !hasLoadedOnce && (
+        {isLoading && !hasLoadedOnce && !isUnavailable && (
           <div
             className="absolute inset-0 flex items-center justify-center z-20"
             data-testid={isMobile ? "mobile-loading" : undefined}
@@ -1067,13 +1104,23 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
         )}
 
         {/* Error state */}
-        {hasError && !requiresAuth && !authDeniedAfterVerification && (
+        {hasError && !requiresAuth && !authDeniedAfterVerification && !isUnavailable && (
           <div className="absolute inset-0 flex items-center justify-center text-muted-foreground">
             <div className="text-center">
               <div>Failed to load video</div>
               {isMobile && (
                 <div className="text-sm mt-2">Tap to retry</div>
               )}
+            </div>
+          </div>
+        )}
+
+        {/* Terminal: blob gone from storage (404/410) */}
+        {isUnavailable && (
+          <div className="absolute inset-0 flex items-center justify-center bg-black/80 text-muted-foreground">
+            <div className="text-center px-4">
+              <div className="text-white font-medium">Video unavailable</div>
+              <div className="text-sm mt-1 text-gray-400">This video is no longer available</div>
             </div>
           </div>
         )}

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -738,16 +738,20 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
         hlsRef.current = null;
       }
 
-      // Preflight auth check for HLS URL
+      // Preflight the direct MP4 URL, not the HLS manifest.
+      //   - HLS can legitimately return 202 (transcode pending) or 404 (never generated
+      //     for classic Vines) while the direct blob is fine. HLS.js has its own error
+      //     handler that falls back to direct src when the manifest fails.
+      //   - VTT / thumbnail 404s are sidecar assets and must not fail the whole video.
       const checkAuth = async () => {
-        const urlToCheck = hlsUrl || allUrls[currentUrlIndex];
+        const urlToCheck = allUrls[currentUrlIndex];
         if (urlToCheck) {
           const result = await checkMediaAuth(urlToCheck);
           const { authorized, status } = result ?? { authorized: true, status: 0 };
           setAuthCheckPending(false);
-          // Terminal: blob is gone. Don't retry, tell the parent to skip.
+          // Terminal: direct blob is gone. Don't retry, tell the parent to skip.
           if (status === 404 || status === 410) {
-            debugError(`[VideoPlayer ${videoId}] Preflight check: blob unavailable (${status})`);
+            debugError(`[VideoPlayer ${videoId}] Preflight: direct blob unavailable (${status})`);
             setIsUnavailable(true);
             setIsLoading(false);
             onError?.();
@@ -812,15 +816,9 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
         hls.on(Hls.Events.ERROR, (event, data) => {
           debugError(`[VideoPlayer ${videoId}] HLS error:`, data);
 
-          // Terminal: blob gone
-          if (data.response && (data.response.code === 404 || data.response.code === 410)) {
-            debugError(`[VideoPlayer ${videoId}] HLS blob unavailable (${data.response.code})`);
-            setIsUnavailable(true);
-            setIsLoading(false);
-            hls.destroy();
-            onError?.();
-            return;
-          }
+          // Note: an HLS 404/410 is NOT terminal — classic Vines often only have a direct
+          // MP4 and never got transcoded to HLS. Fall through to the direct-playback
+          // fallback below and let that path decide if the blob itself is actually gone.
 
           // Check for 401/403 auth errors
           if (data.response && (data.response.code === 401 || data.response.code === 403)) {

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -122,6 +122,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
     const [hasError, setHasError] = useState(false);
     const [requiresAuth, setRequiresAuth] = useState(false);
     const [authDeniedAfterVerification, setAuthDeniedAfterVerification] = useState(false);
+    const [isUnavailable, setIsUnavailable] = useState(false); // Terminal: blob gone (404/410) — don't retry, skip in feeds
     const [authCheckPending, setAuthCheckPending] = useState(true); // Start true, set false after check completes
     const [authRetryCount, setAuthRetryCount] = useState(0);
     const [currentUrlIndex, setCurrentUrlIndex] = useState(0);
@@ -744,6 +745,12 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
         return;
       }
 
+      // Skip if the blob is gone (404/410) — don't keep retrying
+      if (isUnavailable) {
+        verboseLog(`[VideoPlayer ${videoId}] Skipping source setup - unavailable`);
+        return;
+      }
+
       // Cleanup previous HLS instance
       if (hlsRef.current) {
         verboseLog(`[VideoPlayer ${videoId}] Destroying previous HLS instance`);
@@ -754,17 +761,26 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
       // Preflight auth check for HLS URL
       const checkAuth = async () => {
         const urlToCheck = hlsUrl || allUrls[currentUrlIndex];
-        if (urlToCheck && !isAdultVerified) {
-          const authResult = await checkMediaAuth(urlToCheck);
+        if (urlToCheck) {
+          const result = await checkMediaAuth(urlToCheck);
+          const { authorized, status } = result ?? { authorized: true, status: 0 };
           setAuthCheckPending(false);
-          if (authResult && !authResult.authorized && (authResult.status === 401 || authResult.status === 403)) {
-            verboseLog(`[VideoPlayer ${videoId}] Preflight check: auth required (${authResult.status})`);
+          // Terminal: blob is gone. Don't retry, tell the parent to skip.
+          if (status === 404 || status === 410) {
+            debugError(`[VideoPlayer ${videoId}] Preflight check: blob unavailable (${status})`);
+            setIsUnavailable(true);
+            setIsLoading(false);
+            onError?.();
+            return false;
+          }
+          if (!authorized && (status === 401 || status === 403) && !isAdultVerified) {
+            verboseLog(`[VideoPlayer ${videoId}] Preflight check: auth required (${status})`);
             setRequiresAuth(true);
             setIsLoading(false);
             return false;
           }
         } else {
-          // Already verified or no URL to check
+          // No URL to check
           setAuthCheckPending(false);
         }
         return true;
@@ -817,6 +833,16 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
 
         hls.on(Hls.Events.ERROR, (event, data) => {
           debugError(`[VideoPlayer ${videoId}] HLS error:`, data);
+
+          // Terminal: blob gone
+          if (data.response && (data.response.code === 404 || data.response.code === 410)) {
+            debugError(`[VideoPlayer ${videoId}] HLS blob unavailable (${data.response.code})`);
+            setIsUnavailable(true);
+            setIsLoading(false);
+            hls.destroy();
+            onError?.();
+            return;
+          }
 
           // Check for 401/403 auth errors
           if (data.response && (data.response.code === 401 || data.response.code === 403)) {
@@ -902,6 +928,11 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
                     video.onloadeddata = () => {
                       verboseLog(`[VideoPlayer ${videoId}] MP4 blob loaded successfully`);
                     };
+                  } else if (response.status === 404 || response.status === 410) {
+                    debugError(`[VideoPlayer ${videoId}] MP4 fetch: blob unavailable (${response.status})`);
+                    setIsUnavailable(true);
+                    setIsLoading(false);
+                    onError?.();
                   } else if (response.status === 401 || response.status === 403) {
                     debugError(`[VideoPlayer ${videoId}] Auth failed even with NIP-98 (${response.status})`);
                     if (isAdultVerified) {
@@ -952,7 +983,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
         }
       };
 
-    }, [hlsUrl, currentUrlIndex, allUrls, videoId, requiresAuth, isAdultVerified, authRetryCount, getAuthHeader, isKnownAgeRestricted]); // React to HLS URL, fallback, and auth changes
+    }, [hlsUrl, currentUrlIndex, allUrls, videoId, requiresAuth, isUnavailable, isAdultVerified, authRetryCount, getAuthHeader, isKnownAgeRestricted, onError]); // React to HLS URL, fallback, and auth changes
 
     // Cleanup on unmount
     useEffect(() => {
@@ -1076,7 +1107,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
         )}
 
         {/* Loading state - show loading animation over blurhash, only on initial load */}
-        {isLoading && !hasLoadedOnce && (
+        {isLoading && !hasLoadedOnce && !isUnavailable && (
           <div
             className="absolute inset-0 flex items-center justify-center z-20"
             data-testid={isMobile ? "mobile-loading" : undefined}
@@ -1103,13 +1134,23 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
         )}
 
         {/* Error state */}
-        {hasError && !requiresAuth && !authDeniedAfterVerification && (
+        {hasError && !requiresAuth && !authDeniedAfterVerification && !isUnavailable && (
           <div className="absolute inset-0 flex items-center justify-center text-muted-foreground">
             <div className="text-center">
               <div>{t('videoPlayer.loadFailed')}</div>
               {isMobile && (
                 <div className="text-sm mt-2">{t('videoPlayer.tapToRetry')}</div>
               )}
+            </div>
+          </div>
+        )}
+
+        {/* Terminal: blob gone from storage (404/410) */}
+        {isUnavailable && (
+          <div className="absolute inset-0 flex items-center justify-center bg-black/80 text-muted-foreground">
+            <div className="text-center px-4">
+              <div className="text-white font-medium">Video unavailable</div>
+              <div className="text-sm mt-1 text-gray-400">This video is no longer available</div>
             </div>
           </div>
         )}

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -747,7 +747,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
 
       // Skip if the blob is gone (404/410) — don't keep retrying
       if (isUnavailable) {
-        verboseLog(`[VideoPlayer ${videoId}] Skipping source setup - unavailable`);
+        verboseLog(`[VideoPlayer ${videoId}] Skipping source setup - unavailable (404/410)`);
         return;
       }
 

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -758,16 +758,20 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
         hlsRef.current = null;
       }
 
-      // Preflight auth check for HLS URL
+      // Preflight the direct MP4 URL, not the HLS manifest.
+      //   - HLS can legitimately return 202 (transcode pending) or 404 (never generated
+      //     for classic Vines) while the direct blob is fine. HLS.js has its own error
+      //     handler that falls back to direct src when the manifest fails.
+      //   - VTT / thumbnail 404s are sidecar assets and must not fail the whole video.
       const checkAuth = async () => {
-        const urlToCheck = hlsUrl || allUrls[currentUrlIndex];
+        const urlToCheck = allUrls[currentUrlIndex];
         if (urlToCheck) {
           const result = await checkMediaAuth(urlToCheck);
           const { authorized, status } = result ?? { authorized: true, status: 0 };
           setAuthCheckPending(false);
-          // Terminal: blob is gone. Don't retry, tell the parent to skip.
+          // Terminal: direct blob is gone. Don't retry, tell the parent to skip.
           if (status === 404 || status === 410) {
-            debugError(`[VideoPlayer ${videoId}] Preflight check: blob unavailable (${status})`);
+            debugError(`[VideoPlayer ${videoId}] Preflight: direct blob unavailable (${status})`);
             setIsUnavailable(true);
             setIsLoading(false);
             onError?.();
@@ -834,15 +838,9 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
         hls.on(Hls.Events.ERROR, (event, data) => {
           debugError(`[VideoPlayer ${videoId}] HLS error:`, data);
 
-          // Terminal: blob gone
-          if (data.response && (data.response.code === 404 || data.response.code === 410)) {
-            debugError(`[VideoPlayer ${videoId}] HLS blob unavailable (${data.response.code})`);
-            setIsUnavailable(true);
-            setIsLoading(false);
-            hls.destroy();
-            onError?.();
-            return;
-          }
+          // Note: an HLS 404/410 is NOT terminal — classic Vines often only have a direct
+          // MP4 and never got transcoded to HLS. Fall through to the direct-playback
+          // fallback below and let that path decide if the blob itself is actually gone.
 
           // Check for 401/403 auth errors
           if (data.response && (data.response.code === 401 || data.response.code === 403)) {

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -156,11 +156,15 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
     const registerVideoRef = useRef(registerVideo);
     const unregisterVideoRef = useRef(unregisterVideo);
     const globalMutedRef = useRef(globalMuted);
+    // onError is often passed as a fresh inline arrow from the parent; route through a ref
+    // so state-triggered re-renders (like counts, mute, etc.) don't churn the source-loading effect.
+    const onErrorRef = useRef(onError);
 
     // Keep refs updated with latest values
     registerVideoRef.current = registerVideo;
     unregisterVideoRef.current = unregisterVideo;
     globalMutedRef.current = globalMuted;
+    onErrorRef.current = onError;
 
     // Get responsive layout class
     const getLayoutClass = useCallback(() => {
@@ -611,9 +615,9 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
         debugError(`[VideoPlayer ${videoId}] All URLs failed, no more fallbacks`);
         setIsLoading(false);
         setHasError(true);
-        onError?.();
+        onErrorRef.current?.();
       }
-    }, [videoId, currentUrlIndex, allUrls, hlsUrl, src, triedHls, isAdultVerified, onError]);
+    }, [videoId, currentUrlIndex, allUrls, hlsUrl, src, triedHls, isAdultVerified]);
 
     const handleEnded = () => {
       verboseLog(
@@ -774,7 +778,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
             debugError(`[VideoPlayer ${videoId}] Preflight: direct blob unavailable (${status})`);
             setIsUnavailable(true);
             setIsLoading(false);
-            onError?.();
+            onErrorRef.current?.();
             return false;
           }
           if (!authorized && (status === 401 || status === 403) && !isAdultVerified) {
@@ -930,7 +934,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
                     debugError(`[VideoPlayer ${videoId}] MP4 fetch: blob unavailable (${response.status})`);
                     setIsUnavailable(true);
                     setIsLoading(false);
-                    onError?.();
+                    onErrorRef.current?.();
                   } else if (response.status === 401 || response.status === 403) {
                     debugError(`[VideoPlayer ${videoId}] Auth failed even with NIP-98 (${response.status})`);
                     if (isAdultVerified) {
@@ -981,7 +985,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
         }
       };
 
-    }, [hlsUrl, currentUrlIndex, allUrls, videoId, requiresAuth, isUnavailable, isAdultVerified, authRetryCount, getAuthHeader, isKnownAgeRestricted, onError]); // React to HLS URL, fallback, and auth changes
+    }, [hlsUrl, currentUrlIndex, allUrls, videoId, requiresAuth, isUnavailable, isAdultVerified, authRetryCount, getAuthHeader, isKnownAgeRestricted]); // React to HLS URL, fallback, and auth changes — onError goes via ref
 
     // Cleanup on unmount
     useEffect(() => {

--- a/src/components/VideoPlayer.unavailable.test.tsx
+++ b/src/components/VideoPlayer.unavailable.test.tsx
@@ -1,0 +1,129 @@
+// ABOUTME: Verifies VideoPlayer surfaces a terminal "unavailable" state on 404/410 preflight
+// ABOUTME: and signals the parent via onError so feeds/pages can skip or show a message.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+const checkMediaAuth = vi.fn();
+const getAuthHeader = vi.fn();
+
+vi.mock('@/hooks/useVideoPlayback', () => ({
+  useVideoPlayback: vi.fn(() => ({
+    activeVideoId: null,
+    registerVideo: vi.fn(),
+    unregisterVideo: vi.fn(),
+    updateVideoVisibility: vi.fn(),
+    globalMuted: true,
+  })),
+}));
+
+vi.mock('@/hooks/useIsMobile', () => ({
+  useIsMobile: vi.fn(() => false),
+}));
+
+vi.mock('@/hooks/useAdultVerification', () => ({
+  useAdultVerification: vi.fn(() => ({
+    isVerified: false,
+    isLoading: false,
+    hasSigner: false,
+    confirmAdult: vi.fn(),
+    revokeVerification: vi.fn(),
+    getAuthHeader,
+  })),
+  checkMediaAuth: (...args: unknown[]) => checkMediaAuth(...args),
+  fetchWithAuth: vi.fn(),
+}));
+
+vi.mock('@/hooks/useVideoMetricsTracker', () => ({
+  useVideoMetricsTracker: vi.fn(() => ({
+    watchedSeconds: 0,
+    loopCount: 0,
+    isTracking: false,
+  })),
+}));
+
+vi.mock('@/lib/debug', () => ({
+  debugError: vi.fn(),
+  verboseLog: vi.fn(),
+  debugLog: vi.fn(),
+}));
+
+vi.mock('@/lib/analytics', () => ({
+  trackFirstVideoPlayback: vi.fn(),
+}));
+
+vi.mock('hls.js', () => ({
+  default: {
+    isSupported: () => false,
+    Events: { MANIFEST_PARSED: 'hlsManifestParsed', ERROR: 'hlsError' },
+  },
+}));
+
+vi.mock('react-intersection-observer', () => ({
+  useInView: vi.fn(() => ({ ref: vi.fn(), inView: true, entry: null })),
+}));
+
+import { VideoPlayer } from './VideoPlayer';
+
+const URL_MP4 = 'https://media.divine.video/gone-file.mp4';
+
+describe('VideoPlayer — terminal unavailable (404/410)', () => {
+  beforeEach(() => {
+    HTMLMediaElement.prototype.play = vi.fn().mockResolvedValue(undefined);
+    HTMLMediaElement.prototype.pause = vi.fn();
+    HTMLMediaElement.prototype.load = vi.fn();
+    checkMediaAuth.mockReset();
+    getAuthHeader.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows an unavailable placeholder and calls onError when preflight returns 404', async () => {
+    checkMediaAuth.mockResolvedValue({ authorized: false, status: 404 });
+    const onError = vi.fn();
+
+    render(<VideoPlayer videoId="v-404" src={URL_MP4} onError={onError} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/video unavailable/i)).toBeInTheDocument();
+    });
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it('shows an unavailable placeholder when preflight returns 410', async () => {
+    checkMediaAuth.mockResolvedValue({ authorized: false, status: 410 });
+    const onError = vi.fn();
+
+    render(<VideoPlayer videoId="v-410" src={URL_MP4} onError={onError} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/video unavailable/i)).toBeInTheDocument();
+    });
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it('does not surface unavailable on a successful preflight (200)', async () => {
+    checkMediaAuth.mockResolvedValue({ authorized: true, status: 200 });
+    const onError = vi.fn();
+
+    render(<VideoPlayer videoId="v-ok" src={URL_MP4} onError={onError} />);
+
+    // Give the effect a tick to run
+    await new Promise((r) => setTimeout(r, 30));
+    expect(screen.queryByText(/video unavailable/i)).toBeNull();
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('does not surface unavailable on a 401 (that path shows the age-gate overlay instead)', async () => {
+    checkMediaAuth.mockResolvedValue({ authorized: false, status: 401 });
+    const onError = vi.fn();
+
+    render(<VideoPlayer videoId="v-401" src={URL_MP4} onError={onError} />);
+
+    await new Promise((r) => setTimeout(r, 30));
+    expect(screen.queryByText(/video unavailable/i)).toBeNull();
+    expect(onError).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/VideoPlayer.unavailable.test.tsx
+++ b/src/components/VideoPlayer.unavailable.test.tsx
@@ -126,4 +126,32 @@ describe('VideoPlayer — terminal unavailable (404/410)', () => {
     expect(screen.queryByText(/video unavailable/i)).toBeNull();
     expect(onError).not.toHaveBeenCalled();
   });
+
+  it('preflights the direct MP4 — not HLS — so a missing HLS manifest does not mark the video unavailable', async () => {
+    // Most real-world case: classic Vine has a fine MP4 but no HLS transcode yet.
+    // checkMediaAuth will be called with the MP4 URL and return 200.
+    // Fail the test if the HLS URL is ever passed to checkMediaAuth.
+    checkMediaAuth.mockImplementation(async (url: string) => {
+      if (url.includes('/hls/master.m3u8')) {
+        throw new Error('preflight should not hit HLS manifest: ' + url);
+      }
+      return { authorized: true, status: 200 };
+    });
+    const onError = vi.fn();
+
+    render(
+      <VideoPlayer
+        videoId="v-hls-404-but-mp4-ok"
+        src={URL_MP4}
+        hlsUrl="https://media.divine.video/foo/hls/master.m3u8"
+        onError={onError}
+      />,
+    );
+
+    await new Promise((r) => setTimeout(r, 30));
+    expect(screen.queryByText(/video unavailable/i)).toBeNull();
+    expect(onError).not.toHaveBeenCalled();
+    // And we should actually have preflighted the MP4
+    expect(checkMediaAuth).toHaveBeenCalledWith(URL_MP4);
+  });
 });

--- a/src/components/VideoPlayer.unavailable.test.tsx
+++ b/src/components/VideoPlayer.unavailable.test.tsx
@@ -110,8 +110,7 @@ describe('VideoPlayer — terminal unavailable (404/410)', () => {
 
     render(<VideoPlayer videoId="v-ok" src={URL_MP4} onError={onError} />);
 
-    // Give the effect a tick to run
-    await new Promise((r) => setTimeout(r, 30));
+    await waitFor(() => expect(checkMediaAuth).toHaveBeenCalled());
     expect(screen.queryByText(/video unavailable/i)).toBeNull();
     expect(onError).not.toHaveBeenCalled();
   });
@@ -122,7 +121,7 @@ describe('VideoPlayer — terminal unavailable (404/410)', () => {
 
     render(<VideoPlayer videoId="v-401" src={URL_MP4} onError={onError} />);
 
-    await new Promise((r) => setTimeout(r, 30));
+    await waitFor(() => expect(checkMediaAuth).toHaveBeenCalled());
     expect(screen.queryByText(/video unavailable/i)).toBeNull();
     expect(onError).not.toHaveBeenCalled();
   });
@@ -148,10 +147,8 @@ describe('VideoPlayer — terminal unavailable (404/410)', () => {
       />,
     );
 
-    await new Promise((r) => setTimeout(r, 30));
+    await waitFor(() => expect(checkMediaAuth).toHaveBeenCalledWith(URL_MP4));
     expect(screen.queryByText(/video unavailable/i)).toBeNull();
     expect(onError).not.toHaveBeenCalled();
-    // And we should actually have preflighted the MP4
-    expect(checkMediaAuth).toHaveBeenCalledWith(URL_MP4);
   });
 });

--- a/src/hooks/useAdultVerification.test.ts
+++ b/src/hooks/useAdultVerification.test.ts
@@ -2,11 +2,22 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAdultVerification } from './useAdultVerification';
 import { createMediaViewerAuthHeader } from '@/lib/mediaViewerAuth';
+import {
+  ANONYMOUS_SIGNER_SK_KEY,
+  ANONYMOUS_SIGNER_EXPIRY_KEY,
+} from '@/lib/ephemeralSigner';
 
-const mockSigner = { signEvent: vi.fn(), getPublicKey: vi.fn() };
+let mockSigner: { signEvent: ReturnType<typeof vi.fn>; getPublicKey: ReturnType<typeof vi.fn> } | null = {
+  signEvent: vi.fn(),
+  getPublicKey: vi.fn(),
+};
 
 vi.mock('@/hooks/useCurrentUser', () => ({
-  useCurrentUser: () => ({ signer: mockSigner, pubkey: 'pub', user: { pubkey: 'pub' } }),
+  useCurrentUser: () => ({
+    signer: mockSigner,
+    pubkey: mockSigner ? 'pub' : null,
+    user: mockSigner ? { pubkey: 'pub' } : null,
+  }),
 }));
 
 vi.mock('@/lib/mediaViewerAuth', () => ({
@@ -37,6 +48,8 @@ function installMemoryStorage(): void {
 describe('useAdultVerification', () => {
   beforeEach(() => {
     installMemoryStorage();
+    mockSigner = { signEvent: vi.fn(), getPublicKey: vi.fn() };
+    vi.mocked(createMediaViewerAuthHeader).mockReset();
   });
 
   it('synchronizes confirmation across mounted hook instances', async () => {
@@ -60,12 +73,12 @@ describe('useAdultVerification', () => {
     });
   });
 
-  describe('getAuthHeader', () => {
+  describe('getAuthHeader (logged-in user)', () => {
     const HASH = 'a'.repeat(64);
     const URL = 'https://media.divine.video/file.mp4';
 
     beforeEach(() => {
-      vi.mocked(createMediaViewerAuthHeader).mockReset().mockResolvedValue('Nostr HEADER');
+      vi.mocked(createMediaViewerAuthHeader).mockResolvedValue('Nostr HEADER');
     });
 
     it('returns null when not verified', async () => {
@@ -105,6 +118,69 @@ describe('useAdultVerification', () => {
         sha256: HASH,
         method: 'GET',
       });
+    });
+  });
+
+  describe('getAuthHeader (anonymous viewer)', () => {
+    const URL = 'https://media.divine.video/file.mp4';
+
+    beforeEach(() => {
+      mockSigner = null; // no user signer
+      vi.mocked(createMediaViewerAuthHeader).mockResolvedValue('Nostr HEADER');
+    });
+
+    it('uses an ephemeral signer after confirmAdult and persists the key', async () => {
+      const { result } = renderHook(() => useAdultVerification());
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      act(() => result.current.confirmAdult());
+      await waitFor(() => expect(result.current.isVerified).toBe(true));
+
+      const header = await result.current.getAuthHeader(URL);
+      expect(header).toBe('Nostr HEADER');
+
+      expect(createMediaViewerAuthHeader).toHaveBeenCalledTimes(1);
+      const [input] = vi.mocked(createMediaViewerAuthHeader).mock.calls[0];
+      expect(typeof input.signer!.getPublicKey).toBe('function');
+      expect(typeof input.signer!.signEvent).toBe('function');
+      expect(input.url).toBe(URL);
+      expect(input.method).toBe('GET');
+
+      expect(window.localStorage.getItem(ANONYMOUS_SIGNER_SK_KEY)).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it('still returns null if the viewer has not confirmed adult content', async () => {
+      const { result } = renderHook(() => useAdultVerification());
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      const header = await result.current.getAuthHeader(URL);
+      expect(header).toBeNull();
+      expect(createMediaViewerAuthHeader).not.toHaveBeenCalled();
+    });
+
+    it('revokeVerification clears the persisted ephemeral key', async () => {
+      const { result } = renderHook(() => useAdultVerification());
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      act(() => result.current.confirmAdult());
+      await waitFor(() => expect(result.current.isVerified).toBe(true));
+
+      await result.current.getAuthHeader(URL);
+      expect(window.localStorage.getItem(ANONYMOUS_SIGNER_SK_KEY)).not.toBeNull();
+
+      act(() => result.current.revokeVerification());
+      await waitFor(() => expect(result.current.isVerified).toBe(false));
+
+      expect(window.localStorage.getItem(ANONYMOUS_SIGNER_SK_KEY)).toBeNull();
+      expect(window.localStorage.getItem(ANONYMOUS_SIGNER_EXPIRY_KEY)).toBeNull();
+    });
+
+    it('hasSigner is true once verified, even without a user signer', async () => {
+      const { result } = renderHook(() => useAdultVerification());
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(result.current.hasSigner).toBe(false);
+
+      act(() => result.current.confirmAdult());
+      await waitFor(() => expect(result.current.hasSigner).toBe(true));
     });
   });
 });

--- a/src/hooks/useAdultVerification.test.ts
+++ b/src/hooks/useAdultVerification.test.ts
@@ -2,12 +2,22 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAdultVerification } from './useAdultVerification';
 import { createMediaViewerAuthHeader } from '@/lib/mediaViewerAuth';
+import {
+  ANONYMOUS_SIGNER_SK_KEY,
+  ANONYMOUS_SIGNER_EXPIRY_KEY,
+} from '@/lib/ephemeralSigner';
 
-const mockSigner = { signEvent: vi.fn(), getPublicKey: vi.fn() };
-let currentSigner: typeof mockSigner | null = mockSigner;
+let mockSigner: { signEvent: ReturnType<typeof vi.fn>; getPublicKey: ReturnType<typeof vi.fn> } | null = {
+  signEvent: vi.fn(),
+  getPublicKey: vi.fn(),
+};
 
 vi.mock('@/hooks/useCurrentUser', () => ({
-  useCurrentUser: () => ({ signer: currentSigner, pubkey: currentSigner ? 'pub' : null, user: currentSigner ? { pubkey: 'pub' } : null }),
+  useCurrentUser: () => ({
+    signer: mockSigner,
+    pubkey: mockSigner ? 'pub' : null,
+    user: mockSigner ? { pubkey: 'pub' } : null,
+  }),
 }));
 
 vi.mock('@/lib/mediaViewerAuth', () => ({
@@ -38,7 +48,8 @@ function installMemoryStorage(): void {
 describe('useAdultVerification', () => {
   beforeEach(() => {
     installMemoryStorage();
-    currentSigner = mockSigner;
+    mockSigner = { signEvent: vi.fn(), getPublicKey: vi.fn() };
+    vi.mocked(createMediaViewerAuthHeader).mockReset();
   });
 
   it('synchronizes confirmation across mounted hook instances', async () => {
@@ -62,25 +73,12 @@ describe('useAdultVerification', () => {
     });
   });
 
-  it('does not treat stored adult confirmation as verified without a signer', async () => {
-    currentSigner = null;
-    window.localStorage.setItem('adult-verification-confirmed', 'true');
-    window.localStorage.setItem('adult-verification-expiry', String(Date.now() + 60_000));
-
-    const { result } = renderHook(() => useAdultVerification());
-
-    await waitFor(() => expect(result.current.isLoading).toBe(false));
-
-    expect(result.current.isVerified).toBe(false);
-    expect(result.current.hasSigner).toBe(false);
-  });
-
-  describe('getAuthHeader', () => {
+  describe('getAuthHeader (logged-in user)', () => {
     const HASH = 'a'.repeat(64);
     const URL = 'https://media.divine.video/file.mp4';
 
     beforeEach(() => {
-      vi.mocked(createMediaViewerAuthHeader).mockReset().mockResolvedValue('Nostr HEADER');
+      vi.mocked(createMediaViewerAuthHeader).mockResolvedValue('Nostr HEADER');
     });
 
     it('returns null when not verified', async () => {
@@ -120,6 +118,69 @@ describe('useAdultVerification', () => {
         sha256: HASH,
         method: 'GET',
       });
+    });
+  });
+
+  describe('getAuthHeader (anonymous viewer)', () => {
+    const URL = 'https://media.divine.video/file.mp4';
+
+    beforeEach(() => {
+      mockSigner = null; // no user signer
+      vi.mocked(createMediaViewerAuthHeader).mockResolvedValue('Nostr HEADER');
+    });
+
+    it('uses an ephemeral signer after confirmAdult and persists the key', async () => {
+      const { result } = renderHook(() => useAdultVerification());
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      act(() => result.current.confirmAdult());
+      await waitFor(() => expect(result.current.isVerified).toBe(true));
+
+      const header = await result.current.getAuthHeader(URL);
+      expect(header).toBe('Nostr HEADER');
+
+      expect(createMediaViewerAuthHeader).toHaveBeenCalledTimes(1);
+      const [input] = vi.mocked(createMediaViewerAuthHeader).mock.calls[0];
+      expect(typeof input.signer!.getPublicKey).toBe('function');
+      expect(typeof input.signer!.signEvent).toBe('function');
+      expect(input.url).toBe(URL);
+      expect(input.method).toBe('GET');
+
+      expect(window.localStorage.getItem(ANONYMOUS_SIGNER_SK_KEY)).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it('still returns null if the viewer has not confirmed adult content', async () => {
+      const { result } = renderHook(() => useAdultVerification());
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      const header = await result.current.getAuthHeader(URL);
+      expect(header).toBeNull();
+      expect(createMediaViewerAuthHeader).not.toHaveBeenCalled();
+    });
+
+    it('revokeVerification clears the persisted ephemeral key', async () => {
+      const { result } = renderHook(() => useAdultVerification());
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      act(() => result.current.confirmAdult());
+      await waitFor(() => expect(result.current.isVerified).toBe(true));
+
+      await result.current.getAuthHeader(URL);
+      expect(window.localStorage.getItem(ANONYMOUS_SIGNER_SK_KEY)).not.toBeNull();
+
+      act(() => result.current.revokeVerification());
+      await waitFor(() => expect(result.current.isVerified).toBe(false));
+
+      expect(window.localStorage.getItem(ANONYMOUS_SIGNER_SK_KEY)).toBeNull();
+      expect(window.localStorage.getItem(ANONYMOUS_SIGNER_EXPIRY_KEY)).toBeNull();
+    });
+
+    it('hasSigner is true once verified, even without a user signer', async () => {
+      const { result } = renderHook(() => useAdultVerification());
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(result.current.hasSigner).toBe(false);
+
+      act(() => result.current.confirmAdult());
+      await waitFor(() => expect(result.current.hasSigner).toBe(true));
     });
   });
 });

--- a/src/hooks/useAdultVerification.ts
+++ b/src/hooks/useAdultVerification.ts
@@ -4,6 +4,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { createMediaViewerAuthHeader } from '@/lib/mediaViewerAuth';
+import { clearAnonymousSigner, getOrCreateAnonymousSigner } from '@/lib/ephemeralSigner';
 
 const STORAGE_KEY = 'adult-verification-confirmed';
 const STORAGE_EXPIRY_KEY = 'adult-verification-expiry';
@@ -88,21 +89,25 @@ export function useAdultVerification(): AdultVerificationState {
   const revokeVerification = useCallback(() => {
     localStorage.removeItem(STORAGE_KEY);
     localStorage.removeItem(STORAGE_EXPIRY_KEY);
+    clearAnonymousSigner();
     setIsVerified(false);
     notifyVerificationChange();
   }, []);
 
-  // Generate viewer auth header for a given URL (Blossom or NIP-98 depending on inputs)
+  // Generate viewer auth header for a given URL (Blossom or NIP-98 depending on inputs).
+  // Prefers the logged-in user's signer; falls back to a device-scoped anonymous signer
+  // once the viewer has confirmed adult content.
   const getAuthHeader = useCallback(
     async (
       url: string,
       method: string = 'GET',
       sha256?: string,
     ): Promise<string | null> => {
-      if (!signer || !isVerified) {
+      if (!isVerified) {
         return null;
       }
-      return createMediaViewerAuthHeader({ signer, url, sha256, method });
+      const effectiveSigner = signer ?? getOrCreateAnonymousSigner();
+      return createMediaViewerAuthHeader({ signer: effectiveSigner, url, sha256, method });
     },
     [signer, isVerified],
   );
@@ -110,7 +115,7 @@ export function useAdultVerification(): AdultVerificationState {
   return {
     isVerified,
     isLoading,
-    hasSigner: !!signer,
+    hasSigner: !!signer || isVerified,
     confirmAdult,
     revokeVerification,
     getAuthHeader,

--- a/src/hooks/useAdultVerification.ts
+++ b/src/hooks/useAdultVerification.ts
@@ -4,6 +4,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { createMediaViewerAuthHeader } from '@/lib/mediaViewerAuth';
+import { clearAnonymousSigner, getOrCreateAnonymousSigner } from '@/lib/ephemeralSigner';
 
 const STORAGE_KEY = 'adult-verification-confirmed';
 const STORAGE_EXPIRY_KEY = 'adult-verification-expiry';
@@ -52,7 +53,7 @@ export function useAdultVerification(): AdultVerificationState {
   const [storedIsVerified, setStoredIsVerified] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const { signer } = useCurrentUser();
-  const isVerified = storedIsVerified && !!signer;
+  const isVerified = storedIsVerified;
 
   useEffect(() => {
     const syncFromStorage = () => {
@@ -90,20 +91,24 @@ export function useAdultVerification(): AdultVerificationState {
     localStorage.removeItem(STORAGE_KEY);
     localStorage.removeItem(STORAGE_EXPIRY_KEY);
     setStoredIsVerified(false);
+    clearAnonymousSigner();
     notifyVerificationChange();
   }, []);
 
-  // Generate viewer auth header for a given URL (Blossom or NIP-98 depending on inputs)
+  // Generate viewer auth header for a given URL (Blossom or NIP-98 depending on inputs).
+  // Prefers the logged-in user's signer; falls back to a device-scoped anonymous signer
+  // once the viewer has confirmed adult content.
   const getAuthHeader = useCallback(
     async (
       url: string,
       method: string = 'GET',
       sha256?: string,
     ): Promise<string | null> => {
-      if (!signer || !isVerified) {
+      if (!isVerified) {
         return null;
       }
-      return createMediaViewerAuthHeader({ signer, url, sha256, method });
+      const effectiveSigner = signer ?? getOrCreateAnonymousSigner();
+      return createMediaViewerAuthHeader({ signer: effectiveSigner, url, sha256, method });
     },
     [signer, isVerified],
   );
@@ -111,7 +116,7 @@ export function useAdultVerification(): AdultVerificationState {
   return {
     isVerified,
     isLoading,
-    hasSigner: !!signer,
+    hasSigner: !!signer || isVerified,
     confirmAdult,
     revokeVerification,
     getAuthHeader,

--- a/src/lib/ephemeralSigner.test.ts
+++ b/src/lib/ephemeralSigner.test.ts
@@ -48,7 +48,7 @@ describe('ephemeralSigner', () => {
     expect(secondPubkey).toBe(firstPubkey);
   });
 
-  it('refreshes the expiry timestamp on each call within the TTL window', async () => {
+  it('does NOT refresh expiry on subsequent calls — TTL is anchored at the first call', async () => {
     getOrCreateAnonymousSigner();
     const firstExpiry = Number(localStorage.getItem(ANONYMOUS_SIGNER_EXPIRY_KEY));
 
@@ -57,7 +57,9 @@ describe('ephemeralSigner', () => {
     getOrCreateAnonymousSigner();
     const secondExpiry = Number(localStorage.getItem(ANONYMOUS_SIGNER_EXPIRY_KEY));
 
-    expect(secondExpiry).toBeGreaterThanOrEqual(firstExpiry);
+    // Matches the UI promise "Your choice will be remembered for 30 days" — from
+    // confirm-time, not from last-view. Otherwise the key would never expire.
+    expect(secondExpiry).toBe(firstExpiry);
   });
 
   it('generates a new key if the stored key is expired', async () => {

--- a/src/lib/ephemeralSigner.test.ts
+++ b/src/lib/ephemeralSigner.test.ts
@@ -1,0 +1,97 @@
+// ABOUTME: Tests for the device-scoped ephemeral Nostr signer used for anonymous NIP-98 auth
+// ABOUTME: Covers generation, persistence, expiry, and signEvent output shape.
+
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  clearAnonymousSigner,
+  getOrCreateAnonymousSigner,
+  ANONYMOUS_SIGNER_SK_KEY,
+  ANONYMOUS_SIGNER_EXPIRY_KEY,
+  ANONYMOUS_SIGNER_TTL_MS,
+} from './ephemeralSigner';
+
+describe('ephemeralSigner', () => {
+  beforeEach(() => {
+    const storage = new Map<string, string>();
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: (key: string) => storage.get(key) ?? null,
+        setItem: (key: string, value: string) => storage.set(key, String(value)),
+        removeItem: (key: string) => storage.delete(key),
+        clear: () => storage.clear(),
+        get length() { return storage.size; },
+        key: (i: number) => Array.from(storage.keys())[i] ?? null,
+      } satisfies Storage,
+    });
+  });
+
+  it('generates a new secret key and persists it on first call', async () => {
+    expect(localStorage.getItem(ANONYMOUS_SIGNER_SK_KEY)).toBeNull();
+
+    const signer = getOrCreateAnonymousSigner();
+    const pubkey = await signer.getPublicKey();
+
+    expect(pubkey).toMatch(/^[0-9a-f]{64}$/);
+    expect(localStorage.getItem(ANONYMOUS_SIGNER_SK_KEY)).toMatch(/^[0-9a-f]{64}$/);
+    expect(localStorage.getItem(ANONYMOUS_SIGNER_EXPIRY_KEY)).not.toBeNull();
+  });
+
+  it('returns the same pubkey on subsequent calls (persistence across instances)', async () => {
+    const first = getOrCreateAnonymousSigner();
+    const firstPubkey = await first.getPublicKey();
+
+    const second = getOrCreateAnonymousSigner();
+    const secondPubkey = await second.getPublicKey();
+
+    expect(secondPubkey).toBe(firstPubkey);
+  });
+
+  it('refreshes the expiry timestamp on each call within the TTL window', async () => {
+    getOrCreateAnonymousSigner();
+    const firstExpiry = Number(localStorage.getItem(ANONYMOUS_SIGNER_EXPIRY_KEY));
+
+    // Force a later timestamp
+    await new Promise((r) => setTimeout(r, 5));
+    getOrCreateAnonymousSigner();
+    const secondExpiry = Number(localStorage.getItem(ANONYMOUS_SIGNER_EXPIRY_KEY));
+
+    expect(secondExpiry).toBeGreaterThanOrEqual(firstExpiry);
+  });
+
+  it('generates a new key if the stored key is expired', async () => {
+    const first = getOrCreateAnonymousSigner();
+    const firstPubkey = await first.getPublicKey();
+
+    // Force expiry
+    localStorage.setItem(ANONYMOUS_SIGNER_EXPIRY_KEY, String(Date.now() - 1000));
+
+    const second = getOrCreateAnonymousSigner();
+    const secondPubkey = await second.getPublicKey();
+
+    expect(secondPubkey).not.toBe(firstPubkey);
+  });
+
+  it('produces a NostrSigner with getPublicKey and signEvent', async () => {
+    const signer = getOrCreateAnonymousSigner();
+    expect(typeof signer.getPublicKey).toBe('function');
+    expect(typeof signer.signEvent).toBe('function');
+    const pubkey = await signer.getPublicKey();
+    expect(pubkey).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('clearAnonymousSigner removes the persisted key and expiry', async () => {
+    getOrCreateAnonymousSigner();
+    expect(localStorage.getItem(ANONYMOUS_SIGNER_SK_KEY)).not.toBeNull();
+
+    clearAnonymousSigner();
+
+    expect(localStorage.getItem(ANONYMOUS_SIGNER_SK_KEY)).toBeNull();
+    expect(localStorage.getItem(ANONYMOUS_SIGNER_EXPIRY_KEY)).toBeNull();
+  });
+
+  it('TTL constant matches the 30-day age-verification window', () => {
+    expect(ANONYMOUS_SIGNER_TTL_MS).toBe(30 * 24 * 60 * 60 * 1000);
+  });
+});

--- a/src/lib/ephemeralSigner.test.ts
+++ b/src/lib/ephemeralSigner.test.ts
@@ -1,7 +1,17 @@
 // ABOUTME: Tests for the device-scoped ephemeral Nostr signer used for anonymous NIP-98 auth
 // ABOUTME: Covers generation, persistence, expiry, and signEvent output shape.
 
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('nostr-tools', async () => {
+  const actual = await vi.importActual<typeof import('nostr-tools')>('nostr-tools');
+  return {
+    ...actual,
+    getPublicKey: vi.fn(actual.getPublicKey),
+  };
+});
+
+import { getPublicKey } from 'nostr-tools';
 
 import {
   clearAnonymousSigner,
@@ -12,6 +22,8 @@ import {
 } from './ephemeralSigner';
 
 describe('ephemeralSigner', () => {
+  const originalLocalStorageDescriptor = Object.getOwnPropertyDescriptor(window, 'localStorage');
+
   beforeEach(() => {
     const storage = new Map<string, string>();
     Object.defineProperty(window, 'localStorage', {
@@ -25,6 +37,13 @@ describe('ephemeralSigner', () => {
         key: (i: number) => Array.from(storage.keys())[i] ?? null,
       } satisfies Storage,
     });
+  });
+
+  afterEach(() => {
+    if (originalLocalStorageDescriptor) {
+      Object.defineProperty(window, 'localStorage', originalLocalStorageDescriptor);
+    }
+    vi.restoreAllMocks();
   });
 
   it('generates a new secret key and persists it on first call', async () => {
@@ -95,5 +114,15 @@ describe('ephemeralSigner', () => {
 
   it('TTL constant matches the 30-day age-verification window', () => {
     expect(ANONYMOUS_SIGNER_TTL_MS).toBe(30 * 24 * 60 * 60 * 1000);
+  });
+
+  it('does NOT persist the key if validation throws (regression #263)', () => {
+    vi.mocked(getPublicKey).mockImplementationOnce(() => {
+      throw new Error('corrupt key — refuse to persist');
+    });
+
+    expect(() => getOrCreateAnonymousSigner()).toThrow(/corrupt key/);
+    expect(localStorage.getItem(ANONYMOUS_SIGNER_SK_KEY)).toBeNull();
+    expect(localStorage.getItem(ANONYMOUS_SIGNER_EXPIRY_KEY)).toBeNull();
   });
 });

--- a/src/lib/ephemeralSigner.ts
+++ b/src/lib/ephemeralSigner.ts
@@ -1,0 +1,77 @@
+// ABOUTME: Device-scoped ephemeral Nostr signer used for anonymous NIP-98 media auth
+// ABOUTME: Generates a secp256k1 keypair on first use, persists it in localStorage for 30 days.
+
+import { generateSecretKey, getPublicKey } from 'nostr-tools';
+import { NSecSigner } from '@nostrify/nostrify';
+import type { NostrSigner } from '@nostrify/nostrify';
+
+function bytesToHex(bytes: Uint8Array): string {
+  let hex = '';
+  for (let i = 0; i < bytes.length; i++) {
+    hex += bytes[i].toString(16).padStart(2, '0');
+  }
+  return hex;
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const len = hex.length / 2;
+  const out = new Uint8Array(len);
+  for (let i = 0; i < len; i++) {
+    out[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+export const ANONYMOUS_SIGNER_SK_KEY = 'divine-anon-signer-sk';
+export const ANONYMOUS_SIGNER_EXPIRY_KEY = 'divine-anon-signer-expiry';
+export const ANONYMOUS_SIGNER_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
+function readPersistedSecretKey(): Uint8Array | null {
+  if (typeof window === 'undefined') return null;
+
+  const hex = localStorage.getItem(ANONYMOUS_SIGNER_SK_KEY);
+  const expiryRaw = localStorage.getItem(ANONYMOUS_SIGNER_EXPIRY_KEY);
+  if (!hex || !expiryRaw) return null;
+
+  const expiry = Number(expiryRaw);
+  if (!Number.isFinite(expiry) || Date.now() >= expiry) return null;
+
+  if (!/^[0-9a-f]{64}$/i.test(hex)) return null;
+
+  try {
+    return hexToBytes(hex);
+  } catch {
+    return null;
+  }
+}
+
+function persistSecretKey(sk: Uint8Array): void {
+  if (typeof window === 'undefined') return;
+  localStorage.setItem(ANONYMOUS_SIGNER_SK_KEY, bytesToHex(sk));
+  localStorage.setItem(
+    ANONYMOUS_SIGNER_EXPIRY_KEY,
+    String(Date.now() + ANONYMOUS_SIGNER_TTL_MS),
+  );
+  // Validate that the key yields a pubkey — dead-check against weird storage corruption
+  getPublicKey(sk);
+}
+
+/**
+ * Return a signer backed by a persistent per-device anonymous key.
+ * Creates one on first call; reuses and bumps the expiry on subsequent calls.
+ */
+export function getOrCreateAnonymousSigner(): NostrSigner {
+  let sk = readPersistedSecretKey();
+  if (!sk) {
+    sk = generateSecretKey();
+  }
+  persistSecretKey(sk);
+  return new NSecSigner(sk);
+}
+
+/** Clear the persisted anonymous key (e.g. when the user revokes age verification). */
+export function clearAnonymousSigner(): void {
+  if (typeof window === 'undefined') return;
+  localStorage.removeItem(ANONYMOUS_SIGNER_SK_KEY);
+  localStorage.removeItem(ANONYMOUS_SIGNER_EXPIRY_KEY);
+}

--- a/src/lib/ephemeralSigner.ts
+++ b/src/lib/ephemeralSigner.ts
@@ -58,13 +58,19 @@ function persistSecretKey(sk: Uint8Array): void {
 
 /**
  * Return a signer backed by a persistent per-device anonymous key.
- * Creates one on first call; reuses and bumps the expiry on subsequent calls.
+ *
+ * Creates and persists a new key on the first call (anchoring the 30-day expiry
+ * at "the moment the viewer confirmed adult"). Subsequent calls reuse the
+ * existing key *without* resetting the expiry — matching the UI copy
+ * "Your choice will be remembered for 30 days" so the key lifetime is tied to
+ * the confirm moment, not to "30 days from the last view".
  */
 export function getOrCreateAnonymousSigner(): NostrSigner {
-  let sk = readPersistedSecretKey();
-  if (!sk) {
-    sk = generateSecretKey();
+  const existing = readPersistedSecretKey();
+  if (existing) {
+    return new NSecSigner(existing);
   }
+  const sk = generateSecretKey();
   persistSecretKey(sk);
   return new NSecSigner(sk);
 }

--- a/src/lib/ephemeralSigner.ts
+++ b/src/lib/ephemeralSigner.ts
@@ -47,13 +47,12 @@ function readPersistedSecretKey(): Uint8Array | null {
 
 function persistSecretKey(sk: Uint8Array): void {
   if (typeof window === 'undefined') return;
+  getPublicKey(sk);
   localStorage.setItem(ANONYMOUS_SIGNER_SK_KEY, bytesToHex(sk));
   localStorage.setItem(
     ANONYMOUS_SIGNER_EXPIRY_KEY,
     String(Date.now() + ANONYMOUS_SIGNER_TTL_MS),
   );
-  // Validate that the key yields a pubkey — dead-check against weird storage corruption
-  getPublicKey(sk);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Age-restricted media blobs on `media.divine.video` return 401 to anonymous viewers because the `<video>` element can't send NIP-98 headers, and the existing `useAdultVerification` flow returned `null` from `getAuthHeader()` whenever no NIP-07/JWT signer was present. Result: logged-out viewers saw the console flooded with 401s and couldn't ever unlock the content — the overlay explicitly said "Sign in to view this content."
- This PR adds a device-scoped ephemeral secp256k1 signer (`src/lib/ephemeralSigner.ts`) that is generated lazily on first use, persisted in `localStorage` with the same 30-day TTL as the adult-verification flag, and used as a fallback when no user signer is present. The overlay now shows the "I'm 18 or older" button to everyone; clicking it produces a valid NIP-98 header on the next media fetch.
- No server changes required: `divine-blossom` already accepts any valid NIP-98 signature via `authenticate_blob_viewer` (per the 2026-04-16 media-age-auth-debug plan).

## Scope & guarantees
- Ephemeral key is **only** used for media auth. View events (kind 22236) and other identity-bearing flows still require a real user signer.
- `revokeVerification()` now also wipes the ephemeral key so the opt-out is clean.
- `hasSigner` is true once the viewer is verified even without a real user signer, so downstream code that gates on it keeps working.

## Test plan
- [x] New unit tests: `src/lib/ephemeralSigner.test.ts` (7 tests: generation, persistence, expiry, clearing, TTL constant, shape).
- [x] New hook tests in `src/hooks/useAdultVerification.test.ts`: anonymous fallback uses ephemeral signer; `getAuthHeader` still returns `null` when not verified; `revokeVerification` clears the ephemeral key; `hasSigner` flips true on confirm.
- [x] `npx tsc --noEmit` clean.
- [x] `npx vitest run` — 540/540 passing.
- [ ] Manual smoke on prod: visit `divine.video/discovery/new` logged out, hit an age-restricted video, click "I'm 18 or older", confirm the video plays (NIP-98 header now present in the fetch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)