### PR TITLE
fix(funnelcake): tolerate both raw-array and {data,pagination} envelope responses

### DIFF
--- a/src/lib/funnelcakeClient.test.ts
+++ b/src/lib/funnelcakeClient.test.ts
@@ -34,6 +34,9 @@ describe('funnelcakeClient', () => {
   let markNotificationsRead: typeof import('./funnelcakeClient').markNotificationsRead;
   let fetchNotifications: typeof import('./funnelcakeClient').fetchNotifications;
   let fetchVideoById: typeof import('./funnelcakeClient').fetchVideoById;
+  let fetchVideos: typeof import('./funnelcakeClient').fetchVideos;
+  let fetchUserVideos: typeof import('./funnelcakeClient').fetchUserVideos;
+  let unwrapListResponse: typeof import('./funnelcakeClient').unwrapListResponse;
 
   beforeEach(async () => {
     vi.resetModules();
@@ -51,6 +54,9 @@ describe('funnelcakeClient', () => {
     markNotificationsRead = client.markNotificationsRead;
     fetchNotifications = client.fetchNotifications;
     fetchVideoById = client.fetchVideoById;
+    fetchVideos = client.fetchVideos;
+    fetchUserVideos = client.fetchUserVideos;
+    unwrapListResponse = client.unwrapListResponse;
   });
 
   afterEach(() => {
@@ -658,6 +664,180 @@ describe('funnelcakeClient', () => {
       expect(result.videos).toHaveLength(1);
       expect(result.has_more).toBe(true);
       expect(result.next_cursor).toBe('36');
+    });
+
+    it('reads videos from the post-#238 envelope (`data` + `pagination`)', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          data: [
+            {
+              id: 'vid-env',
+              pubkey: TEST_PUBKEY,
+              created_at: 123,
+              kind: 34236,
+              d_tag: 'd-env',
+              title: 'Envelope Video',
+              video_url: 'https://example.com/envelope.mp4',
+            },
+          ],
+          pagination: {
+            has_more: true,
+            next_cursor: 'opaque-next',
+          },
+          source: 'personalized',
+        }),
+      });
+
+      const result = await fetchRecommendations(API_URL, {
+        pubkey: TEST_PUBKEY,
+        limit: 12,
+        cursor: 'opaque-prev',
+        fallback: 'popular',
+      });
+
+      expect(result.videos).toHaveLength(1);
+      expect(result.videos[0].id).toBe('vid-env');
+      expect(result.has_more).toBe(true);
+      expect(result.next_cursor).toBe('opaque-next');
+    });
+  });
+
+  describe('unwrapListResponse', () => {
+    it('passes through a raw array as items with no pagination metadata', () => {
+      const result = unwrapListResponse<number>([1, 2, 3]);
+      expect(result.items).toEqual([1, 2, 3]);
+      expect(result.hasMore).toBeUndefined();
+      expect(result.nextCursor).toBeUndefined();
+    });
+
+    it('extracts items + pagination from the post-#238 envelope', () => {
+      const result = unwrapListResponse<number>({
+        data: [10, 11, 12],
+        pagination: { has_more: true, next_cursor: 'cur-2' },
+      });
+      expect(result.items).toEqual([10, 11, 12]);
+      expect(result.hasMore).toBe(true);
+      expect(result.nextCursor).toBe('cur-2');
+    });
+
+    it('falls back to next_offset when the envelope omits next_cursor', () => {
+      const result = unwrapListResponse<number>({
+        data: [1],
+        pagination: { has_more: true, next_offset: 42 },
+      });
+      expect(result.nextCursor).toBe('42');
+    });
+
+    it('returns empty + hasMore=false for null/non-list garbage', () => {
+      const result = unwrapListResponse<number>(null);
+      expect(result.items).toEqual([]);
+      expect(result.hasMore).toBe(false);
+    });
+  });
+
+  describe('fetchVideos shape tolerance', () => {
+    function makeRawVideo(id: string) {
+      return {
+        id,
+        pubkey: TEST_PUBKEY,
+        created_at: 1700000000,
+        kind: 34236,
+        d_tag: id,
+        title: id,
+        video_url: `https://example.com/${id}.mp4`,
+      };
+    }
+
+    it('handles a raw-array response (legacy / `legacy-array-response` flag on)', async () => {
+      const rawArray = Array.from({ length: 3 }, (_, i) => makeRawVideo(`raw-${i}`));
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(rawArray),
+      });
+
+      const result = await fetchVideos(API_URL, { sort: 'trending', limit: 20 });
+
+      expect(result.videos).toHaveLength(3);
+      expect(result.videos[0].id).toBe('raw-0');
+      // Page wasn't full, so legacy heuristic says no more.
+      expect(result.has_more).toBe(false);
+      expect(result.next_cursor).toBeUndefined();
+    });
+
+    it('handles the post-#238 `{ data, pagination }` envelope', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          data: [makeRawVideo('env-0'), makeRawVideo('env-1')],
+          pagination: {
+            has_more: true,
+            next_cursor: 'envelope-cursor-2',
+          },
+        }),
+      });
+
+      const result = await fetchVideos(API_URL, { sort: 'trending', limit: 20 });
+
+      expect(result.videos).toHaveLength(2);
+      expect(result.videos[0].id).toBe('env-0');
+      expect(result.has_more).toBe(true);
+      expect(result.next_cursor).toBe('envelope-cursor-2');
+    });
+
+    it('returns no videos and has_more=false for an unrecognised shape', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ unexpected: 'shape' }),
+      });
+
+      const result = await fetchVideos(API_URL, { sort: 'trending', limit: 20 });
+
+      expect(result.videos).toEqual([]);
+      expect(result.has_more).toBe(false);
+      expect(result.next_cursor).toBeUndefined();
+    });
+  });
+
+  describe('fetchUserVideos shape tolerance', () => {
+    function makeRawVideo(id: string) {
+      return {
+        id,
+        pubkey: TEST_PUBKEY,
+        created_at: 1700000000,
+        kind: 34236,
+        d_tag: id,
+        title: id,
+        video_url: `https://example.com/${id}.mp4`,
+      };
+    }
+
+    it('handles a raw-array response', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve([makeRawVideo('uv-0')]),
+      });
+
+      const result = await fetchUserVideos(API_URL, TEST_PUBKEY, { limit: 20 });
+      expect(result.videos).toHaveLength(1);
+      expect(result.videos[0].id).toBe('uv-0');
+      expect(result.has_more).toBe(false);
+    });
+
+    it('handles the post-#238 envelope', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          data: [makeRawVideo('uv-env-0')],
+          pagination: { has_more: false, next_cursor: null },
+        }),
+      });
+
+      const result = await fetchUserVideos(API_URL, TEST_PUBKEY, { limit: 20 });
+      expect(result.videos).toHaveLength(1);
+      expect(result.videos[0].id).toBe('uv-env-0');
+      expect(result.has_more).toBe(false);
+      expect(result.next_cursor).toBeUndefined();
     });
   });
 });

