### PR TITLE
feat: sim-suppression hooks for divine-brain virtual-persona PR runner

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,26 +124,9 @@
   <body>
     <div id="root"></div>
 
-    <!-- HubSpot tracking code & GDPR cookie consent banner.
-         Wrapped in a sim-suppression guard: HubSpot's tracker fires
-         independently of the Firebase/GA4 consent gate, so it must be
-         loaded conditionally. The flag is set by divine-brain's
-         virtual-persona PR runner via Stagehand `page.addInitScript`
-         BEFORE the document is parsed, so this guard sees an already-
-         set window flag in those sessions. Production traffic
-         (no flag set) loads HubSpot exactly as before. -->
-    <script>
-      (function () {
-        if (window.__DIVINE_ANALYTICS_DISABLED__) return;
-        var s = document.createElement('script');
-        s.type = 'text/javascript';
-        s.id = 'hs-script-loader';
-        s.async = true;
-        s.defer = true;
-        s.src = 'https://js-na2.hs-scripts.com/244466832.js';
-        document.head.appendChild(s);
-      })();
-    </script>
+    <!-- HubSpot tracking code & GDPR cookie consent banner. The module keeps
+         the sim-suppression guard out of inline HTML so CSP lint stays clean. -->
+    <script type="module" src="/src/lib/hubSpotLoader.ts"></script>
 
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/index.html
+++ b/index.html
@@ -124,8 +124,26 @@
   <body>
     <div id="root"></div>
 
-    <!-- HubSpot tracking code & GDPR cookie consent banner -->
-    <script type="text/javascript" id="hs-script-loader" async defer src="https://js-na2.hs-scripts.com/244466832.js"></script>
+    <!-- HubSpot tracking code & GDPR cookie consent banner.
+         Wrapped in a sim-suppression guard: HubSpot's tracker fires
+         independently of the Firebase/GA4 consent gate, so it must be
+         loaded conditionally. The flag is set by divine-brain's
+         virtual-persona PR runner via Stagehand `page.addInitScript`
+         BEFORE the document is parsed, so this guard sees an already-
+         set window flag in those sessions. Production traffic
+         (no flag set) loads HubSpot exactly as before. -->
+    <script>
+      (function () {
+        if (window.__DIVINE_ANALYTICS_DISABLED__) return;
+        var s = document.createElement('script');
+        s.type = 'text/javascript';
+        s.id = 'hs-script-loader';
+        s.async = true;
+        s.defer = true;
+        s.src = 'https://js-na2.hs-scripts.com/244466832.js';
+        document.head.appendChild(s);
+      })();
+    </script>
 
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import { VideoPlaybackProvider } from '@/contexts/VideoPlaybackContext';
 import { FullscreenFeedProvider } from '@/contexts/FullscreenFeedContext';
 import AppRouter from './AppRouter';
 import { PRIMARY_RELAY, PRESET_RELAYS, toLegacyFormat } from '@/config/relays';
