### PR TITLE
fix(sidebar): align Google Play badge left edge with App Store badge

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -165,7 +165,7 @@ export function AppSidebar({ className }: { className?: string }) {
             <img
               src="/store-badges/google-play-badge.png"
               alt="Get it on Google Play"
-              className="h-[58px] w-auto -ml-[7px]"
+              className="h-[58px] w-auto -ml-[10px]"
             />
           </a>
         </div>


### PR DESCRIPTION
## Summary
- The Google Play badge PNG has ~9.5px of transparent safe-zone padding on its left side at the displayed height (h=58px).
- The previous `-ml-[7px]` under-compensated, leaving the visible black backgrounds 3px out of alignment.
- Bumped to `-ml-[10px]` — both badges' visible left edges now land at the same x-coordinate (verified with pixel measurement).

## Test plan
- [ ] Open the home page and visually confirm both store badges in the top-left sidebar share a common left edge
- [ ] Verify each badge still links to the correct store URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)