### PR TITLE
feat: linkify bare nostr identifiers in note content

### DIFF
--- a/src/components/InlineNostrText.test.tsx
+++ b/src/components/InlineNostrText.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { nip19 } from 'nostr-tools';
+import { InlineNostrText } from './InlineNostrText';
+
+vi.mock('@/hooks/useAuthor', () => ({
+  useAuthor: () => ({
+    data: { metadata: { name: 'rabble' } },
+    isLoading: false,
+  }),
+}));
+
+const PUBKEY_HEX = 'a'.repeat(64);
+const NPUB = nip19.npubEncode(PUBKEY_HEX);
+
+describe('InlineNostrText', () => {
+  it('replaces a bare npub1... with @displayName', () => {
+    render(<InlineNostrText text={`hi ${NPUB}!`} />);
+    expect(screen.getByText(/@rabble/)).toBeInTheDocument();
+  });
+
+  it('still replaces nostr:npub1... with @displayName (regression)', () => {
+    render(<InlineNostrText text={`hi nostr:${NPUB}!`} />);
+    expect(screen.getByText(/@rabble/)).toBeInTheDocument();
+  });
+
+  it('renders plain text when no mention is present', () => {
+    render(<InlineNostrText text="hello world" />);
+    expect(screen.getByText('hello world')).toBeInTheDocument();
+  });
+
+  it('does not match bech32-shaped strings mid-word', () => {
+    const { container } = render(<InlineNostrText text={`xxx${NPUB}yyy`} />);
+    expect(container.textContent).toBe(`xxx${NPUB}yyy`);
+    expect(container.textContent).not.toContain('@rabble');
+  });
+});

--- a/src/components/InlineNostrText.tsx
+++ b/src/components/InlineNostrText.tsx
@@ -6,7 +6,9 @@ import { nip19 } from 'nostr-tools';
 import { useAuthor } from '@/hooks/useAuthor';
 import { genUserName } from '@/lib/genUserName';
 
