### PR TITLE
fix: publish kind 0 to profile relays, sync display_name

### DIFF
--- a/src/components/EditProfileForm.tsx
+++ b/src/components/EditProfileForm.tsx
@@ -100,6 +100,13 @@ export const EditProfileForm: React.FC<EditProfileFormProps> = ({ onSuccess }) =
       // This helps with follow list safety checks
       data.client = 'divine.video';
 
+      // Keep display_name in sync with name to prevent stale values from other clients
+      if (data.name) {
+        data.display_name = data.name;
+      } else {
+        delete data.display_name;
+      }
+
       // Clean up empty values
       for (const key in data) {
         if (data[key] === '') {

--- a/src/components/NostrProvider.tsx
+++ b/src/components/NostrProvider.tsx
@@ -133,8 +133,8 @@ const NostrProvider: React.FC<NostrProviderProps> = (props) => {
         // Publish to the selected relay
         const allRelays = new Set<string>([relayUrl.current]);
 
-        // For contact lists (kind 3) and identity claims (kind 10011), publish to multiple relays for better availability
-        if (event.kind === 3 || event.kind === 10011) {
+        // For profiles (kind 0), contact lists (kind 3), and identity claims (kind 10011), publish to multiple relays for better availability
+        if (event.kind === 0 || event.kind === 3 || event.kind === 10011) {
           getRelayUrls(PROFILE_RELAYS).forEach(url => allRelays.add(url));
         }
 


### PR DESCRIPTION
## Summary

- **eventRouter** now publishes kind 0 (profile metadata) to `PROFILE_RELAYS`, matching the read path in `reqRouter`. Previously only kind 3 and kind 10011 were broadcast — profile edits went to the selected relay only, so public profiles and other clients never saw updates.
- **EditProfileForm** syncs `display_name` to `name` on save. The form doesn't expose `display_name`, but the `{ ...metadata, ...values }` spread preserves stale values set by other clients. This caused the Sony Pictures brand account to display "nicole" as its name.

## Verified

Tested on local dev (localhost:8080) against production relays using Matt's account (`9cfa7d57...`):

| Relay | Before fix | After fix (name set to "Bob") | After fix (name set to "Jerry") |
|-------|-----------|-------------------------------|----------------------------------|
| relay.divine.video | `display_name: mjb`, `name: null` | `name: Bob`, `display_name: Bob` | `name: Jerry`, `display_name: Jerry` |
| relay.damus.io | stale | `name: Bob`, `display_name: Bob` | `name: Jerry`, `display_name: Jerry` |
| relay.primal.net | stale | `name: Bob`, `display_name: Bob` | `name: Jerry`, `display_name: Jerry` |
| purplepag.es | `display_name: mjb`, `name: null` | stale (may reject unsigned writes or have propagation delay) | stale |

- Kind 0 now published to 3/4 profile relays (up from 1)
- `display_name` syncs to `name` on every save (no more stale divergence)
- Event ID for "Bob" test: `30f95ee8d6eba16c0bf6a0a83b8b40cb1250f41e89b83a410eee436dba8f8045` ([njump](https://njump.me/30f95ee8d6eba16c0bf6a0a83b8b40cb1250f41e89b83a410eee436dba8f8045))

## Note: Sony Pictures account

The Sony Pictures account (`207da1e5...`) still has `display_name: "nicole"` on the relay. This fix prevents future divergence but someone needs to re-edit that profile after merge to correct the existing event.