### PR TITLE
feat(leaderboard): use views as headline metric on alltime tab

### DIFF
--- a/src/pages/LeaderboardPage.tsx
+++ b/src/pages/LeaderboardPage.tsx
@@ -77,6 +77,19 @@ function getTimePeriodIcon(period: TimePeriod) {
   }
 }
 
+// For alltime, the API returns time-correct `views` (every play start) which is bigger
+// than `loops` (Vine-style replay/completion count). For windowed periods the API does
+// NOT honor the filter on `views` (it leaks alltime totals), so we fall back to `loops`,
+// which IS windowed. Label tracks which value we used so we never lie about the metric.
+function getHeadlineCount(entry: { views?: number; loops?: number }, period: TimePeriod): number {
+  if (period === 'alltime') return entry.views || entry.loops || 0;
+  return entry.loops || 0;
+}
+
+function getHeadlineLabel(period: TimePeriod): string {
+  return period === 'alltime' ? 'plays' : 'loops';
+}
+
 function VideoLeaderboardSkeleton() {
   return (
     <div className="space-y-3">
@@ -192,8 +205,8 @@ function VideoLeaderboard({ period }: { period: TimePeriod }) {
         }
       }
 
-      // Sort client-side as workaround for backend sorting bug
-      return entries.sort((a, b) => (b.loops || 0) - (a.loops || 0));
+      // Sort client-side by the same metric we display so rank matches the headline number.
+      return entries.sort((a, b) => getHeadlineCount(b, period) - getHeadlineCount(a, period));
     },
     staleTime: 60000, // 1 minute
     retry: 1,
@@ -260,8 +273,8 @@ function VideoLeaderboard({ period }: { period: TimePeriod }) {
             </div>
 
             <div className="text-right">
-              <p className="font-bold text-lg">{formatLoops(video.loops || 0)}</p>
-              <p className="text-xs text-muted-foreground">loops</p>
+              <p className="font-bold text-lg">{formatLoops(getHeadlineCount(video, period))}</p>
+              <p className="text-xs text-muted-foreground">{getHeadlineLabel(period)}</p>
             </div>
           </Link>
         );
@@ -293,8 +306,8 @@ function CreatorLeaderboard({ period }: { period: TimePeriod }) {
       const data = await response.json();
       // API returns { period, entries: [...] }
       const entries = (data.entries || data) as CreatorLeaderboardItem[];
-      // Sort client-side as workaround for backend sorting bug
-      return entries.sort((a, b) => (b.loops || 0) - (a.loops || 0));
+      // Sort client-side by the same metric we display so rank matches the headline number.
+      return entries.sort((a, b) => getHeadlineCount(b, period) - getHeadlineCount(a, period));
     },
     staleTime: 60000,
     retry: 1,
@@ -356,8 +369,8 @@ function CreatorLeaderboard({ period }: { period: TimePeriod }) {
             </div>
 
             <div className="text-right">
-              <p className="font-bold text-lg">{formatLoops(creator.loops || 0)}</p>
-              <p className="text-xs text-muted-foreground">total loops</p>
+              <p className="font-bold text-lg">{formatLoops(getHeadlineCount(creator, period))}</p>
+              <p className="text-xs text-muted-foreground">total {getHeadlineLabel(period)}</p>
             </div>
           </Link>
         );


### PR DESCRIPTION
## Summary
The All Time leaderboard was sorting and displaying `loops` only — a Vine-style replay/completion counter. The same API response also returns `views` (every play start), which is consistently 10–30% larger and equally meaningful as a popularity metric. Switch to `views` for All Time, label it "plays", and keep `loops` for the windowed periods.

## Why per-period instead of always views
I verified against `https://api.divine.video/api/leaderboard/videos`:

| period   | views  | unique_viewers | loops  |
|----------|--------|----------------|--------|
| alltime  | 18,409 |          4,461 | 16,598 |
| day      | 18,409 |            526 |    487 |

`views` is **the same value** in `alltime` and `day` — the backend doesn't honor the `period` filter on `views`. `loops` and `unique_viewers` *are* time-windowed correctly. So showing `views` for `period=day` would surface alltime totals under a day filter, which is worse than showing the smaller-but-correct number. Once the backend honors `period` on `views`, we can drop the special case and always pick `views`.

## Changes
- `getHeadlineCount(entry, period)`: returns `views` for alltime, `loops` otherwise.
- `getHeadlineLabel(period)`: returns `"plays"` for alltime, `"loops"` otherwise. The label always matches the value being shown — no mislabeling.
- Both `VideoLeaderboard` and `CreatorLeaderboard` use the same helper for sort and display, so rank order matches the headline number.

## Test plan
- [ ] `/leaderboard` (defaults to videos / alltime): top entry shows the bigger `views` number with the label "plays".
- [ ] Switch to "Today": the number drops to the windowed `loops` count and label switches to "loops".
- [ ] Same for week / month / year.
- [ ] Creators tab follows the same pattern ("total plays" on alltime, "total loops" on windowed periods).
- [ ] Ranking remains consistent (highest number on top in every view).

## Follow-up
Backend ticket worth filing: `views` should honor the `period` query parameter on `/api/leaderboard/{videos,creators}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)