### PR TITLE
feat: add newsletter consent to waitlist signup

### DIFF
--- a/src/components/auth/LoginDialog.tsx
+++ b/src/components/auth/LoginDialog.tsx
@@ -53,6 +53,7 @@ const LoginDialog: React.FC<LoginDialogProps> = ({ isOpen, onClose, onLogin }) =
   const [waitlistContact, setWaitlistContact] = useState('');
   const [waitlistEnabled, setWaitlistEnabled] = useState(false);
   const [waitlistError, setWaitlistError] = useState<string | null>(null);
+  const [waitlistNewsletterOptIn, setWaitlistNewsletterOptIn] = useState(true);
   const [waitlistSuccess, setWaitlistSuccess] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const login = useLoginActions();
@@ -82,6 +83,7 @@ const LoginDialog: React.FC<LoginDialogProps> = ({ isOpen, onClose, onLogin }) =
     setWaitlistContact('');
     setWaitlistEnabled(false);
     setWaitlistError(null);
+    setWaitlistNewsletterOptIn(true);
     setWaitlistSuccess(false);
 
     let isCancelled = false;
@@ -261,7 +263,7 @@ const LoginDialog: React.FC<LoginDialogProps> = ({ isOpen, onClose, onLogin }) =
     setIsWaitlistLoading(true);
 
     try {
-      await joinInviteWaitlist(waitlistContact);
+      await joinInviteWaitlist(waitlistContact, waitlistNewsletterOptIn);
       setWaitlistSuccess(true);
     } catch (caughtError) {
       setWaitlistError(caughtError instanceof Error ? caughtError.message : 'Unable to join the waitlist');
@@ -337,8 +339,10 @@ const LoginDialog: React.FC<LoginDialogProps> = ({ isOpen, onClose, onLogin }) =
                   error={waitlistError}
                   isLoading={isWaitlistLoading}
                   isSuccess={waitlistSuccess}
+                  newsletterOptIn={waitlistNewsletterOptIn}
                   onBack={() => setRegisterView('invite')}
                   onContactChange={setWaitlistContact}
+                  onNewsletterOptInChange={setWaitlistNewsletterOptIn}
                   onSubmit={handleWaitlistSubmit}
                 />
               )}

--- a/src/components/auth/LoginDialog.tsx
+++ b/src/components/auth/LoginDialog.tsx
@@ -53,7 +53,7 @@ const LoginDialog: React.FC<LoginDialogProps> = ({ isOpen, onClose, onLogin }) =
   const [waitlistContact, setWaitlistContact] = useState('');
   const [waitlistEnabled, setWaitlistEnabled] = useState(false);
   const [waitlistError, setWaitlistError] = useState<string | null>(null);
-  const [waitlistNewsletterOptIn, setWaitlistNewsletterOptIn] = useState(true);
+  const [waitlistNewsletterOptIn, setWaitlistNewsletterOptIn] = useState(false);
   const [waitlistSuccess, setWaitlistSuccess] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const login = useLoginActions();
@@ -83,7 +83,7 @@ const LoginDialog: React.FC<LoginDialogProps> = ({ isOpen, onClose, onLogin }) =
     setWaitlistContact('');
     setWaitlistEnabled(false);
     setWaitlistError(null);
-    setWaitlistNewsletterOptIn(true);
+    setWaitlistNewsletterOptIn(false);
     setWaitlistSuccess(false);
 
     let isCancelled = false;

