### PR TITLE
Simplify classic Vine loop labels

### DIFF
--- a/src/lib/formatUtils.test.ts
+++ b/src/lib/formatUtils.test.ts
@@ -6,20 +6,20 @@ describe('formatClassicVineViewBreakdown', () => {
     expect(formatClassicVineViewBreakdown(25, 0)).toBeNull();
   });
 
-  it('shows only Vine loops when there are no new Divine views yet', () => {
-    expect(formatClassicVineViewBreakdown(100, 100)).toBe('100 Classic Loops');
+  it('shows only the archived Vine loop count', () => {
+    expect(formatClassicVineViewBreakdown(100, 100)).toBe('100 Loops');
   });
 
-  it('shows archived and new views when classic Vines receive fresh traffic', () => {
-    expect(formatClassicVineViewBreakdown(120, 100)).toBe('100 Classic Loops - 20 New');
+  it('does not show new Divine views for classic Vines', () => {
+    expect(formatClassicVineViewBreakdown(120, 100)).toBe('100 Loops');
   });
 
-  it('keeps the classic loop count compact and the new delta precise', () => {
-    expect(formatClassicVineViewBreakdown(50453074, 50453008)).toBe('50.5M Classic Loops - 66 New');
+  it('keeps the archived loop count compact', () => {
+    expect(formatClassicVineViewBreakdown(50453074, 50453008)).toBe('50.5M Loops');
   });
 
-  it('handles singular new view labels and guards against negative deltas', () => {
-    expect(formatClassicVineViewBreakdown(101, 100)).toBe('100 Classic Loops - 1 New');
-    expect(formatClassicVineViewBreakdown(90, 100)).toBe('100 Classic Loops');
+  it('handles singular loop labels and ignores negative new-view deltas', () => {
+    expect(formatClassicVineViewBreakdown(2, 1)).toBe('1 Loop');
+    expect(formatClassicVineViewBreakdown(90, 100)).toBe('100 Loops');
   });
 });

--- a/src/lib/formatUtils.ts
+++ b/src/lib/formatUtils.ts
@@ -38,20 +38,13 @@ export function formatViewCount(count: number): string {
 }
 
 /**
- * Format a classic Vine summary so archived loops and new Divine views stay visible
- * without duplicating the total on a second line.
+ * Format a classic Vine summary using the original archive loop count.
  */
-export function formatClassicVineViewBreakdown(totalViews: number, originalLoops: number): string | null {
+export function formatClassicVineViewBreakdown(_totalViews: number, originalLoops: number): string | null {
   if (originalLoops <= 0) {
     return null;
   }
 
-  const newViews = Math.max(totalViews - originalLoops, 0);
-  const classicLoopLabel = `${formatCount(originalLoops)} Classic ${originalLoops === 1 ? 'Loop' : 'Loops'}`;
-
-  if (newViews <= 0) {
-    return classicLoopLabel;
-  }
-
-  return `${classicLoopLabel} - ${newViews < 1000 ? newViews.toString() : formatCount(newViews)} New`;
+  const loopLabel = originalLoops === 1 ? 'Loop' : 'Loops';
+  return `${formatCount(originalLoops)} ${loopLabel}`;
 }


### PR DESCRIPTION
## Summary
- show classic Vine counts as the original archived loop total only, e.g. `100 Loops`
- remove the visible `Classic` qualifier and `New` Divine view delta from classic Vine count formatting
- update formatter tests for compact, singular, and no-new-views behavior

## Test Plan
- [x] `npx vitest run src/lib/formatUtils.test.ts`
- [x] `npx vitest run src/lib/formatUtils.test.ts src/components/VideoCard.test.tsx src/pages/VideoPage.test.tsx`
- [x] `npm run test`
