### PR TITLE
fix(follow): add relay content test coverage and suppress race-condition toast

### DIFF
--- a/src/hooks/useFollowRelationship.test.ts
+++ b/src/hooks/useFollowRelationship.test.ts
@@ -219,11 +219,12 @@ describe('useFollowUser - follow list overwrite protection', () => {
       });
     });
 
-    // Should publish a Kind 3 with just the one new follow
+    // Should publish a Kind 3 with just the one new follow and default relay content
     expect(mockPublishEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         kind: 3,
         tags: [['p', mockTargetPubkey, '', 'Test User']],
+        content: JSON.stringify({ 'wss://relay.divine.video': { read: true, write: true } }),
       }),
     );
   });

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -341,11 +341,15 @@ export function ProfilePage() {
       }
     } catch (error) {
       console.error('Failed to update follow status:', error);
-      toast({
-        title: "Couldn't update follow.",
-        description: error instanceof Error ? error.message : 'Please try again.',
-        variant: "destructive",
-      });
+      const message = error instanceof Error ? error.message : '';
+      const isRaceCondition = message === 'Already following this user';
+      if (!isRaceCondition) {
+        toast({
+          title: "Couldn't update follow.",
+          description: message || 'Please try again.',
+          variant: "destructive",
+        });
+      }
     }
   };
 


### PR DESCRIPTION
## Summary

- Add explicit content assertion to the first-follow test so the default relay JSON fallback is protected from silent regressions
- Suppress destructive toast for "Already following" race-condition errors — this guard fires when the UI shows stale follow state, not when the user did something wrong

## Motivation

Non-blocking review feedback from @NotThatKindOfDrLiz on #297.

## Related Issue

- Closes #298
- Closes #299

## Testing

- [x] `npm run test` (6/6 follow tests pass, including tightened content assertion)
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [ ] Manual verification — not performed; test-only and error-string filtering changes, no behavioral change to follow path. #297 was verified in prod (confirmed Kind 3 published to relay for a brand new account).

## Visuals

- [x] No visual change