--- a/src/lib/funnelcakeClient.ts
+++ b/src/lib/funnelcakeClient.ts
@@ -86,7 +86,16 @@ async function funnelcakeRequest<T>(
     const data = await response.json();
     recordFunnelcakeSuccess(apiUrl);
 
-    debugLog(`[FunnelcakeClient] Response OK:`, { endpoint, resultCount: Array.isArray(data?.videos) ? data.videos.length : 'N/A' });
+    // Cover all known shapes for the debug log: raw array, legacy `{videos: [...]}`,
+    // and post-#238 envelope `{data: [...]}`.
+    const resultCount = Array.isArray(data)
+      ? data.length
+      : Array.isArray(data?.videos)
+        ? data.videos.length
+        : Array.isArray(data?.data)
+          ? data.data.length
+          : 'N/A';
+    debugLog(`[FunnelcakeClient] Response OK:`, { endpoint, resultCount });
 
     return data as T;
   } catch (err) {
@@ -123,6 +132,56 @@ export class FunnelcakeApiError extends Error {
     super(message);
     this.name = 'FunnelcakeApiError';
   }
+}
+
+/**
+ * Envelope response shape introduced by divine-funnelcake PR #238.
+ *
+ * The API may return either a raw array (legacy/`legacy-array-response`
+ * Cargo feature) or a `{ data, pagination }` envelope. Mobile clients in
+ * the wild expect the legacy raw-array shape, so the production API is
+ * currently emitting raw arrays — but we need to tolerate both so the
+ * web client keeps working when the flag eventually flips.
+ */
+interface FunnelcakeListEnvelope<T> {
+  data: T[];
+  pagination?: {
+    has_more?: boolean;
+    next_cursor?: string | null;
+    next_offset?: number | null;
+  };
+}
+
+/**
+ * Unwrap a Funnelcake list response that may arrive as either a raw array
+ * (legacy shape) or a `{ data, pagination }` envelope (post-#238 shape).
+ *
+ * Returns a normalised `{ items, hasMore, nextCursor }` triple. For raw
+ * arrays the caller must compute `hasMore`/`nextCursor` itself (we pass
+ * `hasMore: undefined` so the caller can decide based on `items.length`);
+ * for envelopes we use the server-provided pagination fields.
+ */
+export function unwrapListResponse<T>(
+  raw: unknown,
+): { items: T[]; hasMore: boolean | undefined; nextCursor: string | undefined } {
+  if (Array.isArray(raw)) {
+    return { items: raw as T[], hasMore: undefined, nextCursor: undefined };
+  }
+
+  if (raw && typeof raw === 'object' && Array.isArray((raw as FunnelcakeListEnvelope<T>).data)) {
+    const env = raw as FunnelcakeListEnvelope<T>;
+    const pagination = env.pagination;
+    const nextCursor = pagination?.next_cursor != null
+      ? String(pagination.next_cursor)
+      : (pagination?.next_offset != null ? String(pagination.next_offset) : undefined);
+    return {
+      items: env.data,
+      hasMore: pagination?.has_more,
+      nextCursor,
+    };
+  }
+
+  return { items: [], hasMore: false, nextCursor: undefined };
 }
 
 /**
@@ -190,26 +249,34 @@ export async function fetchVideos(
     }
   }
 
-  // API returns array directly, wrap it in expected format
-  const videos = await funnelcakeRequest<FunnelcakeVideoRaw[]>(
+  // API may return either a raw array (legacy/`legacy-array-response`)
+  // or a `{ data, pagination }` envelope (post divine-funnelcake #238).
+  const raw = await funnelcakeRequest<unknown>(
     apiUrl,
     API_CONFIG.funnelcake.endpoints.videos,
     params,
     signal
   );
+  const { items: videos, hasMore: envelopeHasMore, nextCursor: envelopeCursor } =
+    unwrapListResponse<FunnelcakeVideoRaw>(raw);
 
   const videoCount = videos.length;
   const currentOffset = offset ?? (params.offset as number | undefined) ?? 0;
   const nextOffset = currentOffset + videoCount;
 
-  // For sorted feeds, return offset-based cursor; for chronological, return timestamp
-  const next_cursor = videoCount >= limit
+  // Prefer the envelope's pagination metadata when present; otherwise
+  // fall back to the legacy "page is full ⇒ probably more" heuristic.
+  const has_more = envelopeHasMore ?? videoCount >= limit;
+  const computedNextCursor = videoCount >= limit
     ? (sort !== 'recent' ? String(nextOffset) : String(videos[videoCount - 1].created_at))
+    : undefined;
+  const next_cursor = has_more
+    ? (envelopeCursor ?? computedNextCursor)
     : undefined;
 
   return {
     videos,
-    has_more: videoCount >= limit,
+    has_more,
     next_cursor,
   };
 }
@@ -327,26 +394,31 @@ export async function searchVideos(
     }
   }
 
-  // API returns array directly, wrap it in expected format
-  const videos = await funnelcakeRequest<FunnelcakeVideoRaw[]>(
+  // Tolerate both raw-array and envelope shapes (see unwrapListResponse).
+  const raw = await funnelcakeRequest<unknown>(
     apiUrl,
     endpoint,
     params,
     signal
   );
+  const { items: videos, hasMore: envelopeHasMore, nextCursor: envelopeCursor } =
+    unwrapListResponse<FunnelcakeVideoRaw>(raw);
 
   const videoCount = videos.length;
   const currentOffset = offset ?? (params.offset as number | undefined) ?? 0;
   const nextOffset = currentOffset + videoCount;
 
-  // For sorted feeds, return offset-based cursor; for chronological, return timestamp
-  const next_cursor = videoCount >= limit
+  const has_more = envelopeHasMore ?? videoCount >= limit;
+  const computedNextCursor = videoCount >= limit
     ? (sort !== 'recent' ? String(nextOffset) : String(videos[videoCount - 1].created_at))
+    : undefined;
+  const next_cursor = has_more
+    ? (envelopeCursor ?? computedNextCursor)
     : undefined;
 
   return {
     videos,
-    has_more: videoCount >= limit,
+    has_more,
     next_cursor,
   };
 }
@@ -389,7 +461,7 @@ export async function searchProfiles(
     signal,
   } = options;
 
-  return funnelcakeRequest<FunnelcakeProfileResult[]>(
+  const raw = await funnelcakeRequest<unknown>(
     apiUrl,
     API_CONFIG.funnelcake.endpoints.searchProfiles,
     {
@@ -401,6 +473,8 @@ export async function searchProfiles(
     },
     signal,
   );
+  // Tolerate both raw-array and envelope shapes.
+  return unwrapListResponse<FunnelcakeProfileResult>(raw).items;
 }
 
 /**
@@ -431,21 +505,28 @@ export async function fetchUserVideos(
     sort: sort || undefined,
   };
 
-  // API returns array directly, wrap it in expected format
-  const videos = await funnelcakeRequest<FunnelcakeVideoRaw[]>(
+  // Tolerate both raw-array and envelope shapes (see unwrapListResponse).
+  const raw = await funnelcakeRequest<unknown>(
     apiUrl,
     endpoint,
     params,
     signal
   );
+  const { items: videos, hasMore: envelopeHasMore, nextCursor: envelopeCursor } =
+    unwrapListResponse<FunnelcakeVideoRaw>(raw);
 
   const videoCount = videos.length;
   const nextOffset = currentOffset + videoCount;
 
+  const has_more = envelopeHasMore ?? videoCount >= limit;
+  const next_cursor = has_more
+    ? (envelopeCursor ?? (videoCount >= limit ? String(nextOffset) : undefined))
+    : undefined;
+
   return {
     videos,
-    has_more: videoCount >= limit,
-    next_cursor: videoCount >= limit ? String(nextOffset) : undefined,
+    has_more,
+    next_cursor,
   };
 }
 
@@ -481,41 +562,59 @@ export async function fetchUserFeed(
     }
   }
 
-  // API returns array directly, wrap it in expected format
-  const videos = await funnelcakeRequest<FunnelcakeVideoRaw[]>(
+  // Tolerate both raw-array and envelope shapes (see unwrapListResponse).
+  const raw = await funnelcakeRequest<unknown>(
     apiUrl,
     endpoint,
     params,
     signal
   );
+  const { items: videos, hasMore: envelopeHasMore, nextCursor: envelopeCursor } =
+    unwrapListResponse<FunnelcakeVideoRaw>(raw);
 
   const videoCount = videos.length;
   const currentOffset = offset ?? (params.offset as number | undefined) ?? 0;
   const nextOffset = currentOffset + videoCount;
 
-  const next_cursor = videoCount >= limit
+  const has_more = envelopeHasMore ?? videoCount >= limit;
+  const computedNextCursor = videoCount >= limit
     ? (sort !== 'recent' ? String(nextOffset) : String(videos[videoCount - 1].created_at))
+    : undefined;
+  const next_cursor = has_more
+    ? (envelopeCursor ?? computedNextCursor)
     : undefined;
 
   return {
     videos,
-    has_more: videoCount >= limit,
+    has_more,
     next_cursor,
   };
 }
 
 /**
- * Response from recommendations endpoint
+ * Response from recommendations endpoint.
+ *
+ * Historically the recommendations endpoint returned its videos in a
+ * top-level `videos` field with sibling pagination metadata. After
+ * divine-funnelcake PR #238 it may also return the post-#238 envelope
+ * (`{ data: [...], pagination: {...}, source, fallback_applied }`).
+ * We tolerate both shapes when parsing.
  */
 interface FunnelcakeRecommendationsResponse {
-  videos: FunnelcakeVideoRaw[];
-  source: 'personalized' | 'popular' | 'recent';
-  limit: number;
-  offset: number;
-  has_more: boolean;
-  next_offset: number | null;
-  next_cursor: string | null;
-  fallback_applied: boolean;
+  videos?: FunnelcakeVideoRaw[];
+  data?: FunnelcakeVideoRaw[];
+  source?: 'personalized' | 'popular' | 'recent';
+  limit?: number;
+  offset?: number;
+  has_more?: boolean;
+  next_offset?: number | null;
+  next_cursor?: string | null;
+  fallback_applied?: boolean;
+  pagination?: {
+    has_more?: boolean;
+    next_cursor?: string | null;
+    next_offset?: number | null;
+  };
 }
 
 /**
@@ -569,13 +668,22 @@ export async function fetchRecommendations(
     signal
   );
 
-  const videoCount = response.videos?.length || 0;
-  const serverSupportsCursorMetadata = 'has_more' in response;
+  // Pull videos from either the legacy `videos` field or the post-#238
+  // envelope `data` field. Pagination metadata may also live in either
+  // top-level fields or under `pagination`.
+  const videos = response.videos ?? response.data ?? [];
+  const videoCount = videos.length;
+  const pagination = response.pagination;
+  const hasMoreField = response.has_more ?? pagination?.has_more;
+  const nextCursorField = response.next_cursor ?? pagination?.next_cursor;
+  const nextOffsetField = response.next_offset ?? pagination?.next_offset;
+  const serverSupportsCursorMetadata = hasMoreField !== undefined;
+
   const hasMore = serverSupportsCursorMetadata
-    ? (response.has_more ?? false)
+    ? (hasMoreField ?? false)
     : videoCount > 0;
   const nextCursor = serverSupportsCursorMetadata
-    ? (response.next_cursor ?? (response.next_offset !== null ? String(response.next_offset) : undefined))
+    ? (nextCursorField ?? (nextOffsetField != null ? String(nextOffsetField) : undefined))
     : (videoCount > 0 ? String((offset || 0) + limit) : undefined);
 
   debugLog(
@@ -583,9 +691,9 @@ export async function fetchRecommendations(
   );
 
   return {
-    videos: response.videos || [],
+    videos,
     has_more: hasMore,
-    next_cursor: nextCursor,
+    next_cursor: nextCursor ?? undefined,
     source: response.source,
     fallback_applied: response.fallback_applied,
   };
@@ -627,13 +735,14 @@ export async function fetchPopularHashtags(
   limit: number = 50,
   signal?: AbortSignal
 ): Promise<FunnelcakeHashtag[]> {
-  // API returns array directly
-  return funnelcakeRequest<FunnelcakeHashtag[]>(
+  // Tolerate both raw-array and `{ data, pagination }` envelope shapes.
+  const raw = await funnelcakeRequest<unknown>(
     apiUrl,
     API_CONFIG.funnelcake.endpoints.hashtags,
     { limit },
     signal
   );
+  return unwrapListResponse<FunnelcakeHashtag>(raw).items;
 }
 
 /**
@@ -649,13 +758,14 @@ export async function fetchTrendingHashtags(
   limit: number = 20,
   signal?: AbortSignal
 ): Promise<FunnelcakeHashtag[]> {
-  // API returns array directly
-  return funnelcakeRequest<FunnelcakeHashtag[]>(
+  // Tolerate both raw-array and `{ data, pagination }` envelope shapes.
+  const raw = await funnelcakeRequest<unknown>(
     apiUrl,
     API_CONFIG.funnelcake.endpoints.trendingHashtags,
     { limit },
     signal
   );
+  return unwrapListResponse<FunnelcakeHashtag>(raw).items;
 }
 
 /**
@@ -671,13 +781,14 @@ export async function fetchClassicViners(
   limit: number = 20,
   signal?: AbortSignal
 ): Promise<FunnelcakeViner[]> {
-  // API returns array directly
-  return funnelcakeRequest<FunnelcakeViner[]>(
+  // Tolerate both raw-array and `{ data, pagination }` envelope shapes.
+  const raw = await funnelcakeRequest<unknown>(
     apiUrl,
     API_CONFIG.funnelcake.endpoints.viners,
     { limit },
     signal
   );
+  return unwrapListResponse<FunnelcakeViner>(raw).items;
 }
 
 /**
@@ -691,12 +802,14 @@ export async function fetchCategories(
   apiUrl: string = API_CONFIG.funnelcake.baseUrl,
   signal?: AbortSignal
 ): Promise<FunnelcakeCategory[]> {
-  return funnelcakeRequest<FunnelcakeCategory[]>(
+  // Tolerate both raw-array and `{ data, pagination }` envelope shapes.
+  const raw = await funnelcakeRequest<unknown>(
     apiUrl,
     API_CONFIG.funnelcake.endpoints.categories,
     {},
     signal
   );
+  return unwrapListResponse<FunnelcakeCategory>(raw).items;
 }
 
 /**

--- a/src/lib/funnelcakeTransform.test.ts
+++ b/src/lib/funnelcakeTransform.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { transformFunnelcakeVideo, transformToVideoPage } from './funnelcakeTransform';
+import { transformFunnelcakeResponse, transformFunnelcakeVideo, transformToVideoPage } from './funnelcakeTransform';
 import type { FunnelcakeVideoRaw, FunnelcakeResponse } from '@/types/funnelcake';
 
 function makeRawVideo(overrides: Partial<FunnelcakeVideoRaw> = {}): FunnelcakeVideoRaw {
@@ -203,5 +203,35 @@ describe('transformToVideoPage', () => {
     expect(page.nextCursor).toBeUndefined();
     expect(page.offset).toBeUndefined();
     expect(page.rawCursor).toBeUndefined();
+  });
+});
+
+describe('transformFunnelcakeResponse shape tolerance', () => {
+  it('transforms the internal wrapped shape ({videos, has_more, next_cursor})', () => {
+    const result = transformFunnelcakeResponse(makeResponse());
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('video-1');
+  });
+
+  it('transforms a raw-array response (legacy `legacy-array-response`)', () => {
+    const result = transformFunnelcakeResponse([makeRawVideo({ id: 'raw-array-vid', d_tag: 'raw' })]);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('raw-array-vid');
+  });
+
+  it('transforms the post-#238 envelope ({data, pagination})', () => {
+    const result = transformFunnelcakeResponse({
+      data: [makeRawVideo({ id: 'envelope-vid', d_tag: 'env' })],
+      pagination: { has_more: true, next_cursor: 'cur' },
+      // deliberately use `unknown` to mimic real API objects with extras
+    } as unknown as FunnelcakeResponse);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('envelope-vid');
+  });
+
+  it('returns [] for null/undefined/garbage', () => {
+    expect(transformFunnelcakeResponse(null)).toEqual([]);
+    expect(transformFunnelcakeResponse(undefined)).toEqual([]);
+    expect(transformFunnelcakeResponse({} as FunnelcakeResponse)).toEqual([]);
   });
 });

--- a/src/lib/funnelcakeTransform.ts
+++ b/src/lib/funnelcakeTransform.ts
@@ -146,15 +146,35 @@ export function transformFunnelcakeVideo(raw: FunnelcakeVideoRaw): ParsedVideoDa
 }
 
 /**
- * Transform a Funnelcake API response to an array of ParsedVideoData
+ * Transform a Funnelcake API response to an array of ParsedVideoData.
+ *
+ * Tolerant of three shapes so that callers that hand us a raw API
+ * response (or a future envelope) keep working:
+ *  - Internal wrapped shape: `{ videos, has_more, next_cursor }` (default)
+ *  - Raw array: `FunnelcakeVideoRaw[]` (legacy / `legacy-array-response`)
+ *  - Envelope: `{ data: FunnelcakeVideoRaw[], pagination: {...} }`
+ *    (post divine-funnelcake PR #238)
  */