--- a/src/components/auth/WaitlistForm.tsx
+++ b/src/components/auth/WaitlistForm.tsx
@@ -1,6 +1,7 @@
 import { FormEvent } from 'react';
 
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 
 interface WaitlistFormProps {
@@ -49,12 +50,10 @@ export function WaitlistForm(props: WaitlistFormProps) {
   return (
     <form className="space-y-4" onSubmit={onSubmit}>
       <label className="flex cursor-pointer items-center justify-center gap-2 text-sm text-muted-foreground" htmlFor="waitlist-newsletter">
-        <input
+        <Checkbox
           checked={newsletterOptIn}
-          className="h-4 w-4 rounded border-border"
           id="waitlist-newsletter"
-          onChange={(event) => onNewsletterOptInChange(event.target.checked)}
-          type="checkbox"
+          onCheckedChange={(checked) => onNewsletterOptInChange(checked === true)}
         />
         Send me Divine inspiration
       </label>
@@ -86,7 +85,6 @@ export function WaitlistForm(props: WaitlistFormProps) {
       >
         I have an invite code
       </Button>
-
     </form>
   );
 }

--- a/src/components/auth/WaitlistForm.tsx
+++ b/src/components/auth/WaitlistForm.tsx
@@ -8,8 +8,10 @@ interface WaitlistFormProps {
   error?: string | null;
   isLoading: boolean;
   isSuccess: boolean;
+  newsletterOptIn: boolean;
   onBack: () => void;
   onContactChange: (value: string) => void;
+  onNewsletterOptInChange: (value: boolean) => void;
   onSubmit: (event: FormEvent<HTMLFormElement>) => void;
 }
 
@@ -19,8 +21,10 @@ export function WaitlistForm(props: WaitlistFormProps) {
     error,
     isLoading,
     isSuccess,
+    newsletterOptIn,
     onBack,
     onContactChange,
+    onNewsletterOptInChange,
     onSubmit,
   } = props;
 
@@ -44,6 +48,17 @@ export function WaitlistForm(props: WaitlistFormProps) {
 
   return (
     <form className="space-y-4" onSubmit={onSubmit}>
+      <label className="flex cursor-pointer items-center justify-center gap-2 text-sm text-muted-foreground" htmlFor="waitlist-newsletter">
+        <input
+          checked={newsletterOptIn}
+          className="h-4 w-4 rounded border-border"
+          id="waitlist-newsletter"
+          onChange={(event) => onNewsletterOptInChange(event.target.checked)}
+          type="checkbox"
+        />
+        Send me Divine inspiration
+      </label>
+
       <div className="space-y-2">
         <label className="text-sm font-medium" htmlFor="waitlist-contact">
           Email
@@ -71,6 +86,7 @@ export function WaitlistForm(props: WaitlistFormProps) {
       >
         I have an invite code
       </Button>
+
     </form>
   );
 }

--- a/src/lib/inviteApi.test.ts
+++ b/src/lib/inviteApi.test.ts
@@ -106,7 +106,7 @@ describe('inviteApi', () => {
     expect(fetchMock).toHaveBeenCalledWith(
       'https://invite.divine.video/v1/waitlist',
       expect.objectContaining({
-        body: JSON.stringify({ contact: 'person@example.com' }),
+        body: JSON.stringify({ contact: 'person@example.com', newsletter_opt_in: false }),
         headers: { 'Content-Type': 'application/json' },
         method: 'POST',
       }),

--- a/src/lib/inviteApi.test.ts
+++ b/src/lib/inviteApi.test.ts
@@ -112,4 +112,26 @@ describe('inviteApi', () => {
       }),
     );
   });
+
+  it('submits opted-in waitlist entries to the invite service', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({
+        ok: true,
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    await expect(joinInviteWaitlist('person@example.com', true)).resolves.toEqual({ ok: true });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://invite.divine.video/v1/waitlist',
+      expect.objectContaining({
+        body: JSON.stringify({ contact: 'person@example.com', newsletter_opt_in: true }),
+        headers: { 'Content-Type': 'application/json' },
+        method: 'POST',
+      }),
+    );
+  });
 });

--- a/src/lib/inviteApi.ts
+++ b/src/lib/inviteApi.ts
@@ -121,13 +121,13 @@ export async function validateInviteCode(code: string): Promise<InviteValidation
   };
 }
 
-export async function joinInviteWaitlist(contact: string): Promise<WaitlistJoinResult> {
+export async function joinInviteWaitlist(contact: string, newsletterOptIn = false): Promise<WaitlistJoinResult> {
   let response: Response;
   try {
     response = await fetch(`${INVITE_API_BASE_URL}/v1/waitlist`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ contact: contact.trim() }),
+      body: JSON.stringify({ contact: contact.trim(), newsletter_opt_in: newsletterOptIn }),
     });
   } catch (error) {
     throw toNetworkInviteApiError(error);


### PR DESCRIPTION
## Summary
- Adds a "Sign up for the Divine newsletter" checkbox (default unchecked) to the waitlist form
- Passes `newsletter_opt_in: true/false` in the POST /v1/waitlist request body
- Client side of divinevideo/divine-invite-darshan#57 item 3; server-side field shipping separately on invite-darshan

## Changes
- `inviteApi.ts`: added `newsletterOptIn` parameter to `joinInviteWaitlist()`
- `WaitlistForm.tsx`: added checkbox props and UI element
- `LoginDialog.tsx`: threaded newsletter state through to form and API call
- `inviteApi.test.ts`: updated assertion to include `newsletter_opt_in` in request body

## Test plan
- [ ] Open the waitlist form (Register tab → "No invite? Get on the waitlist")
- [ ] Verify checkbox renders unchecked by default
- [ ] Submit with checkbox unchecked, verify `newsletter_opt_in: false` in request payload
- [ ] Submit with checkbox checked, verify `newsletter_opt_in: true` in request payload
- [ ] Verify success state still renders correctly after submission