### PR TITLE
chore: add repo contribution guardrails

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,50 @@
+name: Bug Report
+description: Report a bug or regression in divine-web.
+title: "fix: "
+labels:
+  - bug
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What is broken? Avoid naming corporate partners, customers, or other sensitive external brands; use generic descriptors unless explicitly approved.
+      placeholder: Briefly describe the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: How can someone reproduce the issue?
+      placeholder: |
+        1. Go to ...
+        2. Click ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      placeholder: What should have happened?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      placeholder: What happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: regression
+    attributes:
+      label: Regression Notes
+      description: If known, note whether this worked before and what changed.
+      placeholder: Optional context about when the regression started.
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots or Recording
+      description: Add any relevant screenshots, recordings, or logs. Redact sensitive external brand or partner names unless explicitly approved.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,40 @@
+name: Feature Request
+description: Propose a new capability or product improvement for divine-web.
+title: "feat: "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What should be added or changed? Avoid naming corporate partners, customers, or other sensitive external brands; use generic descriptors unless explicitly approved.
+      placeholder: Briefly describe the feature request.
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or Opportunity
+      description: What user or product problem does this solve?
+      placeholder: Explain the gap or opportunity.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed Approach
+      description: Describe the desired behavior or UX at a high level.
+      placeholder: Outline the proposed change.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Optional alternatives, tradeoffs, or rejected ideas.
+  - type: textarea
+    id: visuals
+    attributes:
+      label: Mockups, References, or Context
+      description: Add links, screenshots, or examples that clarify the request. Redact sensitive external brand or partner names unless explicitly approved.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+## Summary
+
+- 
+
+> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.
+
+## Motivation
+
+- 
+
+## Related Issue
+
+- Closes #
+
+## Testing
+
+- [ ] `npm run test`
+- [ ] Manual verification completed
+
+## Visuals
+
+- [ ] UI change with screenshots/video attached
+- [ ] No visual change
+- [ ] Visuals and text avoid sensitive external brand or partner names unless explicitly approved

--- a/.github/workflows/semantic_pr.yml
+++ b/.github/workflows/semantic_pr.yml
@@ -1,0 +1,13 @@
+name: Semantic PR
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  semantic-pull-request:
+    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/semantic_pull_request.yml@v1
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,15 @@
 - Commits: imperative, present tense (e.g., "Add profile page"); keep focused; reference issue IDs when applicable.
 - PRs: include summary, motivation, screenshots for UI changes, and tests for new logic.
 - CI hygiene: ensure `npm run test` passes locally before opening/merging PRs.
+- PR titles must use Conventional Commit format: `type(scope): summary` or `type: summary`.
+- Set the correct PR title when opening the PR instead of relying on title edits afterward.
+- If a PR title must be fixed after opening, verify that the semantic PR title check reruns successfully.
+- Keep PRs tightly scoped to the task. Do not include unrelated formatting churn, lockfile noise, drive-by refactors, or incidental cleanup.
+- Do not mention corporate partners, customers, brands, campaign names, or other sensitive external identities in public issue titles, PR titles, branch names, screenshots, or descriptions unless a maintainer explicitly approves it. Use generic descriptors instead, such as "partner subdomain", "brand account", or "external partner".
+- Temporary or transitional code must include `TODO(#issue):` with a tracking issue for later removal.
+- UI changes should include screenshots or video in the PR, or explicitly state that there is no visual change.
+- PR descriptions should include a concise summary, motivation, linked issue, and manual test plan.
+- Do not continue speculative feature implementation after exploratory UI work if maintainer alignment on scope or UX is still missing.
 
 ## Security & Deployment Notes
 - Do not commit secrets. Configure deploy targets via `wrangler.toml` and environment variables.


### PR DESCRIPTION
## Summary

- add repo-local contributor guardrails in `AGENTS.md` so humans and AI agents get the same instructions after cloning the repo
- add semantic PR title enforcement via GitHub Actions
- add PR and issue templates to standardize titles, descriptions, testing notes, and visual-change expectations
- add explicit guidance to avoid naming corporate partners or other sensitive external brands in public issues, PRs, branch names, screenshots, or descriptions

## Motivation

The repo had very little GitHub-native process scaffolding, which meant contributors and AI agents were relying on inconsistent habits rather than repo-local instructions. This change moves the key expectations into the repo itself and reinforces them through templates and workflow checks.

It also adds a soft privacy/sensitivity guardrail so public GitHub artifacts avoid naming external partners or brands unless a maintainer explicitly approves it.

## Related Issue

- N/A

## Testing

- [ ] `npm run test`
- [x] Manual verification completed

Manual verification:
- reviewed the new `AGENTS.md` rules for clarity and repo fit
- reviewed the new PR template, issue templates, and semantic PR workflow for correctness
- confirmed only the intended repo-policy files were staged and committed

## Visuals

- [x] No visual change