+import { resolveRelayUrl, resolveRelayUrls } from '@/lib/simRelay';
 
 const head = createHead({
   plugins: [
@@ -43,10 +44,13 @@ const queryClient = new QueryClient({
 
 const defaultConfig: AppConfig = {
   theme: "system",
-  relayUrl: PRIMARY_RELAY.url, // Primary relay with NIP-50 support
-  relayUrls: [
+  // Sim-suppression: in divine-brain virtual-persona PR runs the
+  // override flips this to wss://relay.staging.divine.video. In prod
+  // (no flag set) the default is unchanged.
+  relayUrl: resolveRelayUrl(PRIMARY_RELAY.url),
+  relayUrls: resolveRelayUrls([
     'wss://relay.divine.video',
-  ],
+  ]),
 };
 
 const presetRelays = toLegacyFormat(PRESET_RELAYS);

--- a/src/lib/analytics-suppression.test.ts
+++ b/src/lib/analytics-suppression.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// We're testing module-level behavior — initializeAnalytics() is
+// called once at app boot. Use vi.resetModules() between cases so
+// the module re-evaluates with a fresh window flag state.
+
+describe('analytics suppression', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    delete (window as unknown as { __DIVINE_ANALYTICS_DISABLED__?: boolean })
+      .__DIVINE_ANALYTICS_DISABLED__;
+  });
+
+  it('initializeAnalytics is a no-op when __DIVINE_ANALYTICS_DISABLED__ is set', async () => {
+    (window as unknown as { __DIVINE_ANALYTICS_DISABLED__?: boolean })
+      .__DIVINE_ANALYTICS_DISABLED__ = true;
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const mod = await import('./analytics');
+    mod.initializeAnalytics();
+
+    // The suppressed log line is deterministic; the "Firebase App
+    // initialized" line should NOT appear.
+    const calls = log.mock.calls.map((c) => String(c[0]));
+    expect(calls.some((c) => c.includes('Suppressed by __DIVINE_ANALYTICS_DISABLED__'))).toBe(
+      true,
+    );
+    expect(calls.some((c) => c.includes('Firebase App initialized'))).toBe(false);
+    log.mockRestore();
+  });
+
+  it('trackEvent is a no-op when suppressed (no analytics object exists)', async () => {
+    (window as unknown as { __DIVINE_ANALYTICS_DISABLED__?: boolean })
+      .__DIVINE_ANALYTICS_DISABLED__ = true;
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const mod = await import('./analytics');
+    mod.initializeAnalytics();
+    mod.trackEvent('test_event', { foo: 'bar' });
+
+    const calls = log.mock.calls.map((c) => String(c[0]));
+    expect(calls.some((c) => c.includes('Event tracked'))).toBe(false);
+    log.mockRestore();
+  });
+});

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -6,6 +6,21 @@ import { getAnalytics, logEvent, setUserId, setAnalyticsCollectionEnabled, type 
 import { getPerformance, trace, type FirebasePerformance } from 'firebase/performance';
 import { onAnalyticsConsentChanged } from './cookieConsent';
 
+// Sim-suppression hard block. Set by divine-brain's virtual-persona
+// PR runner via Stagehand `page.addInitScript` BEFORE any document is
+// parsed, so this runs before initializeApp ever fires. Without this,
+// Firebase auto-tracking (via GTM) emits `page_view` to G-FTDHC8JHYF
+// even before the GDPR consent listener gets a chance — verified
+// empirically via divine-brain/sim/experiments/smoke-one-persona.ts
+// on 2026-05-08 (2 first-visit sessions polluted prod GA4 in a 32s
+// headless scroll). Production traffic is unaffected because the flag
+// is never set there.
+function isSuppressed(): boolean {
+  if (typeof window === 'undefined') return false;
+  return !!(window as unknown as { __DIVINE_ANALYTICS_DISABLED__?: boolean })
+    .__DIVINE_ANALYTICS_DISABLED__;
+}
+
 const firebaseConfig = {
   apiKey: "AIzaSyDiq-KGmtI9wHNxSkL-QT4HzRckdS_0vQw",
   authDomain: "divine-web-e8688.firebaseapp.com",
@@ -28,6 +43,15 @@ let analyticsEnabled = false;
 export function initializeAnalytics() {
   try {
     if (typeof window === 'undefined') return;
+
+    // Hard block — never even call initializeApp under the suppression
+    // flag. Firebase's auto-tracking + GTM bootstrap (page_view,
+    // installations, remoteconfig) fire from initializeApp regardless
+    // of consent state, so blocking only enableAnalytics is too late.
+    if (isSuppressed()) {
+      console.log('[Analytics] Suppressed by __DIVINE_ANALYTICS_DISABLED__');
+      return;
+    }
 
     app = initializeApp(firebaseConfig);
     console.log('[Analytics] Firebase App initialized (analytics pending consent)');
@@ -74,7 +98,7 @@ function disableAnalytics() {
  * Log a custom analytics event
  */
 export function trackEvent(eventName: string, params?: Record<string, unknown>) {
-  if (!analytics) return;
+  if (isSuppressed() || !analytics) return;
 
   try {
     logEvent(analytics, eventName, params);

--- a/src/lib/hubSpotLoader.test.ts
+++ b/src/lib/hubSpotLoader.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const HUBSPOT_SCRIPT_ID = 'hs-script-loader';
+const HUBSPOT_SCRIPT_SRC = 'https://js-na2.hs-scripts.com/244466832.js';
+
+describe('HubSpot loader', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    delete window.__DIVINE_ANALYTICS_DISABLED__;
+    document.getElementById(HUBSPOT_SCRIPT_ID)?.remove();
+  });
+
+  it('loads HubSpot tracking by default', async () => {
+    await import('./hubSpotLoader');
+
+    const script = document.getElementById(HUBSPOT_SCRIPT_ID) as HTMLScriptElement | null;
+    expect(script).not.toBeNull();
+    expect(script?.src).toBe(HUBSPOT_SCRIPT_SRC);
+    expect(script?.async).toBe(true);
+    expect(script?.defer).toBe(true);
+  });
+
+  it('does not load HubSpot tracking when analytics are suppressed', async () => {
+    window.__DIVINE_ANALYTICS_DISABLED__ = true;
+
+    await import('./hubSpotLoader');
+
+    expect(document.getElementById(HUBSPOT_SCRIPT_ID)).toBeNull();
+  });
+
+  it('does not duplicate an existing HubSpot script', async () => {
+    const existing = document.createElement('script');
+    existing.id = HUBSPOT_SCRIPT_ID;
+    existing.src = HUBSPOT_SCRIPT_SRC;
+    document.head.appendChild(existing);
+
+    const { loadHubSpotTracking } = await import('./hubSpotLoader');
+    loadHubSpotTracking();
+
+    expect(document.querySelectorAll(`#${HUBSPOT_SCRIPT_ID}`)).toHaveLength(1);
+  });
+});

--- a/src/lib/hubSpotLoader.ts
+++ b/src/lib/hubSpotLoader.ts
@@ -1,0 +1,23 @@
+const HUBSPOT_SCRIPT_ID = 'hs-script-loader';
+const HUBSPOT_SCRIPT_SRC = 'https://js-na2.hs-scripts.com/244466832.js';
+
+function isAnalyticsSuppressed(): boolean {
+  if (typeof window === 'undefined') return false;
+  return !!window.__DIVINE_ANALYTICS_DISABLED__;
+}
+
+export function loadHubSpotTracking(): void {
+  if (typeof document === 'undefined') return;
+  if (isAnalyticsSuppressed()) return;
+  if (document.getElementById(HUBSPOT_SCRIPT_ID)) return;
+
+  const script = document.createElement('script');
+  script.type = 'text/javascript';
+  script.id = HUBSPOT_SCRIPT_ID;
+  script.async = true;
+  script.defer = true;
+  script.src = HUBSPOT_SCRIPT_SRC;
+  document.head.appendChild(script);
+}
+
+loadHubSpotTracking();

--- a/src/lib/simRelay.test.ts
+++ b/src/lib/simRelay.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { resolveRelayUrl, resolveRelayUrls } from './simRelay';
+
+// jsdom in this repo doesn't ship a working localStorage by default;
+// install a small in-memory shim per test.
+function installLocalStorageShim(): void {
+  const store = new Map<string, string>();
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem: (k: string) => (store.has(k) ? (store.get(k) as string) : null),
+      setItem: (k: string, v: string) => {
+        store.set(k, String(v));
+      },
+      removeItem: (k: string) => {
+        store.delete(k);
+      },
+      clear: () => store.clear(),
+      key: (i: number) => Array.from(store.keys())[i] ?? null,
+      get length(): number {
+        return store.size;
+      },
+    },
+  });
+}
+
+describe('resolveRelayUrl', () => {
+  beforeEach(() => {
+    installLocalStorageShim();
+  });
+
+  it('returns default when override is unset', () => {
+    expect(resolveRelayUrl('wss://relay.divine.video')).toBe(
+      'wss://relay.divine.video',
+    );
+  });
+
+  it('returns override when it is a valid wss URL', () => {
+    window.localStorage.setItem(
+      'DIVINE_RELAY_OVERRIDE',
+      'wss://relay.staging.divine.video',
+    );
+    expect(resolveRelayUrl('wss://relay.divine.video')).toBe(
+      'wss://relay.staging.divine.video',
+    );
+  });
+
+  it('ignores non-wss override values (defensive)', () => {
+    window.localStorage.setItem('DIVINE_RELAY_OVERRIDE', 'https://attacker.example');
+    expect(resolveRelayUrl('wss://relay.divine.video')).toBe(
+      'wss://relay.divine.video',
+    );
+  });
+
+  it('ignores empty override', () => {
+    window.localStorage.setItem('DIVINE_RELAY_OVERRIDE', '');
+    expect(resolveRelayUrl('wss://relay.divine.video')).toBe(
+      'wss://relay.divine.video',
+    );
+  });
+});
+
+describe('resolveRelayUrls', () => {
+  beforeEach(() => {
+    installLocalStorageShim();
+  });
+
+  it('returns defaults unchanged when override unset', () => {
+    expect(resolveRelayUrls(['wss://relay.divine.video', 'wss://other.example'])).toEqual([
+      'wss://relay.divine.video',
+      'wss://other.example',
+    ]);
+  });
+
+  it('replaces only relay.divine.video entries when override set', () => {
+    window.localStorage.setItem(
+      'DIVINE_RELAY_OVERRIDE',
+      'wss://relay.staging.divine.video',
+    );
+    expect(
+      resolveRelayUrls(['wss://relay.divine.video', 'wss://search.example']),
+    ).toEqual(['wss://relay.staging.divine.video', 'wss://search.example']);
+  });
+
+  it('does NOT replace already-staging URLs', () => {
+    window.localStorage.setItem(
+      'DIVINE_RELAY_OVERRIDE',
+      'wss://relay.staging.divine.video',
+    );
+    expect(resolveRelayUrls(['wss://relay.staging.divine.video'])).toEqual([
+      'wss://relay.staging.divine.video',
+    ]);
+  });
+});

--- a/src/lib/simRelay.ts
+++ b/src/lib/simRelay.ts
@@ -1,0 +1,57 @@
+// Sim-suppression hook for relay routing. Reads
+// `localStorage.DIVINE_RELAY_OVERRIDE` (set by divine-brain's
+// virtual-persona PR runner via Stagehand `page.addInitScript` before
+// navigation) and uses it instead of the production relay URL when set.
+//
+// In production no override is ever set, so resolveRelayUrl returns
+// the default unchanged. In sim sessions the override points at
+// `wss://relay.staging.divine.video` so simulated personas never
+// touch the production relay.
+//
+// Empirical motivation: divine-brain/sim/experiments/smoke-one-persona.ts
+// against divine.video on 2026-05-08 showed 9+ WS connections to
+// `wss://relay.divine.video` despite the override being set in
+// localStorage (no production code was reading it yet). This module
+// is the read.
+
+const STORAGE_KEY = 'DIVINE_RELAY_OVERRIDE';
+
+/**
+ * Returns the override relay URL when the sim flag is set, otherwise
+ * the supplied default. The override must be a `wss://` URL — anything
+ * else is ignored as a defensive measure (a sim that mis-set the flag
+ * shouldn't be able to redirect production users to an attacker URL).
+ */
+export function resolveRelayUrl(defaultUrl: string): string {
+  if (typeof window === 'undefined') return defaultUrl;
+  try {
+    const v = window.localStorage.getItem(STORAGE_KEY);
+    if (v && /^wss:\/\//.test(v)) return v;
+  } catch {
+    // localStorage may be blocked (private mode, sandbox, etc.) — fall through.
+  }
+  return defaultUrl;
+}
+
+/**
+ * Same as resolveRelayUrl but maps each entry of an array. Used where
+ * the app keeps a relay set rather than a single URL.
+ */
+export function resolveRelayUrls(defaults: string[]): string[] {
+  if (typeof window === 'undefined') return defaults;
+  try {
+    const v = window.localStorage.getItem(STORAGE_KEY);
+    if (v && /^wss:\/\//.test(v)) {
+      // Replace the production relay everywhere it appears in the
+      // default set; preserve any others. This keeps preset relays
+      // (search relays, profile relays) intact while routing the
+      // primary write/read traffic to staging.
+      return defaults.map((d) =>
+        /\brelay\.divine\.video\b/i.test(d) && !/\bstaging\b/.test(d) ? v : d,
+      );
+    }
+  } catch {
+    // see above
+  }
+  return defaults;
+}

--- a/src/types/window.d.ts
+++ b/src/types/window.d.ts
@@ -13,6 +13,8 @@ declare global {
     __DIVINE_FEED__?: FunnelcakeResponse;
     /** Feed type that was injected (trending, recent, classics) */
     __DIVINE_FEED_TYPE__?: string;
+    /** Set by divine-brain simulations before page scripts run to suppress analytics. */
+    __DIVINE_ANALYTICS_DISABLED__?: boolean;
   }
 }
 


### PR DESCRIPTION
Adds three sim-suppression hooks so divine-brain's virtual-persona PR runner (https://github.com/divinevideo/divine-brain) can drive divine.video against staging without contaminating production.

- `src/lib/analytics.ts` — short-circuit `initializeAnalytics()` when `window.__DIVINE_ANALYTICS_DISABLED__` is set. The existing GDPR consent gate fires too late: Firebase auto-tracking via GTM emits `page_view` to `G-FTDHC8JHYF` before the consent listener runs.
- `index.html` — wrap the HubSpot script tag in an inline conditional so it loads only when the flag is unset.
- `src/lib/simRelay.ts` + `src/App.tsx` — `resolveRelayUrl` / `resolveRelayUrls` read `localStorage.DIVINE_RELAY_OVERRIDE` (`wss://`-only). `defaultConfig` uses them.

Production unaffected — the flags are never set there, all three guards fall through.

Empirical motivation: a 32 s headless scroll against divine.video on 2026-05-08 emitted 2 real `_fv=1` GA4 sessions to prod and made 9+ WS connections to `wss://relay.divine.video` despite the override being set. Trace + analysis: https://github.com/divinevideo/divine-brain/blob/main/docs/notes/2026-05-08-first-real-persona-run.md

Tests: 9 new specs (`src/lib/simRelay.test.ts`, `src/lib/analytics-suppression.test.ts`). Full repo: 731 pass, 5 pre-existing fails in `DivineJWTSigner.test.ts` (RPC mocks; on `main` already).