### PR TITLE
fix: allow first follow for accounts with no existing contact list

### DIFF
--- a/src/hooks/useFollowRelationship.test.ts
+++ b/src/hooks/useFollowRelationship.test.ts
@@ -204,6 +204,30 @@ describe('useFollowUser - follow list overwrite protection', () => {
     expect(pTags).toHaveLength(11); // 10 from relay + 1 new
   });
 
+  it('allows first follow when user has no existing contact list', async () => {
+    // Relay query succeeds but returns nothing — brand new account
+    mockNostrQuery.mockResolvedValue([]);
+
+    const { useFollowUser } = await import('./useFollowRelationship');
+    const { result } = renderHook(() => useFollowUser(), { wrapper: createWrapper() });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        targetPubkey: mockTargetPubkey,
+        currentContactList: null,
+        targetDisplayName: 'Test User',
+      });
+    });
+
+    // Should publish a Kind 3 with just the one new follow
+    expect(mockPublishEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 3,
+        tags: [['p', mockTargetPubkey, '', 'Test User']],
+      }),
+    );
+  });
+
   it('does not add duplicate follow if target already in fetched contact list', async () => {
     // Target is already in the relay's contact list
     const existingFollows = [mockTargetPubkey, 'bbbb'.padEnd(64, '0')];

--- a/src/hooks/useFollowRelationship.ts
+++ b/src/hooks/useFollowRelationship.ts
@@ -137,11 +137,14 @@ export function useFollowUser() {
       // The passed currentContactList may be stale or null if the UI query hasn't
       // loaded yet (race condition on fresh sessions / mobile browsers).
       let bestContactList = currentContactList;
+      let relayQuerySucceeded = false;
 
       try {
         const relayEvents = await nostr.query([
           { kinds: [3], authors: [user.pubkey], limit: 1 },
         ], { signal: AbortSignal.timeout(5000) });
+
+        relayQuerySucceeded = true;
 
         const relayContactList = relayEvents
           .filter((e: NostrEvent) => e.kind === 3)
@@ -163,15 +166,17 @@ export function useFollowUser() {
         debugLog('[useFollowUser] Failed to fetch latest Kind 3 from relay, using passed contact list:', error);
       }
 
-      // If we still have no contact list after trying both sources, refuse to publish
-      // to prevent creating a Kind 3 with only 1 follow that overwrites an existing list
-      if (!bestContactList) {
+      // If relay query failed and we have no cached list, refuse to publish
+      // to prevent creating a Kind 3 with only 1 follow that overwrites an existing list.
+      // But if the relay query succeeded and returned nothing, this user has genuinely
+      // never followed anyone — allow creating their first Kind 3.
+      if (!bestContactList && !relayQuerySucceeded) {
         throw new Error(
           'Could not load your existing follow list. Please try again in a moment.'
         );
       }
 
-      const currentTags = bestContactList.tags;
+      const currentTags = bestContactList?.tags ?? [];
 
       // Check if already following (shouldn't happen but good safety check)
       const alreadyFollowing = currentTags.some(tag => tag[0] === 'p' && tag[1] === targetPubkey);
@@ -185,7 +190,7 @@ export function useFollowUser() {
       const updatedTags = [...currentTags, newFollowTag];
 
       // Preserve relay information from existing contact list or use default
-      const relayContent = bestContactList.content || JSON.stringify({
+      const relayContent = bestContactList?.content || JSON.stringify({
         [PRIMARY_RELAY.url]: { read: true, write: true },
       });
 

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -30,6 +30,7 @@ import { useFollowRelationship, useFollowUser, useUnfollowUser } from '@/hooks/u
 import { useFollowListSafetyCheck } from '@/hooks/useFollowListSafetyCheck';
 import { PinnedVideosSection } from '@/components/PinnedVideosSection';
 import { useLoginDialog } from '@/contexts/LoginDialogContext';
+import { toast } from '@/hooks/useToast';
 import { debugLog } from '@/lib/debug';
 import { getDivineNip05Info } from '@/lib/nip05Utils';
 import { useNip05Validation } from '@/hooks/useNip05Validation';
@@ -340,6 +341,11 @@ export function ProfilePage() {
       }
     } catch (error) {
       console.error('Failed to update follow status:', error);
+      toast({
+        title: "Couldn't update follow.",
+        description: error instanceof Error ? error.message : 'Please try again.',
+        variant: "destructive",
+      });
     }
   };
 


### PR DESCRIPTION
## Summary

- Brand new accounts (no existing Kind 3 contact list) could never make their first follow on divine-web — the safety check that prevents overwriting an existing follow list also blocked creating the first one
- Follow errors were silently swallowed (`console.error` only) — users got no feedback when follows failed
- Surfaced during Sony partner onboarding: sonypictures.divine.video could not follow anyone from web

## Changes

- **`useFollowRelationship.ts`**: Track whether the relay query succeeded vs failed. Only block the follow when the query *failed* (timeout/network — unsafe, might overwrite). When it succeeded with no results, allow creating a first Kind 3.
- **`useFollowRelationship.test.ts`**: Added test for first-follow case (relay returns empty, no cached list → should publish Kind 3 with single follow)
- **`ProfilePage.tsx`**: Surface follow errors via destructive toast instead of silently swallowing

## Test plan

- [x] Existing 5 tests pass (overwrite protection still works)
- [x] New test: first follow with empty relay response succeeds
- [x] TypeScript clean (`tsc --noEmit`)
- [ ] **Test in prod after merge** — preview deploys can't authenticate against Keycast (OAuth redirect mismatch). Verify with any brand new account that has never followed anyone (sonypictures.divine.video, or create a fresh test account): follow someone, confirm Kind 3 published to relay.

Closes #296