### PR TITLE
fix(verification): lazy-fetch proofMode when list endpoints omit tags

### DIFF
--- a/src/components/VideoVerificationDetailsDialog.tsx
+++ b/src/components/VideoVerificationDetailsDialog.tsx
@@ -1,8 +1,10 @@
 // ABOUTME: Modal explaining original Vine, Proofmode, AI detection, and hosting badges for a video
 // ABOUTME: Uses the same decision helpers as the badge row so the UI stays aligned with mobile badge rules
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Archive, CheckCircle as CheckCircle2, ArrowSquareOut as ExternalLink, CircleNotch as Loader2, MagnifyingGlass as Search, ShieldCheck, XCircle } from '@phosphor-icons/react';
+import { useQuery } from '@tanstack/react-query';
+import type { NostrEvent } from '@nostrify/nostrify';
 import {
   Dialog,
   DialogContent,
@@ -18,9 +20,12 @@ import {
   getProofChecklist,
   getVerificationDescription,
   getVerificationIntroText,
+  isDivineHostedVideo,
   isOriginalVineVideo,
   shouldFetchAiForDetails,
 } from '@/lib/videoVerification';
+import { fetchVideoById } from '@/lib/funnelcakeClient';
+import { getProofModeData } from '@/lib/videoParser';
 import type { ParsedVideoData } from '@/types/video';
 import { Link } from 'react-router-dom';
 
@@ -35,11 +40,47 @@ export function VideoVerificationDetailsDialog({
   open,
   onOpenChange,
 }: VideoVerificationDetailsDialogProps) {
-  const { aiResult, isFetching, refetch } = useVideoVerification(video, {
-    autoFetchAi: open && shouldFetchAiForDetails(video),
+  const isOriginalVine = isOriginalVineVideo(video);
+
+  // Funnelcake list endpoints (e.g. /api/videos) don't return Nostr `tags`,
+  // so list-loaded videos arrive with `proofMode` undefined even when the
+  // underlying event has verification tags. Lazily fetch the single-video
+  // endpoint (which includes `event.tags`) when the dialog opens so the
+  // checklist reflects reality.
+  const proofModeFallbackQuery = useQuery({
+    queryKey: ['video-proofmode-fallback', video.id],
+    queryFn: async ({ signal }) => {
+      const raw = await fetchVideoById(undefined, video.id, undefined, signal);
+      if (!raw?.tags) return null;
+      const fullEvent: NostrEvent = {
+        id: raw.id,
+        pubkey: raw.pubkey,
+        created_at: raw.created_at,
+        kind: raw.kind,
+        tags: raw.tags,
+        content: raw.content || '',
+        sig: '',
+      };
+      return getProofModeData(fullEvent) ?? null;
+    },
+    enabled:
+      open &&
+      !isOriginalVine &&
+      !video.proofMode &&
+      isDivineHostedVideo(video.videoUrl),
+    staleTime: 10 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
+  });
+
+  const effectiveVideo = useMemo<ParsedVideoData>(() => {
+    if (video.proofMode || !proofModeFallbackQuery.data) return video;
+    return { ...video, proofMode: proofModeFallbackQuery.data };
+  }, [video, proofModeFallbackQuery.data]);
+
+  const { aiResult, isFetching, refetch } = useVideoVerification(effectiveVideo, {
+    autoFetchAi: open && shouldFetchAiForDetails(effectiveVideo),
   });
   const [checkedAndEmpty, setCheckedAndEmpty] = useState(false);
-  const isOriginalVine = isOriginalVineVideo(video);
 
   useEffect(() => {
     if (!open) {
@@ -70,14 +111,15 @@ export function VideoVerificationDetailsDialog({
         </DialogHeader>
 
         {isOriginalVine ? (
-          <OriginalVineDetails video={video} />
+          <OriginalVineDetails video={effectiveVideo} />
         ) : (
           <VerificationDetails
-            video={video}
+            video={effectiveVideo}
             aiResult={aiResult}
             isFetching={isFetching}
             checkedAndEmpty={checkedAndEmpty}
             onManualCheck={handleManualCheck}
+            proofModeLoading={proofModeFallbackQuery.isFetching}
           />
         )}
       </DialogContent>
@@ -116,6 +158,7 @@ interface VerificationDetailsProps {
   isFetching: boolean;
   checkedAndEmpty: boolean;
   onManualCheck: () => void;
+  proofModeLoading: boolean;
 }
 
 function VerificationDetails({
@@ -124,6 +167,7 @@ function VerificationDetails({
   isFetching,
   checkedAndEmpty,
   onManualCheck,
+  proofModeLoading,
 }: VerificationDetailsProps) {
   const summary = getVerificationDescription(video, aiResult);
   const checklist = getProofChecklist(video.proofMode);
@@ -140,12 +184,19 @@ function VerificationDetails({
           <span>ProofMode Verification</span>
         </div>
 
+        {proofModeLoading ? (
+          <div className="flex items-center gap-2 rounded-lg border border-border/70 bg-muted/40 p-3 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            <span>Loading verification data…</span>
+          </div>
+        ) : (
         <div className="flex items-start gap-3 rounded-lg border border-border/70 bg-muted/40 p-3">
           <div className={getSummaryToneClass(summary.tone)}>
             <ShieldCheck className="h-4 w-4" />
           </div>
           <p className="text-sm text-muted-foreground">{summary.text}</p>
         </div>
+        )}
 
         <div className="space-y-2">
           {checklist.map((item) => (

--- a/src/lib/funnelcakeTransform.test.ts
+++ b/src/lib/funnelcakeTransform.test.ts
@@ -87,6 +87,31 @@ describe('transformFunnelcakeVideo', () => {
     expect(archived.commentCount).toBe(3014);
     expect(archived.repostCount).toBe(37586);
   });
+
+  // Regression guard: list endpoints (/api/videos, /api/users/{pubkey}/videos,
+  // discovery, etc.) omit Nostr `tags`, so proofMode arrives undefined and the
+  // verification dialog must lazy-fetch the single-video endpoint to recover
+  // it. See VideoVerificationDetailsDialog.tsx.
+  it('returns proofMode undefined when tags are absent (list endpoint shape)', () => {
+    const video = transformFunnelcakeVideo(makeRawVideo());
+    expect(video.proofMode).toBeUndefined();
+  });
+
+  it('extracts proofMode when verification tags are present (single-video shape)', () => {
+    const video = transformFunnelcakeVideo(makeRawVideo({
+      tags: [
+        ['d', 'vine-id'],
+        ['verification', 'verified_mobile'],
+        ['c2pa_manifest_id', 'urn:c2pa:test'],
+        ['device_attestation', 'attest-blob'],
+        ['proofmode', '{"videoHash":"abc"}'],
+      ],
+    }));
+
+    expect(video.proofMode?.level).toBe('verified_mobile');
+    expect(video.proofMode?.c2paManifestId).toBe('urn:c2pa:test');
+    expect(video.proofMode?.deviceAttestation).toBe('attest-blob');
+  });
 });
 
 function makeResponse(overrides: Partial<FunnelcakeResponse> = {}): FunnelcakeResponse {


### PR DESCRIPTION
## Summary

The verification dialog renders "This video is unverified" with four ✗ checkmarks for videos that have full ProofMode data on the relay, because Funnelcake list endpoints (`/api/videos`, `/api/users/{pubkey}/videos`, discovery, search) strip the Nostr `tags` array. Single-video reads (`GET /api/videos/{id}`) include `event.tags` and work correctly — only list-loaded videos break.

Reproduce: open `divine.video/discovery/new`, click the verification badge on any post-archive video. Compare to the same video at `divine.video/video/{id}` — the latter shows the correct verified badge and checklist.

## Fix

`VideoVerificationDetailsDialog` now lazy-calls `fetchVideoById` on open for Divine-hosted, non-archived videos missing `proofMode`, extracts `proofMode` via `getProofModeData`, and merges it into the video used by the helpers. Loading state shows "Loading verification data…" in place of the summary line. The fallback request is React-Query-cached for 10 minutes per video id.

Card badges (the green/unverified pill) still come from list-row data and stay wrong until the API side ships compact verification fields — fetching per-card would be too expensive.

## Server-side follow-up

Funnelcake should add compact summary fields to every list row (`verification_level`, `has_c2pa`, `has_proofmode`, `has_device_attestation`, `has_pgp_signature`) so clients can render the right badge without an extra round-trip, while keeping the heavy `proofmode` and `device_attestation` blobs exclusive to `/api/videos/{id}`. Tracked separately.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run funnelcakeTransform videoVerification` — 24 pass
- [ ] Manually open the dialog on a list-loaded verified video and confirm checklist populates after the fallback fetch resolves
- [ ] Open the dialog on an archived Vine — should still skip the fetch (no proofMode expected)
- [ ] Open the dialog on a non-Divine-hosted video — should still skip the fetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)