### PR TITLE
fix: use unified profile views for public loop totals

### DIFF
--- a/src/lib/profileStats.test.ts
+++ b/src/lib/profileStats.test.ts
@@ -47,6 +47,23 @@ describe('buildProfileStats', () => {
 
     expect(stats.classicVineCount).toBe(398);
     expect(stats.originalLoopCount).toBe(2300000000);
-    expect(stats.totalLoops).toBe(2256);
+    expect(stats.totalLoops).toBe(2578);
+  });
+
+  it('falls back to watch-duration loops when unified views are unavailable', () => {
+    const stats = buildProfileStats({
+      funnelcakeProfile: {
+        pubkey: 'pubkey-1',
+        video_count: 1,
+        follower_count: 0,
+        following_count: 0,
+        total_loops: 12.6,
+        total_reactions: 0,
+      },
+      loadedVideos: [],
+      joinedDate: null,
+    });
+
+    expect(stats.totalLoops).toBe(12);
   });
 });

--- a/src/lib/profileStats.ts
+++ b/src/lib/profileStats.ts
@@ -41,6 +41,8 @@ export function buildProfileStats(input: BuildProfileStatsInput): ProfileStats {
   const originalLoopCount = input.archiveStats?.originalLoopCount ?? fallbackOriginalLoopCount;
   const isClassicViner = classicVineCount > 0;
   const allLoaded = !input.hasNextPage && input.loadedVideos.length > 0;
+  const publicLoopTotal =
+    input.funnelcakeProfile?.total_views ?? Math.floor(input.funnelcakeProfile?.total_loops ?? 0);
 
   return {
     videosCount: allLoaded
@@ -49,7 +51,7 @@ export function buildProfileStats(input: BuildProfileStatsInput): ProfileStats {
     followersCount: input.funnelcakeProfile?.follower_count ?? 0,
     followingCount: input.funnelcakeProfile?.following_count ?? 0,
     totalViews: input.funnelcakeProfile?.total_views ?? 0,
-    totalLoops: Math.floor(input.funnelcakeProfile?.total_loops ?? 0),
+    totalLoops: publicLoopTotal,
     totalReactions: input.funnelcakeProfile?.total_reactions ?? 0,
     joinedDate: input.joinedDate,
     joinedDateLoading: input.joinedDateLoading,


### PR DESCRIPTION
## Summary
- Use CDN-inclusive total_views for the web profile public loop total
- Keep total_loops as a fallback for older API responses
- Update profileStats coverage for unified views and fallback behavior

## Test Plan
- [x] npx vitest run src/lib/profileStats.test.ts