### PR TITLE
fix(deploy): publish well-known app-link files

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,6 +77,38 @@ jobs:
           FASTLY_API_TOKEN: ${{ secrets.FASTLY_API_TOKEN }}
         run: npx @fastly/compute-js-static-publish publish-content
 
+      - name: Verify live .well-known endpoints
+        run: |
+          set -euo pipefail
+
+          check_json_endpoint() {
+            url="$1"
+            headers="$(curl -fsSI "$url")"
+            printf '%s\n' "$headers"
+
+            status="$(printf '%s\n' "$headers" | awk 'tolower($1) ~ /^http/ {print $2; exit}')"
+            content_type="$(printf '%s\n' "$headers" | awk -F': ' 'tolower($1) == "content-type" {print tolower($2); exit}' | tr -d '\r')"
+
+            if [ "$status" != "200" ]; then
+              echo "Expected 200 from $url but got $status" >&2
+              exit 1
+            fi
+
+            case "$content_type" in
+              application/json*|application/pkcs7-mime*)
+                ;;
+              *)
+                echo "Expected JSON content-type from $url but got $content_type" >&2
+                exit 1
+                ;;
+            esac
+          }
+
+          check_json_endpoint "https://divine.video/.well-known/apple-app-site-association"
+          check_json_endpoint "https://www.divine.video/.well-known/apple-app-site-association"
+          check_json_endpoint "https://divine.video/.well-known/assetlinks.json"
+          check_json_endpoint "https://www.divine.video/.well-known/assetlinks.json"
+
   deploy-cloudflare:
     needs: build
     runs-on: ubuntu-latest

--- a/compute-js/src/index.js
+++ b/compute-js/src/index.js
@@ -8,6 +8,7 @@ import { SecretStore } from 'fastly:secret-store';
 import { PublisherServer } from '@fastly/compute-js-static-publish';
 import rc from '../static-publish.rc.js';
 import { buildFunnelcakeUrl, getFunnelcakeOriginForApiHost } from './funnelcakeOrigin.js';
+import { isJsonWellKnownPath, shouldServeWellKnownBeforeWwwRedirect } from './wellKnownPaths.js';
 
 const publisherServer = PublisherServer.fromStaticPublishRc(rc);
 const DEFAULT_OG_IMAGE = 'https://divine.video/og.png';
