### PR TITLE
Fix retry for failed video playback

### DIFF
--- a/src/components/VideoCard.test.tsx
+++ b/src/components/VideoCard.test.tsx
@@ -74,13 +74,22 @@ vi.mock('@/components/ui/dropdown-menu', () => ({
 vi.mock('@/components/VideoPlayer', () => ({
   VideoPlayer: ({
     videoId,
+    onError,
     onPlaybackStarted,
   }: {
     videoId: string;
+    onError?: () => void;
     onPlaybackStarted?: () => void;
   }) => (
     <div data-testid={`video-player-${videoId}`}>
       Video Player
+      <button
+        aria-label={`fail-video-${videoId}`}
+        onClick={onError}
+        type="button"
+      >
+        Fail video
+      </button>
       <button
         aria-label={`start-playback-${videoId}`}
         onClick={onPlaybackStarted}
@@ -460,5 +469,21 @@ describe('VideoCard', () => {
 
     expect(screen.getByTestId('thumbnail-player')).toBeInTheDocument();
     expect(screen.queryByText('Log in to view')).not.toBeInTheDocument();
+  });
+
+  it('lets failed playback be retried without remounting the card', () => {
+    const video = makeVideo();
+    render(<VideoCard video={video} />);
+
+    fireEvent.click(screen.getByLabelText(`fail-video-${video.id}`));
+    expect(screen.getByTestId(`video-player-${video.id}`)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText(`fail-video-${video.id}`));
+    expect(screen.getByText('Failed to load video')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+
+    expect(screen.getByTestId(`video-player-${video.id}`)).toBeInTheDocument();
+    expect(screen.queryByText('Failed to load video')).not.toBeInTheDocument();
   });
 });

--- a/src/components/VideoCard.tsx
+++ b/src/components/VideoCard.tsx
@@ -2,7 +2,7 @@
 // ABOUTME: Shows video player, metadata, author info, and social interactions
 
 import { useState, useCallback, useRef, useMemo, useEffect } from 'react';
-import { Heart, Repeat as Repeat2, ChatCircle as MessageCircle, Share, Eye, DotsThreeVertical as MoreVertical, Flag, UserMinus as UserX, Trash as Trash2, SpeakerHigh as Volume2, SpeakerX as VolumeX, Code, Users, ListPlus, DownloadSimple as Download, ArrowsOutSimple as Maximize2, ClosedCaptioning as Captions, PushPin as Pin, PushPinSlash as PinOff } from '@phosphor-icons/react';
+import { Heart, Repeat as Repeat2, ChatCircle as MessageCircle, Share, Eye, DotsThreeVertical as MoreVertical, Flag, UserMinus as UserX, Trash as Trash2, SpeakerHigh as Volume2, SpeakerX as VolumeX, Code, Users, ListPlus, DownloadSimple as Download, ArrowsOutSimple as Maximize2, ClosedCaptioning as Captions, PushPin as Pin, PushPinSlash as PinOff, ArrowClockwise } from '@phosphor-icons/react';
 import { nip19 } from 'nostr-tools';
 import { Card, CardContent, type CardAccent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -152,6 +152,7 @@ export function VideoCard({
   const shouldShowReposter = hasReposts && reposterPubkey;
   const classicViewBreakdown = formatClassicVineViewBreakdown(viewCount, video.loopCount ?? 0);
   const [videoError, setVideoError] = useState(false);
+  const [retryAttempt, setRetryAttempt] = useState(0);
   // Always start with video player visible in auto-play mode, but let VideoPlaybackContext control actual playback
   // The VideoPlayer component will only play when it's the activeVideoId (most visible)
   const [isPlaying, setIsPlaying] = useState(mode === 'auto-play');
@@ -396,6 +397,12 @@ export function VideoCard({
     }
   }, [isPlaying]);
 
+  useEffect(() => {
+    setVideoError(false);
+    setMp4Failed(false);
+    setRetryAttempt(0);
+  }, [video.id, video.videoUrl]);
+
   const handlePlaybackStarted = () => {
     setShowThumbnailDuringStartup(false);
     onPlaybackStarted?.();
@@ -409,6 +416,16 @@ export function VideoCard({
     } else {
       setVideoError(true);
     }
+  };
+
+  const handleRetryVideo = () => {
+    setVideoError(false);
+    setMp4Failed(false);
+    setShowThumbnailDuringStartup(false);
+    setIsPlaying(true);
+    setActiveVideo(video.id);
+    setRetryAttempt(prev => prev + 1);
+    onPlay?.();
   };
 
   const handleMuteUser = async () => {
@@ -606,6 +623,7 @@ export function VideoCard({
               ) : !videoError ? (
                 <>
                   <VideoPlayer
+                    key={`${video.id}-${video.videoUrl}-${retryAttempt}-${mp4Failed ? 'hls' : 'direct'}`}
                     videoId={video.id}
                     src={video.videoUrl}
                     hlsUrl={effectiveHlsUrl}
@@ -641,7 +659,19 @@ export function VideoCard({
                 </>
               ) : (
                 <div className="flex items-center justify-center h-full text-muted-foreground">
-                  <p>Failed to load video</p>
+                  <div className="text-center space-y-3">
+                    <p>Failed to load video</p>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={handleRetryVideo}
+                      className="gap-2"
+                    >
+                      <ArrowClockwise className="h-4 w-4" />
+                      Retry
+                    </Button>
+                  </div>
                 </div>
               )}
 

--- a/src/components/VideoPlayer.test.tsx
+++ b/src/components/VideoPlayer.test.tsx
@@ -2,12 +2,23 @@
 // ABOUTME: Verifies video loading, auth handling, and URL management
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { VideoPlayer } from './VideoPlayer';
 
 const mockRegisterVideo = vi.fn();
 const mockUnregisterVideo = vi.fn();
 const mockUpdateVideoVisibility = vi.fn();
+const hlsTestState = vi.hoisted(() => ({
+  instances: [] as Array<{
+    attachMedia: ReturnType<typeof vi.fn>;
+    destroy: ReturnType<typeof vi.fn>;
+    handlers: Record<string, Array<(event: string, data: unknown) => void>>;
+    levels: unknown[];
+    loadSource: ReturnType<typeof vi.fn>;
+    on: ReturnType<typeof vi.fn>;
+  }>,
+  isSupported: vi.fn(() => false),
+}));
 
 // Mock dependencies
 vi.mock('@/hooks/useVideoPlayback', () => ({
@@ -72,12 +83,37 @@ vi.mock('@/components/AgeRestrictedMediaPlaceholder', () => ({
   ),
 }));
 
-vi.mock('hls.js', () => ({
-  default: {
-    isSupported: () => false,
-    Events: { MANIFEST_PARSED: 'hlsManifestParsed', ERROR: 'hlsError' },
-  },
-}));
+vi.mock('hls.js', () => {
+  const HlsMock = vi.fn(function (this: {
+    attachMedia: ReturnType<typeof vi.fn>;
+    destroy: ReturnType<typeof vi.fn>;
+    handlers: Record<string, Array<(event: string, data: unknown) => void>>;
+    levels: unknown[];
+    loadSource: ReturnType<typeof vi.fn>;
+    on: ReturnType<typeof vi.fn>;
+  }) {
+    const handlers: Record<string, Array<(event: string, data: unknown) => void>> = {};
+
+    this.attachMedia = vi.fn();
+    this.destroy = vi.fn();
+    this.handlers = handlers;
+    this.levels = [];
+    this.loadSource = vi.fn();
+    this.on = vi.fn((event: string, handler: (event: string, data: unknown) => void) => {
+      handlers[event] = handlers[event] ?? [];
+      handlers[event].push(handler);
+    });
+
+    hlsTestState.instances.push(this);
+  });
+
+  return {
+    default: Object.assign(HlsMock, {
+      isSupported: hlsTestState.isSupported,
+      Events: { MANIFEST_PARSED: 'hlsManifestParsed', ERROR: 'hlsError' },
+    }),
+  };
+});
 
 // Mock react-intersection-observer to avoid observer.observe issues
 vi.mock('react-intersection-observer', () => ({
@@ -107,6 +143,8 @@ beforeEach(() => {
 describe('VideoPlayer', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
+    hlsTestState.instances.length = 0;
+    hlsTestState.isSupported.mockReturnValue(false);
 
     const { useVideoPlayback } = await import('@/hooks/useVideoPlayback');
     (useVideoPlayback as ReturnType<typeof vi.fn>).mockImplementation(() => ({
@@ -299,6 +337,51 @@ describe('VideoPlayer', () => {
       if (createObjectURLSpy.mock.calls.length > 0) {
         expect(revokeObjectURLSpy).toHaveBeenCalledWith('blob:test-123');
       }
+    });
+  });
+
+  describe('HLS fallback failures', () => {
+    it('reports terminal failure after fatal HLS error falls back to direct playback', async () => {
+      hlsTestState.isSupported.mockReturnValue(true);
+
+      const onError = vi.fn();
+      const src = 'https://media.divine.video/test-video.mp4';
+
+      const { container } = render(
+        <VideoPlayer
+          videoId="fatal-hls-fallback"
+          src={src}
+          hlsUrl="https://media.divine.video/test-video/hls/master.m3u8"
+          onError={onError}
+        />
+      );
+
+      await waitFor(() => {
+        expect(hlsTestState.instances.length).toBeGreaterThan(0);
+      });
+
+      const video = container.querySelector('video');
+      expect(video).not.toBeNull();
+      if (!video) {
+        throw new Error('expected rendered video element');
+      }
+
+      const hls = hlsTestState.instances[hlsTestState.instances.length - 1];
+      expect(hls.handlers.hlsError).toHaveLength(1);
+
+      act(() => {
+        hls.handlers.hlsError[0]('hlsError', { fatal: true });
+      });
+
+      await waitFor(() => {
+        expect(video.src).toBe(src);
+      });
+
+      fireEvent.error(video);
+
+      await waitFor(() => {
+        expect(onError).toHaveBeenCalledTimes(1);
+      });
     });
   });
 

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -805,7 +805,9 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
 
           if (data.fatal) {
             debugError(`[VideoPlayer ${videoId}] Fatal HLS error, falling back to direct playback`);
+            setTriedHls(true);
             hls.destroy();
+            hlsRef.current = null;
             // Fall back to direct src playback
             const currentUrl = allUrls[currentUrlIndex];
             if (currentUrl) {


### PR DESCRIPTION
## Summary
- add a retry path for video cards after terminal media load failures
- force `VideoPlayer` to remount on retry and reset MP4/HLS fallback state
- mark HLS as tried after fatal HLS errors so direct fallback failures reach the card error UI

## Test Plan
- [x] `npx vitest run src/components/VideoPlayer.test.tsx src/components/VideoCard.test.tsx`
- [x] `npm run test`
- [x] Playwright check on `/video/a0b51467a6404ba0b918a7116ad94d2dd894c397eeeaea951a5ac0857f1f9086` with media requests forced to 404; Retry appeared and clicking it increased media requests from 8 to 15
