### PR TITLE
fix(media): only attach viewer auth header for age-restricted blobs

### DIFF
--- a/src/components/ThumbnailPlayer.test.tsx
+++ b/src/components/ThumbnailPlayer.test.tsx
@@ -88,6 +88,7 @@ describe('ThumbnailPlayer', () => {
         videoId="restricted-video"
         src="https://media.divine.video/restricted-video"
         thumbnailUrl="https://media.divine.video/restricted-video.jpg"
+        ageRestricted
       />
     );
 

--- a/src/components/ThumbnailPlayer.tsx
+++ b/src/components/ThumbnailPlayer.tsx
@@ -16,6 +16,8 @@ interface ThumbnailPlayerProps {
   thumbnailUrl?: string;
   duration?: number;
   className?: string;
+  /** Whether the source video is age-restricted; gates whether to attach auth on the thumbnail fetch. */
+  ageRestricted?: boolean;
   onClick?: () => void;
   onPlayButtonClick?: () => void;
   onError?: () => void;
@@ -28,6 +30,7 @@ export function ThumbnailPlayer({
   thumbnailUrl,
   duration: _duration,
   className,
+  ageRestricted,
   onClick,
   onPlayButtonClick,
   onError,
@@ -99,6 +102,7 @@ export function ThumbnailPlayer({
   const baseThumbnailUrl = thumbnailUrl || src;
   const { mediaUrl: authenticatedMediaUrl, isLoading: authMediaLoading } = useAuthenticatedMediaUrl(baseThumbnailUrl, {
     enabled: !requiresAuth,
+    ageRestricted: !!ageRestricted,
   });
   const overlayThumbnailUrl = authenticatedMediaUrl ||
     (baseThumbnailUrl && !isProtectedDivineMediaUrl(baseThumbnailUrl) ? baseThumbnailUrl : undefined);

--- a/src/components/VideoCard.tsx
+++ b/src/components/VideoCard.tsx
@@ -614,6 +614,7 @@ export function VideoCard({
                   src={video.videoUrl}
                   thumbnailUrl={video.thumbnailUrl}
                   duration={video.duration}
+                  ageRestricted={video.ageRestricted}
                   className="w-full h-full"
                   onClick={handleThumbnailClick}
                   onPlayButtonClick={handleThumbnailPlayButtonClick}
@@ -651,6 +652,7 @@ export function VideoCard({
                         src={video.videoUrl}
                         thumbnailUrl={video.thumbnailUrl}
                         duration={video.duration}
+                        ageRestricted={video.ageRestricted}
                         className="w-full h-full"
                         onVideoDimensions={handleThumbnailDimensions}
                       />

--- a/src/components/VideoGrid.tsx
+++ b/src/components/VideoGrid.tsx
@@ -56,6 +56,7 @@ function VideoGridMedia({
   const baseThumbnailUrl = video.thumbnailUrl || video.videoUrl;
   const { mediaUrl: authenticatedMediaUrl, isLoading } = useAuthenticatedMediaUrl(baseThumbnailUrl, {
     enabled: true,
+    ageRestricted: !!video.ageRestricted,
   });
 
   if (isLoading) {

--- a/src/components/VideoPlayer.authHeaders.test.tsx
+++ b/src/components/VideoPlayer.authHeaders.test.tsx
@@ -119,6 +119,7 @@ describe('VideoPlayer auth headers', () => {
           vineId: null,
           reposts: [],
           isVineMigrated: false,
+          ageRestricted: true,
         }}
       />,
     );
@@ -146,6 +147,7 @@ describe('VideoPlayer auth headers', () => {
           vineId: null,
           reposts: [],
           isVineMigrated: false,
+          ageRestricted: true,
         }}
       />,
     );

--- a/src/components/VideoPlayer.test.tsx
+++ b/src/components/VideoPlayer.test.tsx
@@ -407,6 +407,19 @@ describe('VideoPlayer', () => {
         <VideoPlayer
           videoId="verified-auth-failure"
           src="https://media.divine.video/protected-video"
+          videoData={{
+            id: 'verified-auth-failure',
+            pubkey: 'pub',
+            kind: 34236,
+            createdAt: 0,
+            content: '',
+            videoUrl: 'https://media.divine.video/protected-video',
+            hashtags: [],
+            vineId: null,
+            reposts: [],
+            isVineMigrated: false,
+            ageRestricted: true,
+          }}
         />
       );
 
@@ -440,6 +453,19 @@ describe('VideoPlayer', () => {
         <VideoPlayer
           videoId="verified-auth-placeholder"
           src="https://media.divine.video/protected-video"
+          videoData={{
+            id: 'verified-auth-placeholder',
+            pubkey: 'pub',
+            kind: 34236,
+            createdAt: 0,
+            content: '',
+            videoUrl: 'https://media.divine.video/protected-video',
+            hashtags: [],
+            vineId: null,
+            reposts: [],
+            isVineMigrated: false,
+            ageRestricted: true,
+          }}
         />
       );
 

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -132,6 +132,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
     const { isVerified: isAdultVerified, getAuthHeader } = useAdultVerification();
     const { mediaUrl: authenticatedPosterUrl } = useAuthenticatedMediaUrl(poster, {
       enabled: !!poster && !requiresAuth && !authCheckPending,
+      ageRestricted: !!videoData?.ageRestricted,
     });
     const overlayPosterUrl = authenticatedPosterUrl ||
       (poster && !isProtectedDivineMediaUrl(poster) ? poster : undefined);
@@ -771,8 +772,10 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
           capLevelToPlayerSize: true, // Match quality to player size
         };
 
-        // Add custom auth loader if adult verified
-        if (isAdultVerified) {
+        // Add custom auth loader only when the video is age-restricted.
+        // Public HLS streams must not carry an Authorization header — divine-blossom
+        // rejects any malformed auth header with 401 even when the blob is public.
+        if (isAdultVerified && videoData?.ageRestricted) {
           verboseLog(`[VideoPlayer ${videoId}] Using NIP-98 auth loader for each HLS request`);
           hlsConfig.loader = createAuthLoader(getAuthHeader);
         }
@@ -835,8 +838,12 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
         verboseLog(`[VideoPlayer ${videoId}] Using direct playback - URL ${currentUrlIndex}/${allUrls.length - 1}: ${currentUrl}`);
 
         if (currentUrl) {
-          // If adult verified, fetch with auth headers and use blob URL
-          if (isAdultVerified) {
+          // Only fetch with auth headers when the video is actually age-restricted.
+          // Public blobs must not carry an Authorization header — divine-blossom
+          // rejects any malformed auth header with 401 even when the blob is public,
+          // so attaching auth optimistically locks users out of public content
+          // whenever their signer produces an invalid event (e.g., JWT signer bugs).
+          if (isAdultVerified && videoData?.ageRestricted) {
             verboseLog(`[VideoPlayer ${videoId}] Fetching MP4 with NIP-98 auth`);
             (async () => {
               try {
@@ -918,7 +925,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
         }
       };
 
-    }, [hlsUrl, currentUrlIndex, allUrls, videoId, requiresAuth, isAdultVerified, authRetryCount, getAuthHeader, videoData?.sha256]); // React to HLS URL, fallback, and auth changes
+    }, [hlsUrl, currentUrlIndex, allUrls, videoId, requiresAuth, isAdultVerified, authRetryCount, getAuthHeader, videoData?.sha256, videoData?.ageRestricted]); // React to HLS URL, fallback, and auth changes
 
     // Cleanup on unmount
     useEffect(() => {

--- a/src/hooks/useAuthenticatedMediaUrl.test.ts
+++ b/src/hooks/useAuthenticatedMediaUrl.test.ts
@@ -27,7 +27,9 @@ describe('useAuthenticatedMediaUrl', () => {
     }) as typeof fetch;
 
     const { result } = renderHook(() =>
-      useAuthenticatedMediaUrl('https://media.divine.video/protected-thumbnail.jpg'),
+      useAuthenticatedMediaUrl('https://media.divine.video/protected-thumbnail.jpg', {
+        ageRestricted: true,
+      }),
     );
 
     await waitFor(() => {

--- a/src/hooks/useAuthenticatedMediaUrl.ts
+++ b/src/hooks/useAuthenticatedMediaUrl.ts
@@ -12,6 +12,13 @@ export function isProtectedDivineMediaUrl(url: string): boolean {
 
 interface UseAuthenticatedMediaUrlOptions {
   enabled?: boolean;
+  /**
+   * Only attach a Nostr auth header when the resource is known to be age-restricted.
+   * Public blobs must NOT receive an Authorization header — the CDN rejects any
+   * malformed/invalid auth header with 401 even when the blob would otherwise
+   * be public. Default: false (assume public; pass through the URL untouched).
+   */
+  ageRestricted?: boolean;
 }
 
 export function useAuthenticatedMediaUrl(
@@ -21,14 +28,15 @@ export function useAuthenticatedMediaUrl(
   mediaUrl: string | undefined;
   isLoading: boolean;
 } {
-  const { enabled = true } = options;
+  const { enabled = true, ageRestricted = false } = options;
   const { isVerified, getAuthHeader } = useAdultVerification();
   const [mediaUrl, setMediaUrl] = useState<string | undefined>(url ?? undefined);
   const [isLoading, setIsLoading] = useState(false);
   const objectUrlRef = useRef<string | null>(null);
 
   useEffect(() => {
-    const shouldAuthenticate = !!url && enabled && isVerified && isProtectedDivineMediaUrl(url);
+    const shouldAuthenticate =
+      !!url && enabled && ageRestricted && isVerified && isProtectedDivineMediaUrl(url);
 
     if (!shouldAuthenticate) {
       setMediaUrl(url ?? undefined);
@@ -84,7 +92,7 @@ export function useAuthenticatedMediaUrl(
     return () => {
       cancelled = true;
     };
-  }, [enabled, getAuthHeader, isVerified, url]);
+  }, [enabled, ageRestricted, getAuthHeader, isVerified, url]);
 
   useEffect(() => (
     () => {


### PR DESCRIPTION
## Summary

A malformed Nostr auth header makes divine-blossom return **401 even on public blobs** — `media_viewer_context` short-circuits to `AuthInvalid` before the public-vs-age-gated access check runs (`divine-blossom/src/main.rs:243-257`). Today the client attaches an `Authorization` header to every `media.divine.video` URL as soon as the viewer has ever clicked "I'm 18+" (`isVerified` is cached 30 days in localStorage), so any signer that produces an invalid event (e.g. the JWT auto-injected `window.nostr`) locks the user out of **every** video, public or restricted — just thumbnails, no playback.

Gate the `Authorization` header behind `videoData.ageRestricted === true` across the four media-fetch paths:

- `useAuthenticatedMediaUrl` (poster + grid thumbnails) — new `ageRestricted` option, default `false`
- `VideoPlayer` HLS auth loader (only attached for restricted videos)
- `VideoPlayer` direct MP4 auth fetch (else direct `video.src = currentUrl`)
- `ThumbnailPlayer` thumbnail fetch (new `ageRestricted` prop, wired from `VideoCard`)

After this change, public blobs are fetched anonymously and play normally; broken signers only fail on actually age-restricted content, where the existing `AgeRestrictedMediaPlaceholder` retry UI surfaces correctly instead of leaving a poster + nothing.

The deeper "why is the JWT-signed event being rejected" question (likely keycast/divine-login pubkey↔sig mismatch or clock skew) is still worth chasing, but it's no longer a site-wide outage.

## Test plan

- [x] `npx vitest run` — 701 pass / 0 fail
- [x] `npx tsc --noEmit` clean
- [ ] Repro on production: open KingBach's profile while age-verified with the JWT signer active → before this PR every video 401s, after this PR public videos play and only age-restricted ones surface the verify/retry overlay
- [ ] Verify Vine archive playback still works for non-age-restricted videos
- [ ] Verify age-verified user can still watch age-restricted videos when the signer is healthy (extension login or fixed JWT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)