### PR TITLE
refactor(follow): replace string-based race error with typed FollowRaceError class

### DIFF
--- a/src/hooks/useFollowRelationship.test.ts
+++ b/src/hooks/useFollowRelationship.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
+import { FollowRaceError } from './useFollowRelationship';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 import type { NostrEvent } from '@nostrify/nostrify';
@@ -247,7 +248,7 @@ describe('useFollowUser - follow list overwrite protection', () => {
           targetDisplayName: 'Test User',
         });
       }),
-    ).rejects.toThrow('Already following');
+    ).rejects.toThrow(FollowRaceError);
 
     expect(mockPublishEvent).not.toHaveBeenCalled();
   });

--- a/src/hooks/useFollowRelationship.ts
+++ b/src/hooks/useFollowRelationship.ts
@@ -11,6 +11,13 @@ import { debugLog } from '@/lib/debug';
 import type { NostrEvent } from '@nostrify/nostrify';
 import { PRIMARY_RELAY } from '@/config/relays';
 
+export class FollowRaceError extends Error {
+  constructor() {
+    super('Already following this user');
+    this.name = 'FollowRaceError';
+  }
+}
+
 interface FollowRelationshipData {
   isFollowing: boolean;
   mutualFollows: number;
@@ -181,7 +188,7 @@ export function useFollowUser() {
       // Check if already following (shouldn't happen but good safety check)
       const alreadyFollowing = currentTags.some(tag => tag[0] === 'p' && tag[1] === targetPubkey);
       if (alreadyFollowing) {
-        throw new Error('Already following this user');
+        throw new FollowRaceError();
       }
 
       // Add new follow tag

--- a/src/hooks/useFollowRelationship.ts
+++ b/src/hooks/useFollowRelationship.ts
@@ -11,6 +11,7 @@ import { debugLog } from '@/lib/debug';
 import type { NostrEvent } from '@nostrify/nostrify';
 import { PRIMARY_RELAY } from '@/config/relays';
 
+/** Thrown when a follow request races with stale UI state. */
 export class FollowRaceError extends Error {
   constructor() {
     super('Already following this user');

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -342,6 +342,7 @@ export function ProfilePage() {
     } catch (error) {
       console.error('Failed to update follow status:', error);
       if (!(error instanceof FollowRaceError)) {
+        // Suppress the stale-UI follow race because the user is already in the desired state.
         const message = error instanceof Error ? error.message : '';
         toast({
           title: "Couldn't update follow.",

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -26,7 +26,7 @@ import { useVideoProvider } from '@/hooks/useVideoProvider';
 import { useFunnelcakeProfile } from '@/hooks/useFunnelcakeProfile';
 import { useProfileJoinedDate } from '@/hooks/useProfileJoinedDate';
 import { useClassicVineArchiveStats } from '@/hooks/useClassicVineArchiveStats';
-import { useFollowRelationship, useFollowUser, useUnfollowUser } from '@/hooks/useFollowRelationship';
+import { useFollowRelationship, useFollowUser, useUnfollowUser, FollowRaceError } from '@/hooks/useFollowRelationship';
 import { useFollowListSafetyCheck } from '@/hooks/useFollowListSafetyCheck';
 import { PinnedVideosSection } from '@/components/PinnedVideosSection';
 import { useLoginDialog } from '@/contexts/LoginDialogContext';
@@ -341,9 +341,8 @@ export function ProfilePage() {
       }
     } catch (error) {
       console.error('Failed to update follow status:', error);
-      const message = error instanceof Error ? error.message : '';
-      const isRaceCondition = message === 'Already following this user';
-      if (!isRaceCondition) {
+      if (!(error instanceof FollowRaceError)) {
+        const message = error instanceof Error ? error.message : '';
         toast({
           title: "Couldn't update follow.",
           description: message || 'Please try again.',


### PR DESCRIPTION
## Summary

- Replaces the brittle string-match toast suppression (`error.message === 'Already following this user'`) with a typed `FollowRaceError` class and `instanceof` check
- Matches the existing custom error pattern in the codebase (`FunnelcakeApiError`, `InviteApiError`, `UserNotFoundError`)
- Updates the existing hook-level test to assert on error type instead of string

## Why no page-level test

ProfilePage has ~45 hook calls and no existing test file. Standing up a test would mean mocking 15-20 dependencies just to render the component, and the actual assertion would be "when a mocked function throws a specific error type, another mocked function isn't called." That tests mock wiring, not application behavior. The typed error class is the structural fix — `instanceof` can't silently drift like a string match can. The only remaining failure mode is someone removing the catch branch entirely, which is a code review concern, not a unit test concern.

## Test plan

- [x] `vitest run useFollowRelationship.test.ts` — 6/6 passing
- [x] `tsc --noEmit` — clean
- [x] `eslint` — clean

Closes #303