-const NOSTR_MENTION_REGEX = /nostr:(npub1[023456789acdefghjklmnpqrstuvwxyz]+)/g;
+// Matches both prefixed (nostr:npub1...) and bare (npub1...) forms.
+// Word boundary keeps `xxxnpub1...yyy` mid-word strings from matching.
+const NOSTR_MENTION_REGEX = /(?:nostr:)?\b(npub1[023456789acdefghjklmnpqrstuvwxyz]+)\b/g;
 
 /** Extract all npub pubkeys from a text string */
 function extractPubkeys(text: string): string[] {

--- a/src/components/NoteContent.test.tsx
+++ b/src/components/NoteContent.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { nip19 } from 'nostr-tools';
+import { NoteContent } from './NoteContent';
+import type { NostrEvent } from '@nostrify/nostrify';
+
+vi.mock('@/hooks/useAuthor', () => ({
+  useAuthor: () => ({
+    data: { metadata: { name: 'rabble' } },
+    isLoading: false,
+  }),
+}));
+
+const PUBKEY_HEX = 'a'.repeat(64);
+const NPUB = nip19.npubEncode(PUBKEY_HEX);
+const NOTE = nip19.noteEncode('b'.repeat(64));
+const NEVENT = nip19.neventEncode({ id: 'c'.repeat(64) });
+const NADDR = nip19.naddrEncode({ kind: 34236, pubkey: PUBKEY_HEX, identifier: 'video-id' });
+const NPROFILE = nip19.nprofileEncode({ pubkey: PUBKEY_HEX });
+
+function makeEvent(content: string): NostrEvent {
+  return {
+    id: '0'.repeat(64),
+    pubkey: '1'.repeat(64),
+    created_at: 0,
+    kind: 1,
+    tags: [],
+    content,
+    sig: '0'.repeat(128),
+  };
+}
+
+function renderContent(content: string) {
+  return render(
+    <MemoryRouter>
+      <NoteContent event={makeEvent(content)} />
+    </MemoryRouter>,
+  );
+}
+
+describe('NoteContent — bare nostr identifiers', () => {
+  it('linkifies a bare npub1... as @mention', () => {
+    renderContent(`hello ${NPUB}`);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', `/${NPUB}`);
+    expect(link.textContent).toBe('@rabble');
+  });
+
+  it('linkifies a bare note1...', () => {
+    renderContent(`see ${NOTE}`);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', `/${NOTE}`);
+    expect(link.textContent).toBe(NOTE);
+  });
+
+  it('linkifies a bare nevent1...', () => {
+    renderContent(`watch ${NEVENT}`);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', `/${NEVENT}`);
+  });
+
+  it('linkifies a bare naddr1...', () => {
+    renderContent(`open ${NADDR}`);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', `/${NADDR}`);
+  });
+
+  it('linkifies a bare nprofile1...', () => {
+    renderContent(`hi ${NPROFILE}`);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', `/${NPROFILE}`);
+  });
+});
+
+describe('NoteContent — prefixed nostr: form (regression)', () => {
+  it('still linkifies nostr:npub1... as @mention', () => {
+    renderContent(`hello nostr:${NPUB}`);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', `/${NPUB}`);
+    expect(link.textContent).toBe('@rabble');
+  });
+
+  it('still linkifies nostr:note1...', () => {
+    renderContent(`see nostr:${NOTE}`);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', `/${NOTE}`);
+  });
+});
+
+describe('NoteContent — non-matches', () => {
+  it('does not linkify a bech32-shaped id mid-word', () => {
+    renderContent(`xxx${NPUB}yyy`);
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('does not linkify obviously invalid bech32', () => {
+    renderContent('npub1notvalid');
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('still linkifies URLs', () => {
+    renderContent('check https://example.com out');
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', 'https://example.com');
+  });
+
+  it('still linkifies hashtags', () => {
+    renderContent('check #skating out');
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', '/t/skating');
+  });
+});

--- a/src/components/NoteContent.tsx
+++ b/src/components/NoteContent.tsx
@@ -20,16 +20,17 @@ export function NoteContent({
   const content = useMemo(() => {
     const text = event.content;
     
-    // Regex to find URLs, Nostr references, and hashtags
-    const regex = /(https?:\/\/[^\s]+)|nostr:(npub1|note1|nprofile1|nevent1)([023456789acdefghjklmnpqrstuvwxyz]+)|(#\w+)/g;
-    
+    // Regex to find URLs, Nostr references (with optional `nostr:` prefix), and hashtags.
+    // Word boundaries (\b) prevent mid-word false positives like `xxxnpub1...yyy`.
+    const regex = /(https?:\/\/[^\s]+)|(?:nostr:)?\b((?:npub1|note1|nprofile1|nevent1|naddr1)[023456789acdefghjklmnpqrstuvwxyz]+)\b|(#\w+)/g;
+
     const parts: React.ReactNode[] = [];
     let lastIndex = 0;
     let match: RegExpExecArray | null;
     let keyCounter = 0;
-    
+
     while ((match = regex.exec(text)) !== null) {
-      const [fullMatch, url, nostrPrefix, nostrData, hashtag] = match;
+      const [fullMatch, url, nostrId, hashtag] = match;
       const index = match.index;
       
       // Add text before this match
@@ -50,12 +51,11 @@ export function NoteContent({
             {url}
           </a>
         );
-      } else if (nostrPrefix && nostrData) {
+      } else if (nostrId) {
         // Handle Nostr references
         try {
-          const nostrId = `${nostrPrefix}${nostrData}`;
           const decoded = nip19.decode(nostrId);
-          
+
           if (decoded.type === 'npub') {
             const pubkey = decoded.data;
             parts.push(


### PR DESCRIPTION
## Summary

- `NoteContent` and `InlineNostrText` previously only matched the NIP-21 prefixed form (`nostr:npub1...`). Bare forms typed in video descriptions / bios (`npub1...`, `note1...`, etc.) rendered as plain text.
- Made `nostr:` prefix optional and added `\b` word boundaries to prevent mid-word false matches.
- Added `naddr1` support to `NoteContent` (was missing entirely — kind 30000+ addressable refs were never linkified).
- Added tests for both components covering bare + prefixed forms for every supported identifier type, plus regression coverage for URLs and hashtags.

Triggered by a video description containing a bare `npub1...` mention that wasn't clickable.

## Test plan

- [x] `npx vitest run src/components/NoteContent.test.tsx src/components/InlineNostrText.test.tsx` — 15/15 pass
- [x] `npx vitest run src/components/VideoCard.test.tsx src/pages/EventPage.test.tsx` — 10/10 regression pass
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: visit a video with a bare `npub1...` in its description and confirm it renders as `@displayname` linked to `/<npub>`
- [ ] Manual: confirm `nostr:npub1...` (prefixed) still works
- [ ] Manual: confirm a comment containing a bare `note1...` linkifies

🤖 Generated with [Claude Code](https://claude.com/claude-code)