### PR TITLE
fix(#266): auth refresh persistence

### DIFF
--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -62,10 +62,10 @@ const BrandPreview = import.meta.env.DEV
   : null;
 
 export function AppRouter() {
-  const { user } = useCurrentUser();
+  const { user, isAuthRestoring } = useCurrentUser();
 
   // Check if user is logged in
-  const isLoggedIn = Boolean(user);
+  const isLoggedIn = Boolean(user) || isAuthRestoring;
 
   // Check if we're on a subdomain profile (username.divine.video)
   const subdomainUser = getSubdomainUser();

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -16,12 +16,12 @@ import {
 export function AppLayout() {
   const location = useLocation();
   const [searchParams, setSearchParams] = useSearchParams();
-  const { user } = useCurrentUser();
+  const { user, isAuthRestoring } = useCurrentUser();
   const { isRecording } = useAppContext();
   const { state: fullscreenState, exitFullscreen, onLoadMore, hasMore } = useFullscreenFeed();
   const compilationRequest = parseCompilationPlaybackParams(searchParams);
 
-  const isLoggedIn = Boolean(user);
+  const isLoggedIn = Boolean(user) || isAuthRestoring;
 
   // Hide header/sidebar on landing page (when logged out on root path), but NOT on subdomain profiles
   const isLandingPage = location.pathname === '/' && !isLoggedIn && !getSubdomainUser();

--- a/src/hooks/useCurrentUser.test.ts
+++ b/src/hooks/useCurrentUser.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { NLoginType } from '@nostrify/react/login';
 
@@ -138,9 +138,7 @@ describe('useCurrentUser', () => {
     expect(result.current.signer).toBeUndefined();
   });
 
-  it('skips extension logins when no browser extension is available', () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
+  it('does not resolve extension logins when no browser extension is available', () => {
     mockLogins.push({
       id: 'extension:pub123',
       type: 'extension',
@@ -155,7 +153,28 @@ describe('useCurrentUser', () => {
     expect(result.current.users).toEqual([]);
     expect(result.current.signer).toBeUndefined();
     expect(mockUseAuthor).toHaveBeenCalledWith(undefined);
-    expect(warnSpy).toHaveBeenCalledWith('Skipped invalid login', 'extension:pub123', expect.any(Error));
+  });
+
+  it('recovers extension login when provider appears shortly after mount', async () => {
+    mockLogins.push({
+      id: 'extension:pub123',
+      type: 'extension',
+      pubkey: 'pub123',
+      createdAt: '2026-03-10T00:00:00.000Z',
+      data: null,
+    });
+
+    const { result } = renderHook(() => useCurrentUser());
+
+    expect(result.current.user).toBeUndefined();
+
+    await act(async () => {
+      setNostrProvider();
+    });
+
+    await waitFor(() => {
+      expect(result.current.user?.pubkey).toBe('pub123');
+    });
   });
 
   it('returns an extension user and signer when a browser extension is available', () => {

--- a/src/hooks/useCurrentUser.test.ts
+++ b/src/hooks/useCurrentUser.test.ts
@@ -76,6 +76,7 @@ describe('useCurrentUser', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
     resetNostrProvider();
   });
@@ -149,10 +150,11 @@ describe('useCurrentUser', () => {
 
     const { result } = renderHook(() => useCurrentUser());
 
-    expect(result.current.user).toBeUndefined();
-    expect(result.current.users).toEqual([]);
+    expect(result.current.user?.pubkey).toBe('pub123');
+    expect(result.current.users).toEqual([{ pubkey: 'pub123' }]);
     expect(result.current.signer).toBeUndefined();
-    expect(mockUseAuthor).toHaveBeenCalledWith(undefined);
+    expect(result.current.isAuthRestoring).toBe(true);
+    expect(mockUseAuthor).toHaveBeenCalledWith('pub123');
   });
 
   it('recovers extension login when provider appears shortly after mount', async () => {
@@ -166,7 +168,9 @@ describe('useCurrentUser', () => {
 
     const { result } = renderHook(() => useCurrentUser());
 
-    expect(result.current.user).toBeUndefined();
+    expect(result.current.user?.pubkey).toBe('pub123');
+    expect(result.current.signer).toBeUndefined();
+    expect(result.current.isAuthRestoring).toBe(true);
 
     await act(async () => {
       setNostrProvider();
@@ -174,7 +178,42 @@ describe('useCurrentUser', () => {
 
     await waitFor(() => {
       expect(result.current.user?.pubkey).toBe('pub123');
+      expect(result.current.signer).toBeDefined();
+      expect(result.current.isAuthRestoring).toBe(false);
     });
+  });
+
+  it('keeps extension auth in restoring mode and recovers after a delayed provider injection', () => {
+    vi.useFakeTimers();
+
+    mockLogins.push({
+      id: 'extension:pub123',
+      type: 'extension',
+      pubkey: 'pub123',
+      createdAt: '2026-03-10T00:00:00.000Z',
+      data: null,
+    });
+
+    const { result } = renderHook(() => useCurrentUser());
+
+    expect(result.current.user?.pubkey).toBe('pub123');
+    expect(result.current.signer).toBeUndefined();
+    expect(result.current.isAuthRestoring).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    expect(result.current.user?.pubkey).toBe('pub123');
+    expect(result.current.isAuthRestoring).toBe(true);
+
+    act(() => {
+      setNostrProvider();
+      vi.advanceTimersByTime(2500);
+    });
+
+    expect(result.current.signer).toBeDefined();
+    expect(result.current.isAuthRestoring).toBe(false);
   });
 
   it('returns an extension user and signer when a browser extension is available', () => {

--- a/src/hooks/useCurrentUser.ts
+++ b/src/hooks/useCurrentUser.ts
@@ -23,7 +23,8 @@ export function useCurrentUser() {
   const hasExtensionLogin = useMemo(() => (
     logins.some((login) => login.type === 'extension')
   ), [logins]);
-  const isNip07Available = useNip07Availability(hasExtensionLogin);
+  const { isAvailable: isNip07Available, isRestoring: isNip07Restoring } = useNip07Availability(hasExtensionLogin);
+  const isAuthRestoring = hasExtensionLogin && isNip07Restoring;
   const jwtSigner = useMemo(() => (
     token ? new DivineJWTSigner({ token }) : null
   ), [token]);
@@ -65,6 +66,7 @@ export function useCurrentUser() {
 
     for (const login of logins) {
       if (login.type === 'extension' && !isNip07Available) {
+        users.push({ pubkey: login.pubkey });
         continue;
       }
 
@@ -102,6 +104,7 @@ export function useCurrentUser() {
     user,
     users,
     signer,
+    isAuthRestoring,
     ...author.data,
   };
 }

--- a/src/hooks/useCurrentUser.ts
+++ b/src/hooks/useCurrentUser.ts
@@ -7,6 +7,7 @@ import { createUserFromLogin, getSafeUserSigner } from '@/lib/nostrLogin';
 
 import { useAuthor } from './useAuthor.ts';
 import { useDivineSession } from './useDivineSession';
+import { useNip07Availability } from './useNip07Availability';
 
 type CurrentUser = {
   pubkey: string;
@@ -19,6 +20,10 @@ export function useCurrentUser() {
   const { getValidToken } = useDivineSession();
   const token = getValidToken();
   const [jwtPubkey, setJwtPubkey] = useState<string>();
+  const hasExtensionLogin = useMemo(() => (
+    logins.some((login) => login.type === 'extension')
+  ), [logins]);
+  const isNip07Available = useNip07Availability(hasExtensionLogin);
   const jwtSigner = useMemo(() => (
     token ? new DivineJWTSigner({ token }) : null
   ), [token]);
@@ -59,6 +64,10 @@ export function useCurrentUser() {
     const users: CurrentUser[] = [];
 
     for (const login of logins) {
+      if (login.type === 'extension' && !isNip07Available) {
+        continue;
+      }
+
       try {
         const user = loginToUser(login);
         users.push(user);
@@ -68,7 +77,7 @@ export function useCurrentUser() {
     }
 
     return users;
-  }, [logins, loginToUser]);
+  }, [isNip07Available, logins, loginToUser]);
 
   const jwtUser = useMemo<CurrentUser | undefined>(() => {
     if (!jwtSigner || !jwtPubkey) {

--- a/src/hooks/useLoggedInAccounts.ts
+++ b/src/hooks/useLoggedInAccounts.ts
@@ -6,6 +6,7 @@ import { NSchema as n, NostrEvent, NostrMetadata } from '@nostrify/nostrify';
 import { createUserFromLogin } from '@/lib/nostrLogin';
 import { useCurrentUser } from './useCurrentUser';
 import { useDivineSession } from './useDivineSession';
+import { useNip07Availability } from './useNip07Availability';
 
 export interface Account {
   id: string;
@@ -20,8 +21,16 @@ export function useLoggedInAccounts() {
   const { getValidToken } = useDivineSession();
   const { metadata, user } = useCurrentUser();
   const token = getValidToken();
+  const hasExtensionLogin = useMemo(() => (
+    logins.some((login) => login.type === 'extension')
+  ), [logins]);
+  const isNip07Available = useNip07Availability(hasExtensionLogin);
   const activeLogins = useMemo(
     () => logins.filter((login) => {
+      if (login.type === 'extension' && !isNip07Available) {
+        return false;
+      }
+
       try {
         createUserFromLogin(login, nostr);
         return true;
@@ -29,7 +38,7 @@ export function useLoggedInAccounts() {
         return false;
       }
     }),
-    [logins, nostr],
+    [isNip07Available, logins, nostr],
   );
 
   const jwtCurrentUser = useMemo<Account | undefined>(() => {

--- a/src/hooks/useLoggedInAccounts.ts
+++ b/src/hooks/useLoggedInAccounts.ts
@@ -24,11 +24,11 @@ export function useLoggedInAccounts() {
   const hasExtensionLogin = useMemo(() => (
     logins.some((login) => login.type === 'extension')
   ), [logins]);
-  const isNip07Available = useNip07Availability(hasExtensionLogin);
+  const { isAvailable: isNip07Available } = useNip07Availability(hasExtensionLogin);
   const activeLogins = useMemo(
     () => logins.filter((login) => {
       if (login.type === 'extension' && !isNip07Available) {
-        return false;
+        return Boolean(login.pubkey);
       }
 
       try {

--- a/src/hooks/useNip07Availability.test.ts
+++ b/src/hooks/useNip07Availability.test.ts
@@ -1,0 +1,63 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useNip07Availability } from './useNip07Availability';
+
+const originalNostrDescriptor = Object.getOwnPropertyDescriptor(window, 'nostr');
+
+function resetNostrProvider() {
+  if (originalNostrDescriptor) {
+    Object.defineProperty(window, 'nostr', originalNostrDescriptor);
+    return;
+  }
+
+  delete (window as Window & { nostr?: unknown }).nostr;
+}
+
+function setNostrProvider(value: unknown = { getPublicKey: vi.fn() }) {
+  Object.defineProperty(window, 'nostr', {
+    value,
+    writable: true,
+    configurable: true,
+  });
+}
+
+describe('useNip07Availability', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    resetNostrProvider();
+  });
+
+  it('reports auth restoring while extension provider is unavailable', () => {
+    resetNostrProvider();
+
+    const { result } = renderHook(() => useNip07Availability(true));
+
+    expect(result.current.isAvailable).toBe(false);
+    expect(result.current.isRestoring).toBe(true);
+  });
+
+  it('recovers after provider appears beyond the initial retry window', () => {
+    vi.useFakeTimers();
+    resetNostrProvider();
+
+    const { result } = renderHook(() => useNip07Availability(true));
+
+    expect(result.current.isAvailable).toBe(false);
+    expect(result.current.isRestoring).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    expect(result.current.isAvailable).toBe(false);
+    expect(result.current.isRestoring).toBe(true);
+
+    act(() => {
+      setNostrProvider();
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(result.current.isAvailable).toBe(true);
+    expect(result.current.isRestoring).toBe(false);
+  });
+});

--- a/src/hooks/useNip07Availability.ts
+++ b/src/hooks/useNip07Availability.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+import { hasNip07Provider } from '@/lib/nostrLogin';
+
+const RETRY_INTERVAL_MS = 200;
+const MAX_RETRY_MS = 4000;
+
+export function useNip07Availability(shouldWatch: boolean): boolean {
+  const [isAvailable, setIsAvailable] = useState(() => hasNip07Provider());
+
+  useEffect(() => {
+    if (!shouldWatch) {
+      setIsAvailable(hasNip07Provider());
+      return;
+    }
+
+    if (hasNip07Provider()) {
+      setIsAvailable(true);
+      return;
+    }
+
+    setIsAvailable(false);
+
+    let elapsedMs = 0;
+    const intervalId = window.setInterval(() => {
+      if (hasNip07Provider()) {
+        setIsAvailable(true);
+        window.clearInterval(intervalId);
+        return;
+      }
+
+      elapsedMs += RETRY_INTERVAL_MS;
+      if (elapsedMs >= MAX_RETRY_MS) {
+        window.clearInterval(intervalId);
+      }
+    }, RETRY_INTERVAL_MS);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [shouldWatch]);
+
+  return isAvailable;
+}

--- a/src/hooks/useNip07Availability.ts
+++ b/src/hooks/useNip07Availability.ts
@@ -1,43 +1,97 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { hasNip07Provider } from '@/lib/nostrLogin';
 
 const RETRY_INTERVAL_MS = 200;
 const MAX_RETRY_MS = 4000;
+const RECOVERY_RETRY_INTERVAL_MS = 2000;
 
-export function useNip07Availability(shouldWatch: boolean): boolean {
-  const [isAvailable, setIsAvailable] = useState(() => hasNip07Provider());
+type Nip07AvailabilityState = {
+  isAvailable: boolean;
+  isRestoring: boolean;
+};
+
+function getAvailabilityState(shouldWatch: boolean): Nip07AvailabilityState {
+  const isAvailable = hasNip07Provider();
+  return {
+    isAvailable,
+    isRestoring: shouldWatch && !isAvailable,
+  };
+}
+
+export function useNip07Availability(shouldWatch: boolean): Nip07AvailabilityState {
+  const [state, setState] = useState(() => getAvailabilityState(shouldWatch));
+
+  const updateState = useCallback((isAvailable: boolean) => {
+    const isRestoring = shouldWatch && !isAvailable;
+    setState((prev) => {
+      if (prev.isAvailable === isAvailable && prev.isRestoring === isRestoring) {
+        return prev;
+      }
+
+      return { isAvailable, isRestoring };
+    });
+  }, [shouldWatch]);
 
   useEffect(() => {
+    const checkAvailability = (): boolean => {
+      const isAvailable = hasNip07Provider();
+      updateState(isAvailable);
+      return isAvailable;
+    };
+
     if (!shouldWatch) {
-      setIsAvailable(hasNip07Provider());
+      updateState(hasNip07Provider());
       return;
     }
 
-    if (hasNip07Provider()) {
-      setIsAvailable(true);
+    if (checkAvailability()) {
       return;
     }
-
-    setIsAvailable(false);
 
     let elapsedMs = 0;
-    const intervalId = window.setInterval(() => {
-      if (hasNip07Provider()) {
-        setIsAvailable(true);
+    let intervalMs = RETRY_INTERVAL_MS;
+    let intervalId = window.setInterval(() => {
+      if (checkAvailability()) {
         window.clearInterval(intervalId);
         return;
       }
 
-      elapsedMs += RETRY_INTERVAL_MS;
-      if (elapsedMs >= MAX_RETRY_MS) {
+      elapsedMs += intervalMs;
+
+      // Keep watching after the initial retry window so late provider
+      // injection can still recover in the same mounted tree.
+      if (intervalMs === RETRY_INTERVAL_MS && elapsedMs >= MAX_RETRY_MS) {
+        window.clearInterval(intervalId);
+        intervalMs = RECOVERY_RETRY_INTERVAL_MS;
+        intervalId = window.setInterval(() => {
+          if (checkAvailability()) {
+            window.clearInterval(intervalId);
+          }
+        }, intervalMs);
+      }
+    }, intervalMs);
+
+    const handlePotentialRecovery = () => {
+      if (document.visibilityState === 'hidden') {
+        return;
+      }
+
+      if (checkAvailability()) {
         window.clearInterval(intervalId);
       }
-    }, RETRY_INTERVAL_MS);
+    };
+
+    window.addEventListener('focus', handlePotentialRecovery);
+    window.addEventListener('pageshow', handlePotentialRecovery);
+    document.addEventListener('visibilitychange', handlePotentialRecovery);
 
     return () => {
       window.clearInterval(intervalId);
+      window.removeEventListener('focus', handlePotentialRecovery);
+      window.removeEventListener('pageshow', handlePotentialRecovery);
+      document.removeEventListener('visibilitychange', handlePotentialRecovery);
     };
-  }, [shouldWatch]);
+  }, [shouldWatch, updateState]);
 
-  return isAvailable;
+  return state;
 }


### PR DESCRIPTION
## Summary

- Fixes a refresh-time auth regression where extension-based Nostr sessions could appear logged out.
- Adds a small NIP-07 availability watcher to handle delayed `window.nostr` injection after page reload.
- Updates account/user resolution logic to wait for extension provider availability instead of immediately treating extension login as invalid.
- Adds test coverage for the delayed-provider recovery path.

## Problem

After login via browser extension, reloading the page could temporarily mark the extension login as invalid if `window.nostr` was not yet injected at first render.  
This could surface as an authorization reset for the user.

Closes: #266