### PR TITLE
feat(sidebar): show social-media icons in the left sidebar

### DIFF
--- a/src/components/AppFooter.tsx
+++ b/src/components/AppFooter.tsx
@@ -1,5 +1,6 @@
 import { SmartLink } from '@/components/SmartLink';
 import { useTranslation } from 'react-i18next';
+import { SocialLinks } from '@/components/SocialLinks';
 import { HubSpotSignup } from './HubSpotSignup';
 
 export function AppFooter() {
@@ -105,112 +106,7 @@ export function AppFooter() {
               </div>
 
               {/* Social Media Icons */}
-              <div className="flex items-center gap-3 mt-1" aria-label="Social media links">
-                <a
-                  href="https://www.instagram.com/divinevideoapp"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  aria-label="Follow us on Instagram"
-                  className="opacity-60 hover:opacity-100 transition-opacity"
-                >
-                  <img
-                    src="/social-icons/instagram.svg"
-                    alt="Instagram"
-                    className="w-5 h-5 invert"
-                  />
-                </a>
-                <a
-                  href="https://www.reddit.com/r/divinevideo/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  aria-label="Follow us on Reddit"
-                  className="opacity-60 hover:opacity-100 transition-opacity"
-                >
-                  <img
-                    src="/social-icons/reddit.svg"
-                    alt="Reddit"
-                    className="w-5 h-5 invert"
-                  />
-                </a>
-                <a
-                  href="https://discord.gg/d6HpB6XnHp"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  aria-label="Join us on Discord"
-                  className="opacity-60 hover:opacity-100 transition-opacity"
-                >
-                  <img
-                    src="/social-icons/discord.svg"
-                    alt="Discord"
-                    className="w-5 h-5 invert"
-                  />
-                </a>
-                <a
-                  href="https://twitter.com/divinevideoapp"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  aria-label="Follow us on Twitter"
-                  className="opacity-60 hover:opacity-100 transition-opacity"
-                >
-                  <img
-                    src="/social-icons/twitter.svg"
-                    alt="Twitter"
-                    className="w-5 h-5 invert"
-                  />
-                </a>
-                <a
-                  href="https://bsky.app/profile/divine.video"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  aria-label="Follow us on Bluesky"
-                  className="opacity-60 hover:opacity-100 transition-opacity"
-                >
-                  <img
-                    src="/social-icons/bluesky.svg"
-                    alt="Bluesky"
-                    className="w-5 h-5 invert"
-                  />
-                </a>
-                <a
-                  href="https://www.tiktok.com/@divine.video"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  aria-label="Follow us on TikTok"
-                  className="opacity-60 hover:opacity-100 transition-opacity"
-                >
-                  <img
-                    src="/social-icons/tiktok.svg"
-                    alt="TikTok"
-                    className="w-5 h-5 invert"
-                  />
-                </a>
-                <a
-                  href="https://github.com/divinevideo"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  aria-label="Follow us on GitHub"
-                  className="opacity-60 hover:opacity-100 transition-opacity"
-                >
-                  <img
-                    src="/social-icons/github.svg"
-                    alt="GitHub"
-                    className="w-5 h-5 invert"
-                  />
-                </a>
-                <a
-                  href="https://www.youtube.com/channel/UCkAaxItWqDpTgngWAS2cAtQ"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  aria-label="Follow us on YouTube"
-                  className="opacity-60 hover:opacity-100 transition-opacity"
-                >
-                  <img
-                    src="/social-icons/youtube.svg"
-                    alt="YouTube"
-                    className="w-5 h-5 invert"
-                  />
-                </a>
-              </div>
+              <SocialLinks className="mt-1" iconClassName="invert" />
             </div>
           </div>
 

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -25,6 +25,7 @@ import { feedUrls } from '@/lib/feedUrls';
 import { useRssFeedAvailable } from '@/hooks/useRssFeedAvailable';
 import { usePlatformStats } from '@/hooks/usePlatformStats';
 import { LanguageMenu } from '@/components/LanguageMenu';
+import { SocialLinks } from '@/components/SocialLinks';
 import { getTranslatedCategoryLabel } from '@/lib/constants/categories';
 import { getPreferredAppStoreCountry, lookupAppStoreUrl, PLAY_STORE_URL } from '@/lib/mobileStoreLinks';
 
@@ -386,6 +387,9 @@ export function AppSidebar({ className }: { className?: string }) {
             />
           )}
         </div>
+
+        {/* Social media — visible on every page, not just About/ProofMode. */}
+        <SocialLinks className="mt-6 px-4 flex-wrap gap-y-2" iconClassName="dark:invert" />
 
         {/* Footer Section - flows naturally, no pinning */}
         <div className="mt-6 px-4">

--- a/src/components/SocialLinks.tsx
+++ b/src/components/SocialLinks.tsx
@@ -1,0 +1,95 @@
+// ABOUTME: Renders the standard divine social-media icon row (Instagram, Reddit,
+// ABOUTME: Discord, Twitter, Bluesky, TikTok, GitHub, YouTube). Single source of truth
+// ABOUTME: so the sidebar and footer never drift apart.
+
+import { cn } from '@/lib/utils';
+
+interface SocialLink {
+  name: string;
+  href: string;
+  icon: string;
+  ariaLabel: string;
+}
+
+const SOCIAL_LINKS: readonly SocialLink[] = [
+  {
+    name: 'Instagram',
+    href: 'https://www.instagram.com/divinevideoapp',
+    icon: '/social-icons/instagram.svg',
+    ariaLabel: 'Follow us on Instagram',
+  },
+  {
+    name: 'Reddit',
+    href: 'https://www.reddit.com/r/divinevideo/',
+    icon: '/social-icons/reddit.svg',
+    ariaLabel: 'Follow us on Reddit',
+  },
+  {
+    name: 'Discord',
+    href: 'https://discord.gg/d6HpB6XnHp',
+    icon: '/social-icons/discord.svg',
+    ariaLabel: 'Join us on Discord',
+  },
+  {
+    name: 'Twitter',
+    href: 'https://twitter.com/divinevideoapp',
+    icon: '/social-icons/twitter.svg',
+    ariaLabel: 'Follow us on Twitter',
+  },
+  {
+    name: 'Bluesky',
+    href: 'https://bsky.app/profile/divine.video',
+    icon: '/social-icons/bluesky.svg',
+    ariaLabel: 'Follow us on Bluesky',
+  },
+  {
+    name: 'TikTok',
+    href: 'https://www.tiktok.com/@divine.video',
+    icon: '/social-icons/tiktok.svg',
+    ariaLabel: 'Follow us on TikTok',
+  },
+  {
+    name: 'GitHub',
+    href: 'https://github.com/divinevideo',
+    icon: '/social-icons/github.svg',
+    ariaLabel: 'Follow us on GitHub',
+  },
+  {
+    name: 'YouTube',
+    href: 'https://www.youtube.com/channel/UCkAaxItWqDpTgngWAS2cAtQ',
+    icon: '/social-icons/youtube.svg',
+    ariaLabel: 'Follow us on YouTube',
+  },
+] as const;
+
+interface SocialLinksProps {
+  className?: string;
+  /** Tailwind class applied to each <img>. Use `invert` on dark surfaces, `dark:invert` for surfaces that switch. */
+  iconClassName?: string;
+  /** Tailwind size class for each icon. Defaults to w-5 h-5. */
+  size?: string;
+}
+
+export function SocialLinks({ className, iconClassName, size = 'w-5 h-5' }: SocialLinksProps) {
+  return (
+    <div
+      className={cn('flex items-center gap-3', className)}
+      aria-label="Social media links"
+    >
+      {SOCIAL_LINKS.map((link) => (
+        <a
+          key={link.name}
+          href={link.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label={link.ariaLabel}
+          className="opacity-60 hover:opacity-100 transition-opacity"
+        >
+          <img src={link.icon} alt={link.name} className={cn(size, iconClassName)} />
+        </a>
+      ))}
+    </div>
+  );
+}
+
+export default SocialLinks;


### PR DESCRIPTION
## Summary
Social icons (Instagram, Reddit, Discord, Twitter, Bluesky, TikTok, GitHub, YouTube) used to live only in `AppFooter`, which scrolls out of view in long feeds and isn't visible alongside most in-feed pages. They now also appear in the left sidebar — visible on every page on `lg+`.

## What changed
- New `<SocialLinks>` component (`src/components/SocialLinks.tsx`) — single source of truth for the 8 icons + URLs.
- `AppFooter` swapped to render `<SocialLinks iconClassName="invert">` (footer is on a dark surface).
- `AppSidebar` adds `<SocialLinks iconClassName="dark:invert">` between the auth area and the "About Divine" group, so the icons read correctly in both light and dark mode.
- Net delta: −106 lines duplicated markup, +95 lines reusable component.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 714/714 PASS (3 affected component-test files all green)
- [ ] Smoke at `divine.video/discovery` after deploy: confirm the 8 icons show in the left sidebar above "About Divine," and still in the footer at the bottom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)