### PR TITLE
test: combined age-gate fix (PR #279 + VideoPlayer auth)

### DIFF
--- a/src/components/VideoCard.test.tsx
+++ b/src/components/VideoCard.test.tsx
@@ -74,14 +74,16 @@ vi.mock('@/components/ui/dropdown-menu', () => ({
 vi.mock('@/components/VideoPlayer', () => ({
   VideoPlayer: ({
     videoId,
+    hlsUrl,
     onError,
     onPlaybackStarted,
   }: {
     videoId: string;
+    hlsUrl?: string;
     onError?: () => void;
     onPlaybackStarted?: () => void;
   }) => (
-    <div data-testid={`video-player-${videoId}`}>
+    <div data-testid={`video-player-${videoId}`} data-hls-url={hlsUrl ?? ''}>
       Video Player
       <button
         aria-label={`fail-video-${videoId}`}
@@ -469,6 +471,33 @@ describe('VideoCard', () => {
 
     expect(screen.getByTestId('thumbnail-player')).toBeInTheDocument();
     expect(screen.queryByText('Log in to view')).not.toBeInTheDocument();
+  });
+
+  it('shows a gated card for protected media with unknown age status', () => {
+    const video = makeVideo({
+      ageRestricted: undefined,
+      duration: 6,
+      hlsUrl: 'https://media.divine.video/video-1/hls/master.m3u8',
+      videoUrl: 'https://media.divine.video/video-1',
+    });
+
+    render(<VideoCard video={video} />);
+    expect(screen.getByText('Log in to view')).toBeInTheDocument();
+    expect(screen.queryByTestId(`video-player-${video.id}`)).not.toBeInTheDocument();
+    expect(screen.queryByTestId('thumbnail-player')).not.toBeInTheDocument();
+  });
+
+  it('shows verify-age CTA for logged-in viewers on protected media with unknown age status', () => {
+    authMocks.useCurrentUser.mockReturnValue({
+      user: { pubkey: 'a'.repeat(64) },
+    });
+    const video = makeVideo({
+      ageRestricted: undefined,
+      videoUrl: 'https://media.divine.video/video-1',
+    });
+
+    render(<VideoCard video={video} mode="thumbnail" />);
+    expect(screen.getByText('Verify age to view')).toBeInTheDocument();
   });
 
   it('lets failed playback be retried without remounting the card', () => {

--- a/src/components/VideoCard.tsx
+++ b/src/components/VideoCard.tsx
@@ -54,6 +54,7 @@ import { useSubtitles } from '@/hooks/useSubtitles';
 import { debugLog } from '@/lib/debug';
 import { useLoginDialog } from '@/contexts/LoginDialogContext';
 import { AgeRestrictedMediaPlaceholder } from '@/components/AgeRestrictedMediaPlaceholder';
+import { isProtectedDivineMediaUrl } from '@/hooks/useAuthenticatedMediaUrl';
 
 interface VideoCardProps {
   video: ParsedVideoData;
@@ -121,6 +122,9 @@ export function VideoCard({
   // Subscribe to bandwidth tier changes - triggers re-render when tier changes
   // The tier itself is used internally by getOptimalVideoUrl
   const _bandwidthTier = useBandwidthTier();
+  const { user: currentUser } = useCurrentUser();
+  const { isVerified: isAdultVerified, confirmAdult } = useAdultVerification();
+  const { openLoginDialog } = useLoginDialog();
 
   // Compute optimal HLS URL based on current bandwidth tier
   // This dynamically selects 480p/720p/adaptive based on observed load performance
@@ -135,13 +139,17 @@ export function VideoCard({
   // Classic Vines also skip HLS because the transcoder distorts square 480x480 aspect ratio.
   // Only use HLS for longer content (>60s) if divine ever supports it.
   const isShortForm = !video.duration || video.duration <= 60;
+  const isProtectedMedia = isProtectedDivineMediaUrl(video.videoUrl);
+  const shouldBlockSecondaryAssetFallbacks = isProtectedMedia && !isAdultVerified && video.ageRestricted !== false;
   // When direct MP4 fails, retry with HLS as fallback (blob may be missing but transcode exists)
   const [mp4Failed, setMp4Failed] = useState(false);
   // When MP4 blob is missing (404), fall back to HLS if available (transcoded copy may exist)
-  const hlsFallbackUrl = mp4Failed && video.videoUrl?.includes('media.divine.video')
+  const hlsFallbackUrl = mp4Failed && video.videoUrl?.includes('media.divine.video') && !shouldBlockSecondaryAssetFallbacks
     ? video.hlsUrl || optimalHlsUrl
     : undefined;
-  const effectiveHlsUrl = hlsFallbackUrl || ((isClassicVine || isShortForm) ? undefined : (video.hlsUrl || (optimalHlsUrl !== video.videoUrl ? optimalHlsUrl : undefined)));
+  const effectiveHlsUrl = shouldBlockSecondaryAssetFallbacks
+    ? undefined
+    : (hlsFallbackUrl || ((isClassicVine || isShortForm) ? undefined : (video.hlsUrl || (optimalHlsUrl !== video.videoUrl ? optimalHlsUrl : undefined))));
   const { data: lists } = useVideosInLists(video.vineId ?? undefined);
 
   // NEW: Get reposter data from reposts array
@@ -261,13 +269,10 @@ export function VideoCard({
 
   const { mutate: deleteVideo, isPending: isDeleting } = useDeleteVideo();
   const canDelete = useCanDeleteVideo(video);
-  const { user: currentUser } = useCurrentUser();
   const coordinate = video.vineId ? `${SHORT_VIDEO_KIND}:${video.pubkey}:${video.vineId}` : undefined;
   const isPinned = useIsVideoPinned(coordinate);
   const { mutateAsync: pinVideo } = usePinVideo();
   const { mutateAsync: unpinVideo } = useUnpinVideo();
-  const { isVerified: isAdultVerified, confirmAdult } = useAdultVerification();
-  const { openLoginDialog } = useLoginDialog();
 
   // Get reactions data for the modal
   const { data: reactions } = useVideoReactions(video.id, video.pubkey, video.vineId);
@@ -310,7 +315,8 @@ export function VideoCard({
   const timestamp = video.originalVineTimestamp || video.createdAt;
 
   const date = new Date(timestamp * 1000);
-  const isAgeGated = video.ageRestricted === true && (!currentUser || !isAdultVerified);
+  const shouldTreatAsGatedMedia = video.ageRestricted === true || (isProtectedMedia && video.ageRestricted !== false);
+  const isAgeGated = shouldTreatAsGatedMedia && (!currentUser || !isAdultVerified);
 
   // Calculate timeAgo only for pre-2025 videos
   const isFrom2025 = date.getFullYear() >= 2025;
@@ -411,7 +417,7 @@ export function VideoCard({
   const handleVideoError = () => {
     setShowThumbnailDuringStartup(false);
     // If MP4 failed and we haven't tried HLS yet, retry with HLS fallback
-    if (!mp4Failed && !effectiveHlsUrl && video.videoUrl?.includes('media.divine.video')) {
+    if (!mp4Failed && !effectiveHlsUrl && video.videoUrl?.includes('media.divine.video') && !shouldBlockSecondaryAssetFallbacks) {
       setMp4Failed(true);
     } else {
       setVideoError(true);

--- a/src/components/VideoGrid.test.tsx
+++ b/src/components/VideoGrid.test.tsx
@@ -117,6 +117,24 @@ describe('VideoGrid age-restricted gating', () => {
     expect(screen.queryByText('Log in to view')).not.toBeInTheDocument();
   });
 
+  it('treats protected media with unknown age status as gated for logged-out viewers', () => {
+    render(
+      <VideoGrid
+        videos={[
+          makeVideo({
+            id: 'unknown-status-video',
+            ageRestricted: undefined,
+            videoUrl: 'https://media.divine.video/unknown-status-video',
+          }),
+        ]}
+      />
+    );
+
+    expect(screen.getByText('Log in to view')).toBeInTheDocument();
+    expect(screen.queryByTestId('video-thumbnail-unknown-status-video')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('video-player-unknown-status-video')).not.toBeInTheDocument();
+  });
+
   it('fetches protected thumbnails with auth for verified viewers', async () => {
     mockUseCurrentUser.mockReturnValue({ user: { pubkey: 'a'.repeat(64) } });
     mockUseAdultVerification.mockReturnValue({

--- a/src/components/VideoGrid.tsx
+++ b/src/components/VideoGrid.tsx
@@ -10,7 +10,7 @@ import { AgeRestrictedMediaPlaceholder } from '@/components/AgeRestrictedMediaPl
 import { useLoginDialog } from '@/contexts/LoginDialogContext';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { useAdultVerification } from '@/hooks/useAdultVerification';
-import { useAuthenticatedMediaUrl } from '@/hooks/useAuthenticatedMediaUrl';
+import { isProtectedDivineMediaUrl, useAuthenticatedMediaUrl } from '@/hooks/useAuthenticatedMediaUrl';
 import { cn } from '@/lib/utils';
 import type { ParsedVideoData } from '@/types/video';
 import { buildVideoNavigationUrl, type VideoNavigationContext } from '@/hooks/useVideoNavigation';
@@ -247,7 +247,9 @@ export function VideoGrid({ videos, loading = false, className, navigationContex
       {videos.map((video, index) => {
         const isHovered = hoveredVideo === video.id;
         const thumbnailFailed = failedThumbnails.has(video.id);
-        const isAgeGated = video.ageRestricted === true && (!user || !isAdultVerified);
+        const isProtectedMedia = isProtectedDivineMediaUrl(video.videoUrl);
+        const shouldTreatAsGatedMedia = video.ageRestricted === true || (isProtectedMedia && video.ageRestricted !== false);
+        const isAgeGated = shouldTreatAsGatedMedia && (!user || !isAdultVerified);
 
         return (
           <Card

--- a/src/components/VideoPlayer.authHeaders.test.tsx
+++ b/src/components/VideoPlayer.authHeaders.test.tsx
@@ -1,5 +1,5 @@
-// ABOUTME: Tests that VideoPlayer forwards videoData.sha256 into getAuthHeader for MP4 fetches
-// ABOUTME: Verifies Blossom auth hint flows through for age-gated direct playback; absent when unknown
+// ABOUTME: Tests that VideoPlayer calls getAuthHeader for age-gated MP4 fetches
+// ABOUTME: Verifies NIP-98 viewer auth (no sha256 hint) for direct playback
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, waitFor } from '@testing-library/react';
@@ -102,7 +102,7 @@ describe('VideoPlayer auth headers', () => {
     vi.restoreAllMocks();
   });
 
-  it('passes sha256 into getAuthHeader for direct MP4 fetch when videoData.sha256 is set', async () => {
+  it('uses NIP-98 (no sha256) for direct MP4 fetch even when videoData.sha256 is set', async () => {
     render(
       <VideoPlayer
         videoId="v1"
@@ -128,32 +128,6 @@ describe('VideoPlayer auth headers', () => {
     const [url, method, sha256] = getAuthHeader.mock.calls[0];
     expect(url).toBe(URL_MP4);
     expect(method ?? 'GET').toBe('GET');
-    expect(sha256).toBe(HASH);
-  });
-
-  it('omits the sha256 hint when videoData.sha256 is absent', async () => {
-    render(
-      <VideoPlayer
-        videoId="v2"
-        src={URL_MP4}
-        videoData={{
-          id: 'v2',
-          pubkey: 'pub',
-          kind: SHORT_VIDEO_KIND,
-          createdAt: 0,
-          content: '',
-          videoUrl: URL_MP4,
-          hashtags: [],
-          vineId: null,
-          reposts: [],
-          isVineMigrated: false,
-          ageRestricted: true,
-        }}
-      />,
-    );
-
-    await waitFor(() => expect(getAuthHeader).toHaveBeenCalled());
-    const [, , sha256] = getAuthHeader.mock.calls[0];
     expect(sha256).toBeUndefined();
   });
 });

--- a/src/components/VideoPlayer.authHeaders.test.tsx
+++ b/src/components/VideoPlayer.authHeaders.test.tsx
@@ -130,4 +130,54 @@ describe('VideoPlayer auth headers', () => {
     expect(method ?? 'GET').toBe('GET');
     expect(sha256).toBeUndefined();
   });
+
+  it('sends auth headers when ageRestricted is undefined (unknown moderation status)', async () => {
+    render(
+      <VideoPlayer
+        videoId="v2"
+        src={URL_MP4}
+        videoData={{
+          id: 'v2',
+          pubkey: 'pub',
+          kind: SHORT_VIDEO_KIND,
+          createdAt: 0,
+          content: '',
+          videoUrl: URL_MP4,
+          hashtags: [],
+          vineId: null,
+          reposts: [],
+          isVineMigrated: false,
+          ageRestricted: undefined,
+        }}
+      />,
+    );
+
+    await waitFor(() => expect(getAuthHeader).toHaveBeenCalled());
+  });
+
+  it('skips auth headers when ageRestricted is explicitly false', async () => {
+    render(
+      <VideoPlayer
+        videoId="v3"
+        src={URL_MP4}
+        videoData={{
+          id: 'v3',
+          pubkey: 'pub',
+          kind: SHORT_VIDEO_KIND,
+          createdAt: 0,
+          content: '',
+          videoUrl: URL_MP4,
+          hashtags: [],
+          vineId: null,
+          reposts: [],
+          isVineMigrated: false,
+          ageRestricted: false,
+        }}
+      />,
+    );
+
+    // Give the effect time to run, then verify no auth call was made
+    await new Promise((r) => setTimeout(r, 100));
+    expect(getAuthHeader).not.toHaveBeenCalled();
+  });
 });

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -847,7 +847,9 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
             verboseLog(`[VideoPlayer ${videoId}] Fetching MP4 with NIP-98 auth`);
             (async () => {
               try {
-                const authHeader = await getAuthHeader(currentUrl, 'GET', videoData?.sha256);
+                // NIP-98 (not BUD-01): Blossom's viewer auth path only accepts
+                // BUD-01 list events, rejecting get events with an action mismatch.
+                const authHeader = await getAuthHeader(currentUrl, 'GET');
                 // Check if request was aborted while getting auth header
                 if (abortController.signal.aborted) {
                   verboseLog(`[VideoPlayer ${videoId}] Fetch aborted before starting`);

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -132,7 +132,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
     const { isVerified: isAdultVerified, getAuthHeader } = useAdultVerification();
     const { mediaUrl: authenticatedPosterUrl } = useAuthenticatedMediaUrl(poster, {
       enabled: !!poster && !requiresAuth && !authCheckPending,
-      ageRestricted: videoData?.ageRestricted !== false,
+      ageRestricted: !!videoData?.ageRestricted,
     });
     const overlayPosterUrl = authenticatedPosterUrl ||
       (poster && !isProtectedDivineMediaUrl(poster) ? poster : undefined);

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -927,7 +927,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
         }
       };
 
-    }, [hlsUrl, currentUrlIndex, allUrls, videoId, requiresAuth, isAdultVerified, authRetryCount, getAuthHeader, videoData?.sha256, videoData?.ageRestricted]); // React to HLS URL, fallback, and auth changes
+    }, [hlsUrl, currentUrlIndex, allUrls, videoId, requiresAuth, isAdultVerified, authRetryCount, getAuthHeader, videoData?.ageRestricted]); // React to HLS URL, fallback, and auth changes
 
     // Cleanup on unmount
     useEffect(() => {

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -132,7 +132,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
     const { isVerified: isAdultVerified, getAuthHeader } = useAdultVerification();
     const { mediaUrl: authenticatedPosterUrl } = useAuthenticatedMediaUrl(poster, {
       enabled: !!poster && !requiresAuth && !authCheckPending,
-      ageRestricted: !!videoData?.ageRestricted,
+      ageRestricted: videoData?.ageRestricted !== false,
     });
     const overlayPosterUrl = authenticatedPosterUrl ||
       (poster && !isProtectedDivineMediaUrl(poster) ? poster : undefined);
@@ -772,10 +772,10 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
           capLevelToPlayerSize: true, // Match quality to player size
         };
 
-        // Add custom auth loader only when the video is age-restricted.
+        // Add custom auth loader when the video is (or may be) age-restricted.
         // Public HLS streams must not carry an Authorization header — divine-blossom
         // rejects any malformed auth header with 401 even when the blob is public.
-        if (isAdultVerified && videoData?.ageRestricted) {
+        if (isAdultVerified && videoData?.ageRestricted !== false && isProtectedDivineMediaUrl(hlsUrl)) {
           verboseLog(`[VideoPlayer ${videoId}] Using NIP-98 auth loader for each HLS request`);
           hlsConfig.loader = createAuthLoader(getAuthHeader);
         }
@@ -838,12 +838,12 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
         verboseLog(`[VideoPlayer ${videoId}] Using direct playback - URL ${currentUrlIndex}/${allUrls.length - 1}: ${currentUrl}`);
 
         if (currentUrl) {
-          // Only fetch with auth headers when the video is actually age-restricted.
+          // Only fetch with auth headers when the video is (or may be) age-restricted.
           // Public blobs must not carry an Authorization header — divine-blossom
           // rejects any malformed auth header with 401 even when the blob is public,
           // so attaching auth optimistically locks users out of public content
           // whenever their signer produces an invalid event (e.g., JWT signer bugs).
-          if (isAdultVerified && videoData?.ageRestricted) {
+          if (isAdultVerified && videoData?.ageRestricted !== false && isProtectedDivineMediaUrl(currentUrl)) {
             verboseLog(`[VideoPlayer ${videoId}] Fetching MP4 with NIP-98 auth`);
             (async () => {
               try {

--- a/src/hooks/useInfiniteVideosFunnelcake.test.ts
+++ b/src/hooks/useInfiniteVideosFunnelcake.test.ts
@@ -105,7 +105,18 @@ describe('useInfiniteVideosFunnelcake', () => {
     const enrichedVideos = [{ ...transformedVideos[0], ageRestricted: true }];
 
     window.__DIVINE_FEED_TYPE__ = 'classics';
-    window.__DIVINE_FEED__ = { videos: [{}], has_more: false, next_cursor: undefined };
+    window.__DIVINE_FEED__ = {
+      videos: [{
+        id: 'raw-edge-id',
+        pubkey: 'p'.repeat(64),
+        created_at: 1700000200,
+        kind: 34236,
+        d_tag: 'raw-edge-d-tag',
+        video_url: 'https://media.divine.video/raw-edge-hash',
+      }],
+      has_more: false,
+      next_cursor: undefined,
+    };
     mockTransformToVideoPage.mockReturnValueOnce({
       videos: transformedVideos,
       nextCursor: undefined,

--- a/src/hooks/useInfiniteVideosFunnelcake.test.ts
+++ b/src/hooks/useInfiniteVideosFunnelcake.test.ts
@@ -6,6 +6,7 @@ import React from 'react';
 const mockFetchVideos = vi.fn();
 const mockFetchRecommendations = vi.fn();
 const mockTransformToVideoPage = vi.fn();
+const mockEnrichAgeRestrictedVideos = vi.fn();
 
 vi.mock('@/hooks/useCurrentUser', () => ({
   useCurrentUser: () => ({
@@ -23,6 +24,10 @@ vi.mock('@/lib/funnelcakeClient', () => ({
 
 vi.mock('@/lib/funnelcakeTransform', () => ({
   transformToVideoPage: mockTransformToVideoPage,
+}));
+
+vi.mock('@/lib/ageRestrictedVideos', () => ({
+  enrichAgeRestrictedVideos: mockEnrichAgeRestrictedVideos,
 }));
 
 vi.mock('@/lib/debug', () => ({
@@ -54,10 +59,77 @@ let useInfiniteVideosFunnelcake: typeof import('./useInfiniteVideosFunnelcake').
 
 beforeEach(async () => {
   vi.clearAllMocks();
+  mockEnrichAgeRestrictedVideos.mockImplementation(async (videos) => videos);
+  delete window.__DIVINE_FEED__;
+  delete window.__DIVINE_FEED_TYPE__;
   ({ useInfiniteVideosFunnelcake } = await import('./useInfiniteVideosFunnelcake'));
 });
 
 describe('useInfiniteVideosFunnelcake', () => {
+  it('enriches classics feeds with moderation age-gate status', async () => {
+    const transformedVideos = [
+      { id: 'video-1', pubkey: 'p1', kind: 34236, createdAt: 101, vineId: 'd-1', videoUrl: 'https://media.divine.video/hash1', reposts: [], isVineMigrated: true },
+    ];
+    const enrichedVideos = [
+      { ...transformedVideos[0], ageRestricted: true },
+    ];
+
+    mockFetchVideos.mockResolvedValueOnce({ videos: [{}], has_more: false, next_cursor: undefined });
+    mockTransformToVideoPage.mockReturnValueOnce({
+      videos: transformedVideos,
+      nextCursor: undefined,
+      hasMore: false,
+    });
+    mockEnrichAgeRestrictedVideos.mockResolvedValueOnce(enrichedVideos);
+
+    const { result } = renderHook(
+      () => useInfiniteVideosFunnelcake({ feedType: 'classics', pageSize: 12 }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockEnrichAgeRestrictedVideos).toHaveBeenCalledWith(
+      transformedVideos,
+      expect.any(AbortSignal)
+    );
+    expect(result.current.data?.pages[0].videos[0].ageRestricted).toBe(true);
+  });
+
+  it('enriches edge-injected classics page before returning results', async () => {
+    const transformedVideos = [
+      { id: 'edge-video', pubkey: 'p2', kind: 34236, createdAt: 201, vineId: 'd-edge', videoUrl: 'https://media.divine.video/hash-edge', reposts: [], isVineMigrated: true },
+    ];
+    const enrichedVideos = [{ ...transformedVideos[0], ageRestricted: true }];
+
+    window.__DIVINE_FEED_TYPE__ = 'classics';
+    window.__DIVINE_FEED__ = { videos: [{}], has_more: false, next_cursor: undefined };
+    mockTransformToVideoPage.mockReturnValueOnce({
+      videos: transformedVideos,
+      nextCursor: undefined,
+      hasMore: false,
+    });
+    mockEnrichAgeRestrictedVideos.mockResolvedValueOnce(enrichedVideos);
+
+    const { result } = renderHook(
+      () => useInfiniteVideosFunnelcake({ feedType: 'classics', pageSize: 12 }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockFetchVideos).not.toHaveBeenCalled();
+    expect(mockEnrichAgeRestrictedVideos).toHaveBeenCalledWith(
+      transformedVideos,
+      expect.any(AbortSignal)
+    );
+    expect(result.current.data?.pages[0].videos[0].ageRestricted).toBe(true);
+  });
+
   it('uses cursor-based pagination for recommendations', async () => {
     // Page 1: server returns cursor for next page
     mockFetchRecommendations

--- a/src/hooks/useInfiniteVideosFunnelcake.ts
+++ b/src/hooks/useInfiniteVideosFunnelcake.ts
@@ -84,6 +84,10 @@ function isRecommendationsCursorPageParam(
     && typeof (pageParam as { popularOffset?: unknown }).popularOffset === 'number';
 }
 
+function shouldEnrichAgeGate(feedType: FunnelcakeFeedType): boolean {
+  return feedType === 'profile' || feedType === 'classics';
+}
+
 /**
  * Map feed type and sort mode to Funnelcake API options
  */
@@ -214,16 +218,19 @@ export function useInfiniteVideosFunnelcake({
         debugLog(`[useInfiniteVideosFunnelcake] Using edge-injected ${feedType} feed data`);
 
         const page = transformToVideoPage(edgeData);
+        const enrichedEdgeVideos = shouldEnrichAgeGate(feedType)
+          ? await enrichAgeRestrictedVideos(page.videos, signal)
+          : page.videos;
         performanceMonitor.recordFeedLoad({
           feedType: 'funnelcake-trending',
           queryTime: 0,
           parseTime: performance.now() - totalStart,
           totalTime: performance.now() - totalStart,
-          videoCount: page.videos.length,
+          videoCount: enrichedEdgeVideos.length,
           sortMode,
         });
         return {
-          videos: page.videos,
+          videos: enrichedEdgeVideos,
           nextCursor: page.nextCursor,
           offset: page.offset,
         };
@@ -369,7 +376,7 @@ export function useInfiniteVideosFunnelcake({
         }
       }
 
-      const enrichedVideos = feedType === 'profile'
+      const enrichedVideos = shouldEnrichAgeGate(feedType)
         ? await enrichAgeRestrictedVideos(page.videos, signal)
         : page.videos;
       const parseTime = performance.now() - parseStart;

--- a/src/hooks/useSubtitles.test.ts
+++ b/src/hooks/useSubtitles.test.ts
@@ -118,4 +118,21 @@ describe('useSubtitles protected media auth', () => {
     expect(fetchSpy).not.toHaveBeenCalled();
     expect(result.current.hasSubtitles).toBe(false);
   });
+
+  it('does not make raw CDN subtitle requests for protected media with unknown age gate status', async () => {
+    const fetchSpy = vi.fn();
+    global.fetch = fetchSpy as typeof fetch;
+
+    const { result } = renderHook(
+      () => useSubtitles(makeVideo({ ageRestricted: undefined })),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(result.current.hasSubtitles).toBe(false);
+  });
 });

--- a/src/hooks/useSubtitles.ts
+++ b/src/hooks/useSubtitles.ts
@@ -67,11 +67,12 @@ export function useSubtitles(
   const hasEmbeddedContent = !!video?.textTrackContent;
   const hasRef = !!video?.textTrackRef;
   const cdnHash = video?.videoUrl ? extractCdnHash(video.videoUrl) : null;
-  const requiresProtectedCdnAuth = !!video?.ageRestricted && !!video?.videoUrl && isProtectedDivineMediaUrl(video.videoUrl);
+  const isProtectedCdnUrl = !!video?.videoUrl && isProtectedDivineMediaUrl(video.videoUrl);
+  const shouldTreatAsProtectedCdn = isProtectedCdnUrl && video?.ageRestricted !== false;
   const queryEnabled = !!video && (hasEmbeddedContent || hasRef || !!cdnHash);
 
   const { data: cues = [], isLoading } = useQuery({
-    queryKey: ['subtitles', video?.id, video?.textTrackRef, cdnHash, requiresProtectedCdnAuth, isAdultVerified],
+    queryKey: ['subtitles', video?.id, video?.textTrackRef, cdnHash, shouldTreatAsProtectedCdn, isAdultVerified],
     queryFn: async ({ signal }) => {
       if (!video) return [];
 
@@ -106,7 +107,11 @@ export function useSubtitles(
       if (cdnHash) {
         try {
           const vttUrl = `https://media.divine.video/${cdnHash}/vtt`;
-          const response = requiresProtectedCdnAuth
+          if (shouldTreatAsProtectedCdn && !isAdultVerified) {
+            return [];
+          }
+
+          const response = shouldTreatAsProtectedCdn
             ? await (async () => {
                 const authHeader = await getAuthHeader(vttUrl, 'GET');
                 if (!authHeader) {

--- a/src/hooks/useVideoPrefetch.test.ts
+++ b/src/hooks/useVideoPrefetch.test.ts
@@ -49,6 +49,26 @@ describe('useVideoPrefetch', () => {
     expect(prefetchHrefs).not.toContain('https://media.divine.video/restricted-video.jpg');
   });
 
+  it('does not prefetch protected media when age-restriction status is unknown', () => {
+    renderHook(() =>
+      useVideoPrefetch('video-1', [
+        makeVideo({ id: 'video-1' }),
+        makeVideo({
+          id: 'unknown-status-video',
+          ageRestricted: undefined,
+          videoUrl: 'https://media.divine.video/unknown-status-video',
+          thumbnailUrl: 'https://media.divine.video/unknown-status-video.jpg',
+        }),
+      ]),
+    );
+
+    const prefetchHrefs = Array.from(document.head.querySelectorAll('link[rel="prefetch"]'))
+      .map((link) => (link as HTMLLinkElement).href);
+
+    expect(prefetchHrefs).not.toContain('https://media.divine.video/unknown-status-video');
+    expect(prefetchHrefs).not.toContain('https://media.divine.video/unknown-status-video.jpg');
+  });
+
   it('continues prefetching unrestricted upcoming media', () => {
     renderHook(() =>
       useVideoPrefetch('video-1', [

--- a/src/hooks/useVideoPrefetch.ts
+++ b/src/hooks/useVideoPrefetch.ts
@@ -64,7 +64,7 @@ export function useVideoPrefetch(
       if (!shouldSkipProtectedPrefetch(video.videoUrl, video.ageRestricted)) {
         urlsToPrefetch.push({ url: video.videoUrl, as: 'video' });
       }
-      if (!shouldSkipProtectedPrefetch(video.thumbnailUrl, video.ageRestricted)) {
+      if (video.thumbnailUrl && !shouldSkipProtectedPrefetch(video.thumbnailUrl, video.ageRestricted)) {
         urlsToPrefetch.push({ url: video.thumbnailUrl, as: 'image' });
       }
     }

--- a/src/hooks/useVideoPrefetch.ts
+++ b/src/hooks/useVideoPrefetch.ts
@@ -15,6 +15,10 @@ function isProtectedDivineMediaUrl(url: string): boolean {
   }
 }
 
+function shouldSkipProtectedPrefetch(url: string | undefined, ageRestricted: boolean | undefined): boolean {
+  return !!url && isProtectedDivineMediaUrl(url) && ageRestricted !== false;
+}
+
 /**
  * Prefetch upcoming video URLs when the active video changes.
  * Inserts <link rel="prefetch"> elements into <head> for the next
@@ -57,12 +61,10 @@ export function useVideoPrefetch(
     // Collect unique URLs to prefetch (video URL + thumbnail)
     const urlsToPrefetch: { url: string; as: string }[] = [];
     for (const video of nextVideos) {
-      const shouldSkipProtectedMediaPrefetch = !!video.ageRestricted;
-
-      if (video.videoUrl && !(shouldSkipProtectedMediaPrefetch && isProtectedDivineMediaUrl(video.videoUrl))) {
+      if (!shouldSkipProtectedPrefetch(video.videoUrl, video.ageRestricted)) {
         urlsToPrefetch.push({ url: video.videoUrl, as: 'video' });
       }
-      if (video.thumbnailUrl && !(shouldSkipProtectedMediaPrefetch && isProtectedDivineMediaUrl(video.thumbnailUrl))) {
+      if (!shouldSkipProtectedPrefetch(video.thumbnailUrl, video.ageRestricted)) {
         urlsToPrefetch.push({ url: video.thumbnailUrl, as: 'image' });
       }
     }

--- a/src/lib/funnelcakeTransform.test.ts
+++ b/src/lib/funnelcakeTransform.test.ts
@@ -54,6 +54,32 @@ describe('transformFunnelcakeVideo', () => {
 
     expect(video.ageRestricted).toBe(true);
   });
+
+  it('preserves explicit non-restricted videos from the API payload', () => {
+    const video = transformFunnelcakeVideo(makeRawVideo({
+      age_restricted: false,
+    }));
+
+    expect(video.ageRestricted).toBe(false);
+  });
+
+  it('keeps age restriction unknown when API provides no moderation fields', () => {
+    const video = transformFunnelcakeVideo(makeRawVideo({
+      age_restricted: undefined,
+      moderation_status: undefined,
+    }));
+
+    expect(video.ageRestricted).toBeUndefined();
+  });
+
+  it('marks videos restricted when moderation status says age_restricted', () => {
+    const video = transformFunnelcakeVideo(makeRawVideo({
+      age_restricted: undefined,
+      moderation_status: 'age_restricted',
+    }));
+
+    expect(video.ageRestricted).toBe(true);
+  });
 });
 
 function makeResponse(overrides: Partial<FunnelcakeResponse> = {}): FunnelcakeResponse {

--- a/src/lib/funnelcakeTransform.ts
+++ b/src/lib/funnelcakeTransform.ts
@@ -36,6 +36,18 @@ function parseLoopsFromTags(tags?: string[][]): number | null {
   return Number.isFinite(loops) && loops > 0 ? loops : null;
 }
 
+function resolveAgeRestricted(raw: FunnelcakeVideoRaw): boolean | undefined {
+  if (raw.age_restricted === true || raw.moderation_status === 'age_restricted') {
+    return true;
+  }
+
+  if (raw.age_restricted === false) {
+    return false;
+  }
+
+  return undefined;
+}
+
 /**
  * Transform a single Funnelcake video to ParsedVideoData format
  */
@@ -86,7 +98,7 @@ export function transformFunnelcakeVideo(raw: FunnelcakeVideoRaw): ParsedVideoDa
     title: raw.title,
     dimensions: raw.dim, // Video dimensions from API (e.g., "1080x1920")
     sha256: extractSha256FromVideoUrl(raw.video_url),
-    ageRestricted: raw.age_restricted === true || raw.moderation_status === 'age_restricted',
+    ageRestricted: resolveAgeRestricted(raw),
     hashtags,
 
     // Vine-specific fields


### PR DESCRIPTION
Throwaway merge branch for testing. Combines:
- PR #279 (classics age-gated secondary assets)
- VideoPlayer auth header fix for unknown age status

Test: visit a classic vine with age restriction, verify playback works after clicking through age gate.

**Do not merge — delete after testing.**