-export function transformFunnelcakeResponse(response: FunnelcakeResponse): ParsedVideoData[] {
-  if (!response.videos || !Array.isArray(response.videos)) {
+export function transformFunnelcakeResponse(
+  response: FunnelcakeResponse | FunnelcakeVideoRaw[] | { data?: FunnelcakeVideoRaw[] } | null | undefined
+): ParsedVideoData[] {
+  let rawVideos: FunnelcakeVideoRaw[] | undefined;
+  if (Array.isArray(response)) {
+    rawVideos = response;
+  } else if (response && typeof response === 'object') {
+    if (Array.isArray((response as FunnelcakeResponse).videos)) {
+      rawVideos = (response as FunnelcakeResponse).videos;
+    } else if (Array.isArray((response as { data?: FunnelcakeVideoRaw[] }).data)) {
+      rawVideos = (response as { data: FunnelcakeVideoRaw[] }).data;
+    }
+  }
+
+  if (!rawVideos) {
     debugLog('[FunnelcakeTransform] No videos in response');
     return [];
   }
 
-  const transformed = response.videos
+  const transformed = rawVideos
     .map(raw => {
       try {
         return transformFunnelcakeVideo(raw);
@@ -178,7 +198,7 @@ export function transformFunnelcakeResponse(response: FunnelcakeResponse): Parse
   if (videos.length < transformed.length) {
     debugLog(`[FunnelcakeTransform] Deduplicated ${transformed.length} → ${videos.length} videos`);
   }
-  debugLog(`[FunnelcakeTransform] Transformed ${videos.length}/${response.videos.length} videos`);
+  debugLog(`[FunnelcakeTransform] Transformed ${videos.length}/${rawVideos.length} videos`);
 
   return videos;
 }


### PR DESCRIPTION
## Summary

divine-funnelcake PR [#238](https://github.com/DVMcastr/divine-funnelcake/pull/238) (commit ca96050) changed list endpoints on `api.divine.video` to return responses in a `{data: [...], pagination: {has_more, next_cursor}}` envelope. That broke every list-feed in divine-web because the client treats the response as a raw array — `Array.isArray(...)` fails on the envelope object, returning `[]`, which renders as "No recent videos" everywhere.

Production was hot-fixed by adding a Cargo feature flag (`legacy-array-response`) to the API server that re-serializes envelope responses as raw arrays. **That flag is currently ON** because mobile apps in the wild also expect raw array. The flag will eventually flip once mobile is updated, so we need divine-web tolerant of **both** shapes:

- works **today** (raw array, because flag is on)
- works **tomorrow** when the flag flips (envelope)

### Changes

- New `unwrapListResponse<T>(raw)` helper in `src/lib/funnelcakeClient.ts` that detects both shapes and returns `{ items, hasMore, nextCursor }`.
- All list callsites refactored to use it: `fetchVideos`, `searchVideos`, `searchProfiles`, `fetchUserVideos`, `fetchUserFeed`, `fetchPopularHashtags`, `fetchTrendingHashtags`, `fetchClassicViners`, `fetchCategories`.
- When the envelope provides `pagination.has_more` / `pagination.next_cursor` we use those; otherwise we fall back to the existing offset/timestamp heuristic so legacy raw-array behavior is unchanged.
- `fetchRecommendations` now reads videos from either `videos` or `data` and pulls pagination from either top-level fields or a nested `pagination` object.
- `transformFunnelcakeResponse` now also accepts a raw array or an envelope as a defensive last line of tolerance.
- Public `FunnelcakeResponse` interface and the wrapped `{ videos, has_more, next_cursor }` shape returned from each client function are unchanged — only what populates them changed.

## Test plan

- [x] Vitest passes locally (715 tests)
- [x] `tsc --noEmit` is clean for the touched files
- [x] eslint clean for the touched files
- [x] New test: `fetchVideos` returns transformed videos when API responds with raw array (legacy path, current production)
- [x] New test: `fetchVideos` returns transformed videos when API responds with `{data, pagination}` envelope (post-flag-flip path)
- [x] New test: `fetchUserVideos` covers both shapes
- [x] New test: `fetchRecommendations` covers both shapes (legacy `videos` field and post-#238 `data` + `pagination`)
- [x] New unit tests for `unwrapListResponse` directly (raw array, envelope, `next_offset`-only envelope, null/garbage)
- [x] New tests for `transformFunnelcakeResponse` covering all three shapes (wrapped, raw array, envelope)
- [ ] Smoke-test against staging/poc once deployed (visible feeds load)

## Context

- Server hotfix flag: `legacy-array-response` (currently ON in production)
- Original breakage: `src/lib/funnelcakeClient.ts:194` and ~5 sister callsites
- See divine-funnelcake PR #238 / commit `ca96050` for the upstream change