### PR TITLE
fix: raise relay selector dropdown layer above account menu (#264)

### DIFF
--- a/src/components/RelaySelector.tsx
+++ b/src/components/RelaySelector.tsx
@@ -13,9 +13,10 @@ import { PRESET_RELAYS, toLegacyFormat } from '@/config/relays';
 
 interface RelaySelectorProps {
   className?: string;
+  contentClassName?: string;
 }
 
-export function RelaySelector({ className }: RelaySelectorProps) {
+export function RelaySelector({ className, contentClassName }: RelaySelectorProps) {
   const { config, updateConfig, presetRelays } = useAppContext();
 
   const handleRelayChange = (newRelayUrl: string) => {
@@ -33,7 +34,7 @@ export function RelaySelector({ className }: RelaySelectorProps) {
       <SelectTrigger className={className}>
         <SelectValue placeholder="Select relay" />
       </SelectTrigger>
-      <SelectContent>
+      <SelectContent className={contentClassName}>
         {relays.map(({ name, url }) => (
           <SelectItem key={url} value={url}>
             {name}

--- a/src/components/auth/AccountSwitcher.tsx
+++ b/src/components/auth/AccountSwitcher.tsx
@@ -99,7 +99,7 @@ export function AccountSwitcher({ onAddAccountClick }: AccountSwitcherProps) {
           <DropdownMenuSeparator />
           <DropdownMenuLabel>Switch Relay</DropdownMenuLabel>
           <DropdownMenuItem onSelect={(e) => e.preventDefault()} className='p-2'>
-            <RelaySelector className='w-full' />
+            <RelaySelector className='w-full' contentClassName='z-[210]' />
           </DropdownMenuItem>
           {!isJwtCurrentUser ? (
             <>

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -71,7 +71,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "relative z-[210] max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -71,7 +71,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-[210] max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className


### PR DESCRIPTION
## Summary

This fixes the relay selector overlap bug reported in [#264](https://github.com/divinevideo/divine-web/issues/264).

- Increased the `SelectContent` layer in `src/components/ui/select.tsx` from `z-50` to `z-[210]`.
- Ensured the relay-switching dropdown renders above the surrounding account/profile UI instead of being visually covered.
