### PR TITLE
fix(profile): hide profile and sidebar count totals

### DIFF
--- a/src/components/AppSidebar.test.tsx
+++ b/src/components/AppSidebar.test.tsx
@@ -123,6 +123,16 @@ describe('AppSidebar', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/dmca');
   });
 
+  it('hides the sidebar imported Vines total', () => {
+    render(
+      <MemoryRouter>
+        <AppSidebar />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByText(/vines (recovered|recuperados)/i)).not.toBeInTheDocument();
+  });
+
   it('shows the App Store badge when Apple lookup finds the regional listing', async () => {
     setLanguages(['en-NZ']);
 

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -23,7 +23,6 @@ import { LoginArea } from '@/components/auth/LoginArea';
 import { cn } from '@/lib/utils';
 import { feedUrls } from '@/lib/feedUrls';
 import { useRssFeedAvailable } from '@/hooks/useRssFeedAvailable';
-import { usePlatformStats } from '@/hooks/usePlatformStats';
 import { LanguageMenu } from '@/components/LanguageMenu';
 import { SocialLinks } from '@/components/SocialLinks';
 import { getTranslatedCategoryLabel } from '@/lib/constants/categories';
@@ -69,14 +68,12 @@ export function AppSidebar({ className }: { className?: string }) {
   const { data: unreadCount } = useUnreadNotificationCount();
   const { data: unreadDmCount } = useUnreadDmCount();
   const rssFeedAvailable = useRssFeedAvailable();
-  const { data: platformStats } = usePlatformStats();
   const [categoriesOpen, setCategoriesOpen] = useState(true);
   const [rssOpen, setRssOpen] = useState(false);
   const [divineOpen, setDivineOpen] = useState(false);
   const [termsOpen, setTermsOpen] = useState(false);
   const [appStoreUrl, setAppStoreUrl] = useState<string | null>(null);
   const { data: categories } = useCategories();
-  const classicVinesRecovered = platformStats?.vine_videos?.toLocaleString();
 
   const isActive = (path: string) => location.pathname === path;
   const isDiscoveryActive = () =>
@@ -410,11 +407,6 @@ export function AppSidebar({ className }: { className?: string }) {
             >
               <div className="min-w-0">
                 <div>{t('footer.aboutDivine')}</div>
-                {classicVinesRecovered && (
-                  <div className="mt-0.5 text-[11px] font-normal text-muted-foreground group-hover:text-muted-foreground">
-                    {t('footer.vinesRecovered', { count: classicVinesRecovered })}
-                  </div>
-                )}
               </div>
               <ChevronDown className={cn(
                 "mt-0.5 h-3.5 w-3.5 shrink-0 transition-transform duration-200",

--- a/src/components/ProfileHeader.test.tsx
+++ b/src/components/ProfileHeader.test.tsx
@@ -92,6 +92,27 @@ describe('ProfileHeader', () => {
     await initializeI18n({ force: true, languages: ['en-US'] });
   });
 
+  it('hides the total video count stat', () => {
+    render(
+      <MemoryRouter>
+        <ProfileHeader
+          pubkey={'a'.repeat(64)}
+          metadata={{ display_name: 'Modern Creator' }}
+          stats={baseStats}
+          isOwnProfile={false}
+          isFollowing={false}
+          onFollowToggle={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByText('Videos')).not.toBeInTheDocument();
+    expect(screen.queryByText('10')).not.toBeInTheDocument();
+    expect(screen.getByText('Followers')).toBeInTheDocument();
+    expect(screen.getByText('Following')).toBeInTheDocument();
+    expect(screen.getByText('Divine Loops')).toBeInTheDocument();
+  });
+
   it('shows clickable legacy socials for classic viners only', () => {
     render(
       <MemoryRouter>

--- a/src/components/ProfileHeader.test.tsx
+++ b/src/components/ProfileHeader.test.tsx
@@ -113,6 +113,27 @@ describe('ProfileHeader', () => {
     expect(screen.getByText('Divine Loops')).toBeInTheDocument();
   });
 
+  it('keeps the joined stat in the two-column mobile stats grid', () => {
+    render(
+      <MemoryRouter>
+        <ProfileHeader
+          pubkey={'a'.repeat(64)}
+          metadata={{ display_name: 'Modern Creator' }}
+          stats={{ ...baseStats, joinedDate: new Date('2024-01-01T00:00:00Z') }}
+          isOwnProfile={false}
+          isFollowing={false}
+          onFollowToggle={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+
+    const statsGrid = screen.getByTestId('profile-stats');
+    expect(statsGrid).toHaveClass('grid-cols-2', 'sm:grid-cols-4');
+
+    const joinedStat = screen.getByText(/Joined January 2024/).closest('.text-center');
+    expect(joinedStat).not.toHaveClass('col-span-2');
+  });
+
   it('shows clickable legacy socials for classic viners only', () => {
     render(
       <MemoryRouter>

--- a/src/components/ProfileHeader.tsx
+++ b/src/components/ProfileHeader.tsx
@@ -458,7 +458,7 @@ export function ProfileHeader({
         </div>
 
         {/* Joined Date / Classic Viner Status */}
-        <div className="text-center">
+        <div className="text-center col-span-2 sm:col-span-1">
           {stats ? (
             stats.joinedDateLoading ? (
               <Skeleton className="h-4 w-20 mx-auto" data-testid="stat-skeleton-joined" />

--- a/src/components/ProfileHeader.tsx
+++ b/src/components/ProfileHeader.tsx
@@ -458,7 +458,7 @@ export function ProfileHeader({
         </div>
 
         {/* Joined Date / Classic Viner Status */}
-        <div className="text-center col-span-2 sm:col-span-1">
+        <div className="text-center">
           {stats ? (
             stats.joinedDateLoading ? (
               <Skeleton className="h-4 w-20 mx-auto" data-testid="stat-skeleton-joined" />

--- a/src/components/ProfileHeader.tsx
+++ b/src/components/ProfileHeader.tsx
@@ -395,26 +395,9 @@ export function ProfileHeader({
 
       {/* Stats Section */}
       <div
-        className="grid grid-cols-2 sm:grid-cols-5 gap-4 py-4 border-t"
+        className="grid grid-cols-2 sm:grid-cols-4 gap-4 py-4 border-t"
         data-testid="profile-stats"
       >
-        {/* Videos Count */}
-        <div className="text-center">
-          {stats ? (
-            <>
-              <div className="text-xl sm:text-2xl font-bold text-foreground">
-                {formatNumber(stats.videosCount)}
-              </div>
-              <div className="text-xs sm:text-sm text-muted-foreground">{t('profileHeader.videos')}</div>
-            </>
-          ) : (
-            <>
-              <Skeleton className="h-6 w-12 mx-auto mb-1" data-testid="stat-skeleton-videos" />
-              <div className="text-xs sm:text-sm text-muted-foreground">{t('profileHeader.videos')}</div>
-            </>
-          )}
-        </div>
-
         {/* Followers Count */}
         <div className="text-center">
           {stats ? (
@@ -475,7 +458,7 @@ export function ProfileHeader({
         </div>
 
         {/* Joined Date / Classic Viner Status */}
-        <div className="text-center col-span-2 sm:col-span-1">
+        <div className="text-center">
           {stats ? (
             stats.joinedDateLoading ? (
               <Skeleton className="h-4 w-20 mx-auto" data-testid="stat-skeleton-joined" />


### PR DESCRIPTION
## Summary
- Hide the total Videos stat from profile headers for now
- Hide the sidebar imported Vines recovered total for now
- Reflow the remaining profile stats into a four-column desktop grid and a clean two-by-two mobile grid
- Add regression coverage for the hidden counts and mobile Joined stat layout

## Test Plan
- [x] npx vitest run src/components/ProfileHeader.test.tsx
- [x] npx vitest run src/components/ProfileHeader.test.tsx src/components/AppSidebar.test.tsx
- [x] npx tsc -p tsconfig.app.json --noEmit
- [x] npx eslint src/components/ProfileHeader.tsx src/components/ProfileHeader.test.tsx src/components/AppSidebar.tsx src/components/AppSidebar.test.tsx
- [x] npm run test
