### PR TITLE
feat(#269): document overlay layering and add regression coverage for nested radix overlays

### DIFF
--- a/docs/overlay-layering.md
+++ b/docs/overlay-layering.md
@@ -1,0 +1,47 @@
+# Overlay Layering Strategy
+
+This document defines the layering ownership model for shared Radix overlays and nested combinations.
+
+## Canonical Tokens
+
+Use `src/lib/overlayLayers.ts` as the single source of truth:
+
+- `OVERLAY_LAYERS.floating` (`z-50`)
+- `OVERLAY_LAYERS.toast` (`z-[100]`)
+- `OVERLAY_LAYERS.overlay` (`z-[200]`)
+- `OVERLAY_LAYERS.nestedOverlayFloating` (`z-[210]`)
+
+## Layer Hierarchy
+
+From lowest to highest:
+
+1. Floating surfaces (`SelectContent`, `PopoverContent`, `TooltipContent`, `HoverCardContent`, `AlertDialog`)
+2. Toast viewport
+3. Overlay containers (`DropdownMenu`, `Dialog`, `Sheet`)
+4. Nested floating content that must stay above its parent overlay (instance-level override only)
+
+## Ownership Rules
+
+1. Shared primitives keep conservative defaults from the token map.
+2. Do not raise a shared primitive globally to fix a local nesting bug.
+3. For nested portal overlays (example: `Select` inside `DropdownMenu`), apply `nestedOverlayFloating` on the specific instance.
+4. Document any new layer before introducing a new z-index class.
+
+## Nested Overlay Pattern
+
+Use an instance-level class override on the nested content:
+
+```tsx
+<RelaySelector
+  className="w-full"
+  contentClassName={OVERLAY_LAYERS.nestedOverlayFloating}
+/>
+```
+
+`RelaySelector` forwards `contentClassName` to `SelectContent`, so only this nesting path is elevated.
+
+## Regression Coverage
+
+- `src/components/auth/AccountSwitcher.test.tsx`
+  - Guards that `AccountSwitcher` passes `OVERLAY_LAYERS.nestedOverlayFloating` to the nested `RelaySelector`.
+  - Prevents future regressions where the local override is removed and someone re-introduces a global `Select` z-index bump.

--- a/src/components/RelaySelector.tsx
+++ b/src/components/RelaySelector.tsx
@@ -13,9 +13,10 @@ import { PRESET_RELAYS, toLegacyFormat } from '@/config/relays';
 
 interface RelaySelectorProps {
   className?: string;
+  contentClassName?: string;
 }
 
-export function RelaySelector({ className }: RelaySelectorProps) {
+export function RelaySelector({ className, contentClassName }: RelaySelectorProps) {
   const { config, updateConfig, presetRelays } = useAppContext();
 
   const handleRelayChange = (newRelayUrl: string) => {
@@ -33,7 +34,7 @@ export function RelaySelector({ className }: RelaySelectorProps) {
       <SelectTrigger className={className}>
         <SelectValue placeholder="Select relay" />
       </SelectTrigger>
-      <SelectContent>
+      <SelectContent className={contentClassName}>
         {relays.map(({ name, url }) => (
           <SelectItem key={url} value={url}>
             {name}

--- a/src/components/auth/AccountSwitcher.test.tsx
+++ b/src/components/auth/AccountSwitcher.test.tsx
@@ -7,6 +7,7 @@ const {
   mockClearSession,
   mockNavigate,
   mockRemoveLogin,
+  mockRelaySelector,
   mockSetLogin,
   mockUseLoggedInAccounts,
 } = vi.hoisted(() => ({
@@ -14,6 +15,7 @@ const {
   mockClearSession: vi.fn(),
   mockNavigate: vi.fn(),
   mockRemoveLogin: vi.fn(),
+  mockRelaySelector: vi.fn(),
   mockSetLogin: vi.fn(),
   mockUseLoggedInAccounts: vi.fn(),
 }));
@@ -66,7 +68,10 @@ vi.mock('@/components/ui/avatar.tsx', () => ({
 }));
 
 vi.mock('@/components/RelaySelector', () => ({
-  RelaySelector: () => <div>Relay Selector</div>,
+  RelaySelector: (props: { className?: string; contentClassName?: string }) => {
+    mockRelaySelector(props);
+    return <div>Relay Selector</div>;
+  },
 }));
 
 vi.mock('./LocalNsecBanner', () => ({
@@ -74,6 +79,7 @@ vi.mock('./LocalNsecBanner', () => ({
 }));
 
 import { AccountSwitcher } from './AccountSwitcher';
+import { OVERLAY_LAYERS } from '@/lib/overlayLayers';
 
 describe('AccountSwitcher', () => {
   beforeEach(() => {
@@ -81,6 +87,7 @@ describe('AccountSwitcher', () => {
     mockClearSession.mockClear();
     mockNavigate.mockClear();
     mockRemoveLogin.mockClear();
+    mockRelaySelector.mockClear();
     mockSetLogin.mockClear();
     mockUseLoggedInAccounts.mockReturnValue({
       currentUser: {
@@ -104,5 +111,16 @@ describe('AccountSwitcher', () => {
     expect(mockClearSession).toHaveBeenCalled();
     expect(mockClearLoginCookie).toHaveBeenCalled();
     expect(mockRemoveLogin).not.toHaveBeenCalled();
+  });
+
+  it('keeps the relay selector layer override scoped to account menu usage', () => {
+    render(<AccountSwitcher onAddAccountClick={vi.fn()} />);
+
+    expect(mockRelaySelector).toHaveBeenCalledWith(
+      expect.objectContaining({
+        className: 'w-full',
+        contentClassName: OVERLAY_LAYERS.nestedOverlayFloating,
+      }),
+    );
   });
 });

--- a/src/components/auth/AccountSwitcher.tsx
+++ b/src/components/auth/AccountSwitcher.tsx
@@ -21,6 +21,7 @@ import { clearLoginCookie } from '@/lib/crossSubdomainAuth';
 import { genUserName } from '@/lib/genUserName';
 import { getSafeProfileImage } from '@/lib/imageUtils';
 import { getActiveLocalNsecLogin } from '@/lib/localNsecAccount';
+import { OVERLAY_LAYERS } from '@/lib/overlayLayers';
 import { RelaySelector } from '@/components/RelaySelector';
 import { LocalNsecBanner } from './LocalNsecBanner';
 
@@ -99,7 +100,7 @@ export function AccountSwitcher({ onAddAccountClick }: AccountSwitcherProps) {
           <DropdownMenuSeparator />
           <DropdownMenuLabel>Switch Relay</DropdownMenuLabel>
           <DropdownMenuItem onSelect={(e) => e.preventDefault()} className='p-2'>
-            <RelaySelector className='w-full' />
+            <RelaySelector className='w-full' contentClassName={OVERLAY_LAYERS.nestedOverlayFloating} />
           </DropdownMenuItem>
           {!isJwtCurrentUser ? (
             <>

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -3,6 +3,7 @@ import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
 
 import { cn } from "@/lib/utils"
 import { buttonVariants } from "@/components/ui/button-variants"
+import { OVERLAY_LAYERS } from "@/lib/overlayLayers"
 
 const AlertDialog = AlertDialogPrimitive.Root
 
@@ -16,7 +17,8 @@ const AlertDialogOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Overlay
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      OVERLAY_LAYERS.floating,
       className
     )}
     {...props}
@@ -34,7 +36,8 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        OVERLAY_LAYERS.floating,
         className
       )}
       {...props}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,6 +1,8 @@
 import * as React from "react"
 import * as DialogPrimitive from "@radix-ui/react-dialog"
-import { X } from '@phosphor-icons/react';import { cn } from "@/lib/utils"
+import { X } from '@phosphor-icons/react'
+import { cn } from "@/lib/utils"
+import { OVERLAY_LAYERS } from "@/lib/overlayLayers"
 
 const Dialog = DialogPrimitive.Root
 
@@ -17,7 +19,8 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-[200] bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      OVERLAY_LAYERS.overlay,
       className
     )}
     {...props}
@@ -34,7 +37,8 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-[200] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg max-h-[90vh] overflow-y-auto",
+        "fixed left-[50%] top-[50%] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg max-h-[90vh] overflow-y-auto",
+        OVERLAY_LAYERS.overlay,
         className
       )}
       {...props}

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,6 +1,8 @@
 import * as React from "react"
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
-import { Check, CaretRight as ChevronRight, Circle } from '@phosphor-icons/react';import { cn } from "@/lib/utils"
+import { Check, CaretRight as ChevronRight, Circle } from '@phosphor-icons/react'
+import { cn } from "@/lib/utils"
+import { OVERLAY_LAYERS } from "@/lib/overlayLayers"
 
 const DropdownMenu = DropdownMenuPrimitive.Root
 
@@ -43,7 +45,8 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-[200] min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      OVERLAY_LAYERS.overlay,
       className
     )}
     {...props}
@@ -61,7 +64,8 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-[200] min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        OVERLAY_LAYERS.overlay,
         className
       )}
       {...props}

--- a/src/components/ui/hover-card.tsx
+++ b/src/components/ui/hover-card.tsx
@@ -2,6 +2,7 @@ import * as React from "react"
 import * as HoverCardPrimitive from "@radix-ui/react-hover-card"
 
 import { cn } from "@/lib/utils"
+import { OVERLAY_LAYERS } from "@/lib/overlayLayers"
 
 const HoverCard = HoverCardPrimitive.Root
 
@@ -16,7 +17,8 @@ const HoverCardContent = React.forwardRef<
     align={align}
     sideOffset={sideOffset}
     className={cn(
-      "z-50 w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      OVERLAY_LAYERS.floating,
       className
     )}
     {...props}

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -2,6 +2,7 @@ import * as React from "react"
 import * as PopoverPrimitive from "@radix-ui/react-popover"
 
 import { cn } from "@/lib/utils"
+import { OVERLAY_LAYERS } from "@/lib/overlayLayers"
 
 const Popover = PopoverPrimitive.Root
 
@@ -17,7 +18,8 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        OVERLAY_LAYERS.floating,
         className
       )}
       {...props}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,6 +1,8 @@
 import * as React from "react"
 import * as SelectPrimitive from "@radix-ui/react-select"
-import { Check, CaretDown as ChevronDown, CaretUp as ChevronUp } from '@phosphor-icons/react';import { cn } from "@/lib/utils"
+import { Check, CaretDown as ChevronDown, CaretUp as ChevronUp } from '@phosphor-icons/react'
+import { cn } from "@/lib/utils"
+import { OVERLAY_LAYERS } from "@/lib/overlayLayers"
 
 const Select = SelectPrimitive.Root
 
@@ -71,7 +73,8 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "relative max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        OVERLAY_LAYERS.floating,
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,8 +1,10 @@
 import * as SheetPrimitive from "@radix-ui/react-dialog"
 import { cva, type VariantProps } from "class-variance-authority"
-import { X } from '@phosphor-icons/react';import * as React from "react"
+import { X } from '@phosphor-icons/react'
+import * as React from "react"
 
 import { cn } from "@/lib/utils"
+import { OVERLAY_LAYERS } from "@/lib/overlayLayers"
 
 const Sheet = SheetPrimitive.Root
 
@@ -18,7 +20,8 @@ const SheetOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Overlay
     className={cn(
-      "fixed inset-0 z-[200] bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      OVERLAY_LAYERS.overlay,
       className
     )}
     {...props}
@@ -28,7 +31,7 @@ const SheetOverlay = React.forwardRef<
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
 
 const sheetVariants = cva(
-  "fixed z-[200] gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+  `fixed ${OVERLAY_LAYERS.overlay} gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500`,
   {
     variants: {
       side: {

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -1,7 +1,9 @@
 import * as React from "react"
 import * as ToastPrimitives from "@radix-ui/react-toast"
 import { cva, type VariantProps } from "class-variance-authority"
-import { X } from '@phosphor-icons/react';import { cn } from "@/lib/utils"
+import { X } from '@phosphor-icons/react'
+import { cn } from "@/lib/utils"
+import { OVERLAY_LAYERS } from "@/lib/overlayLayers"
 
 const ToastProvider = ToastPrimitives.Provider
 
@@ -12,7 +14,8 @@ const ToastViewport = React.forwardRef<
   <ToastPrimitives.Viewport
     ref={ref}
     className={cn(
-      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
+      "fixed top-0 flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
+      OVERLAY_LAYERS.toast,
       className
     )}
     {...props}

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -2,6 +2,7 @@ import * as React from "react"
 import * as TooltipPrimitive from "@radix-ui/react-tooltip"
 
 import { cn } from "@/lib/utils"
+import { OVERLAY_LAYERS } from "@/lib/overlayLayers"
 
 const TooltipProvider = TooltipPrimitive.Provider
 
@@ -17,7 +18,8 @@ const TooltipContent = React.forwardRef<
     ref={ref}
     sideOffset={sideOffset}
     className={cn(
-      "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      OVERLAY_LAYERS.floating,
       className
     )}
     {...props}

--- a/src/lib/overlayLayers.test.ts
+++ b/src/lib/overlayLayers.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { OVERLAY_LAYERS, OVERLAY_LAYER_VALUES } from './overlayLayers';
+
+describe('overlayLayers', () => {
+  it('keeps documented class tokens stable', () => {
+    expect(OVERLAY_LAYERS).toEqual({
+      floating: 'z-50',
+      toast: 'z-[100]',
+      overlay: 'z-[200]',
+      nestedOverlayFloating: 'z-[210]',
+    });
+  });
+
+  it('keeps nested floating content above parent overlays', () => {
+    expect(OVERLAY_LAYER_VALUES.nestedOverlayFloating).toBeGreaterThan(OVERLAY_LAYER_VALUES.overlay);
+    expect(OVERLAY_LAYER_VALUES.overlay).toBeGreaterThan(OVERLAY_LAYER_VALUES.floating);
+  });
+});

--- a/src/lib/overlayLayers.ts
+++ b/src/lib/overlayLayers.ts
@@ -1,0 +1,13 @@
+export const OVERLAY_LAYERS = {
+  floating: "z-50",
+  toast: "z-[100]",
+  overlay: "z-[200]",
+  nestedOverlayFloating: "z-[210]",
+} as const;
+
+export const OVERLAY_LAYER_VALUES = {
+  floating: 50,
+  toast: 100,
+  overlay: 200,
+  nestedOverlayFloating: 210,
+} as const;


### PR DESCRIPTION
## Summary

This PR implements the layering follow-up from #269 after the localized fix in #265.

### What changed

- Added a shared overlay layer token map in `src/lib/overlayLayers.ts`.
- Replaced hardcoded z-index values in shared Radix UI primitives with reusable layer tokens:
  - `Select`, `DropdownMenu`, `Dialog`, `Sheet`, `Popover`, `Tooltip`, `HoverCard`, `Toast`, `AlertDialog`.
- Scoped nested overlay elevation to the affected path instead of changing shared primitive behavior:
  - `RelaySelector` now accepts `contentClassName`.
  - `AccountSwitcher` passes `OVERLAY_LAYERS.nestedOverlayFloating` to the relay selector instance inside the account dropdown.
- Added regression coverage for the nested overlay path:
  - `AccountSwitcher` test now asserts the local relay selector layer override is present.
  - `overlayLayers` unit test locks token values and ordering.
- Documented the layering ownership model and nested overlay pattern in `docs/overlay-layering.md`.

## Related

- Follow-up issue: #269
- Previous fix context: #265