### PR TITLE
docs: align web copy with welcome home language

### DIFF
--- a/docs/brand/AGENT_QUICK_REFERENCE.md
+++ b/docs/brand/AGENT_QUICK_REFERENCE.md
@@ -51,6 +51,7 @@ Divine is a decentralized short-form video app reviving Vine's 6-second format, 
 
 ## Key Messages
 
+- **Welcome Home**: our arrival greeting for people coming to Divine or returning to it. It signals inclusion, belonging, and a human place to land on the internet.
 - **No AI slop**: Human-made content only. We detect and remove machine-generated content.
 - **User ownership**: Your content, your data, your feed. Built on Nostr where you own everything.
 - **Joy scrolling**: Trade doom scrolling for delight. Quick bursts of real human creativity.
@@ -92,6 +93,7 @@ Secondary accent colors: Yellow `#FFF140`, Lime `#D2FF40`, Pink `#FF7FAF`, Orang
 
 ## Taglines / Phrases to Use
 
+- "Welcome Home"
 - "Life in Loops"
 - "Live, Love, Loop"
 - "Your playground for human creativity"

--- a/docs/brand/BRAND_DNA.md
+++ b/docs/brand/BRAND_DNA.md
@@ -23,6 +23,7 @@ Then social media grew darker. It got hateful and heavier. It learned how to div
 At Divine, we say: fuck that.
 
 We want you to own what you make. Choose what you see. Trade doom scrolling for joy scrolling. Trade keyboard wars for a playground of human creativity. Crack the algorithm open and make it work for you. Bring your weird unfiltered self. Chances are you'll find someone just like you. Together, we'll put the power of creativity back in human hands.
+When people arrive, we want the feeling to be simple: Welcome Home.
 
 ---
 
@@ -44,6 +45,7 @@ We want you to own what you make. Choose what you see. Trade doom scrolling for 
 - Your content and data stay yours
 - Space to play and experiment
 - Access to 100,000+ archived Vine videos from the original era
+- A place that feels like arrival, not conversion
 
 ---
 

--- a/docs/brand/TONE_OF_VOICE.md
+++ b/docs/brand/TONE_OF_VOICE.md
@@ -81,6 +81,10 @@ We have three tone of voice principles that shape how we sound. They ensure cons
 - Calling AI-generated content "creative" -- this is a human creativity space
 - Sounding polished or sterile -- a little rough around the edges is on brand
 
+### Arrival Language
+
+When someone is arriving for the first time or coming back, use "Welcome Home" as the default greeting if the copy needs to feel warm, direct, and inclusive.
+
 ### Tone Dial by Context
 
 | Context | Rebel | Playful |

--- a/src/lib/i18n/locales/en/common.json
+++ b/src/lib/i18n/locales/en/common.json
@@ -47,7 +47,7 @@
     "logInOnDivine": "Jump in"
   },
   "home": {
-    "welcomeTitle": "Your feed, your rules.",
+    "welcomeTitle": "Welcome Home.",
     "welcomeSubtitle": "Sign in to see loops from the people you follow.",
     "title": "Home",
     "subtitle": "Loops from the people you follow.",


### PR DESCRIPTION
## Summary
- Update the web brand docs to treat "Welcome Home" as the canonical arrival phrase.
- Change the signed-out home welcome title to match the new brand language.

## Test Plan
- [x] Verified the edited files with `git diff --check`.
- [x] Pushed branch `fix/cross-subdomain-auth-server-cookie` to origin.
