### PR TITLE
revert: undo three-state age gate (#348)

### DIFF
--- a/src/components/ThumbnailPlayer.tsx
+++ b/src/components/ThumbnailPlayer.tsx
@@ -104,7 +104,7 @@ export function ThumbnailPlayer({
   const baseThumbnailUrl = thumbnailUrl || src;
   const { mediaUrl: authenticatedMediaUrl, isLoading: authMediaLoading } = useAuthenticatedMediaUrl(baseThumbnailUrl, {
     enabled: !requiresAuth,
-    ageRestricted,
+    ageRestricted: !!ageRestricted,
   });
   const overlayThumbnailUrl = authenticatedMediaUrl ||
     (baseThumbnailUrl && !isProtectedDivineMediaUrl(baseThumbnailUrl) ? baseThumbnailUrl : undefined);

--- a/src/components/VideoCard.test.tsx
+++ b/src/components/VideoCard.test.tsx
@@ -75,16 +75,14 @@ vi.mock('@/components/ui/dropdown-menu', () => ({
 vi.mock('@/components/VideoPlayer', () => ({
   VideoPlayer: ({
     videoId,
-    hlsUrl,
     onError,
     onPlaybackStarted,
   }: {
     videoId: string;
-    hlsUrl?: string;
     onError?: () => void;
     onPlaybackStarted?: () => void;
   }) => (
-    <div data-testid={`video-player-${videoId}`} data-hls-url={hlsUrl ?? ''}>
+    <div data-testid={`video-player-${videoId}`}>
       Video Player
       <button
         aria-label={`fail-video-${videoId}`}
@@ -483,33 +481,6 @@ describe('VideoCard', () => {
 
     expect(screen.getByTestId('thumbnail-player')).toBeInTheDocument();
     expect(screen.queryByText('Log in to view')).not.toBeInTheDocument();
-  });
-
-  it('renders video normally for protected media with unknown age status', () => {
-    const video = makeVideo({
-      ageRestricted: undefined,
-      duration: 6,
-      hlsUrl: 'https://media.divine.video/video-1/hls/master.m3u8',
-      videoUrl: 'https://media.divine.video/video-1',
-    });
-
-    render(<VideoCard video={video} />);
-    expect(screen.queryByText('Log in to view')).not.toBeInTheDocument();
-    expect(screen.getByTestId(`video-player-${video.id}`)).toBeInTheDocument();
-  });
-
-  it('renders video normally for logged-in viewers on protected media with unknown age status', () => {
-    authMocks.useCurrentUser.mockReturnValue({
-      user: { pubkey: 'a'.repeat(64) },
-    });
-    const video = makeVideo({
-      ageRestricted: undefined,
-      videoUrl: 'https://media.divine.video/video-1',
-    });
-
-    render(<VideoCard video={video} mode="thumbnail" />);
-    expect(screen.queryByText('Verify age to view')).not.toBeInTheDocument();
-    expect(screen.getByTestId('thumbnail-player')).toBeInTheDocument();
   });
 
   it('lets failed playback be retried without remounting the card', () => {

--- a/src/components/VideoCard.test.tsx
+++ b/src/components/VideoCard.test.tsx
@@ -75,14 +75,16 @@ vi.mock('@/components/ui/dropdown-menu', () => ({
 vi.mock('@/components/VideoPlayer', () => ({
   VideoPlayer: ({
     videoId,
+    hlsUrl,
     onError,
     onPlaybackStarted,
   }: {
     videoId: string;
+    hlsUrl?: string;
     onError?: () => void;
     onPlaybackStarted?: () => void;
   }) => (
-    <div data-testid={`video-player-${videoId}`}>
+    <div data-testid={`video-player-${videoId}`} data-hls-url={hlsUrl ?? ''}>
       Video Player
       <button
         aria-label={`fail-video-${videoId}`}

--- a/src/components/VideoCard.tsx
+++ b/src/components/VideoCard.tsx
@@ -55,7 +55,6 @@ import { useSubtitles } from '@/hooks/useSubtitles';
 import { debugLog } from '@/lib/debug';
 import { useLoginDialog } from '@/contexts/LoginDialogContext';
 import { AgeRestrictedMediaPlaceholder } from '@/components/AgeRestrictedMediaPlaceholder';
-import { isProtectedDivineMediaUrl } from '@/hooks/useAuthenticatedMediaUrl';
 
 interface VideoCardProps {
   video: ParsedVideoData;
@@ -124,9 +123,6 @@ export function VideoCard({
   // Subscribe to bandwidth tier changes - triggers re-render when tier changes
   // The tier itself is used internally by getOptimalVideoUrl
   const _bandwidthTier = useBandwidthTier();
-  const { user: currentUser } = useCurrentUser();
-  const { isVerified: isAdultVerified, confirmAdult } = useAdultVerification();
-  const { openLoginDialog } = useLoginDialog();
 
   // Compute optimal HLS URL based on current bandwidth tier
   // This dynamically selects 480p/720p/adaptive based on observed load performance
@@ -141,17 +137,13 @@ export function VideoCard({
   // Classic Vines also skip HLS because the transcoder distorts square 480x480 aspect ratio.
   // Only use HLS for longer content (>60s) if divine ever supports it.
   const isShortForm = !video.duration || video.duration <= 60;
-  const isProtectedMedia = isProtectedDivineMediaUrl(video.videoUrl);
-  const shouldBlockSecondaryAssetFallbacks = isProtectedMedia && !isAdultVerified && video.ageRestricted !== false;
   // When direct MP4 fails, retry with HLS as fallback (blob may be missing but transcode exists)
   const [mp4Failed, setMp4Failed] = useState(false);
   // When MP4 blob is missing (404), fall back to HLS if available (transcoded copy may exist)
-  const hlsFallbackUrl = mp4Failed && video.videoUrl?.includes('media.divine.video') && !shouldBlockSecondaryAssetFallbacks
+  const hlsFallbackUrl = mp4Failed && video.videoUrl?.includes('media.divine.video')
     ? video.hlsUrl || optimalHlsUrl
     : undefined;
-  const effectiveHlsUrl = shouldBlockSecondaryAssetFallbacks
-    ? undefined
-    : (hlsFallbackUrl || ((isClassicVine || isShortForm) ? undefined : (video.hlsUrl || (optimalHlsUrl !== video.videoUrl ? optimalHlsUrl : undefined))));
+  const effectiveHlsUrl = hlsFallbackUrl || ((isClassicVine || isShortForm) ? undefined : (video.hlsUrl || (optimalHlsUrl !== video.videoUrl ? optimalHlsUrl : undefined)));
   const { data: lists } = useVideosInLists(video.vineId ?? undefined);
 
   // NEW: Get reposter data from reposts array
@@ -271,10 +263,13 @@ export function VideoCard({
 
   const { mutate: deleteVideo, isPending: isDeleting } = useDeleteVideo();
   const canDelete = useCanDeleteVideo(video);
+  const { user: currentUser } = useCurrentUser();
   const coordinate = video.vineId ? `${SHORT_VIDEO_KIND}:${video.pubkey}:${video.vineId}` : undefined;
   const isPinned = useIsVideoPinned(coordinate);
   const { mutateAsync: pinVideo } = usePinVideo();
   const { mutateAsync: unpinVideo } = useUnpinVideo();
+  const { isVerified: isAdultVerified, confirmAdult } = useAdultVerification();
+  const { openLoginDialog } = useLoginDialog();
 
   // Get reactions data for the modal
   const { data: reactions } = useVideoReactions(video.id, video.pubkey, video.vineId);
@@ -317,9 +312,6 @@ export function VideoCard({
   const timestamp = video.originalVineTimestamp || video.createdAt;
 
   const date = new Date(timestamp * 1000);
-  // Explicit true only, not !== false: unknown status (undefined) should NOT
-  // show the lock overlay in cards. VideoPlayer's preflight HEAD check handles
-  // discovery of actually-gated content at playback time.
   const isAgeGated = video.ageRestricted === true && (!currentUser || !isAdultVerified);
 
   // Calculate timeAgo only for pre-2025 videos
@@ -421,7 +413,7 @@ export function VideoCard({
   const handleVideoError = () => {
     setShowThumbnailDuringStartup(false);
     // If MP4 failed and we haven't tried HLS yet, retry with HLS fallback
-    if (!mp4Failed && !effectiveHlsUrl && video.videoUrl?.includes('media.divine.video') && !shouldBlockSecondaryAssetFallbacks) {
+    if (!mp4Failed && !effectiveHlsUrl && video.videoUrl?.includes('media.divine.video')) {
       setMp4Failed(true);
     } else {
       setVideoError(true);

--- a/src/components/VideoGrid.test.tsx
+++ b/src/components/VideoGrid.test.tsx
@@ -117,24 +117,6 @@ describe('VideoGrid age-restricted gating', () => {
     expect(screen.queryByText('Log in to view')).not.toBeInTheDocument();
   });
 
-  it('treats protected media with unknown age status as gated for logged-out viewers', () => {
-    render(
-      <VideoGrid
-        videos={[
-          makeVideo({
-            id: 'unknown-status-video',
-            ageRestricted: undefined,
-            videoUrl: 'https://media.divine.video/unknown-status-video',
-          }),
-        ]}
-      />
-    );
-
-    expect(screen.getByText('Log in to view')).toBeInTheDocument();
-    expect(screen.queryByTestId('video-thumbnail-unknown-status-video')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('video-player-unknown-status-video')).not.toBeInTheDocument();
-  });
-
   it('fetches protected thumbnails with auth for verified viewers', async () => {
     mockUseCurrentUser.mockReturnValue({ user: { pubkey: 'a'.repeat(64) } });
     mockUseAdultVerification.mockReturnValue({

--- a/src/components/VideoGrid.tsx
+++ b/src/components/VideoGrid.tsx
@@ -10,7 +10,7 @@ import { AgeRestrictedMediaPlaceholder } from '@/components/AgeRestrictedMediaPl
 import { useLoginDialog } from '@/contexts/LoginDialogContext';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { useAdultVerification } from '@/hooks/useAdultVerification';
-import { isProtectedDivineMediaUrl, useAuthenticatedMediaUrl } from '@/hooks/useAuthenticatedMediaUrl';
+import { useAuthenticatedMediaUrl } from '@/hooks/useAuthenticatedMediaUrl';
 import { cn } from '@/lib/utils';
 import type { ParsedVideoData } from '@/types/video';
 import { buildVideoNavigationUrl, type VideoNavigationContext } from '@/hooks/useVideoNavigation';
@@ -56,7 +56,7 @@ function VideoGridMedia({
   const baseThumbnailUrl = video.thumbnailUrl || video.videoUrl;
   const { mediaUrl: authenticatedMediaUrl, isLoading } = useAuthenticatedMediaUrl(baseThumbnailUrl, {
     enabled: true,
-    ageRestricted: video.ageRestricted,
+    ageRestricted: !!video.ageRestricted,
   });
 
   if (isLoading) {
@@ -248,9 +248,7 @@ export function VideoGrid({ videos, loading = false, className, navigationContex
       {videos.map((video, index) => {
         const isHovered = hoveredVideo === video.id;
         const thumbnailFailed = failedThumbnails.has(video.id);
-        const isProtectedMedia = isProtectedDivineMediaUrl(video.videoUrl);
-        const shouldTreatAsGatedMedia = video.ageRestricted === true || (isProtectedMedia && video.ageRestricted !== false);
-        const isAgeGated = shouldTreatAsGatedMedia && (!user || !isAdultVerified);
+        const isAgeGated = video.ageRestricted === true && (!user || !isAdultVerified);
 
         return (
           <Card

--- a/src/components/VideoPlayer.authHeaders.test.tsx
+++ b/src/components/VideoPlayer.authHeaders.test.tsx
@@ -1,5 +1,5 @@
-// ABOUTME: Tests that VideoPlayer calls getAuthHeader for age-gated MP4 fetches
-// ABOUTME: Verifies NIP-98 viewer auth (no sha256 hint) for direct playback
+// ABOUTME: Tests that VideoPlayer forwards videoData.sha256 into getAuthHeader for MP4 fetches
+// ABOUTME: Verifies Blossom auth hint flows through for age-gated direct playback; absent when unknown
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, waitFor } from '@testing-library/react';
@@ -102,7 +102,7 @@ describe('VideoPlayer auth headers', () => {
     vi.restoreAllMocks();
   });
 
-  it('uses NIP-98 (no sha256) for direct MP4 fetch even when videoData.sha256 is set', async () => {
+  it('passes sha256 into getAuthHeader for direct MP4 fetch when videoData.sha256 is set', async () => {
     render(
       <VideoPlayer
         videoId="v1"
@@ -128,10 +128,10 @@ describe('VideoPlayer auth headers', () => {
     const [url, method, sha256] = getAuthHeader.mock.calls[0];
     expect(url).toBe(URL_MP4);
     expect(method ?? 'GET').toBe('GET');
-    expect(sha256).toBeUndefined();
+    expect(sha256).toBe(HASH);
   });
 
-  it('sends auth headers when ageRestricted is undefined (unknown moderation status)', async () => {
+  it('omits the sha256 hint when videoData.sha256 is absent', async () => {
     render(
       <VideoPlayer
         videoId="v2"
@@ -147,37 +147,13 @@ describe('VideoPlayer auth headers', () => {
           vineId: null,
           reposts: [],
           isVineMigrated: false,
-          ageRestricted: undefined,
+          ageRestricted: true,
         }}
       />,
     );
 
     await waitFor(() => expect(getAuthHeader).toHaveBeenCalled());
-  });
-
-  it('skips auth headers when ageRestricted is explicitly false', async () => {
-    render(
-      <VideoPlayer
-        videoId="v3"
-        src={URL_MP4}
-        videoData={{
-          id: 'v3',
-          pubkey: 'pub',
-          kind: SHORT_VIDEO_KIND,
-          createdAt: 0,
-          content: '',
-          videoUrl: URL_MP4,
-          hashtags: [],
-          vineId: null,
-          reposts: [],
-          isVineMigrated: false,
-          ageRestricted: false,
-        }}
-      />,
-    );
-
-    // Give the effect time to run, then verify no auth call was made
-    await new Promise((r) => setTimeout(r, 100));
-    expect(getAuthHeader).not.toHaveBeenCalled();
+    const [, , sha256] = getAuthHeader.mock.calls[0];
+    expect(sha256).toBeUndefined();
   });
 });

--- a/src/components/VideoPlayer.authHeaders.test.tsx
+++ b/src/components/VideoPlayer.authHeaders.test.tsx
@@ -1,5 +1,5 @@
-// ABOUTME: Tests that VideoPlayer forwards videoData.sha256 into getAuthHeader for MP4 fetches
-// ABOUTME: Verifies Blossom auth hint flows through for age-gated direct playback; absent when unknown
+// ABOUTME: Tests that VideoPlayer calls getAuthHeader for age-gated MP4 fetches
+// ABOUTME: Verifies NIP-98 viewer auth (no sha256 hint) for direct playback
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, waitFor } from '@testing-library/react';
@@ -102,7 +102,7 @@ describe('VideoPlayer auth headers', () => {
     vi.restoreAllMocks();
   });
 
-  it('passes sha256 into getAuthHeader for direct MP4 fetch when videoData.sha256 is set', async () => {
+  it('uses NIP-98 (no sha256) for direct MP4 fetch even when videoData.sha256 is set', async () => {
     render(
       <VideoPlayer
         videoId="v1"
@@ -128,10 +128,10 @@ describe('VideoPlayer auth headers', () => {
     const [url, method, sha256] = getAuthHeader.mock.calls[0];
     expect(url).toBe(URL_MP4);
     expect(method ?? 'GET').toBe('GET');
-    expect(sha256).toBe(HASH);
+    expect(sha256).toBeUndefined();
   });
 
-  it('omits the sha256 hint when videoData.sha256 is absent', async () => {
+  it('skips auth headers when ageRestricted is false', async () => {
     render(
       <VideoPlayer
         videoId="v2"
@@ -147,13 +147,12 @@ describe('VideoPlayer auth headers', () => {
           vineId: null,
           reposts: [],
           isVineMigrated: false,
-          ageRestricted: true,
+          ageRestricted: false,
         }}
       />,
     );
 
-    await waitFor(() => expect(getAuthHeader).toHaveBeenCalled());
-    const [, , sha256] = getAuthHeader.mock.calls[0];
-    expect(sha256).toBeUndefined();
+    await new Promise((r) => setTimeout(r, 100));
+    expect(getAuthHeader).not.toHaveBeenCalled();
   });
 });

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -132,9 +132,6 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
 
     // Adult verification hook
     const { isVerified: isAdultVerified, getAuthHeader } = useAdultVerification();
-    // Truthy-only (not !== false): treating undefined as restricted here causes
-    // getAuthHeader to return null for unsigned-in users, blanking ALL posters.
-    // The preflight HEAD check handles discovery of unknown-status videos.
     const { mediaUrl: authenticatedPosterUrl } = useAuthenticatedMediaUrl(poster, {
       enabled: !!poster && !requiresAuth && !authCheckPending,
       ageRestricted: !!videoData?.ageRestricted,
@@ -777,10 +774,10 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
           capLevelToPlayerSize: true, // Match quality to player size
         };
 
-        // Add custom auth loader when the video is (or may be) age-restricted.
+        // Add custom auth loader only when the video is age-restricted.
         // Public HLS streams must not carry an Authorization header — divine-blossom
         // rejects any malformed auth header with 401 even when the blob is public.
-        if (isAdultVerified && videoData?.ageRestricted !== false && isProtectedDivineMediaUrl(hlsUrl)) {
+        if (isAdultVerified && videoData?.ageRestricted) {
           verboseLog(`[VideoPlayer ${videoId}] Using NIP-98 auth loader for each HLS request`);
           hlsConfig.loader = createAuthLoader(getAuthHeader);
         }
@@ -843,18 +840,16 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
         verboseLog(`[VideoPlayer ${videoId}] Using direct playback - URL ${currentUrlIndex}/${allUrls.length - 1}: ${currentUrl}`);
 
         if (currentUrl) {
-          // Only fetch with auth headers when the video is (or may be) age-restricted.
+          // Only fetch with auth headers when the video is actually age-restricted.
           // Public blobs must not carry an Authorization header — divine-blossom
           // rejects any malformed auth header with 401 even when the blob is public,
           // so attaching auth optimistically locks users out of public content
           // whenever their signer produces an invalid event (e.g., JWT signer bugs).
-          if (isAdultVerified && videoData?.ageRestricted !== false && isProtectedDivineMediaUrl(currentUrl)) {
+          if (isAdultVerified && videoData?.ageRestricted) {
             verboseLog(`[VideoPlayer ${videoId}] Fetching MP4 with NIP-98 auth`);
             (async () => {
               try {
-                // NIP-98 (not BUD-01): Blossom's viewer auth path only accepts
-                // BUD-01 list events, rejecting get events with an action mismatch.
-                const authHeader = await getAuthHeader(currentUrl, 'GET');
+                const authHeader = await getAuthHeader(currentUrl, 'GET', videoData?.sha256);
                 // Check if request was aborted while getting auth header
                 if (abortController.signal.aborted) {
                   verboseLog(`[VideoPlayer ${videoId}] Fetch aborted before starting`);
@@ -932,7 +927,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
         }
       };
 
-    }, [hlsUrl, currentUrlIndex, allUrls, videoId, requiresAuth, isAdultVerified, authRetryCount, getAuthHeader, videoData?.ageRestricted]); // React to HLS URL, fallback, and auth changes
+    }, [hlsUrl, currentUrlIndex, allUrls, videoId, requiresAuth, isAdultVerified, authRetryCount, getAuthHeader, videoData?.sha256, videoData?.ageRestricted]); // React to HLS URL, fallback, and auth changes
 
     // Cleanup on unmount
     useEffect(() => {

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -849,7 +849,9 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
             verboseLog(`[VideoPlayer ${videoId}] Fetching MP4 with NIP-98 auth`);
             (async () => {
               try {
-                const authHeader = await getAuthHeader(currentUrl, 'GET', videoData?.sha256);
+                // NIP-98 (not BUD-01): Blossom's viewer auth path only accepts
+                // BUD-01 list events, rejecting get events with an action mismatch.
+                const authHeader = await getAuthHeader(currentUrl, 'GET');
                 // Check if request was aborted while getting auth header
                 if (abortController.signal.aborted) {
                   verboseLog(`[VideoPlayer ${videoId}] Fetch aborted before starting`);
@@ -927,7 +929,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
         }
       };
 
-    }, [hlsUrl, currentUrlIndex, allUrls, videoId, requiresAuth, isAdultVerified, authRetryCount, getAuthHeader, videoData?.sha256, videoData?.ageRestricted]); // React to HLS URL, fallback, and auth changes
+    }, [hlsUrl, currentUrlIndex, allUrls, videoId, requiresAuth, isAdultVerified, authRetryCount, getAuthHeader, videoData?.ageRestricted]); // React to HLS URL, fallback, and auth changes
 
     // Cleanup on unmount
     useEffect(() => {

--- a/src/hooks/useAuthenticatedMediaUrl.test.ts
+++ b/src/hooks/useAuthenticatedMediaUrl.test.ts
@@ -18,50 +18,6 @@ describe('useAuthenticatedMediaUrl', () => {
       isVerified: true,
       getAuthHeader: vi.fn().mockResolvedValue('Nostr signed-auth-header'),
     });
-    global.URL.createObjectURL = vi.fn().mockReturnValue('blob:authenticated');
-    global.URL.revokeObjectURL = vi.fn();
-  });
-
-  it('sends auth for verified user on unknown-status protected media', async () => {
-    const mockBlob = new Blob(['image'], { type: 'image/jpeg' });
-    global.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      blob: () => Promise.resolve(mockBlob),
-    }) as typeof fetch;
-    const { result } = renderHook(() =>
-      useAuthenticatedMediaUrl('https://media.divine.video/thumb.jpg', {
-        ageRestricted: undefined,
-      }),
-    );
-
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
-    });
-
-    expect(global.fetch).toHaveBeenCalledWith(
-      'https://media.divine.video/thumb.jpg',
-      expect.objectContaining({
-        headers: expect.objectContaining({
-          Authorization: 'Nostr signed-auth-header',
-        }),
-      }),
-    );
-    expect(result.current.mediaUrl).toBe('blob:authenticated');
-  });
-
-  it('skips auth for explicitly safe protected media', async () => {
-    const { result } = renderHook(() =>
-      useAuthenticatedMediaUrl('https://media.divine.video/thumb.jpg', {
-        ageRestricted: false,
-      }),
-    );
-
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
-    });
-
-    expect(global.fetch).not.toHaveBeenCalled();
-    expect(result.current.mediaUrl).toBe('https://media.divine.video/thumb.jpg');
   });
 
   it('does not fall back to the raw protected URL when authenticated fetch fails', async () => {

--- a/src/hooks/useAuthenticatedMediaUrl.ts
+++ b/src/hooks/useAuthenticatedMediaUrl.ts
@@ -13,10 +13,10 @@ export function isProtectedDivineMediaUrl(url: string): boolean {
 interface UseAuthenticatedMediaUrlOptions {
   enabled?: boolean;
   /**
-   * Three-state: true (restricted), false (explicitly safe), undefined (unknown).
-   * When true or undefined, attach auth if the viewer is verified — unknown-status
-   * protected media may be restricted and valid auth is accepted on public blobs.
-   * When false, skip auth (known-public, no header needed).
+   * Only attach a Nostr auth header when the resource is known to be age-restricted.
+   * Public blobs must NOT receive an Authorization header — the CDN rejects any
+   * malformed/invalid auth header with 401 even when the blob would otherwise
+   * be public. Default: false (assume public; pass through the URL untouched).
    */
   ageRestricted?: boolean;
 }
@@ -28,7 +28,7 @@ export function useAuthenticatedMediaUrl(
   mediaUrl: string | undefined;
   isLoading: boolean;
 } {
-  const { enabled = true, ageRestricted } = options;
+  const { enabled = true, ageRestricted = false } = options;
   const { isVerified, getAuthHeader } = useAdultVerification();
   const [mediaUrl, setMediaUrl] = useState<string | undefined>(url ?? undefined);
   const [isLoading, setIsLoading] = useState(false);
@@ -36,7 +36,7 @@ export function useAuthenticatedMediaUrl(
 
   useEffect(() => {
     const shouldAuthenticate =
-      !!url && enabled && ageRestricted !== false && isVerified && isProtectedDivineMediaUrl(url);
+      !!url && enabled && ageRestricted && isVerified && isProtectedDivineMediaUrl(url);
 
     if (!shouldAuthenticate) {
       setMediaUrl(url ?? undefined);

--- a/src/hooks/useInfiniteVideosFunnelcake.test.ts
+++ b/src/hooks/useInfiniteVideosFunnelcake.test.ts
@@ -6,7 +6,6 @@ import React from 'react';
 const mockFetchVideos = vi.fn();
 const mockFetchRecommendations = vi.fn();
 const mockTransformToVideoPage = vi.fn();
-const mockEnrichAgeRestrictedVideos = vi.fn();
 
 vi.mock('@/hooks/useCurrentUser', () => ({
   useCurrentUser: () => ({
@@ -24,10 +23,6 @@ vi.mock('@/lib/funnelcakeClient', () => ({
 
 vi.mock('@/lib/funnelcakeTransform', () => ({
   transformToVideoPage: mockTransformToVideoPage,
-}));
-
-vi.mock('@/lib/ageRestrictedVideos', () => ({
-  enrichAgeRestrictedVideos: mockEnrichAgeRestrictedVideos,
 }));
 
 vi.mock('@/lib/debug', () => ({
@@ -59,88 +54,10 @@ let useInfiniteVideosFunnelcake: typeof import('./useInfiniteVideosFunnelcake').
 
 beforeEach(async () => {
   vi.clearAllMocks();
-  mockEnrichAgeRestrictedVideos.mockImplementation(async (videos) => videos);
-  delete window.__DIVINE_FEED__;
-  delete window.__DIVINE_FEED_TYPE__;
   ({ useInfiniteVideosFunnelcake } = await import('./useInfiniteVideosFunnelcake'));
 });
 
 describe('useInfiniteVideosFunnelcake', () => {
-  it('enriches classics feeds with moderation age-gate status', async () => {
-    const transformedVideos = [
-      { id: 'video-1', pubkey: 'p1', kind: 34236, createdAt: 101, vineId: 'd-1', videoUrl: 'https://media.divine.video/hash1', reposts: [], isVineMigrated: true },
-    ];
-    const enrichedVideos = [
-      { ...transformedVideos[0], ageRestricted: true },
-    ];
-
-    mockFetchVideos.mockResolvedValueOnce({ videos: [{}], has_more: false, next_cursor: undefined });
-    mockTransformToVideoPage.mockReturnValueOnce({
-      videos: transformedVideos,
-      nextCursor: undefined,
-      hasMore: false,
-    });
-    mockEnrichAgeRestrictedVideos.mockResolvedValueOnce(enrichedVideos);
-
-    const { result } = renderHook(
-      () => useInfiniteVideosFunnelcake({ feedType: 'classics', pageSize: 12 }),
-      { wrapper: createWrapper() }
-    );
-
-    await waitFor(() => {
-      expect(result.current.isSuccess).toBe(true);
-    });
-
-    expect(mockEnrichAgeRestrictedVideos).toHaveBeenCalledWith(
-      transformedVideos,
-      expect.any(AbortSignal)
-    );
-    expect(result.current.data?.pages[0].videos[0].ageRestricted).toBe(true);
-  });
-
-  it('enriches edge-injected classics page before returning results', async () => {
-    const transformedVideos = [
-      { id: 'edge-video', pubkey: 'p2', kind: 34236, createdAt: 201, vineId: 'd-edge', videoUrl: 'https://media.divine.video/hash-edge', reposts: [], isVineMigrated: true },
-    ];
-    const enrichedVideos = [{ ...transformedVideos[0], ageRestricted: true }];
-
-    window.__DIVINE_FEED_TYPE__ = 'classics';
-    window.__DIVINE_FEED__ = {
-      videos: [{
-        id: 'raw-edge-id',
-        pubkey: 'p'.repeat(64),
-        created_at: 1700000200,
-        kind: 34236,
-        d_tag: 'raw-edge-d-tag',
-        video_url: 'https://media.divine.video/raw-edge-hash',
-      }],
-      has_more: false,
-      next_cursor: undefined,
-    };
-    mockTransformToVideoPage.mockReturnValueOnce({
-      videos: transformedVideos,
-      nextCursor: undefined,
-      hasMore: false,
-    });
-    mockEnrichAgeRestrictedVideos.mockResolvedValueOnce(enrichedVideos);
-
-    const { result } = renderHook(
-      () => useInfiniteVideosFunnelcake({ feedType: 'classics', pageSize: 12 }),
-      { wrapper: createWrapper() }
-    );
-
-    await waitFor(() => {
-      expect(result.current.isSuccess).toBe(true);
-    });
-
-    expect(mockFetchVideos).not.toHaveBeenCalled();
-    expect(mockEnrichAgeRestrictedVideos).toHaveBeenCalledWith(
-      transformedVideos,
-      expect.any(AbortSignal)
-    );
-    expect(result.current.data?.pages[0].videos[0].ageRestricted).toBe(true);
-  });
-
   it('uses cursor-based pagination for recommendations', async () => {
     // Page 1: server returns cursor for next page
     mockFetchRecommendations

--- a/src/hooks/useInfiniteVideosFunnelcake.ts
+++ b/src/hooks/useInfiniteVideosFunnelcake.ts
@@ -86,10 +86,6 @@ function isRecommendationsCursorPageParam(
     && typeof (pageParam as { popularOffset?: unknown }).popularOffset === 'number';
 }
 
-function shouldEnrichAgeGate(feedType: FunnelcakeFeedType): boolean {
-  return feedType === 'profile' || feedType === 'classics';
-}
-
 /**
  * Map feed type and sort mode to Funnelcake API options
  */
@@ -222,19 +218,16 @@ export function useInfiniteVideosFunnelcake({
         debugLog(`[useInfiniteVideosFunnelcake] Using edge-injected ${feedType} feed data`);
 
         const page = transformToVideoPage(edgeData);
-        const enrichedEdgeVideos = shouldEnrichAgeGate(feedType)
-          ? await enrichAgeRestrictedVideos(page.videos, signal)
-          : page.videos;
         performanceMonitor.recordFeedLoad({
           feedType: 'funnelcake-trending',
           queryTime: 0,
           parseTime: performance.now() - totalStart,
           totalTime: performance.now() - totalStart,
-          videoCount: enrichedEdgeVideos.length,
+          videoCount: page.videos.length,
           sortMode,
         });
         return {
-          videos: enrichedEdgeVideos,
+          videos: page.videos,
           nextCursor: page.nextCursor,
           offset: page.offset,
         };
@@ -386,7 +379,7 @@ export function useInfiniteVideosFunnelcake({
         }
       }
 
-      const enrichedVideos = shouldEnrichAgeGate(feedType)
+      const enrichedVideos = feedType === 'profile'
         ? await enrichAgeRestrictedVideos(page.videos, signal)
         : page.videos;
       const parseTime = performance.now() - parseStart;

--- a/src/hooks/useSubtitles.test.ts
+++ b/src/hooks/useSubtitles.test.ts
@@ -118,21 +118,4 @@ describe('useSubtitles protected media auth', () => {
     expect(fetchSpy).not.toHaveBeenCalled();
     expect(result.current.hasSubtitles).toBe(false);
   });
-
-  it('does not make raw CDN subtitle requests for protected media with unknown age gate status', async () => {
-    const fetchSpy = vi.fn();
-    global.fetch = fetchSpy as typeof fetch;
-
-    const { result } = renderHook(
-      () => useSubtitles(makeVideo({ ageRestricted: undefined })),
-      { wrapper: createWrapper() }
-    );
-
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
-    });
-
-    expect(fetchSpy).not.toHaveBeenCalled();
-    expect(result.current.hasSubtitles).toBe(false);
-  });
 });

--- a/src/hooks/useSubtitles.ts
+++ b/src/hooks/useSubtitles.ts
@@ -67,12 +67,11 @@ export function useSubtitles(
   const hasEmbeddedContent = !!video?.textTrackContent;
   const hasRef = !!video?.textTrackRef;
   const cdnHash = video?.videoUrl ? extractCdnHash(video.videoUrl) : null;
-  const isProtectedCdnUrl = !!video?.videoUrl && isProtectedDivineMediaUrl(video.videoUrl);
-  const shouldTreatAsProtectedCdn = isProtectedCdnUrl && video?.ageRestricted !== false;
+  const requiresProtectedCdnAuth = !!video?.ageRestricted && !!video?.videoUrl && isProtectedDivineMediaUrl(video.videoUrl);
   const queryEnabled = !!video && (hasEmbeddedContent || hasRef || !!cdnHash);
 
   const { data: cues = [], isLoading } = useQuery({
-    queryKey: ['subtitles', video?.id, video?.textTrackRef, cdnHash, shouldTreatAsProtectedCdn, isAdultVerified],
+    queryKey: ['subtitles', video?.id, video?.textTrackRef, cdnHash, requiresProtectedCdnAuth, isAdultVerified],
     queryFn: async ({ signal }) => {
       if (!video) return [];
 
@@ -107,11 +106,7 @@ export function useSubtitles(
       if (cdnHash) {
         try {
           const vttUrl = `https://media.divine.video/${cdnHash}/vtt`;
-          if (shouldTreatAsProtectedCdn && !isAdultVerified) {
-            return [];
-          }
-
-          const response = shouldTreatAsProtectedCdn
+          const response = requiresProtectedCdnAuth
             ? await (async () => {
                 const authHeader = await getAuthHeader(vttUrl, 'GET');
                 if (!authHeader) {

--- a/src/hooks/useVideoPrefetch.test.ts
+++ b/src/hooks/useVideoPrefetch.test.ts
@@ -49,26 +49,6 @@ describe('useVideoPrefetch', () => {
     expect(prefetchHrefs).not.toContain('https://media.divine.video/restricted-video.jpg');
   });
 
-  it('does not prefetch protected media when age-restriction status is unknown', () => {
-    renderHook(() =>
-      useVideoPrefetch('video-1', [
-        makeVideo({ id: 'video-1' }),
-        makeVideo({
-          id: 'unknown-status-video',
-          ageRestricted: undefined,
-          videoUrl: 'https://media.divine.video/unknown-status-video',
-          thumbnailUrl: 'https://media.divine.video/unknown-status-video.jpg',
-        }),
-      ]),
-    );
-
-    const prefetchHrefs = Array.from(document.head.querySelectorAll('link[rel="prefetch"]'))
-      .map((link) => (link as HTMLLinkElement).href);
-
-    expect(prefetchHrefs).not.toContain('https://media.divine.video/unknown-status-video');
-    expect(prefetchHrefs).not.toContain('https://media.divine.video/unknown-status-video.jpg');
-  });
-
   it('continues prefetching unrestricted upcoming media', () => {
     renderHook(() =>
       useVideoPrefetch('video-1', [

--- a/src/hooks/useVideoPrefetch.ts
+++ b/src/hooks/useVideoPrefetch.ts
@@ -15,10 +15,6 @@ function isProtectedDivineMediaUrl(url: string): boolean {
   }
 }
 
-function shouldSkipProtectedPrefetch(url: string | undefined, ageRestricted: boolean | undefined): boolean {
-  return !!url && isProtectedDivineMediaUrl(url) && ageRestricted !== false;
-}
-
 /**
  * Prefetch upcoming video URLs when the active video changes.
  * Inserts <link rel="prefetch"> elements into <head> for the next
@@ -61,10 +57,12 @@ export function useVideoPrefetch(
     // Collect unique URLs to prefetch (video URL + thumbnail)
     const urlsToPrefetch: { url: string; as: string }[] = [];
     for (const video of nextVideos) {
-      if (!shouldSkipProtectedPrefetch(video.videoUrl, video.ageRestricted)) {
+      const shouldSkipProtectedMediaPrefetch = !!video.ageRestricted;
+
+      if (video.videoUrl && !(shouldSkipProtectedMediaPrefetch && isProtectedDivineMediaUrl(video.videoUrl))) {
         urlsToPrefetch.push({ url: video.videoUrl, as: 'video' });
       }
-      if (video.thumbnailUrl && !shouldSkipProtectedPrefetch(video.thumbnailUrl, video.ageRestricted)) {
+      if (video.thumbnailUrl && !(shouldSkipProtectedMediaPrefetch && isProtectedDivineMediaUrl(video.thumbnailUrl))) {
         urlsToPrefetch.push({ url: video.thumbnailUrl, as: 'image' });
       }
     }

--- a/src/lib/funnelcakeTransform.test.ts
+++ b/src/lib/funnelcakeTransform.test.ts
@@ -116,11 +116,11 @@ describe('transformFunnelcakeVideo', () => {
   it('maps the raw Nostr content (description) to video.content, not the title', () => {
     const video = transformFunnelcakeVideo(makeRawVideo({
       title: 'First Divine Compilation 2026!',
-      content: 'I just made the world‘s first divine compilation.\n\nLink: https://youtu.be/abc',
+      content: 'I just made the world’s first divine compilation.\n\nLink: https://youtu.be/abc',
     }));
 
     expect(video.title).toBe('First Divine Compilation 2026!');
-    expect(video.content).toBe('I just made the world‘s first divine compilation.\n\nLink: https://youtu.be/abc');
+    expect(video.content).toBe('I just made the world’s first divine compilation.\n\nLink: https://youtu.be/abc');
   });
 
   it('leaves video.content empty when the API response has no content field', () => {

--- a/src/lib/funnelcakeTransform.test.ts
+++ b/src/lib/funnelcakeTransform.test.ts
@@ -116,11 +116,11 @@ describe('transformFunnelcakeVideo', () => {
   it('maps the raw Nostr content (description) to video.content, not the title', () => {
     const video = transformFunnelcakeVideo(makeRawVideo({
       title: 'First Divine Compilation 2026!',
-      content: 'I just made the world’s first divine compilation.\n\nLink: https://youtu.be/abc',
+      content: 'I just made the world‘s first divine compilation.\n\nLink: https://youtu.be/abc',
     }));
 
     expect(video.title).toBe('First Divine Compilation 2026!');
-    expect(video.content).toBe('I just made the world’s first divine compilation.\n\nLink: https://youtu.be/abc');
+    expect(video.content).toBe('I just made the world‘s first divine compilation.\n\nLink: https://youtu.be/abc');
   });
 
   it('leaves video.content empty when the API response has no content field', () => {
@@ -131,32 +131,6 @@ describe('transformFunnelcakeVideo', () => {
 
     expect(video.title).toBe('A title with no description');
     expect(video.content).toBe('');
-  });
-
-  it('preserves explicit non-restricted videos from the API payload', () => {
-    const video = transformFunnelcakeVideo(makeRawVideo({
-      age_restricted: false,
-    }));
-
-    expect(video.ageRestricted).toBe(false);
-  });
-
-  it('keeps age restriction unknown when API provides no moderation fields', () => {
-    const video = transformFunnelcakeVideo(makeRawVideo({
-      age_restricted: undefined,
-      moderation_status: undefined,
-    }));
-
-    expect(video.ageRestricted).toBeUndefined();
-  });
-
-  it('marks videos restricted when moderation status says age_restricted', () => {
-    const video = transformFunnelcakeVideo(makeRawVideo({
-      age_restricted: undefined,
-      moderation_status: 'age_restricted',
-    }));
-
-    expect(video.ageRestricted).toBe(true);
   });
 });
 

--- a/src/lib/funnelcakeTransform.ts
+++ b/src/lib/funnelcakeTransform.ts
@@ -36,18 +36,6 @@ function parseLoopsFromTags(tags?: string[][]): number | null {
   return Number.isFinite(loops) && loops > 0 ? loops : null;
 }
 
-function resolveAgeRestricted(raw: FunnelcakeVideoRaw): boolean | undefined {
-  if (raw.age_restricted === true || raw.moderation_status === 'age_restricted') {
-    return true;
-  }
-
-  if (raw.age_restricted === false) {
-    return false;
-  }
-
-  return undefined;
-}
-
 /**
  * Transform a single Funnelcake video to ParsedVideoData format
  */
@@ -98,7 +86,7 @@ export function transformFunnelcakeVideo(raw: FunnelcakeVideoRaw): ParsedVideoDa
     title: raw.title,
     dimensions: raw.dim ?? raw.dimensions, // Video dimensions from API (e.g., "1080x1920"); v2 uses `dimensions`
     sha256: extractSha256FromVideoUrl(raw.video_url),
-    ageRestricted: resolveAgeRestricted(raw),
+    ageRestricted: raw.age_restricted === true || raw.moderation_status === 'age_restricted',
     hashtags,
 
     // Vine-specific fields


### PR DESCRIPTION
## Summary

Partial revert of #348. Undoes the three-state `ageRestricted` gating that blanket age-gates all divine-hosted videos for unauthenticated users on profile pages. **Preserves the NIP-98 viewer auth fix** (BUD-01 → NIP-98 for MP4 direct fetches) since Blossom rejects BUD-01 get events.

### What's reverted (three-state gating)
- `funnelcakeTransform.ts` — `resolveAgeRestricted()` that returns `undefined` for `null`
- `VideoGrid.tsx` — `shouldTreatAsGatedMedia` with `!== false` pattern
- `useAuthenticatedMediaUrl.ts` — `ageRestricted !== false` default
- `ThumbnailPlayer.tsx` — raw ageRestricted propagation
- `useInfiniteVideosFunnelcake.ts` — expanded enrichment to classics + edge data
- `useSubtitles.ts`, `useVideoPrefetch.ts` — blocking for unknown status

### What's preserved (NIP-98 fix)
- `VideoPlayer.tsx` — `getAuthHeader(url, 'GET')` without sha256 (NIP-98 instead of BUD-01)
- `VideoPlayer.tsx` — dependency array cleanup
- `VideoPlayer.authHeaders.test.tsx` — updated test expectations

### Root cause

Two compounding issues prevent the three-state logic from working in production:

1. **Funnelcake user endpoints return `null` for `age_restricted`** — v1 omits the field, v2 returns `null`. `resolveAgeRestricted()` treats both as `undefined`.

2. **No production route for `/api/moderation/check-result/{sha256}`** — the Vite proxy is dev-only. In prod the fetch returns SPA HTML, json parse fails, enrichment leaves `ageRestricted: undefined`.

With `undefined`, VideoGrid's `isProtectedMedia && ageRestricted !== false` gates every divine-hosted video for unauthenticated users.

### Preconditions for re-landing three-state

- [ ] Funnelcake user endpoints return `false` (not `null`) for unmoderated content
- [ ] OR add production rewrite for `/api/moderation/check-result/*` → `moderation-api.divine.video/check-result/*`
- [ ] OR treat `null` as `false` in `resolveAgeRestricted()`