### PR TITLE
fix(deploy): include hidden build artifacts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,7 @@ jobs:
           name: dist
           path: dist/
           retention-days: 1
+          include-hidden-files: true
 
   deploy-fastly:
     needs: build


### PR DESCRIPTION
## Summary
- include hidden files when uploading the dist build artifact in the production deploy workflow

## Motivation
The Fastly deploy workflow now correctly publishes and verifies .well-known app-link files, but the build artifact upload was excluding hidden paths. That means dist/.well-known never reached the deploy-fastly job, so Fastly kept serving 404 for AASA and assetlinks even after #317 and #318.

## Testing
- workflow-only change

Related Issue:
- divinevideo/divine-mobile#3843