### PR TITLE
fix(search): show view counts on search-result video cards

### DIFF
--- a/src/pages/SearchPage.test.tsx
+++ b/src/pages/SearchPage.test.tsx
@@ -84,18 +84,27 @@ vi.mock('@/components/ui/avatar', () => ({
   AvatarFallback: ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
 }));
 
+// Bare VideoCard mock: search results MUST NOT render this directly because
+// it has no metrics wrapper, which means viewCount/loopCount can never display.
+// The presence of `bare-video-card-*` in a test render is a regression.
 vi.mock('@/components/VideoCard', () => ({
-  VideoCard: ({
+  VideoCard: ({ video }: { video: { id: string } }) => (
+    <div data-testid={`bare-video-card-${video.id}`}>bare {video.id}</div>
+  ),
+}));
+
+vi.mock('@/components/VideoCardWithMetrics', () => ({
+  VideoCardWithMetrics: ({
     video,
     navigationContext,
-    videoIndex,
+    index,
   }: {
     video: { id: string };
     navigationContext?: { source: string; query?: string; sortMode?: string };
-    videoIndex?: number;
+    index?: number;
   }) => {
     const href = navigationContext
-      ? `/video/${video.id}?source=${navigationContext.source}&q=${navigationContext.query}&sort=${navigationContext.sortMode}&index=${videoIndex}`
+      ? `/video/${video.id}?source=${navigationContext.source}&q=${navigationContext.query}&sort=${navigationContext.sortMode}&index=${index}`
       : `/video/${video.id}`;
 
     return (
@@ -483,5 +492,38 @@ describe('SearchPage', () => {
     expect(screen.getByTestId('location-display').textContent).toBe(
       '/search?q=twerking&filter=videos&play=compilation&video=video-1'
     );
+  });
+
+  // Regression: bare VideoCard hides view counts because it has no metrics
+  // wrapper. Search results MUST go through VideoCardWithMetrics so loop /
+  // view counts render alongside other feeds.
+  it('renders the All-tab video grid via VideoCardWithMetrics, not bare VideoCard', () => {
+    mockUseInfiniteSearchVideos.mockReturnValue({
+      data: { pages: [{ videos: [{ id: 'video-1', pubkey: 'a'.repeat(64) }] }] },
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+      isLoading: false,
+      error: null,
+    });
+
+    renderPage(['/search?q=dance']);
+
+    expect(screen.getAllByTestId('video-card-video-1').length).toBeGreaterThan(0);
+    expect(screen.queryAllByTestId('bare-video-card-video-1')).toHaveLength(0);
+  });
+
+  it('renders the videos-only tab grid via VideoCardWithMetrics, not bare VideoCard', () => {
+    mockUseInfiniteSearchVideos.mockReturnValue({
+      data: { pages: [{ videos: [{ id: 'video-2', pubkey: 'b'.repeat(64) }] }] },
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+      isLoading: false,
+      error: null,
+    });
+
+    renderPage(['/search?q=dance&filter=videos']);
+
+    expect(screen.getAllByTestId('video-card-video-2').length).toBeGreaterThan(0);
+    expect(screen.queryAllByTestId('bare-video-card-video-2')).toHaveLength(0);
   });
 });

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -17,7 +17,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Badge } from '@/components/ui/badge';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
-import { VideoCard } from '@/components/VideoCard';
+import { VideoCardWithMetrics } from '@/components/VideoCardWithMetrics';
 import InfiniteScroll from 'react-infinite-scroll-component';
 import { useInfiniteSearchVideos } from '@/hooks/useInfiniteSearchVideos';
 import { useCompilationFullscreen } from '@/hooks/useCompilationFullscreen';
@@ -533,12 +533,15 @@ export function SearchPage() {
                     </div>
                     <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
                       {videoResults.slice(0, 6).map((video, index) => (
-                        <VideoCard
+                        <VideoCardWithMetrics
                           key={video.id}
                           video={video}
+                          index={index}
                           mode="thumbnail"
+                          showComments={false}
+                          onOpenComments={() => undefined}
+                          onCloseComments={() => undefined}
                           navigationContext={searchNavigationContext}
-                          videoIndex={index}
                         />
                       ))}
                     </div>
@@ -632,12 +635,15 @@ export function SearchPage() {
               >
                 <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
                   {videoResults.map((video, index) => (
-                    <VideoCard
+                    <VideoCardWithMetrics
                       key={video.id}
                       video={video}
+                      index={index}
                       mode="thumbnail"
+                      showComments={false}
+                      onOpenComments={() => undefined}
+                      onCloseComments={() => undefined}
                       navigationContext={searchNavigationContext}
-                      videoIndex={index}
                     />
                   ))}
                 </div>


### PR DESCRIPTION
## Summary
Search results weren't showing view / loop counts on video cards (see screenshot in the bug report — `divine.video/search?q=dance` cards have like/repost/comment/share/download icons but no count number).

**Root cause:** `SearchPage` rendered bare `<VideoCard>` directly. That component defaults `viewCount = 0` and gates `viewCount > 0` to render the count, so without the metrics wrapper the count is never shown. Every other feed (Discovery, Trending, Profile, VideoPage) wraps with `<VideoCardWithMetrics>`, which fetches Divine view counts and combines them with the classic-Vine `loopCount` before forwarding to `VideoCard`.

**Fix:** Swap both `<VideoCard>` renderers in `SearchPage` (All-tab preview grid + videos-only tab's `InfiniteScroll` grid) for `<VideoCardWithMetrics>`. Two-line import change + a few prop adjustments (`videoIndex` → `index`, plus the no-op comment-dialog handlers required by the wrapper).

## Test plan
- [x] Two new regression tests assert the metrics wrapper is used in both tabs. Bare `VideoCard` mock now produces a distinct testid (`bare-video-card-*`) so any future regression to bare `VideoCard` fails loudly.
- [x] `npx vitest run` — 714/714 PASS, including 14 SearchPage tests
- [x] `npx tsc --noEmit` — clean
- [ ] Manual smoke at `divine.video/search?q=dance` after deploy: confirm view counts now appear on cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)