### PR TITLE
fix(deploy): purge public app-link URLs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -90,6 +90,10 @@ jobs:
             exit 1
           }
           fastly purge --all --service-id "$service_id" --token="$FASTLY_API_TOKEN"
+          fastly purge --url "https://divine.video/.well-known/apple-app-site-association" --token="$FASTLY_API_TOKEN"
+          fastly purge --url "https://www.divine.video/.well-known/apple-app-site-association" --token="$FASTLY_API_TOKEN"
+          fastly purge --url "https://divine.video/.well-known/assetlinks.json" --token="$FASTLY_API_TOKEN"
+          fastly purge --url "https://www.divine.video/.well-known/assetlinks.json" --token="$FASTLY_API_TOKEN"
 
       - name: Verify live .well-known endpoints
         run: |


### PR DESCRIPTION
## Summary
- keep the existing service-level purge
- add explicit URL purges for the four public AASA/assetlinks endpoints before verification

## Motivation
The current deploy workflow publishes the correct .well-known files, but the live verification step is still hitting stale Fastly 404s on the public URLs. Purging the divine-web service alone is not clearing the cached responses in front of the public endpoints. URL purges target the actual failing cache keys directly with lower risk than changing router code.

## Safety
- workflow-only change
- additive to the existing purge logic
- no app/runtime behavior changes

## Testing
- workflow-only change

Related Issue:
- divinevideo/divine-mobile#3843