@@ -42,6 +43,12 @@ async function handleRequest(event) {
 
   console.log('Request hostname:', url.hostname, 'original:', originalHost, 'path:', url.pathname);
 
+  // App-link verification files must be served directly for every claimed host.
+  // Do this before the generic www redirect so iOS/Android and deploy checks get 200 JSON.
+  if (shouldServeWellKnownBeforeWwwRedirect(hostnameToUse, url.pathname)) {
+    return await serveStaticWellKnownFile(request, url.pathname);
+  }
+
   // 1. Redirect www.* to apex domain (e.g., www.divine.video -> divine.video)
   if (hostnameToUse.startsWith('www.')) {
     const newUrl = new URL(url);
@@ -66,18 +73,7 @@ async function handleRequest(event) {
       }
       // Other .well-known files (apple-app-site-association, assetlinks.json)
       console.log('Handling subdomain .well-known file:', url.pathname);
-      const wkResponse = await publisherServer.serveRequest(request);
-      // Guard: if publisher returns text/html, it's the SPA fallback, not the real file
-      if (wkResponse != null && wkResponse.status === 200 && !wkResponse.headers.get('Content-Type')?.includes('text/html')) {
-        const headers = new Headers(wkResponse.headers);
-        const contentType = url.pathname.endsWith('.json') || url.pathname.endsWith('/apple-app-site-association')
-          ? 'application/json'
-          : headers.get('Content-Type') || 'application/octet-stream';
-        headers.set('Content-Type', contentType);
-        headers.set('Cache-Control', 'public, max-age=3600');
-        return new Response(wkResponse.body, { status: 200, headers });
-      }
-      return new Response('Not Found', { status: 404 });
+      return await serveStaticWellKnownFile(request, url.pathname);
     }
 
     // Subdomain profile - serve SPA with injected user data
@@ -127,24 +123,7 @@ async function handleRequest(event) {
     // apple-app-site-association has no file extension, so the static publisher
     // cannot detect its content type - we handle it explicitly here.
     console.log('Handling .well-known file:', url.pathname);
-    const wkResponse = await publisherServer.serveRequest(request);
-    // Guard: if publisher returns text/html, it's the SPA fallback, not the real file
-    if (wkResponse != null && wkResponse.status === 200 && !wkResponse.headers.get('Content-Type')?.includes('text/html')) {
-      const headers = new Headers(wkResponse.headers);
-      // Ensure correct content type for app association files
-      const contentType = url.pathname.endsWith('.json') || url.pathname.endsWith('/apple-app-site-association')
-        ? 'application/json'
-        : headers.get('Content-Type') || 'application/octet-stream';
-      headers.set('Content-Type', contentType);
-      headers.set('Cache-Control', 'public, max-age=3600');
-      headers.append('Vary', 'X-Original-Host');
-      return new Response(wkResponse.body, {
-        status: 200,
-        headers,
-      });
-    }
-    // File not found in KV - return 404 instead of SPA fallback
-    return new Response('Not Found', { status: 404 });
+    return await serveStaticWellKnownFile(request, url.pathname, { varyByOriginalHost: true });
   }
 
   // 5. Handle dynamic OG meta tags for crawler requests
@@ -248,6 +227,25 @@ async function handleRequest(event) {
       status: response.status,
       headers,
     });
