### PR TITLE
fix(video): show event description on video page

### DIFF
--- a/src/lib/funnelcakeTransform.test.ts
+++ b/src/lib/funnelcakeTransform.test.ts
@@ -112,6 +112,26 @@ describe('transformFunnelcakeVideo', () => {
     expect(video.proofMode?.c2paManifestId).toBe('urn:c2pa:test');
     expect(video.proofMode?.deviceAttestation).toBe('attest-blob');
   });
+
+  it('maps the raw Nostr content (description) to video.content, not the title', () => {
+    const video = transformFunnelcakeVideo(makeRawVideo({
+      title: 'First Divine Compilation 2026!',
+      content: 'I just made the world‘s first divine compilation.\n\nLink: https://youtu.be/abc',
+    }));
+
+    expect(video.title).toBe('First Divine Compilation 2026!');
+    expect(video.content).toBe('I just made the world‘s first divine compilation.\n\nLink: https://youtu.be/abc');
+  });
+
+  it('leaves video.content empty when the API response has no content field', () => {
+    const video = transformFunnelcakeVideo(makeRawVideo({
+      title: 'A title with no description',
+      content: undefined,
+    }));
+
+    expect(video.title).toBe('A title with no description');
+    expect(video.content).toBe('');
+  });
 });
 
 function makeResponse(overrides: Partial<FunnelcakeResponse> = {}): FunnelcakeResponse {

--- a/src/lib/funnelcakeTransform.ts
+++ b/src/lib/funnelcakeTransform.ts
@@ -79,7 +79,7 @@ export function transformFunnelcakeVideo(raw: FunnelcakeVideoRaw): ParsedVideoDa
     authorAvatar: raw.author_avatar, // Cached author avatar from Funnelcake
     kind: SHORT_VIDEO_KIND,
     createdAt: raw.created_at,
-    content: raw.title || '', // Funnelcake uses title field for content
+    content: raw.content || '',
     videoUrl: raw.video_url,
     thumbnailUrl: raw.thumbnail,
     blurhash: raw.blurhash,


### PR DESCRIPTION
## Summary
- Video pages were showing the title but never the user-authored description, even though the Funnelcake API already returned it
- Root cause was client-side: `funnelcakeTransform.ts` mapped `raw.title` into `ParsedVideoData.content` ("Funnelcake uses title field for content"). VideoCard guards against duplicating the title (`video.content !== video.title`), so the description block was always suppressed
- Fix: map `raw.content` through. The API returns `content` on `/api/videos/{id}`, `/api/videos`, and `/api/users/{pubkey}/videos` — confirmed against production. No backend changes needed
- Added two transform tests locking in the mapping (description preserved; empty when API omits content)

Before: video at `/video/c399ead6...` showed only "First Divine Compilation 2026!" with no description, despite the event content being "I just made the world's first divine compilation. Link here: https://youtu.be/...".

## Test plan
- [x] `npx vitest run src/lib/funnelcakeTransform.test.ts` — 10 passing (2 new)
- [x] `npx vitest run` — full suite 531 passing, 0 failing
- [x] `npx tsc --noEmit` — clean
- [ ] Visual check on `/video/:id` for a video with a non-empty description
- [ ] Spot-check feed/grid pages — descriptions now appear in hover previews on `VideoGrid`, share text uses description in `VideoFeed`, hashtag extraction in `lib/hashtag.ts` now reads the real description

🤖 Generated with [Claude Code](https://claude.com/claude-code)