### PR TITLE
fix(signer): self-heal DivineJWTSigner pubkey cache on remote rotation

### DIFF
--- a/src/lib/DivineJWTSigner.test.ts
+++ b/src/lib/DivineJWTSigner.test.ts
@@ -131,6 +131,56 @@ describe('DivineJWTSigner', () => {
     );
   });
 
+  it('self-heals the cached pubkey when the remote signer returns a different pubkey', async () => {
+    const stalePubkey = 'a'.repeat(64);
+    const freshPubkey = 'b'.repeat(64);
+    const unsignedEvent = {
+      kind: 1,
+      content: 'pubkey rotation',
+      tags: [],
+      created_at: 1234567890,
+    };
+    const signedEvent = {
+      ...unsignedEvent,
+      id: 'event-id-rotated',
+      pubkey: freshPubkey, // remote signer used a different key than we cached
+      sig: 'sig-rotated',
+    };
+
+    mockFetch
+      .mockResolvedValueOnce({
+        json: async () => ({ result: stalePubkey }),
+      })
+      .mockResolvedValueOnce({
+        json: async () => ({ result: signedEvent }),
+      })
+      .mockResolvedValueOnce({
+        json: async () => ({ result: signedEvent }),
+      });
+
+    const signer = new DivineJWTSigner({ token: 'rotation-token' });
+
+    // First sign uses the stale cached pubkey on the unsigned event,
+    // but returns a signed event whose pubkey is the fresh one.
+    await expect(signer.signEvent(unsignedEvent)).resolves.toEqual(signedEvent);
+
+    // The cache must now reflect the fresh pubkey, even though we never
+    // re-fetched it from get_public_key.
+    await expect(signer.getPublicKey()).resolves.toBe(freshPubkey);
+
+    // Subsequent signEvent calls put the corrected pubkey on the unsigned event.
+    await signer.signEvent(unsignedEvent);
+    expect(mockFetch).toHaveBeenLastCalledWith(
+      `${DIVINE_LOGIN_ORIGIN}/api/nostr`,
+      expect.objectContaining({
+        body: JSON.stringify({
+          method: 'sign_event',
+          params: [{ ...unsignedEvent, pubkey: freshPubkey }],
+        }),
+      })
+    );
+  });
+
   it('routes nip04 and nip44 encryption through the same RPC endpoint', async () => {
     mockFetch
       .mockResolvedValueOnce({

--- a/src/lib/DivineJWTSigner.ts
+++ b/src/lib/DivineJWTSigner.ts
@@ -129,6 +129,27 @@ export class DivineJWTSigner implements NostrSigner {
       throw new Error('Invalid response: missing signed event');
     }
 
+    // Self-heal a stale pubkey cache. If the remote signer signed with a key
+    // whose pubkey differs from what we cached and put on the unsigned event,
+    // the returned event is internally consistent (signed against its own
+    // `pubkey` field) but our cache is wrong. Trust the returned event and
+    // update the cache so subsequent signEvent calls put the correct pubkey
+    // on the unsigned event. Without this, every subsequent NIP-98 / Blossom
+    // auth event would carry a pubkey that doesn't match its signature, and
+    // every viewer auth check downstream (divine-blossom, NIP-98 consumers)
+    // would 401 with "Invalid signature" until the signer is recreated.
+    if (signedEvent.pubkey && signedEvent.pubkey !== this.cachedPubkey) {
+      console.warn(
+        '[DivineJWTSigner] ⚠️  pubkey mismatch — cached',
+        this.cachedPubkey,
+        'but signed event reports',
+        signedEvent.pubkey,
+        '— updating cache',
+      );
+      this.cachedPubkey = signedEvent.pubkey;
+      DivineJWTSigner.sharedPubkeys.set(this.pubkeyCacheKey, signedEvent.pubkey);
+    }
+
     console.log('[DivineJWTSigner] ✅ Event signed:', signedEvent.id);
     return signedEvent;
   }


### PR DESCRIPTION
## Summary

Defensive client-side guard for the second half of the divine-blossom 401 saga (PR #281 was the first half — gating auth headers on \`videoData.ageRestricted\` so a broken signer didn't poison **public** blobs). This PR addresses the **age-restricted** case where the hosted signer (keycast at \`login.divine.video/api/nostr\`) returns a signed event whose \`pubkey\` field disagrees with what we cached and put on the unsigned event.

When that happens today, the returned event is internally consistent (sig was made by some key K, event reports \`pubkey = K\`) but our cache still holds the stale value. **Subsequent** \`signEvent\` calls put the stale pubkey on the unsigned event, the remote signer signs with K again, and the returned event has \`pubkey: stale\` + \`sig\` made by K. Schnorr verify against \`stale\` fails → divine-blossom 401s with \"Invalid signature\" on every age-restricted blob.

Self-heal: after each successful \`signEvent\`, if \`signedEvent.pubkey !== this.cachedPubkey\`, update the per-instance and \`sharedPubkeys\` static cache to the returned value and \`console.warn\` the mismatch (so we get telemetry on whether this is firing in the wild).

## What this does NOT fix

The underlying remote-signer disagreement. If keycast really is signing with a key that doesn't match its own \`get_public_key\` response, that's a server bug and needs a corresponding patch in \`keycast/core/src/signing_session.rs\` — either reject calls where \`unsigned.pubkey != self.keys.public_key()\`, or canonicalize \`unsigned.pubkey = self.keys.public_key()\` before signing. Filing that separately.

## Test plan

- [x] \`npx vitest run\` — 702/702 pass (one new test for the self-heal)
- [x] \`npx tsc --noEmit\` clean
- [ ] Watch production logs for \`[DivineJWTSigner] ⚠️  pubkey mismatch\` warnings — non-zero count confirms the rotation hypothesis was real
- [ ] Verify age-restricted videos play for users on JWT signer who hit this case

🤖 Generated with [Claude Code](https://claude.com/claude-code)