+  }
+
+  return new Response('Not Found', { status: 404 });
+}
+
+async function serveStaticWellKnownFile(request, pathname, { varyByOriginalHost = false } = {}) {
+  const wkResponse = await publisherServer.serveRequest(request);
+  // Guard: if publisher returns text/html, it's the SPA fallback, not the real file.
+  if (wkResponse != null && wkResponse.status === 200 && !wkResponse.headers.get('Content-Type')?.includes('text/html')) {
+    const headers = new Headers(wkResponse.headers);
+    const contentType = isJsonWellKnownPath(pathname)
+      ? 'application/json'
+      : headers.get('Content-Type') || 'application/octet-stream';
+    headers.set('Content-Type', contentType);
+    headers.set('Cache-Control', 'public, max-age=3600');
+    if (varyByOriginalHost) {
+      headers.append('Vary', 'X-Original-Host');
+    }
+    return new Response(wkResponse.body, { status: 200, headers });
   }
 
   return new Response('Not Found', { status: 404 });

--- a/compute-js/src/wellKnownPaths.js
+++ b/compute-js/src/wellKnownPaths.js
@@ -1,0 +1,12 @@
+const APP_LINK_WELL_KNOWN_PATHS = new Set([
+  '/.well-known/apple-app-site-association',
+  '/.well-known/assetlinks.json',
+]);
+
+export function shouldServeWellKnownBeforeWwwRedirect(hostname, pathname) {
+  return hostname.startsWith('www.') && APP_LINK_WELL_KNOWN_PATHS.has(pathname);
+}
+
+export function isJsonWellKnownPath(pathname) {
+  return pathname.endsWith('.json') || pathname.endsWith('/apple-app-site-association');
+}

--- a/compute-js/src/wellKnownPaths.test.ts
+++ b/compute-js/src/wellKnownPaths.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { shouldServeWellKnownBeforeWwwRedirect } from './wellKnownPaths.js';
+
+describe('shouldServeWellKnownBeforeWwwRedirect', () => {
+  it('serves app-link files directly on www hosts', () => {
+    expect(shouldServeWellKnownBeforeWwwRedirect('www.divine.video', '/.well-known/apple-app-site-association')).toBe(true);
+    expect(shouldServeWellKnownBeforeWwwRedirect('www.divine.video', '/.well-known/assetlinks.json')).toBe(true);
+  });
+
+  it('keeps other www paths on the normal redirect path', () => {
+    expect(shouldServeWellKnownBeforeWwwRedirect('www.divine.video', '/')).toBe(false);
+    expect(shouldServeWellKnownBeforeWwwRedirect('www.divine.video', '/.well-known/nostr.json')).toBe(false);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MPL-2.0",
   "scripts": {
     "dev": "npm i && vite",
-    "build": "npm i && vite build && cp dist/index.html dist/404.html && node scripts/prerender-legal.mjs",
+    "build": "npm i && vite build && cp dist/index.html dist/404.html && node scripts/copy-well-known.mjs && node scripts/prerender-legal.mjs && node scripts/verify-well-known.mjs",
     "preview": "vite preview",
     "test": "npm i && tsc -p tsconfig.app.json --noEmit && eslint && vitest run && vite build",
     "deploy": "npm run build && npx -y nostr-deploy-cli deploy --skip-setup",

--- a/scripts/copy-well-known.mjs
+++ b/scripts/copy-well-known.mjs
@@ -1,0 +1,12 @@
+import { cp, mkdir } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(__dirname, '..');
+const sourceDir = path.join(projectRoot, 'public', '.well-known');
+const targetDir = path.join(projectRoot, 'dist', '.well-known');
+
+await mkdir(targetDir, { recursive: true });
+await cp(sourceDir, targetDir, { recursive: true });
+

--- a/scripts/verify-well-known.mjs
+++ b/scripts/verify-well-known.mjs
@@ -1,0 +1,46 @@
+import { access, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(__dirname, '..');
+
+const requiredFiles = [
+  path.join(projectRoot, 'dist', '.well-known', 'apple-app-site-association'),
+  path.join(projectRoot, 'dist', '.well-known', 'assetlinks.json'),
+];
+
+for (const file of requiredFiles) {
+  await access(file);
+}
+
+const aasa = JSON.parse(
+  await readFile(requiredFiles[0], 'utf8'),
+);
+
+const appIds = aasa?.applinks?.details?.flatMap((detail) => detail.appIDs ?? []);
+if (!Array.isArray(appIds) || appIds.length === 0) {
+  throw new Error('apple-app-site-association is missing applinks.details[].appIDs');
+}
+
+const requiredPaths = new Set(['/video/*', '/profile/*']);
+const declaredPaths = new Set(
+  aasa?.applinks?.details?.flatMap((detail) =>
+    (detail.components ?? []).map((component) => component?.['/']).filter(Boolean),
+  ) ?? [],
+);
+
+for (const requiredPath of requiredPaths) {
+  if (!declaredPaths.has(requiredPath)) {
+    throw new Error(`apple-app-site-association is missing required path ${requiredPath}`);
+  }
+}
+
+const assetlinks = JSON.parse(
+  await readFile(requiredFiles[1], 'utf8'),
+);
+
+if (!Array.isArray(assetlinks) || assetlinks.length === 0) {
+  throw new Error('assetlinks.json must contain at least one target entry');
+}
+


### PR DESCRIPTION
## Summary
- explicitly copy public/.well-known into dist during the web build
- verify the built AASA and assetlinks files exist and contain expected app-link data
- fail the production deploy if Fastly still serves 404 or non-JSON for app-link verification endpoints

## Motivation
Production Fastly is currently returning 404 for:
- https://divine.video/.well-known/apple-app-site-association
- https://www.divine.video/.well-known/apple-app-site-association
- https://divine.video/.well-known/assetlinks.json

That breaks iOS Universal Links and Android App Links even when the mobile apps claim the right hosts.

## Testing
- npm run build

## Manual verification
- no visual change

Related Issue:
- divinevideo/divine-mobile#3843