### PR TITLE
feat: Popular tab with time-window selector on /trending

### DIFF
--- a/docs/superpowers/plans/2026-05-09-popular-time-window.md
+++ b/docs/superpowers/plans/2026-05-09-popular-time-window.md
@@ -280,7 +280,7 @@ vi.mock('@/lib/funnelcakeClient', () => ({
 }));
 ```
 
-In any existing `beforeEach` reset, add `mockFetchVideosV2.mockReset();` next to the existing resets (mirror whatever pattern is already there).
+No changes needed in `beforeEach` — the existing `vi.clearAllMocks()` (line 56) clears the new mock automatically.
 
 - [ ] **Step 2: Write the failing test**
 
@@ -1297,7 +1297,7 @@ In the browser:
 3. Click each period pill. URL updates `?sort=popular&period=…`. Feed re-fetches.
 4. Open DevTools Network tab. Confirm a request to `/api/v2/videos?sort=popular&period=<value>&limit=12` for each window.
 5. Refresh on `/trending?sort=popular&period=week`. Page restores Popular + This Week.
-6. Visit `/trending?sort=controversial`. URL is rewritten to `/trending?sort=hot` and Hot tab is active.
+6. Visit `/trending?sort=controversial`. Hot tab is active and the period row is hidden. (The URL itself stays `?sort=controversial` — coercion is render-only by design.)
 7. Visit `/trending?sort=popular&period=now`. If feed is empty (off-hours), see "Quiet hour — try a wider window" with a button that navigates to `?sort=popular&period=today`.
 
 - [ ] **Step 4: Open the PR**
@@ -1318,7 +1318,7 @@ gh pr create --title "feat: Popular tab with time-window selector on /trending" 
 - [ ] `/trending` defaults to Hot, no period row
 - [ ] `/trending?sort=popular` shows period row, defaults to Today
 - [ ] Each period pill issues `/api/v2/videos?sort=popular&period=…`
-- [ ] `/trending?sort=controversial` redirects to `/trending?sort=hot`
+- [ ] `/trending?sort=controversial` renders the Hot tab (URL stays as-is — coercion is render-only)
 - [ ] `/trending?sort=popular&period=week` deep-link survives refresh
 - [ ] Quiet-hour empty state appears for empty `now` window with one-tap fix
 - [ ] Axe a11y sweep green on `/trending?sort=popular&period=today`

--- a/docs/superpowers/plans/2026-05-09-popular-time-window.md
+++ b/docs/superpowers/plans/2026-05-09-popular-time-window.md
@@ -36,8 +36,8 @@
 | --- | --- |
 | `src/lib/funnelcakeClient.test.ts` (new or extended) | `fetchVideos` / `fetchVideosV2` include `period` when set, omit when undefined |
 | `src/hooks/useInfiniteVideosFunnelcake.test.ts` (extend) | `sortMode='popular'` + `period` plumbs to `fetchVideosV2` |
-| `src/hooks/useVideoProvider.test.ts` (extend, may need creation) | `SortMode 'popular'` maps + `period` passes through |
-| `src/pages/TrendingPage.test.tsx` (new or extended) | URL state, period row visibility, controversial coercion |
+| `src/pages/TrendingPage.test.tsx` (new) | URL state, period row visibility, controversial coercion |
+| `src/components/VideoFeed.test.tsx` (extend) | Quiet-hour empty state for popular + now (Task 9) |
 | `src/lib/constants/sortModes.test.ts` (new) | Asserts shape of constants and that `controversial` is gone |
 
 ---
@@ -53,6 +53,11 @@
 ## Conventions
 
 - Commit format: `type: description` (e.g. `feat(popular): add period selector to /trending`).
+- **Each commit body MUST end with the project's AI-assist footer** (per `CLAUDE.md`):
+  ```
+  Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
+  ```
+  Pass via heredoc — see the project's commit examples. Update the model name only if the project's `CLAUDE.md` has been updated to a newer model.
 - After every task, run `npx tsc --noEmit` and the touched test files; do not commit on red.
 - Each task ends with a `git add <specific files>` (not `-A`) and a commit.
 - Do not amend; if hooks fail, fix and create a new commit.
@@ -728,8 +733,6 @@ Under `trendingPage`, extend the object:
     "rssTitle": "DiVine - Trending",
     "rssLink": "RSS",
     "popular": {
-      "tabLabel": "Popular",
-      "tabDescription": "Trending in this window",
       "period": {
         "label": "Window",
         "now": "Now",
@@ -1226,8 +1229,12 @@ git commit -m "feat(popular): quiet-hour empty state for popular + now"
 For each of the 14 locales, add the same `trendingPage.popular` shape under `trendingPage`. Use locale-appropriate translations (delegate to the same translation pipeline / model used in prior commits — see commit `8ee809b` for the exact prompt style if needed).
 
 Translations must be casual-direct, never corporate. Examples (German):
-- `tabLabel`: `"Beliebt"`
-- `tabDescription`: `"Trends in diesem Zeitraum"`
+- `period.label`: `"Zeitraum"`
+- `period.now`: `"Jetzt"`
+- `period.today`: `"Heute"`
+- `period.week`: `"Diese Woche"`
+- `period.month`: `"Diesen Monat"`
+- `period.all`: `"Alle Zeit"`
 - `emptyHeading`: `"Stille Stunde"`
 - `emptyBody`: `"Versuch ein größeres Zeitfenster."`
 - `emptyAction`: `"Heute anzeigen"`

--- a/docs/superpowers/plans/2026-05-09-popular-time-window.md
+++ b/docs/superpowers/plans/2026-05-09-popular-time-window.md
@@ -1,0 +1,1195 @@
+# Popular feed with time-window selector — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `Popular` tab on `/trending` that calls `api.divine.video` with `sort=popular` and a user-selected time window (`now | today | week | month | all`), deep-linkable via `?sort=&period=`. Drop `Controversial` from visible tabs.
+
+**Architecture:** Page-level URL state (`useSearchParams`) drives `sort` + `period`. `VideoFeed` gains an optional `period` prop, threaded through `useVideoProvider` → `useInfiniteVideosFunnelcake` → `fetchVideosV2`/`fetchVideos`. The period control row is conditionally rendered only when `sort === 'popular'`. No backend changes (the API already supports `period`).
+
+**Tech Stack:** React 18, React Router v6, TanStack Query, Vitest + React Testing Library, Playwright (axe), Tailwind, shadcn/ui, Phosphor icons.
+
+**Spec:** `docs/superpowers/specs/2026-05-09-popular-time-window-design.md`
+
+---
+
+## File Structure
+
+### Modified files
+
+| File | Change |
+| --- | --- |
+| `src/types/funnelcake.ts` | Add `FunnelcakePeriod` type; add `period` to `FunnelcakeFetchOptions` |
+| `src/types/nostr.ts` | Add `'popular'` to `SortMode` union (keep `'controversial'` for URL coercion) |
+| `src/lib/funnelcakeClient.ts` | Thread `period` through `fetchVideos` and `fetchVideosV2` |
+| `src/hooks/useInfiniteVideosFunnelcake.ts` | Add `'popular'` to `FunnelcakeSortMode`; accept `period` option; branch on `sortMode='popular'` |
+| `src/hooks/useVideoProvider.ts` | Accept `period`; map `SortMode 'popular'` → Funnelcake `'popular'`; pass through |
+| `src/components/VideoFeed.tsx` | Accept `period` prop; pass to `useVideoProvider` |
+| `src/lib/constants/sortModes.ts` | Drop `controversial` from `EXTENDED_SORT_MODES` + `SEARCH_SORT_MODES`; add `popular`; add `POPULAR_PERIODS` |
+| `src/pages/TrendingPage.tsx` | URL-driven `sort`+`period`; render period row when `sort='popular'`; coerce legacy `controversial` |
+| `src/lib/i18n/locales/en/common.json` | Add `trendingPage.popular.*` keys |
+| `src/lib/i18n/locales/{de,es,fr,pt,it,ja,ko,zh,ar,hi,ru,nl,sv,pl,ro,fil}/common.json` | Translated keys |
+| `tests/visual/a11y.spec.ts` | Add `/trending?sort=popular&period=today` to axe sweep |
+
+### New / modified test files
+
+| File | Purpose |
+| --- | --- |
+| `src/lib/funnelcakeClient.test.ts` (new or extended) | `fetchVideos` / `fetchVideosV2` include `period` when set, omit when undefined |
+| `src/hooks/useInfiniteVideosFunnelcake.test.ts` (extend) | `sortMode='popular'` + `period` plumbs to `fetchVideosV2` |
+| `src/hooks/useVideoProvider.test.ts` (extend, may need creation) | `SortMode 'popular'` maps + `period` passes through |
+| `src/pages/TrendingPage.test.tsx` (new or extended) | URL state, period row visibility, controversial coercion |
+| `src/lib/constants/sortModes.test.ts` (new) | Asserts shape of constants and that `controversial` is gone |
+
+---
+
+## Skills To Reference
+
+- @superpowers:test-driven-development — Red/Green/Refactor for every step
+- @superpowers:verification-before-completion — Run tests/typecheck before each commit; never claim done without evidence
+- @CLAUDE.md (project) — Brand rules: no `uppercase` Tailwind class, no `lucide-react`, no gradients on layout surfaces; voice = casual-direct
+
+---
+
+## Conventions
+
+- Commit format: `type: description` (e.g. `feat(popular): add period selector to /trending`).
+- After every task, run `npx tsc --noEmit` and the touched test files; do not commit on red.
+- Each task ends with a `git add <specific files>` (not `-A`) and a commit.
+- Do not amend; if hooks fail, fix and create a new commit.
+
+---
+
+## Task 1: Add `FunnelcakePeriod` type and option
+
+**Files:**
+- Modify: `src/types/funnelcake.ts:124-133`
+- Test: (no direct unit test — covered indirectly by client tests in Task 2)
+
+- [ ] **Step 1: Add the type and option field**
+
+In `src/types/funnelcake.ts`, immediately above `export interface FunnelcakeFetchOptions`:
+
+```ts
+/**
+ * Time window for popular/trending sorts on /api/videos and /api/v2/videos.
+ * Maps directly to the API's `period` query parameter.
+ */
+export type FunnelcakePeriod = 'now' | 'today' | 'week' | 'month' | 'all';
+```
+
+In `FunnelcakeFetchOptions`, add a `period` field after `sort`:
+
+```ts
+export interface FunnelcakeFetchOptions {
+  sort?: 'trending' | 'recent' | 'popular' | 'loops' | 'engagement' | 'watching' | 'likes' | 'comments' | 'published';
+  period?: FunnelcakePeriod;   // Window for popular/trending; ignored by other sorts
+  limit?: number;
+  // ...rest unchanged
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: PASS (no TS errors).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/types/funnelcake.ts
+git commit -m "feat(funnelcake): add FunnelcakePeriod type and period option"
+```
+
+---
+
+## Task 2: Thread `period` through `fetchVideos` and `fetchVideosV2`
+
+**Files:**
+- Modify: `src/lib/funnelcakeClient.ts:166-215` (`fetchVideos`) and `:229-271` (`fetchVideosV2`)
+- Test: `src/lib/funnelcakeClient.test.ts` (extend if exists, else create)
+
+- [ ] **Step 1: Locate or create the test file**
+
+Run: `ls src/lib/funnelcakeClient.test.ts 2>/dev/null && echo EXISTS || echo MISSING`
+
+If MISSING, create the file with the standard imports:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fetchVideos, fetchVideosV2 } from './funnelcakeClient';
+
+describe('funnelcakeClient period parameter', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+});
+```
+
+If EXISTS, append the new `describe` block (or add tests inside an existing block).
+
+- [ ] **Step 2: Write failing tests for `period`**
+
+```ts
+it('fetchVideos includes period when provided', async () => {
+  const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+    new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } })
+  );
+
+  await fetchVideos('https://api.divine.video', { sort: 'popular', period: 'week', limit: 12 });
+
+  const calledUrl = String((fetchSpy.mock.calls[0] as [URL | string, ...unknown[]])[0]);
+  expect(calledUrl).toContain('sort=popular');
+  expect(calledUrl).toContain('period=week');
+});
+
+it('fetchVideos omits period when undefined', async () => {
+  const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+    new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } })
+  );
+
+  await fetchVideos('https://api.divine.video', { sort: 'popular', limit: 12 });
+
+  const calledUrl = String((fetchSpy.mock.calls[0] as [URL | string, ...unknown[]])[0]);
+  expect(calledUrl).not.toContain('period=');
+});
+
+it('fetchVideosV2 includes period when provided', async () => {
+  const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+    new Response(JSON.stringify({ data: [], pagination: { has_more: false } }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  );
+
+  await fetchVideosV2('https://api.divine.video', { sort: 'popular', period: 'today', limit: 12 });
+
+  const calledUrl = String((fetchSpy.mock.calls[0] as [URL | string, ...unknown[]])[0]);
+  expect(calledUrl).toContain('sort=popular');
+  expect(calledUrl).toContain('period=today');
+});
+
+it('fetchVideosV2 omits period when undefined', async () => {
+  const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+    new Response(JSON.stringify({ data: [], pagination: { has_more: false } }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  );
+
+  await fetchVideosV2('https://api.divine.video', { sort: 'watching', limit: 12 });
+
+  const calledUrl = String((fetchSpy.mock.calls[0] as [URL | string, ...unknown[]])[0]);
+  expect(calledUrl).not.toContain('period=');
+});
+```
+
+- [ ] **Step 3: Run tests, verify they fail**
+
+Run: `npx vitest run src/lib/funnelcakeClient.test.ts`
+Expected: FAIL — period appears nowhere in URLs.
+
+- [ ] **Step 4: Update `fetchVideos`**
+
+In `src/lib/funnelcakeClient.ts`, edit `fetchVideos` (around line 170):
+
+```ts
+const { sort = 'trending', period, limit = 20, before, offset, classic, platform, category, signal } = options;
+
+const params: Record<string, string | number | boolean | undefined> = {
+  sort,
+  period,
+  limit,
+  classic,
+  platform,
+  category,
+};
+```
+
+(`buildUrl` already drops `undefined` values, so `period` will be omitted when not set.)
+
+- [ ] **Step 5: Update `fetchVideosV2`**
+
+In the same file, edit `fetchVideosV2` (around line 233):
+
+```ts
+const { sort = 'watching', period, limit = 20, before, offset, classic, platform, category, signal } = options;
+
+const params: Record<string, string | number | boolean | undefined> = {
+  sort,
+  period,
+  limit,
+  classic,
+  platform,
+  category,
+};
+```
+
+- [ ] **Step 6: Run tests, verify they pass**
+
+Run: `npx vitest run src/lib/funnelcakeClient.test.ts`
+Expected: PASS.
+
+- [ ] **Step 7: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/lib/funnelcakeClient.ts src/lib/funnelcakeClient.test.ts
+git commit -m "feat(funnelcake): thread period query param through fetchVideos and fetchVideosV2"
+```
+
+---
+
+## Task 3: Add `'popular'` to `FunnelcakeSortMode` and wire `period` through the hook
+
+**Files:**
+- Modify: `src/hooks/useInfiniteVideosFunnelcake.ts:16-17,89-163,177-205`
+- Test: `src/hooks/useInfiniteVideosFunnelcake.test.ts` (extend)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/hooks/useInfiniteVideosFunnelcake.test.ts` (inside the existing `describe`):
+
+```ts
+describe('popular sort with period', () => {
+  it('passes sort=popular and the chosen period to fetchVideosV2', async () => {
+    mockFetchVideosV2.mockResolvedValueOnce({
+      videos: [{}],
+      has_more: false,
+      next_cursor: undefined,
+    });
+    mockTransformToVideoPage.mockReturnValueOnce({
+      videos: [{ id: 'v1', pubkey: 'p1', kind: 34236, createdAt: 1, vineId: 'd1' }],
+      nextCursor: undefined,
+      hasMore: false,
+    });
+
+    const { result } = renderHook(
+      () => useInfiniteVideosFunnelcake({
+        feedType: 'trending',
+        sortMode: 'popular',
+        period: 'week',
+        pageSize: 12,
+      }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockFetchVideosV2).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        sort: 'popular',
+        period: 'week',
+        limit: 12,
+      }),
+    );
+  });
+
+  it('defaults popular sort to period=today when period is omitted', async () => {
+    mockFetchVideosV2.mockResolvedValueOnce({ videos: [], has_more: false, next_cursor: undefined });
+    mockTransformToVideoPage.mockReturnValueOnce({ videos: [], nextCursor: undefined, hasMore: false });
+
+    renderHook(
+      () => useInfiniteVideosFunnelcake({
+        feedType: 'trending',
+        sortMode: 'popular',
+        pageSize: 12,
+      }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() =>
+      expect(mockFetchVideosV2).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ sort: 'popular', period: 'today' }),
+      ),
+    );
+  });
+});
+```
+
+> Note: if `mockFetchVideosV2` does not exist in the test file, add it alongside the existing `mockFetchVideos` mock at the top of the file (mirror the existing pattern that mocks `@/lib/funnelcakeClient`).
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+Run: `npx vitest run src/hooks/useInfiniteVideosFunnelcake.test.ts -t "popular sort with period"`
+Expected: FAIL — `'popular'` not assignable to `FunnelcakeSortMode`.
+
+- [ ] **Step 3: Extend the type and options**
+
+In `src/hooks/useInfiniteVideosFunnelcake.ts`:
+
+```ts
+export type FunnelcakeSortMode = 'trending' | 'recent' | 'loops' | 'engagement' | 'classic' | 'watching' | 'popular';
+
+interface UseInfiniteVideosFunnelcakeOptions {
+  feedType: FunnelcakeFeedType;
+  apiUrl?: string;
+  sortMode?: FunnelcakeSortMode;
+  period?: FunnelcakePeriod;   // NEW
+  hashtag?: string;
+  category?: string;
+  pubkey?: string;
+  pageSize?: number;
+  enabled?: boolean;
+  randomizeWithinTop?: number;
+}
+```
+
+Import `FunnelcakePeriod` from `@/types/funnelcake`.
+
+- [ ] **Step 4: Wire `period` into `getFetchOptions`**
+
+Update the function signature and the `'trending'` branch:
+
+```ts
+function getFetchOptions(
+  feedType: FunnelcakeFeedType,
+  sortMode?: FunnelcakeSortMode,
+  pageSize: number = 20,
+  period?: FunnelcakePeriod,
+): FunnelcakeFetchOptions {
+  const baseOptions: FunnelcakeFetchOptions = { limit: pageSize };
+
+  switch (feedType) {
+    // ...other cases unchanged...
+
+    case 'trending':
+      if (sortMode === 'classic') {
+        return { ...baseOptions, classic: true, platform: 'vine', sort: 'loops' };
+      }
+      if (sortMode === 'popular') {
+        return { ...baseOptions, sort: 'popular', period: period ?? 'today' };
+      }
+      return { ...baseOptions, sort: sortMode || 'watching' };
+
+    // ...
+  }
+}
+```
+
+- [ ] **Step 5: Pass `period` from the hook body and into the queryKey**
+
+Update the `useInfiniteVideosFunnelcake` function signature and queryKey:
+
+```ts
+export function useInfiniteVideosFunnelcake({
+  feedType, apiUrl, sortMode, period, hashtag, category, pubkey,
+  pageSize = 12, enabled = true, randomizeWithinTop,
+}: UseInfiniteVideosFunnelcakeOptions) {
+  // ...existing setup...
+
+  return useInfiniteQuery<FunnelcakeVideoPage, Error>({
+    queryKey: ['funnelcake-videos', feedType, effectiveApiUrl, sortMode, period, hashtag, category, pubkey, pageSize, randomStartOffset],
+    // ...
+  });
+```
+
+And inside the queryFn where `getFetchOptions` is called:
+
+```ts
+const options = getFetchOptions(feedType, sortMode, pageSize, period);
+```
+
+- [ ] **Step 6: Run the popular tests**
+
+Run: `npx vitest run src/hooks/useInfiniteVideosFunnelcake.test.ts -t "popular sort with period"`
+Expected: PASS.
+
+- [ ] **Step 7: Run the full test file to confirm no regressions**
+
+Run: `npx vitest run src/hooks/useInfiniteVideosFunnelcake.test.ts`
+Expected: PASS (all).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/hooks/useInfiniteVideosFunnelcake.ts src/hooks/useInfiniteVideosFunnelcake.test.ts
+git commit -m "feat(feed): wire period through useInfiniteVideosFunnelcake for popular sort"
+```
+
+---
+
+## Task 4: Add `'popular'` to `SortMode` and update `useVideoProvider`
+
+**Files:**
+- Modify: `src/types/nostr.ts:34`
+- Modify: `src/hooks/useVideoProvider.ts:18-26,107-124,207-242`
+
+- [ ] **Step 1: Add `'popular'` to the `SortMode` union**
+
+In `src/types/nostr.ts`:
+
+```ts
+export type SortMode = 'hot' | 'top' | 'rising' | 'controversial' | 'classic' | 'popular';
+```
+
+(`'controversial'` stays for URL coercion. We'll remove it from visible tabs in Task 6.)
+
+- [ ] **Step 2: Update `useVideoProvider` mapping**
+
+In `src/hooks/useVideoProvider.ts`, update `mapToFunnelcakeSortMode`:
+
+```ts
+function mapToFunnelcakeSortMode(sortMode?: SortMode): FunnelcakeSortMode | undefined {
+  if (!sortMode) return undefined;
+  switch (sortMode) {
+    case 'hot':           return 'watching';
+    case 'top':           return 'loops';
+    case 'rising':        return 'engagement';
+    case 'controversial': return 'engagement';
+    case 'classic':       return 'classic';
+    case 'popular':       return 'popular';
+    default:              return 'trending';
+  }
+}
+```
+
+Add `period` to options and pass it through:
+
+```ts
+import type { FunnelcakePeriod } from '@/types/funnelcake';
+
+interface UseVideoProviderOptions {
+  feedType: VideoFeedType;
+  sortMode?: SortMode;
+  period?: FunnelcakePeriod;   // NEW
+  hashtag?: string;
+  category?: string;
+  pubkey?: string;
+  pageSize?: number;
+  enabled?: boolean;
+}
+
+export function useVideoProvider({
+  feedType, sortMode, period, hashtag, category, pubkey,
+  pageSize = 12, enabled = true,
+}: UseVideoProviderOptions): VideoProviderResult {
+  // ...
+
+  const funnelcakeQuery = useInfiniteVideosFunnelcake({
+    feedType: mapToFunnelcakeFeedType(feedType),
+    apiUrl: decision.apiUrl,
+    sortMode: mapToFunnelcakeSortMode(sortMode),
+    period,   // NEW
+    hashtag,
+    category,
+    pubkey,
+    pageSize,
+    enabled: enabled && shouldUseFunnelcake,
+    randomizeWithinTop: feedType === 'classics' ? 500 : undefined,
+  });
+
+  // ...rest unchanged
+}
+```
+
+- [ ] **Step 3: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/types/nostr.ts src/hooks/useVideoProvider.ts
+git commit -m "feat(feed): map SortMode 'popular' and pass period through provider"
+```
+
+---
+
+## Task 5: Add `period` prop to `VideoFeed`
+
+**Files:**
+- Modify: `src/components/VideoFeed.tsx:33-103`
+
+- [ ] **Step 1: Add the prop and forward it**
+
+Update the `VideoFeedProps` interface and the function:
+
+```ts
+import type { FunnelcakePeriod } from '@/types/funnelcake';
+
+interface VideoFeedProps {
+  feedType?: 'discovery' | 'home' | 'trending' | 'hashtag' | 'profile' | 'recent' | 'classics' | 'foryou' | 'category';
+  hashtag?: string;
+  category?: string;
+  pubkey?: string;
+  limit?: number;
+  sortMode?: SortMode;
+  period?: FunnelcakePeriod;   // NEW — only meaningful when sortMode='popular' on a trending feed
+  // ...
+}
+```
+
+In the function body, destructure `period` and pass it into `useVideoProvider`:
+
+```ts
+export function VideoFeed({
+  // ...existing...
+  sortMode,
+  period,
+  // ...
+}: VideoFeedProps) {
+  // ...
+
+  const { data, fetchNextPage, hasNextPage, isLoading, error, refetch, dataSource } = useVideoProvider({
+    feedType,
+    hashtag,
+    category,
+    pubkey,
+    pageSize: limit,
+    sortMode,
+    period,   // NEW
+  });
+  // ...
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 3: Run the existing VideoFeed tests**
+
+Run: `npx vitest run src/components/VideoFeed.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/VideoFeed.tsx
+git commit -m "feat(feed): add period prop to VideoFeed"
+```
+
+---
+
+## Task 6: Update sort-mode constants — drop Controversial, add Popular, add periods
+
+**Files:**
+- Modify: `src/lib/constants/sortModes.ts`
+- Test: `src/lib/constants/sortModes.test.ts` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/constants/sortModes.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import {
+  EXTENDED_SORT_MODES,
+  SEARCH_SORT_MODES,
+  POPULAR_PERIODS,
+} from './sortModes';
+
+describe('sortModes constants', () => {
+  it('EXTENDED_SORT_MODES contains popular and not controversial', () => {
+    const values = EXTENDED_SORT_MODES.map(m => m.value);
+    expect(values).toContain('popular');
+    expect(values).not.toContain('controversial');
+  });
+
+  it('EXTENDED_SORT_MODES places popular between rising and classic', () => {
+    const values = EXTENDED_SORT_MODES.map(m => m.value);
+    const rising = values.indexOf('rising');
+    const popular = values.indexOf('popular');
+    const classic = values.indexOf('classic');
+    expect(rising).toBeGreaterThanOrEqual(0);
+    expect(popular).toBe(rising + 1);
+    expect(classic).toBe(popular + 1);
+  });
+
+  it('SEARCH_SORT_MODES does not contain controversial', () => {
+    const values = SEARCH_SORT_MODES.map(m => m.value);
+    expect(values).not.toContain('controversial');
+  });
+
+  it('POPULAR_PERIODS contains the five expected windows in order', () => {
+    expect(POPULAR_PERIODS.map(p => p.value)).toEqual(['now', 'today', 'week', 'month', 'all']);
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify failure**
+
+Run: `npx vitest run src/lib/constants/sortModes.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Update `sortModes.ts`**
+
+In `src/lib/constants/sortModes.ts`:
+
+1. Add `TrendUp` to the existing import (already imported as `TrendingUp`, reuse) and `Hourglass`, `Calendar`, `CalendarBlank`, `Infinity` from `@phosphor-icons/react` for periods. (Adjust import names to whatever Phosphor exports; if a name is unavailable, fall back to `Clock` for any window.)
+
+2. Replace `EXTENDED_SORT_MODES`:
+
+```ts
+export const EXTENDED_SORT_MODES: SortModeDefinition[] = [
+  { value: 'hot',     label: 'Hot',     description: 'Recent + high engagement', icon: Flame },
+  { value: undefined, label: 'New',     description: 'Latest videos',           icon: Clock },
+  { value: 'top',     label: 'Top',     description: 'Most viewed all-time',    icon: TrendingUp },
+  { value: 'rising',  label: 'Rising',  description: 'Gaining traction',        icon: Zap },
+  { value: 'popular', label: 'Popular', description: 'Trending in this window', icon: TrendingUp },
+  { value: 'classic', label: 'Classic', description: 'Vine archive favorites',  icon: Clapperboard },
+];
+```
+
+3. Update `SEARCH_SORT_MODES` to drop the `controversial` entry.
+
+4. Add `POPULAR_PERIODS`:
+
+```ts
+import type { FunnelcakePeriod } from '@/types/funnelcake';
+
+export interface PopularPeriodDefinition {
+  value: FunnelcakePeriod;
+  label: string;            // i18n key: trendingPage.popular.period.<value>
+  shortLabel: string;       // for compact pills on mobile
+}
+
+export const POPULAR_PERIODS: PopularPeriodDefinition[] = [
+  { value: 'now',   label: 'Now',          shortLabel: 'Now' },
+  { value: 'today', label: 'Today',        shortLabel: 'Today' },
+  { value: 'week',  label: 'This Week',    shortLabel: 'Week' },
+  { value: 'month', label: 'This Month',   shortLabel: 'Month' },
+  { value: 'all',   label: 'All Time',     shortLabel: 'All' },
+];
+```
+
+> Brand check: do **not** add a Tailwind `uppercase` class anywhere. The labels above are in title case as written.
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `npx vitest run src/lib/constants/sortModes.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Run brand guardrail tests (no uppercase, no lucide)**
+
+Run: `npx vitest run tests/brand`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/constants/sortModes.ts src/lib/constants/sortModes.test.ts
+git commit -m "feat(sort): drop Controversial; add Popular sort + POPULAR_PERIODS constants"
+```
+
+---
+
+## Task 7: Add English i18n keys for Popular tab + periods
+
+**Files:**
+- Modify: `src/lib/i18n/locales/en/common.json`
+
+- [ ] **Step 1: Add keys**
+
+Under `trendingPage`, extend the object:
+
+```json
+{
+  "trendingPage": {
+    "heading": "Trending",
+    "subheading": "Discover what's popular in the community",
+    "rssTitle": "DiVine - Trending",
+    "rssLink": "RSS",
+    "popular": {
+      "tabLabel": "Popular",
+      "tabDescription": "Trending in this window",
+      "period": {
+        "label": "Window",
+        "now": "Now",
+        "today": "Today",
+        "week": "This Week",
+        "month": "This Month",
+        "all": "All Time"
+      },
+      "emptyHeading": "Quiet hour",
+      "emptyBody": "Try a wider window.",
+      "emptyAction": "Show today"
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Type-check & smoke test**
+
+Run: `npx tsc --noEmit && npx vitest run src/lib/i18n` (if i18n tests exist; otherwise skip the second).
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/i18n/locales/en/common.json
+git commit -m "i18n(en): add trendingPage.popular.* keys"
+```
+
+---
+
+## Task 8: Update `TrendingPage` — URL state, period row, controversial coercion, empty state
+
+**Files:**
+- Modify: `src/pages/TrendingPage.tsx`
+- Test: `src/pages/TrendingPage.test.tsx` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/pages/TrendingPage.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import TrendingPage from './TrendingPage';
+
+vi.mock('@/components/VideoFeed', () => ({
+  VideoFeed: (props: { sortMode?: string; period?: string }) => (
+    <div data-testid="video-feed" data-sort={props.sortMode ?? ''} data-period={props.period ?? ''} />
+  ),
+}));
+
+vi.mock('@/hooks/useRssFeedAvailable', () => ({ useRssFeedAvailable: () => false }));
+vi.mock('@unhead/react', () => ({ useHead: () => undefined }));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+function renderAt(initial: string) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[initial]}>
+        <Routes>
+          <Route path="/trending" element={<TrendingPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('TrendingPage URL state', () => {
+  it('defaults to sort=hot and renders no period row', () => {
+    renderAt('/trending');
+    const feed = screen.getByTestId('video-feed');
+    expect(feed.dataset.sort).toBe('hot');
+    expect(screen.queryByRole('group', { name: /window/i })).not.toBeInTheDocument();
+  });
+
+  it('shows the period row when sort=popular and defaults period to today', () => {
+    renderAt('/trending?sort=popular');
+    const feed = screen.getByTestId('video-feed');
+    expect(feed.dataset.sort).toBe('popular');
+    expect(feed.dataset.period).toBe('today');
+    expect(screen.getByRole('button', { name: /this week/i })).toBeInTheDocument();
+  });
+
+  it('respects ?sort=popular&period=week', () => {
+    renderAt('/trending?sort=popular&period=week');
+    const feed = screen.getByTestId('video-feed');
+    expect(feed.dataset.period).toBe('week');
+  });
+
+  it('coerces ?sort=controversial to hot', async () => {
+    renderAt('/trending?sort=controversial');
+    await waitFor(() => {
+      expect(screen.getByTestId('video-feed').dataset.sort).toBe('hot');
+    });
+  });
+
+  it('updates the URL when a period pill is clicked', async () => {
+    const user = userEvent.setup();
+    renderAt('/trending?sort=popular');
+    await user.click(screen.getByRole('button', { name: /this month/i }));
+    await waitFor(() => {
+      expect(screen.getByTestId('video-feed').dataset.period).toBe('month');
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify failure**
+
+Run: `npx vitest run src/pages/TrendingPage.test.tsx`
+Expected: FAIL.
+
+- [ ] **Step 3: Rewrite `TrendingPage` to be URL-driven**
+
+Replace the body of `src/pages/TrendingPage.tsx` with:
+
+```tsx
+// ABOUTME: Trending feed page with sort tabs + Popular time-window selector
+// ABOUTME: Sort + period live in URL query params for shareable, refresh-safe views
+
+import { useCallback, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useSearchParams } from 'react-router-dom';
+import { Rss } from '@phosphor-icons/react';
+import { useHead } from '@unhead/react';
+import { VideoFeed } from '@/components/VideoFeed';
+import { feedUrls } from '@/lib/feedUrls';
+import { useRssFeedAvailable } from '@/hooks/useRssFeedAvailable';
+import type { SortMode } from '@/types/nostr';
+import type { FunnelcakePeriod } from '@/types/funnelcake';
+import { EXTENDED_SORT_MODES, POPULAR_PERIODS } from '@/lib/constants/sortModes';
+
+const VALID_SORTS: ReadonlyArray<SortMode | undefined> = ['hot', 'top', 'rising', 'popular', 'classic', undefined];
+const VALID_PERIODS: ReadonlyArray<FunnelcakePeriod> = ['now', 'today', 'week', 'month', 'all'];
+
+function parseSort(raw: string | null): SortMode | undefined {
+  if (raw === null) return 'hot';
+  if (raw === 'controversial') return 'hot';        // legacy URL coercion
+  if (raw === '' || raw === 'new') return undefined;
+  return (VALID_SORTS as readonly string[]).includes(raw) ? (raw as SortMode) : 'hot';
+}
+
+function parsePeriod(raw: string | null): FunnelcakePeriod {
+  if (raw && (VALID_PERIODS as readonly string[]).includes(raw)) return raw as FunnelcakePeriod;
+  return 'today';
+}
+
+export function TrendingPage() {
+  const { t } = useTranslation();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const rawSort = searchParams.get('sort');
+  const rawPeriod = searchParams.get('period');
+  const sortMode = parseSort(rawSort);
+  const period = parsePeriod(rawPeriod);
+
+  // Rewrite the URL when we coerce (e.g. ?sort=controversial), without history entry.
+  useEffect(() => {
+    const desired = sortMode ?? 'new';
+    const incoming = rawSort ?? 'hot';
+    const sortChanged = desired !== incoming && !(desired === 'hot' && rawSort === null);
+    if (sortChanged) {
+      const next = new URLSearchParams(searchParams);
+      if (sortMode) next.set('sort', sortMode); else next.delete('sort');
+      setSearchParams(next, { replace: true });
+    }
+  }, [rawSort, sortMode, searchParams, setSearchParams]);
+
+  const setSort = useCallback((next: SortMode | undefined) => {
+    const params = new URLSearchParams(searchParams);
+    if (next) params.set('sort', next); else params.delete('sort');
+    if (next !== 'popular') params.delete('period');
+    setSearchParams(params, { replace: true });
+  }, [searchParams, setSearchParams]);
+
+  const setPeriod = useCallback((next: FunnelcakePeriod) => {
+    const params = new URLSearchParams(searchParams);
+    params.set('period', next);
+    if (sortMode !== 'popular') params.set('sort', 'popular');
+    setSearchParams(params, { replace: true });
+  }, [searchParams, setSearchParams, sortMode]);
+
+  const rssFeedAvailable = useRssFeedAvailable();
+  useHead({
+    link: rssFeedAvailable
+      ? [{ rel: 'alternate', type: 'application/rss+xml', title: t('trendingPage.rssTitle'), href: feedUrls.trending() }]
+      : [],
+  });
+
+  const showPeriodRow = sortMode === 'popular';
+
+  return (
+    <div className="container mx-auto px-4 py-6">
+      <div className="max-w-2xl mx-auto">
+        <header className="mb-6 space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h1 className="text-2xl font-bold">{t('trendingPage.heading')}</h1>
+              <p className="text-muted-foreground">{t('trendingPage.subheading')}</p>
+            </div>
+            {rssFeedAvailable && (
+              <a
+                href={feedUrls.trending()}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+              >
+                <Rss className="h-3.5 w-3.5" /> {t('trendingPage.rssLink')}
+              </a>
+            )}
+          </div>
+
+          <div className="flex flex-wrap gap-2" role="tablist" aria-label={t('trendingPage.heading')}>
+            {EXTENDED_SORT_MODES.map(mode => {
+              const ModeIcon = mode.icon;
+              const isSelected = sortMode === mode.value;
+              return (
+                <button
+                  key={String(mode.value ?? 'new')}
+                  role="tab"
+                  aria-selected={isSelected}
+                  onClick={() => setSort(mode.value)}
+                  className={`flex items-center gap-2 px-4 py-2 rounded-lg font-medium transition-all
+                    ${isSelected
+                      ? 'bg-primary text-primary-foreground shadow-md'
+                      : 'bg-brand-light-green dark:bg-brand-dark-green hover:bg-muted text-muted-foreground hover:text-foreground'
+                    }`}
+                >
+                  <ModeIcon className="h-4 w-4" />
+                  <span>{mode.label}</span>
+                  {isSelected && (
+                    <span className="text-xs opacity-80 hidden sm:inline">• {mode.description}</span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+
+          {showPeriodRow && (
+            <div
+              role="group"
+              aria-label={t('trendingPage.popular.period.label')}
+              className="flex flex-wrap gap-2 pl-1"
+            >
+              {POPULAR_PERIODS.map(p => {
+                const isSelected = period === p.value;
+                return (
+                  <button
+                    key={p.value}
+                    type="button"
+                    aria-pressed={isSelected}
+                    onClick={() => setPeriod(p.value)}
+                    className={`px-3 py-1.5 rounded-full text-sm font-medium transition-all min-h-[36px]
+                      ${isSelected
+                        ? 'bg-primary text-primary-foreground'
+                        : 'bg-brand-light-green dark:bg-brand-dark-green hover:bg-muted text-muted-foreground hover:text-foreground'
+                      }`}
+                  >
+                    {t(`trendingPage.popular.period.${p.value}`)}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </header>
+
+        <VideoFeed
+          feedType="trending"
+          sortMode={sortMode}
+          period={showPeriodRow ? period : undefined}
+          accent="pink"
+          data-testid="video-feed-trending"
+          className="space-y-6"
+        />
+      </div>
+    </div>
+  );
+}
+
+export default TrendingPage;
+```
+
+- [ ] **Step 4: Run page test**
+
+Run: `npx vitest run src/pages/TrendingPage.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Run the brand guardrails (still no uppercase, no lucide, no gradients)**
+
+Run: `npx vitest run tests/brand`
+Expected: PASS.
+
+- [ ] **Step 6: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/pages/TrendingPage.tsx src/pages/TrendingPage.test.tsx
+git commit -m "feat(trending): URL-driven sort + Popular time-window selector; coerce legacy controversial"
+```
+
+---
+
+## Task 9: Empty state for `popular + now`
+
+**Files:**
+- Modify: `src/components/VideoFeed.tsx` (only the empty-state branch)
+- Or: dedicated empty-state component if `VideoFeed` already has a slot — investigate before changing.
+
+> The brand guideline is voice-first; the technical change is small. The empty state should appear only when `feedType === 'trending'`, `sortMode === 'popular'`, `period === 'now'`, **and** the loaded feed is empty.
+
+- [ ] **Step 1: Locate the existing empty-state branch in `VideoFeed`**
+
+Run: `grep -n "no.*video\|empty\|no results" src/components/VideoFeed.tsx`
+Identify where the "no videos" UI renders (likely after the loading branch and before the list).
+
+- [ ] **Step 2: Add the period-aware variant**
+
+Where the existing empty UI renders, branch on the new props:
+
+```tsx
+const isQuietHour =
+  feedType === 'trending' && sortMode === 'popular' && period === 'now';
+
+if (!isLoading && filteredVideos.length === 0 && isQuietHour) {
+  return (
+    <div className="rounded-lg border bg-card p-8 text-center space-y-3">
+      <h2 className="text-lg font-semibold">{t('trendingPage.popular.emptyHeading')}</h2>
+      <p className="text-muted-foreground">{t('trendingPage.popular.emptyBody')}</p>
+      <Button
+        variant="default"
+        onClick={() => navigate('/trending?sort=popular&period=today', { replace: true })}
+      >
+        {t('trendingPage.popular.emptyAction')}
+      </Button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Add a smoke test**
+
+Append to `src/pages/TrendingPage.test.tsx` (or a new component test under `VideoFeed.test.tsx` if simpler — choose whichever the existing test uses for empty state). The test asserts the empty heading is rendered when the mocked feed returns empty for popular+now. If the page test already mocks `VideoFeed`, add a separate component-level test instead.
+
+- [ ] **Step 4: Run tests**
+
+Run: `npx vitest run src/components/VideoFeed.test.tsx src/pages/TrendingPage.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/VideoFeed.tsx src/pages/TrendingPage.test.tsx
+git commit -m "feat(popular): quiet-hour empty state for popular + now"
+```
+
+---
+
+## Task 10: AI-translate new keys to non-fil locales
+
+**Files:**
+- Modify: 14 locale files under `src/lib/i18n/locales/{de,es,fr,pt,it,ja,ko,zh,ar,hi,ru,nl,sv,pl,ro}/common.json`
+- Filipino (`fil`) gets handled separately by the in-progress fil branch — leave its `trendingPage.popular` block as English so the existing fil pipeline can replace it.
+
+> This mirrors the prior batches (`feat(i18n): translate batch-4 keys (~36) to 14 non-fil locales`). The pattern is: copy the en values into each locale, then translate them. Keep keys identical.
+
+- [ ] **Step 1: Add the `popular` block to each non-fil locale**
+
+For each of the 14 locales, add the same `trendingPage.popular` shape under `trendingPage`. Use locale-appropriate translations (delegate to the same translation pipeline / model used in prior commits — see commit `8ee809b` for the exact prompt style if needed).
+
+Translations must be casual-direct, never corporate. Examples (German):
+- `tabLabel`: `"Beliebt"`
+- `tabDescription`: `"Trends in diesem Zeitraum"`
+- `emptyHeading`: `"Stille Stunde"`
+- `emptyBody`: `"Versuch ein größeres Zeitfenster."`
+- `emptyAction`: `"Heute anzeigen"`
+
+- [ ] **Step 2: Add the same block to `fil/common.json` as English placeholders**
+
+Just copy the English values verbatim. The fil branch owners will translate.
+
+- [ ] **Step 3: Run i18n tests if any**
+
+Run: `npx vitest run src/lib/i18n` (skip if no tests).
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/i18n/locales
+git commit -m "i18n: translate trendingPage.popular keys for 14 non-fil locales"
+```
+
+---
+
+## Task 11: A11y axe sweep on `/trending?sort=popular&period=today`
+
+**Files:**
+- Modify: `tests/visual/a11y.spec.ts`
+
+- [ ] **Step 1: Add the route to the existing axe sweep**
+
+Open `tests/visual/a11y.spec.ts` and add `/trending?sort=popular&period=today` to the array of routes already swept (alongside `/`, `/discovery`, `/search`, `/__brand-preview`).
+
+- [ ] **Step 2: Run the sweep**
+
+Run: `npx playwright test tests/visual/a11y.spec.ts` (assumes Playwright is set up; if it requires a dev server, follow the existing pattern in the repo).
+Expected: PASS — no new color-contrast violations on real surfaces.
+
+> If the run reports a contrast issue on the new period pills, adjust the pill background/text color in Task 8's classNames to match the existing tab pattern (which already passes axe). Do **not** suppress the violation.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/visual/a11y.spec.ts
+git commit -m "test(a11y): add /trending?sort=popular axe sweep"
+```
+
+---
+
+## Task 12: Final verification
+
+- [ ] **Step 1: Type-check the whole project**
+
+Run: `npx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 2: Full unit test suite**
+
+Run: `npm test` (or `npx vitest run`)
+Expected: PASS.
+
+- [ ] **Step 3: Manual browser verification**
+
+Run: `npm run dev`
+
+In the browser:
+1. Visit `/trending`. Verify default tab is `Hot`, no period row visible, `Controversial` tab is gone.
+2. Click `Popular`. URL becomes `/trending?sort=popular`. Period row appears with `Today` selected.
+3. Click each period pill. URL updates `?sort=popular&period=…`. Feed re-fetches.
+4. Open DevTools Network tab. Confirm a request to `/api/v2/videos?sort=popular&period=<value>&limit=12` for each window.
+5. Refresh on `/trending?sort=popular&period=week`. Page restores Popular + This Week.
+6. Visit `/trending?sort=controversial`. URL is rewritten to `/trending?sort=hot` and Hot tab is active.
+7. Visit `/trending?sort=popular&period=now`. If feed is empty (off-hours), see "Quiet hour — try a wider window" with a button that navigates to `?sort=popular&period=today`.
+
+- [ ] **Step 4: Open the PR**
+
+Run:
+
+```bash
+gh pr create --title "feat: Popular tab with time-window selector on /trending" --body "$(cat <<'EOF'
+## Summary
+- Adds a `Popular` tab on `/trending` that calls the API with `sort=popular` and a user-selected period (`now / today / week / month / all`)
+- Sort + period are URL-driven (`?sort=popular&period=…`) for shareable, refresh-safe views
+- Drops `Controversial` from visible tabs (off-brand engagement-bait); legacy URLs coerce to `Hot`
+- Adds a "quiet hour" empty state for `popular + now`
+
+## Test plan
+- [ ] `npx tsc --noEmit` passes
+- [ ] `npm test` passes
+- [ ] `/trending` defaults to Hot, no period row
+- [ ] `/trending?sort=popular` shows period row, defaults to Today
+- [ ] Each period pill issues `/api/v2/videos?sort=popular&period=…`
+- [ ] `/trending?sort=controversial` redirects to `/trending?sort=hot`
+- [ ] `/trending?sort=popular&period=week` deep-link survives refresh
+- [ ] Quiet-hour empty state appears for empty `now` window with one-tap fix
+- [ ] Axe a11y sweep green on `/trending?sort=popular&period=today`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Out of scope (for follow-up)
+
+- Period support on hashtag, search, profile, and category feeds.
+- Edge-cache popular feeds per period (would speed first paint dramatically).
+- Per-period RSS feeds.
+- Renaming `/trending` → `/popular`.
+- Combining `Classic` with `period`.
+- Leaderboard page period changes.

--- a/docs/superpowers/plans/2026-05-09-popular-time-window.md
+++ b/docs/superpowers/plans/2026-05-09-popular-time-window.md
@@ -34,7 +34,7 @@
 
 | File | Purpose |
 | --- | --- |
-| `src/lib/funnelcakeClient.test.ts` (new or extended) | `fetchVideos` / `fetchVideosV2` include `period` when set, omit when undefined |
+| `src/lib/funnelcakeClient.test.ts` (extend — file already exists) | `fetchVideos` / `fetchVideosV2` include `period` when set, omit when undefined |
 | `src/hooks/useInfiniteVideosFunnelcake.test.ts` (extend) | `sortMode='popular'` + `period` plumbs to `fetchVideosV2` |
 | `src/pages/TrendingPage.test.tsx` (new) | URL state, period row visibility, controversial coercion |
 | `src/components/VideoFeed.test.tsx` (extend) | Quiet-hour empty state for popular + now (Task 9) |

--- a/docs/superpowers/plans/2026-05-09-popular-time-window.md
+++ b/docs/superpowers/plans/2026-05-09-popular-time-window.md
@@ -1366,6 +1366,10 @@ In the browser:
 5. Refresh on `/trending?sort=popular&period=week`. Page restores Popular + This Week.
 6. Visit `/trending?sort=controversial`. Hot tab is active and the period row is hidden. (The URL itself stays `?sort=controversial` — coercion is render-only by design.)
 7. Visit `/trending?sort=popular&period=now`. If feed is empty (off-hours), see "Quiet hour — try a wider window" with a button that navigates to `?sort=popular&period=today`.
+8. **Edge-cache deep-link smoke test (validates the Task 3 Step 7 fix).** The edge worker only injects `__DIVINE_FEED__` on the initial HTML response, not on client-side navigations — so this must be tested by opening a *fresh tab* directly to the deep link, not by clicking around the SPA.
+   - Open a brand-new tab. Paste `/trending?sort=popular&period=week` and load it.
+   - DevTools → Network: confirm the very first `/api/v2/videos?...` request includes `sort=popular&period=week`. If it instead requests the default trending feed (or no API call fires for page 1), the edge guard is broken.
+   - In the Console, run `window.__DIVINE_FEED__` — it should still be defined (the hook left it untouched because period was set). If it's `undefined`, the guard didn't fire and the cache was consumed.
 
 - [ ] **Step 4: Open the PR**
 

--- a/docs/superpowers/plans/2026-05-09-popular-time-window.md
+++ b/docs/superpowers/plans/2026-05-09-popular-time-window.md
@@ -196,7 +196,7 @@ describe('fetchVideos / fetchVideosV2 period parameter', () => {
 Run: `npx vitest run src/lib/funnelcakeClient.test.ts -t "period parameter"`
 Expected: FAIL — period appears nowhere in URLs.
 
-- [ ] **Step 4: Update `fetchVideos`**
+- [ ] **Step 3: Update `fetchVideos`**
 
 In `src/lib/funnelcakeClient.ts`, edit `fetchVideos` (around line 170):
 
@@ -215,7 +215,7 @@ const params: Record<string, string | number | boolean | undefined> = {
 
 (`buildUrl` already drops `undefined` values, so `period` will be omitted when not set.)
 
-- [ ] **Step 5: Update `fetchVideosV2`**
+- [ ] **Step 4: Update `fetchVideosV2`**
 
 In the same file, edit `fetchVideosV2` (around line 233):
 
@@ -232,17 +232,17 @@ const params: Record<string, string | number | boolean | undefined> = {
 };
 ```
 
-- [ ] **Step 6: Run tests, verify they pass**
+- [ ] **Step 5: Run tests, verify they pass**
 
 Run: `npx vitest run src/lib/funnelcakeClient.test.ts`
 Expected: PASS.
 
-- [ ] **Step 7: Type-check**
+- [ ] **Step 6: Type-check**
 
 Run: `npx tsc --noEmit`
 Expected: PASS.
 
-- [ ] **Step 8: Commit**
+- [ ] **Step 7: Commit**
 
 ```bash
 git add src/lib/funnelcakeClient.ts src/lib/funnelcakeClient.test.ts
@@ -821,7 +821,7 @@ describe('TrendingPage URL state', () => {
     renderAt('/trending');
     const feed = screen.getByTestId('video-feed');
     expect(feed.dataset.sort).toBe('hot');
-    expect(screen.queryByRole('group', { name: /window/i })).not.toBeInTheDocument();
+    expect(screen.queryByTestId('period-row')).not.toBeInTheDocument();
   });
 
   it('shows the period row when sort=popular and defaults period to today', () => {
@@ -829,17 +829,20 @@ describe('TrendingPage URL state', () => {
     const feed = screen.getByTestId('video-feed');
     expect(feed.dataset.sort).toBe('popular');
     expect(feed.dataset.period).toBe('today');
-    expect(screen.getByRole('button', { name: /this week/i })).toBeInTheDocument();
+    expect(screen.getByTestId('period-row')).toBeInTheDocument();
+    expect(screen.getByTestId('period-pill-week')).toBeInTheDocument();
   });
 
   it('respects ?sort=popular&period=week', () => {
     renderAt('/trending?sort=popular&period=week');
     expect(screen.getByTestId('video-feed').dataset.period).toBe('week');
+    expect(screen.getByTestId('period-pill-week')).toHaveAttribute('aria-pressed', 'true');
   });
 
-  it('renders ?sort=controversial as the Hot tab (no API call uses controversial)', () => {
+  it('renders ?sort=controversial as the Hot tab (no API call uses controversial) and hides the period row', () => {
     renderAt('/trending?sort=controversial');
     expect(screen.getByTestId('video-feed').dataset.sort).toBe('hot');
+    expect(screen.queryByTestId('period-row')).not.toBeInTheDocument();
   });
 
   it('encodes the New tab as ?sort=new (round-trip stable)', () => {
@@ -847,13 +850,13 @@ describe('TrendingPage URL state', () => {
     // sortMode is undefined for New — VideoFeed receives no sort
     expect(screen.getByTestId('video-feed').dataset.sort).toBe('');
     // No period row for New
-    expect(screen.queryByRole('group', { name: /window/i })).not.toBeInTheDocument();
+    expect(screen.queryByTestId('period-row')).not.toBeInTheDocument();
   });
 
   it('updates the URL and feed when a period pill is clicked', async () => {
     const user = userEvent.setup();
     renderAt('/trending?sort=popular');
-    await user.click(screen.getByRole('button', { name: /this month/i }));
+    await user.click(screen.getByTestId('period-pill-month'));
     await waitFor(() => {
       expect(screen.getByTestId('video-feed').dataset.period).toBe('month');
     });
@@ -864,6 +867,7 @@ describe('TrendingPage URL state', () => {
   it('drops period from the URL when switching from Popular to Hot', async () => {
     const user = userEvent.setup();
     renderAt('/trending?sort=popular&period=week');
+    // Sort tabs use hardcoded English labels from EXTENDED_SORT_MODES (not via i18n)
     await user.click(screen.getByRole('tab', { name: /^Hot/i }));
     await waitFor(() => {
       expect(screen.getByTestId('video-feed').dataset.sort).toBe('hot');
@@ -1003,6 +1007,7 @@ export function TrendingPage() {
             <div
               role="group"
               aria-label={t('trendingPage.popular.period.label')}
+              data-testid="period-row"
               className="flex flex-wrap gap-2 pl-1"
             >
               {POPULAR_PERIODS.map(p => {
@@ -1012,6 +1017,7 @@ export function TrendingPage() {
                     key={p.value}
                     type="button"
                     aria-pressed={isSelected}
+                    data-testid={`period-pill-${p.value}`}
                     onClick={() => setPeriod(p.value)}
                     className={`px-3 py-1.5 rounded-full text-sm font-medium transition-all min-h-[36px]
                       ${isSelected
@@ -1133,14 +1139,65 @@ Inside the empty-state early return, replace the existing else-branch (the one t
 
 - [ ] **Step 4: Add a component test**
 
-Append to `src/components/VideoFeed.test.tsx` a test that renders `<VideoFeed feedType="trending" sortMode="popular" period="now" />` with the data hook mocked to return an empty page. Assert that:
+Append to `src/components/VideoFeed.test.tsx` a new `it(...)` inside the existing `describe('VideoFeed', ...)`. The file already initializes real i18n (`await initializeI18n({ force: true, languages: ['en-US'] })`) and mocks `useVideoProvider` via `mockUseVideoProvider`, so we override the data return per-test. The English translation added in Task 7 is "Quiet hour" / "Try a wider window." / "Show today" — match those.
 
-```ts
-expect(screen.getByText(/quiet hour|emptyHeading/i)).toBeInTheDocument();
-expect(screen.getByTestId('quiet-hour-action')).toBeInTheDocument();
+```tsx
+it('renders the quiet-hour empty state for popular + now when feed is empty', async () => {
+  mockUseVideoProvider.mockReturnValue({
+    data: { pages: [{ videos: [] }] },
+    fetchNextPage: vi.fn(),
+    hasNextPage: false,
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+    dataSource: 'funnelcake',
+  });
+
+  render(
+    <MemoryRouter initialEntries={['/trending?sort=popular&period=now']}>
+      <VideoFeed
+        feedType="trending"
+        sortMode="popular"
+        period="now"
+        viewMode="feed"
+        mode="thumbnail"
+      />
+    </MemoryRouter>
+  );
+
+  expect(await screen.findByText(/quiet hour/i)).toBeInTheDocument();
+  expect(screen.getByTestId('quiet-hour-action')).toBeInTheDocument();
+});
+
+it('does not render the quiet-hour empty state for popular + week', async () => {
+  mockUseVideoProvider.mockReturnValue({
+    data: { pages: [{ videos: [] }] },
+    fetchNextPage: vi.fn(),
+    hasNextPage: false,
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+    dataSource: 'funnelcake',
+  });
+
+  render(
+    <MemoryRouter initialEntries={['/trending?sort=popular&period=week']}>
+      <VideoFeed
+        feedType="trending"
+        sortMode="popular"
+        period="week"
+        viewMode="feed"
+        mode="thumbnail"
+      />
+    </MemoryRouter>
+  );
+
+  // Renders the existing "Divine reclining" / "Divine needs a rest" branch instead
+  expect(screen.queryByTestId('quiet-hour-action')).not.toBeInTheDocument();
+});
 ```
 
-> If `VideoFeed.test.tsx` does not already mock `useVideoProvider`, follow the existing test setup pattern in that file (look at line 156 — there's a working test).
+> The new prop `period` must already be on `VideoFeedProps` (Task 5). If TS complains about `sortMode="popular"`, ensure Task 4 has run (`'popular'` added to `SortMode`).
 
 - [ ] **Step 5: Run tests**
 
@@ -1283,6 +1340,7 @@ EOF
 - **The trending feed uses `/api/v2/videos`.** When `sort=popular` is selected, the request becomes `GET /api/v2/videos?sort=popular&period=<value>&limit=12`. Verify in DevTools network tab during Task 12 manual QA.
 - **Edge-injected feed cache (`window.__DIVINE_FEED__`)** is only consumed for the default trending feed (no `pageParam`, no sort filter). Popular requests bypass it because they have a different `queryKey` (period is part of the key). No edge-side change needed.
 - **Brand guardrails** (`tests/brand`) run on the entire src tree. New code must avoid: Tailwind `uppercase` class, `lucide-react` imports, `bg-gradient-*` / `radial-gradient(` / `linear-gradient(` on layout surfaces. The plan's snippets comply, but watch for accidental introductions during Task 8/9.
+- **`'controversial'` is intentionally NOT removed from the `SortMode` type.** Several call sites still reference it in switch/case branches and literal arrays — `useInfiniteSearchVideos.ts:51`, `useInfiniteVideos.ts:83` (`['top', 'hot', 'rising', 'controversial'].includes(...)`), `useVideoProvider.ts:117`, `useVideoByIdFunnelcake.ts:46`, `relayCapabilities.ts:26`. Keeping the type literal means none of those need editing; the only behavioral change is that `EXTENDED_SORT_MODES` and `SEARCH_SORT_MODES` no longer surface a tab for it. Old `?sort=controversial` URLs on `/trending` get coerced to `hot` (Task 8); on `/search`, no tab is highlighted but the search itself still functions.
 
 ---
 

--- a/docs/superpowers/plans/2026-05-09-popular-time-window.md
+++ b/docs/superpowers/plans/2026-05-09-popular-time-window.md
@@ -431,21 +431,81 @@ And inside the queryFn where `getFetchOptions` is called:
 const options = getFetchOptions(feedType, sortMode, pageSize, period);
 ```
 
-- [ ] **Step 7: Run the popular tests**
+- [ ] **Step 7: Guard edge-feed consumption against Popular requests**
+
+> **Real bug to fix here, not just a forward-looking change.** The current hook (`src/hooks/useInfiniteVideosFunnelcake.ts:210-234`) unconditionally consumes `window.__DIVINE_FEED__` on the first page when `feedType === 'trending'`. The Fastly edge worker injects this for the *default* trending feed (sort=watching, no period). When a user deep-links to `/trending?sort=popular&period=today`, page 1 would silently use the wrong sort while page 2+ correctly hits the API. The fix is one line.
+
+Around line 213-214 of `src/hooks/useInfiniteVideosFunnelcake.ts`, change:
+
+```ts
+const edgeMatchesFeed = edgeFeedType === feedType || (edgeFeedType === undefined && feedType === 'trending');
+if (!pageParam && edgeMatchesFeed && typeof window !== 'undefined' && window.__DIVINE_FEED__) {
+```
+
+to:
+
+```ts
+// Edge-injected data only represents the default trending feed (sort=watching, no period).
+// Skip it whenever the request specifies a period — those mean Popular, which the edge
+// hasn't pre-cached.
+const edgeMatchesFeed = edgeFeedType === feedType || (edgeFeedType === undefined && feedType === 'trending');
+const edgeUsable = edgeMatchesFeed && !period;
+if (!pageParam && edgeUsable && typeof window !== 'undefined' && window.__DIVINE_FEED__) {
+```
+
+(Replace just the `edgeMatchesFeed` check in the `if` with `edgeUsable`.)
+
+Add a regression test inside `src/hooks/useInfiniteVideosFunnelcake.test.ts` (in the same `describe('popular sort with period')` block):
+
+```ts
+it('does not consume edge-injected feed when period is set', async () => {
+  // Simulate edge injection
+  (window as Window & { __DIVINE_FEED__?: unknown; __DIVINE_FEED_TYPE__?: string }).__DIVINE_FEED__ = {
+    videos: [{ id: 'edge-video', pubkey: 'edge-p', kind: 34236, createdAt: 1, vineId: 'edge-d' }],
+  };
+  delete (window as { __DIVINE_FEED_TYPE__?: string }).__DIVINE_FEED_TYPE__;
+
+  mockFetchVideosV2.mockResolvedValueOnce({ videos: [{}], has_more: false, next_cursor: undefined });
+  mockTransformToVideoPage.mockReturnValueOnce({
+    videos: [{ id: 'api-video', pubkey: 'api-p', kind: 34236, createdAt: 2, vineId: 'api-d' }],
+    nextCursor: undefined,
+    hasMore: false,
+  });
+
+  const { result } = renderHook(
+    () => useInfiniteVideosFunnelcake({ feedType: 'trending', sortMode: 'popular', period: 'today', pageSize: 12 }),
+    { wrapper: createWrapper() }
+  );
+
+  await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+  // Hook hit the API, not the edge cache
+  expect(mockFetchVideosV2).toHaveBeenCalled();
+  expect(result.current.data?.pages[0]?.videos[0]?.id).toBe('api-video');
+
+  // Edge cache untouched (still present for a future non-period request)
+  expect((window as { __DIVINE_FEED__?: unknown }).__DIVINE_FEED__).toBeDefined();
+
+  // Cleanup
+  delete (window as { __DIVINE_FEED__?: unknown }).__DIVINE_FEED__;
+});
+```
+
+- [ ] **Step 8: Run the popular tests (including the edge-cache regression test)**
 
 Run: `npx vitest run src/hooks/useInfiniteVideosFunnelcake.test.ts -t "popular sort with period"`
-Expected: PASS.
+Expected: PASS — both the period-plumbing tests and the edge-cache guard test.
 
-- [ ] **Step 8: Run the full test file to confirm no regressions**
+- [ ] **Step 9: Run the full test file to confirm no regressions**
 
 Run: `npx vitest run src/hooks/useInfiniteVideosFunnelcake.test.ts`
-Expected: PASS (all).
+Expected: PASS (all). The existing recommendations tests still work because they don't set `period`.
 
-- [ ] **Step 9: Commit**
+- [ ] **Step 10: Commit**
 
 ```bash
 git add src/hooks/useInfiniteVideosFunnelcake.ts src/hooks/useInfiniteVideosFunnelcake.test.ts
-git commit -m "feat(feed): wire period through useInfiniteVideosFunnelcake for popular sort"
+git commit -m "feat(feed): wire period through useInfiniteVideosFunnelcake; skip edge cache for Popular"
 ```
 
 ---
@@ -1345,7 +1405,7 @@ EOF
 - **URL encoding for the New tab:** the tab is encoded as `?sort=new`, **not** as a missing param. Missing `?sort` defaults to Hot (matches today's behavior). Clicking New writes `?sort=new`. This is the only way to make the round-trip stable.
 - **Controversial coercion is render-only**, no URL rewrite. Visiting `?sort=controversial` renders Hot; the URL stays `?sort=controversial` until the user clicks something. This is intentional — rewriting the URL on mount triggers re-render churn and is not testable from `useSearchParams` without a location probe.
 - **The trending feed uses `/api/v2/videos`.** When `sort=popular` is selected, the request becomes `GET /api/v2/videos?sort=popular&period=<value>&limit=12`. Verify in DevTools network tab during Task 12 manual QA.
-- **Edge-injected feed cache (`window.__DIVINE_FEED__`)** is only consumed for the default trending feed (no `pageParam`, no sort filter). Popular requests bypass it because they have a different `queryKey` (period is part of the key). No edge-side change needed.
+- **Edge-injected feed cache (`window.__DIVINE_FEED__`)** is consumed unconditionally on the first `trending` page in the *current* code at `useInfiniteVideosFunnelcake.ts:210-234`, regardless of sortMode/period. This silently breaks deep-links to `/trending?sort=popular&period=…` (page 1 would show the edge's default sort/period; pages 2+ would correctly use Popular). **Task 3 Step 7 fixes this** with a one-line guard (`!period`) plus a regression test. Existing Hot/Top/Rising sorts keep their current edge consumption — production today already accepts that mismatch and this plan deliberately does not expand the fix beyond Popular. No edge-worker change required.
 - **Brand guardrails** (`tests/brand`) run on the entire src tree. New code must avoid: Tailwind `uppercase` class, `lucide-react` imports, `bg-gradient-*` / `radial-gradient(` / `linear-gradient(` on layout surfaces. The plan's snippets comply, but watch for accidental introductions during Task 8/9.
 - **`'controversial'` is intentionally NOT removed from the `SortMode` type.** Several call sites still reference it in switch/case branches and literal arrays — `useInfiniteSearchVideos.ts:51`, `useInfiniteVideos.ts:83` (`['top', 'hot', 'rising', 'controversial'].includes(...)`), `useVideoProvider.ts:117`, `useVideoByIdFunnelcake.ts:46`, `relayCapabilities.ts:26`. Keeping the type literal means none of those need editing; the only behavioral change is that `EXTENDED_SORT_MODES` and `SEARCH_SORT_MODES` no longer surface a tab for it. Old `?sort=controversial` URLs on `/trending` get coerced to `hot` (Task 8); on `/search`, no tab is highlighted but the search itself still functions.
 

--- a/docs/superpowers/plans/2026-05-09-popular-time-window.md
+++ b/docs/superpowers/plans/2026-05-09-popular-time-window.md
@@ -106,86 +106,94 @@ git commit -m "feat(funnelcake): add FunnelcakePeriod type and period option"
 
 **Files:**
 - Modify: `src/lib/funnelcakeClient.ts:166-215` (`fetchVideos`) and `:229-271` (`fetchVideosV2`)
-- Test: `src/lib/funnelcakeClient.test.ts` (extend if exists, else create)
+- Test: `src/lib/funnelcakeClient.test.ts` (already exists — extend with a new `describe` block)
 
-- [ ] **Step 1: Locate or create the test file**
+> **Existing test pattern (must follow):** This file uses `vi.resetModules()` + `global.fetch = vi.fn()` in `beforeEach`, then dynamically `await import('./funnelcakeClient')` so module-level mocks (`./funnelcakeHealth`, `./debug`, `./nip98Auth`) are applied. Do **not** use `vi.spyOn(globalThis, 'fetch')` — it conflicts with the existing module mocks. Follow the existing shape exactly.
 
-Run: `ls src/lib/funnelcakeClient.test.ts 2>/dev/null && echo EXISTS || echo MISSING`
+- [ ] **Step 1: Add a new `describe` block at the bottom of the file**
 
-If MISSING, create the file with the standard imports:
+In `src/lib/funnelcakeClient.test.ts`, append a new top-level `describe('fetchVideos / fetchVideosV2 period parameter', …)` that mirrors the existing pattern. Inside the existing top-level `describe('funnelcakeClient', …)`, the `beforeEach` already wires `global.fetch = vi.fn()`, but the `let fetchUserProfile: …` block does not pull in `fetchVideos` / `fetchVideosV2`. Add a fresh top-level describe so we don't have to amend the shared `let` block:
 
 ```ts
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { fetchVideos, fetchVideosV2 } from './funnelcakeClient';
+describe('fetchVideos / fetchVideosV2 period parameter', () => {
+  let fetchVideos: typeof import('./funnelcakeClient').fetchVideos;
+  let fetchVideosV2: typeof import('./funnelcakeClient').fetchVideosV2;
 
-describe('funnelcakeClient period parameter', () => {
-  beforeEach(() => {
-    vi.restoreAllMocks();
+  beforeEach(async () => {
+    vi.resetModules();
+    global.fetch = vi.fn();
+    const client = await import('./funnelcakeClient');
+    fetchVideos = client.fetchVideos;
+    fetchVideosV2 = client.fetchVideosV2;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function lastFetchUrl(): string {
+    const mockFetch = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    const calls = mockFetch.mock.calls;
+    return String(calls[calls.length - 1][0]);
+  }
+
+  it('fetchVideos includes period when provided', async () => {
+    (global.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } })
+    );
+
+    await fetchVideos(API_URL, { sort: 'popular', period: 'week', limit: 12 });
+
+    const url = lastFetchUrl();
+    expect(url).toContain('sort=popular');
+    expect(url).toContain('period=week');
+  });
+
+  it('fetchVideos omits period when undefined', async () => {
+    (global.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } })
+    );
+
+    await fetchVideos(API_URL, { sort: 'popular', limit: 12 });
+
+    expect(lastFetchUrl()).not.toContain('period=');
+  });
+
+  it('fetchVideosV2 includes period when provided', async () => {
+    (global.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(JSON.stringify({ data: [], pagination: { has_more: false } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    await fetchVideosV2(API_URL, { sort: 'popular', period: 'today', limit: 12 });
+
+    const url = lastFetchUrl();
+    expect(url).toContain('sort=popular');
+    expect(url).toContain('period=today');
+  });
+
+  it('fetchVideosV2 omits period when undefined', async () => {
+    (global.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(JSON.stringify({ data: [], pagination: { has_more: false } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    await fetchVideosV2(API_URL, { sort: 'watching', limit: 12 });
+
+    expect(lastFetchUrl()).not.toContain('period=');
   });
 });
 ```
 
-If EXISTS, append the new `describe` block (or add tests inside an existing block).
+> `API_URL` is already defined at the top of the file as `'https://api.divine.video'`. Reuse it.
 
-- [ ] **Step 2: Write failing tests for `period`**
+- [ ] **Step 2: Run tests, verify they fail**
 
-```ts
-it('fetchVideos includes period when provided', async () => {
-  const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-    new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } })
-  );
-
-  await fetchVideos('https://api.divine.video', { sort: 'popular', period: 'week', limit: 12 });
-
-  const calledUrl = String((fetchSpy.mock.calls[0] as [URL | string, ...unknown[]])[0]);
-  expect(calledUrl).toContain('sort=popular');
-  expect(calledUrl).toContain('period=week');
-});
-
-it('fetchVideos omits period when undefined', async () => {
-  const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-    new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } })
-  );
-
-  await fetchVideos('https://api.divine.video', { sort: 'popular', limit: 12 });
-
-  const calledUrl = String((fetchSpy.mock.calls[0] as [URL | string, ...unknown[]])[0]);
-  expect(calledUrl).not.toContain('period=');
-});
-
-it('fetchVideosV2 includes period when provided', async () => {
-  const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-    new Response(JSON.stringify({ data: [], pagination: { has_more: false } }), {
-      status: 200,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  );
-
-  await fetchVideosV2('https://api.divine.video', { sort: 'popular', period: 'today', limit: 12 });
-
-  const calledUrl = String((fetchSpy.mock.calls[0] as [URL | string, ...unknown[]])[0]);
-  expect(calledUrl).toContain('sort=popular');
-  expect(calledUrl).toContain('period=today');
-});
-
-it('fetchVideosV2 omits period when undefined', async () => {
-  const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-    new Response(JSON.stringify({ data: [], pagination: { has_more: false } }), {
-      status: 200,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  );
-
-  await fetchVideosV2('https://api.divine.video', { sort: 'watching', limit: 12 });
-
-  const calledUrl = String((fetchSpy.mock.calls[0] as [URL | string, ...unknown[]])[0]);
-  expect(calledUrl).not.toContain('period=');
-});
-```
-
-- [ ] **Step 3: Run tests, verify they fail**
-
-Run: `npx vitest run src/lib/funnelcakeClient.test.ts`
+Run: `npx vitest run src/lib/funnelcakeClient.test.ts -t "period parameter"`
 Expected: FAIL — period appears nowhere in URLs.
 
 - [ ] **Step 4: Update `fetchVideos`**
@@ -249,9 +257,34 @@ git commit -m "feat(funnelcake): thread period query param through fetchVideos a
 - Modify: `src/hooks/useInfiniteVideosFunnelcake.ts:16-17,89-163,177-205`
 - Test: `src/hooks/useInfiniteVideosFunnelcake.test.ts` (extend)
 
-- [ ] **Step 1: Write the failing test**
+- [ ] **Step 1: Add `mockFetchVideosV2` to the existing module mock**
 
-Append to `src/hooks/useInfiniteVideosFunnelcake.test.ts` (inside the existing `describe`):
+The current test file (`src/hooks/useInfiniteVideosFunnelcake.test.ts:6-22`) does **not** mock `fetchVideosV2`. The trending feed path calls `fetchVideosV2`, so calling `useInfiniteVideosFunnelcake({ feedType: 'trending', ... })` from a test today silently invokes `undefined()`. Fix this first — even before adding period — because all popular tests depend on it.
+
+At the top of the file, alongside `const mockFetchVideos = vi.fn();`, add:
+
+```ts
+const mockFetchVideosV2 = vi.fn();
+```
+
+In the `vi.mock('@/lib/funnelcakeClient', …)` block, add the new entry:
+
+```ts
+vi.mock('@/lib/funnelcakeClient', () => ({
+  fetchVideos: mockFetchVideos,
+  fetchVideosV2: mockFetchVideosV2,   // NEW
+  searchVideos: vi.fn(),
+  fetchUserVideos: vi.fn(),
+  fetchUserFeed: vi.fn(),
+  fetchRecommendations: mockFetchRecommendations,
+}));
+```
+
+In any existing `beforeEach` reset, add `mockFetchVideosV2.mockReset();` next to the existing resets (mirror whatever pattern is already there).
+
+- [ ] **Step 2: Write the failing test**
+
+Append to `src/hooks/useInfiniteVideosFunnelcake.test.ts` (as a new top-level `describe`):
 
 ```ts
 describe('popular sort with period', () => {
@@ -312,14 +345,12 @@ describe('popular sort with period', () => {
 });
 ```
 
-> Note: if `mockFetchVideosV2` does not exist in the test file, add it alongside the existing `mockFetchVideos` mock at the top of the file (mirror the existing pattern that mocks `@/lib/funnelcakeClient`).
-
-- [ ] **Step 2: Run tests, verify they fail**
+- [ ] **Step 3: Run tests, verify they fail**
 
 Run: `npx vitest run src/hooks/useInfiniteVideosFunnelcake.test.ts -t "popular sort with period"`
 Expected: FAIL — `'popular'` not assignable to `FunnelcakeSortMode`.
 
-- [ ] **Step 3: Extend the type and options**
+- [ ] **Step 4: Extend the type and options**
 
 In `src/hooks/useInfiniteVideosFunnelcake.ts`:
 
@@ -342,7 +373,7 @@ interface UseInfiniteVideosFunnelcakeOptions {
 
 Import `FunnelcakePeriod` from `@/types/funnelcake`.
 
-- [ ] **Step 4: Wire `period` into `getFetchOptions`**
+- [ ] **Step 5: Wire `period` into `getFetchOptions`**
 
 Update the function signature and the `'trending'` branch:
 
@@ -372,7 +403,7 @@ function getFetchOptions(
 }
 ```
 
-- [ ] **Step 5: Pass `period` from the hook body and into the queryKey**
+- [ ] **Step 6: Pass `period` from the hook body and into the queryKey**
 
 Update the `useInfiniteVideosFunnelcake` function signature and queryKey:
 
@@ -395,17 +426,17 @@ And inside the queryFn where `getFetchOptions` is called:
 const options = getFetchOptions(feedType, sortMode, pageSize, period);
 ```
 
-- [ ] **Step 6: Run the popular tests**
+- [ ] **Step 7: Run the popular tests**
 
 Run: `npx vitest run src/hooks/useInfiniteVideosFunnelcake.test.ts -t "popular sort with period"`
 Expected: PASS.
 
-- [ ] **Step 7: Run the full test file to confirm no regressions**
+- [ ] **Step 8: Run the full test file to confirm no regressions**
 
 Run: `npx vitest run src/hooks/useInfiniteVideosFunnelcake.test.ts`
 Expected: PASS (all).
 
-- [ ] **Step 8: Commit**
+- [ ] **Step 9: Commit**
 
 ```bash
 git add src/hooks/useInfiniteVideosFunnelcake.ts src/hooks/useInfiniteVideosFunnelcake.test.ts
@@ -622,11 +653,9 @@ Expected: FAIL.
 
 - [ ] **Step 3: Update `sortModes.ts`**
 
-In `src/lib/constants/sortModes.ts`:
+In `src/lib/constants/sortModes.ts` (no new icon imports needed — period pills are text-only; the existing `TrendingUp` is reused for the Popular tab):
 
-1. Add `TrendUp` to the existing import (already imported as `TrendingUp`, reuse) and `Hourglass`, `Calendar`, `CalendarBlank`, `Infinity` from `@phosphor-icons/react` for periods. (Adjust import names to whatever Phosphor exports; if a name is unavailable, fall back to `Clock` for any window.)
-
-2. Replace `EXTENDED_SORT_MODES`:
+1. Replace `EXTENDED_SORT_MODES`:
 
 ```ts
 export const EXTENDED_SORT_MODES: SortModeDefinition[] = [
@@ -639,9 +668,9 @@ export const EXTENDED_SORT_MODES: SortModeDefinition[] = [
 ];
 ```
 
-3. Update `SEARCH_SORT_MODES` to drop the `controversial` entry.
+2. Update `SEARCH_SORT_MODES` to drop the `controversial` entry.
 
-4. Add `POPULAR_PERIODS`:
+3. Add `POPULAR_PERIODS`:
 
 ```ts
 import type { FunnelcakePeriod } from '@/types/funnelcake';
@@ -739,16 +768,17 @@ git commit -m "i18n(en): add trendingPage.popular.* keys"
 
 - [ ] **Step 1: Write the failing test**
 
-Create `src/pages/TrendingPage.test.tsx`:
+Create `src/pages/TrendingPage.test.tsx`. Note the URL encoding: the **New** tab (sortMode `undefined`) is encoded as `?sort=new` — not as a missing param — so the round-trip `URL → state → URL` is stable and clicking New doesn't silently revert to Hot.
 
 ```tsx
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import TrendingPage from './TrendingPage';
 
+// Mock VideoFeed to a probe div that exposes the props through dataset.
 vi.mock('@/components/VideoFeed', () => ({
   VideoFeed: (props: { sortMode?: string; period?: string }) => (
     <div data-testid="video-feed" data-sort={props.sortMode ?? ''} data-period={props.period ?? ''} />
@@ -761,13 +791,25 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (k: string) => k }),
 }));
 
+// Watcher exposes the current URL search to the DOM so tests can assert on URL rewrites.
+function LocationProbe() {
+  const location = useLocation();
+  return <div data-testid="location-search">{location.search}</div>;
+}
+
 function renderAt(initial: string) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={qc}>
       <MemoryRouter initialEntries={[initial]}>
         <Routes>
-          <Route path="/trending" element={<TrendingPage />} />
+          <Route
+            path="/trending"
+            element={<>
+              <TrendingPage />
+              <LocationProbe />
+            </>}
+          />
         </Routes>
       </MemoryRouter>
     </QueryClientProvider>,
@@ -775,7 +817,7 @@ function renderAt(initial: string) {
 }
 
 describe('TrendingPage URL state', () => {
-  it('defaults to sort=hot and renders no period row', () => {
+  it('defaults to sort=hot and renders no period row when no params', () => {
     renderAt('/trending');
     const feed = screen.getByTestId('video-feed');
     expect(feed.dataset.sort).toBe('hot');
@@ -792,24 +834,41 @@ describe('TrendingPage URL state', () => {
 
   it('respects ?sort=popular&period=week', () => {
     renderAt('/trending?sort=popular&period=week');
-    const feed = screen.getByTestId('video-feed');
-    expect(feed.dataset.period).toBe('week');
+    expect(screen.getByTestId('video-feed').dataset.period).toBe('week');
   });
 
-  it('coerces ?sort=controversial to hot', async () => {
+  it('renders ?sort=controversial as the Hot tab (no API call uses controversial)', () => {
     renderAt('/trending?sort=controversial');
-    await waitFor(() => {
-      expect(screen.getByTestId('video-feed').dataset.sort).toBe('hot');
-    });
+    expect(screen.getByTestId('video-feed').dataset.sort).toBe('hot');
   });
 
-  it('updates the URL when a period pill is clicked', async () => {
+  it('encodes the New tab as ?sort=new (round-trip stable)', () => {
+    renderAt('/trending?sort=new');
+    // sortMode is undefined for New — VideoFeed receives no sort
+    expect(screen.getByTestId('video-feed').dataset.sort).toBe('');
+    // No period row for New
+    expect(screen.queryByRole('group', { name: /window/i })).not.toBeInTheDocument();
+  });
+
+  it('updates the URL and feed when a period pill is clicked', async () => {
     const user = userEvent.setup();
     renderAt('/trending?sort=popular');
     await user.click(screen.getByRole('button', { name: /this month/i }));
     await waitFor(() => {
       expect(screen.getByTestId('video-feed').dataset.period).toBe('month');
     });
+    expect(screen.getByTestId('location-search').textContent).toContain('period=month');
+    expect(screen.getByTestId('location-search').textContent).toContain('sort=popular');
+  });
+
+  it('drops period from the URL when switching from Popular to Hot', async () => {
+    const user = userEvent.setup();
+    renderAt('/trending?sort=popular&period=week');
+    await user.click(screen.getByRole('tab', { name: /^Hot/i }));
+    await waitFor(() => {
+      expect(screen.getByTestId('video-feed').dataset.sort).toBe('hot');
+    });
+    expect(screen.getByTestId('location-search').textContent).not.toContain('period=');
   });
 });
 ```
@@ -827,7 +886,7 @@ Replace the body of `src/pages/TrendingPage.tsx` with:
 // ABOUTME: Trending feed page with sort tabs + Popular time-window selector
 // ABOUTME: Sort + period live in URL query params for shareable, refresh-safe views
 
-import { useCallback, useEffect } from 'react';
+import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSearchParams } from 'react-router-dom';
 import { Rss } from '@phosphor-icons/react';
@@ -839,45 +898,40 @@ import type { SortMode } from '@/types/nostr';
 import type { FunnelcakePeriod } from '@/types/funnelcake';
 import { EXTENDED_SORT_MODES, POPULAR_PERIODS } from '@/lib/constants/sortModes';
 
-const VALID_SORTS: ReadonlyArray<SortMode | undefined> = ['hot', 'top', 'rising', 'popular', 'classic', undefined];
-const VALID_PERIODS: ReadonlyArray<FunnelcakePeriod> = ['now', 'today', 'week', 'month', 'all'];
+const VALID_SORTS: ReadonlyArray<string> = ['hot', 'top', 'rising', 'popular', 'classic', 'new'];
+const VALID_PERIODS: ReadonlyArray<string> = ['now', 'today', 'week', 'month', 'all'];
 
+// URL encoding rules:
+// - Missing sort param → 'hot' (default)
+// - 'new' (the New tab; sortMode undefined) → 'new' in URL, undefined in state
+// - 'controversial' (legacy) → coerced to 'hot' in state; URL not rewritten (cosmetic only)
+// - Unknown values → 'hot'
 function parseSort(raw: string | null): SortMode | undefined {
   if (raw === null) return 'hot';
-  if (raw === 'controversial') return 'hot';        // legacy URL coercion
-  if (raw === '' || raw === 'new') return undefined;
-  return (VALID_SORTS as readonly string[]).includes(raw) ? (raw as SortMode) : 'hot';
+  if (raw === 'new') return undefined;
+  if (raw === 'controversial') return 'hot';
+  return (VALID_SORTS.includes(raw) ? (raw as SortMode) : 'hot');
 }
 
 function parsePeriod(raw: string | null): FunnelcakePeriod {
-  if (raw && (VALID_PERIODS as readonly string[]).includes(raw)) return raw as FunnelcakePeriod;
+  if (raw && VALID_PERIODS.includes(raw)) return raw as FunnelcakePeriod;
   return 'today';
+}
+
+function sortToUrl(sort: SortMode | undefined): string {
+  return sort ?? 'new';
 }
 
 export function TrendingPage() {
   const { t } = useTranslation();
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const rawSort = searchParams.get('sort');
-  const rawPeriod = searchParams.get('period');
-  const sortMode = parseSort(rawSort);
-  const period = parsePeriod(rawPeriod);
-
-  // Rewrite the URL when we coerce (e.g. ?sort=controversial), without history entry.
-  useEffect(() => {
-    const desired = sortMode ?? 'new';
-    const incoming = rawSort ?? 'hot';
-    const sortChanged = desired !== incoming && !(desired === 'hot' && rawSort === null);
-    if (sortChanged) {
-      const next = new URLSearchParams(searchParams);
-      if (sortMode) next.set('sort', sortMode); else next.delete('sort');
-      setSearchParams(next, { replace: true });
-    }
-  }, [rawSort, sortMode, searchParams, setSearchParams]);
+  const sortMode = parseSort(searchParams.get('sort'));
+  const period = parsePeriod(searchParams.get('period'));
 
   const setSort = useCallback((next: SortMode | undefined) => {
     const params = new URLSearchParams(searchParams);
-    if (next) params.set('sort', next); else params.delete('sort');
+    params.set('sort', sortToUrl(next));
     if (next !== 'popular') params.delete('period');
     setSearchParams(params, { replace: true });
   }, [searchParams, setSearchParams]);
@@ -885,9 +939,9 @@ export function TrendingPage() {
   const setPeriod = useCallback((next: FunnelcakePeriod) => {
     const params = new URLSearchParams(searchParams);
     params.set('period', next);
-    if (sortMode !== 'popular') params.set('sort', 'popular');
+    params.set('sort', 'popular');
     setSearchParams(params, { replace: true });
-  }, [searchParams, setSearchParams, sortMode]);
+  }, [searchParams, setSearchParams]);
 
   const rssFeedAvailable = useRssFeedAvailable();
   useHead({
@@ -1016,53 +1070,87 @@ git commit -m "feat(trending): URL-driven sort + Popular time-window selector; c
 ## Task 9: Empty state for `popular + now`
 
 **Files:**
-- Modify: `src/components/VideoFeed.tsx` (only the empty-state branch)
-- Or: dedicated empty-state component if `VideoFeed` already has a slot — investigate before changing.
+- Modify: `src/components/VideoFeed.tsx` (extend the existing empty-state branch — do NOT add a separate early return)
+- Test: `src/components/VideoFeed.test.tsx` (extend)
 
-> The brand guideline is voice-first; the technical change is small. The empty state should appear only when `feedType === 'trending'`, `sortMode === 'popular'`, `period === 'now'`, **and** the loaded feed is empty.
+> The empty state at `src/components/VideoFeed.tsx:362-437` is a single early return that swaps copy based on `feedType`. Reuse its wrapper (refs, testids, Card layout). Don't duplicate the wrapper — extend the conditional with a new "quiet hour" branch in the heading/subtitle/action area.
 
-- [ ] **Step 1: Locate the existing empty-state branch in `VideoFeed`**
+- [ ] **Step 1: Locate the empty-state branch**
 
-Run: `grep -n "no.*video\|empty\|no results" src/components/VideoFeed.tsx`
-Identify where the "no videos" UI renders (likely after the loading branch and before the list).
-
-- [ ] **Step 2: Add the period-aware variant**
-
-Where the existing empty UI renders, branch on the new props:
+Open `src/components/VideoFeed.tsx` around line 361. The structure is:
 
 ```tsx
-const isQuietHour =
-  feedType === 'trending' && sortMode === 'popular' && period === 'now';
-
-if (!isLoading && filteredVideos.length === 0 && isQuietHour) {
-  return (
-    <div className="rounded-lg border bg-card p-8 text-center space-y-3">
-      <h2 className="text-lg font-semibold">{t('trendingPage.popular.emptyHeading')}</h2>
-      <p className="text-muted-foreground">{t('trendingPage.popular.emptyBody')}</p>
-      <Button
-        variant="default"
-        onClick={() => navigate('/trending?sort=popular&period=today', { replace: true })}
-      >
-        {t('trendingPage.popular.emptyAction')}
-      </Button>
-    </div>
-  );
+if (!filteredVideos || filteredVideos.length === 0) {
+  // ...wrapper Card with conditional copy keyed off feedType...
 }
 ```
 
-- [ ] **Step 3: Add a smoke test**
+- [ ] **Step 2: Compute `isQuietHour` near the top of `VideoFeed`**
 
-Append to `src/pages/TrendingPage.test.tsx` (or a new component test under `VideoFeed.test.tsx` if simpler — choose whichever the existing test uses for empty state). The test asserts the empty heading is rendered when the mocked feed returns empty for popular+now. If the page test already mocks `VideoFeed`, add a separate component-level test instead.
+Right after `const filteredVideos = useMemo(...)` (around line 128), add:
 
-- [ ] **Step 4: Run tests**
+```ts
+const isQuietHour =
+  feedType === 'trending' && sortMode === 'popular' && period === 'now';
+```
 
-Run: `npx vitest run src/components/VideoFeed.test.tsx src/pages/TrendingPage.test.tsx`
-Expected: PASS.
+> `period` is the new prop added in Task 5.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 3: Branch the empty-state copy**
+
+Inside the empty-state early return, replace the existing else-branch (the one that renders the green circle + Video icon + headings) so the quiet-hour variant takes precedence over the generic "No videos found" copy. Keep the existing reclining-Divine branch for `discovery`/`trending`/`classics` only when `!isQuietHour`:
+
+```tsx
+{(feedType === 'discovery' || feedType === 'trending' || feedType === 'classics') && !allFiltered && !isQuietHour ? (
+  // ...existing reclining-Divine branch unchanged...
+) : isQuietHour ? (
+  <>
+    <div className="w-16 h-16 rounded-full bg-brand-light-green dark:bg-brand-dark-green flex items-center justify-center mx-auto">
+      <Video className="h-8 w-8 text-primary" />
+    </div>
+    <div className="space-y-2">
+      <p className="text-lg font-medium text-foreground">
+        {t('trendingPage.popular.emptyHeading')}
+      </p>
+      <p className="text-sm text-muted-foreground">
+        {t('trendingPage.popular.emptyBody')}
+      </p>
+    </div>
+    <Button
+      variant="default"
+      onClick={() => navigate('/trending?sort=popular&period=today', { replace: true })}
+      data-testid="quiet-hour-action"
+    >
+      {t('trendingPage.popular.emptyAction')}
+    </Button>
+  </>
+) : (
+  // ...existing generic empty branch unchanged (the green circle + per-feedType copy)...
+)}
+```
+
+> The existing `useTranslation` hook (`const { t } = useTranslation();`) is already in scope at the top of the function. The existing `Button` import is already present (used on line 248-258 area). `navigate` is already in scope from `useSubdomainNavigate` — reuse it.
+
+- [ ] **Step 4: Add a component test**
+
+Append to `src/components/VideoFeed.test.tsx` a test that renders `<VideoFeed feedType="trending" sortMode="popular" period="now" />` with the data hook mocked to return an empty page. Assert that:
+
+```ts
+expect(screen.getByText(/quiet hour|emptyHeading/i)).toBeInTheDocument();
+expect(screen.getByTestId('quiet-hour-action')).toBeInTheDocument();
+```
+
+> If `VideoFeed.test.tsx` does not already mock `useVideoProvider`, follow the existing test setup pattern in that file (look at line 156 — there's a working test).
+
+- [ ] **Step 5: Run tests**
+
+Run: `npx vitest run src/components/VideoFeed.test.tsx`
+Expected: PASS (including the new quiet-hour test).
+
+- [ ] **Step 6: Commit**
 
 ```bash
-git add src/components/VideoFeed.tsx src/pages/TrendingPage.test.tsx
+git add src/components/VideoFeed.tsx src/components/VideoFeed.test.tsx
 git commit -m "feat(popular): quiet-hour empty state for popular + now"
 ```
 
@@ -1182,6 +1270,19 @@ gh pr create --title "feat: Popular tab with time-window selector on /trending" 
 EOF
 )"
 ```
+
+---
+
+## Risks & gotchas (read before executing)
+
+- **`DiscoveryPage` also passes `feedType="trending"` to `VideoFeed`** (`src/pages/DiscoveryPage.tsx:185,198`). The new `period` prop is optional and defaults to `undefined` for those calls — Discovery keeps its current behavior. No changes required there. Verify the discovery feed still loads in Task 12.
+- **The existing `useInfiniteVideosFunnelcake.test.ts` does not mock `fetchVideosV2`.** Today, any test that drives the trending feed silently calls `undefined()`. Task 3 fixes this by adding `mockFetchVideosV2` — ensure existing tests in that file still pass after the mock is added (they may have been incidentally relying on the missing mock returning `undefined`).
+- **`funnelcakeClient.test.ts` uses `vi.resetModules()` per test.** Do not introduce `vi.spyOn(globalThis, 'fetch')` — it conflicts with the dynamic-import + `global.fetch = vi.fn()` pattern. Stick to the existing pattern (Task 2).
+- **URL encoding for the New tab:** the tab is encoded as `?sort=new`, **not** as a missing param. Missing `?sort` defaults to Hot (matches today's behavior). Clicking New writes `?sort=new`. This is the only way to make the round-trip stable.
+- **Controversial coercion is render-only**, no URL rewrite. Visiting `?sort=controversial` renders Hot; the URL stays `?sort=controversial` until the user clicks something. This is intentional — rewriting the URL on mount triggers re-render churn and is not testable from `useSearchParams` without a location probe.
+- **The trending feed uses `/api/v2/videos`.** When `sort=popular` is selected, the request becomes `GET /api/v2/videos?sort=popular&period=<value>&limit=12`. Verify in DevTools network tab during Task 12 manual QA.
+- **Edge-injected feed cache (`window.__DIVINE_FEED__`)** is only consumed for the default trending feed (no `pageParam`, no sort filter). Popular requests bypass it because they have a different `queryKey` (period is part of the key). No edge-side change needed.
+- **Brand guardrails** (`tests/brand`) run on the entire src tree. New code must avoid: Tailwind `uppercase` class, `lucide-react` imports, `bg-gradient-*` / `radial-gradient(` / `linear-gradient(` on layout surfaces. The plan's snippets comply, but watch for accidental introductions during Task 8/9.
 
 ---
 

--- a/docs/superpowers/plans/2026-05-09-popular-time-window.md
+++ b/docs/superpowers/plans/2026-05-09-popular-time-window.md
@@ -459,11 +459,15 @@ Add a regression test inside `src/hooks/useInfiniteVideosFunnelcake.test.ts` (in
 
 ```ts
 it('does not consume edge-injected feed when period is set', async () => {
-  // Simulate edge injection
-  (window as Window & { __DIVINE_FEED__?: unknown; __DIVINE_FEED_TYPE__?: string }).__DIVINE_FEED__ = {
+  // Simulate the real edge worker: it sets BOTH globals together.
+  // See compute-js/src/index.js:207 — `window.__DIVINE_FEED_TYPE__="trending"`.
+  // (The hook also has a fallback path for `__DIVINE_FEED_TYPE__ === undefined`
+  // but that's not what production looks like.)
+  type EdgeWindow = Window & { __DIVINE_FEED__?: unknown; __DIVINE_FEED_TYPE__?: string };
+  (window as EdgeWindow).__DIVINE_FEED__ = {
     videos: [{ id: 'edge-video', pubkey: 'edge-p', kind: 34236, createdAt: 1, vineId: 'edge-d' }],
   };
-  delete (window as { __DIVINE_FEED_TYPE__?: string }).__DIVINE_FEED_TYPE__;
+  (window as EdgeWindow).__DIVINE_FEED_TYPE__ = 'trending';
 
   mockFetchVideosV2.mockResolvedValueOnce({ videos: [{}], has_more: false, next_cursor: undefined });
   mockTransformToVideoPage.mockReturnValueOnce({
@@ -483,11 +487,14 @@ it('does not consume edge-injected feed when period is set', async () => {
   expect(mockFetchVideosV2).toHaveBeenCalled();
   expect(result.current.data?.pages[0]?.videos[0]?.id).toBe('api-video');
 
-  // Edge cache untouched (still present for a future non-period request)
-  expect((window as { __DIVINE_FEED__?: unknown }).__DIVINE_FEED__).toBeDefined();
+  // Edge cache untouched — still available for a future non-period request
+  // (e.g., switching back to Hot would let the hook consume it).
+  expect((window as EdgeWindow).__DIVINE_FEED__).toBeDefined();
+  expect((window as EdgeWindow).__DIVINE_FEED_TYPE__).toBe('trending');
 
-  // Cleanup
-  delete (window as { __DIVINE_FEED__?: unknown }).__DIVINE_FEED__;
+  // Cleanup so test order doesn't leak into other suites
+  delete (window as EdgeWindow).__DIVINE_FEED__;
+  delete (window as EdgeWindow).__DIVINE_FEED_TYPE__;
 });
 ```
 

--- a/docs/superpowers/specs/2026-05-09-popular-time-window-design.md
+++ b/docs/superpowers/specs/2026-05-09-popular-time-window-design.md
@@ -1,0 +1,215 @@
+# Popular feed with time-window selector
+
+**Date:** 2026-05-09
+**Status:** Approved
+**Owner:** rabble + Claude
+
+## Problem
+
+`api.divine.video` now supports a `period` parameter on `/api/v2/videos` and `/api/videos`
+(`now | today | week | month | all`) alongside a `sort=popular` mode. The web app's
+trending page (`/trending`) cannot expose this — it only ships the NIP-50 string sorts
+(`hot`, `top`, `rising`, `classic`, `controversial`) with no time-window control. Users
+have no way to ask for "popular this hour" vs "popular this month."
+
+## Goals
+
+1. Add a `Popular` tab on `/trending` that calls the API with `sort=popular` and a
+   user-selected `period`.
+2. Expose all five periods: `Now`, `Today`, `This Week`, `This Month`, `All Time`.
+3. Make the selection deep-linkable (`?sort=…&period=…`) so views are shareable and
+   survive refresh / browser back.
+4. Drop `Controversial` from the visible tabs (off-brand for Divine; engagement-bait by
+   design).
+
+## Non-goals
+
+- Leaderboard page changes (separate endpoint, separate UX).
+- Period support on hashtag, search, or profile feeds.
+- Per-period RSS feeds.
+- Combining `Classic` with `period`.
+- Renaming `/trending` → `/popular` (kept as `/trending` for low churn).
+
+## Decisions
+
+| # | Decision | Choice |
+|---|----------|--------|
+| A | Sort vs period UX | **Two separate controls** — sort tabs row + period pills row |
+| A3 | Which sort exposes period | **Only `Popular`** (new tab); other sorts unchanged |
+| B1 | Routing | **Keep `/trending`**; Popular is a tab inside |
+| C1 | Default period when Popular is selected | **`Today`** |
+| D1 | URL persistence | **Both sort and period in query params** |
+| E2 | Controversial | **Drop from visible tabs**; keep type literal for URL coercion |
+
+## UI
+
+`/trending` page renders two stacked control rows above the feed.
+
+**Row 1 — Sort tabs.** Existing pill/button styling (`EXTENDED_SORT_MODES`).
+Final order: `Hot · New · Top · Rising · Popular · Classic`.
+- `Popular` slots between `Rising` and `Classic`.
+- Tab description: "Trending in this window."
+- Icon: `TrendUp` (Phosphor, weight=bold; weight=fill when active).
+- `Controversial` removed from `EXTENDED_SORT_MODES` and `SEARCH_SORT_MODES`.
+
+**Row 2 — Period pills.** Renders only when `sort === 'popular'`.
+- Pills: `Now · Today · This Week · This Month · All Time` mapping to API values
+  `now | today | week | month | all`.
+- Visually subordinate to Row 1: smaller pills, indented or set in a sub-bar.
+- Default: `Today`.
+- Mobile: horizontally scrollable; min 44px tap target.
+
+**Empty state.** When `sort=popular` + `period=now` returns 0 results, render an empty
+state with copy "Quiet hour — try a wider window" and a one-tap action that switches to
+`period=today`. Reuse the existing empty primitive on `VideoFeed`.
+
+**Voice.** Casual-direct (per `CLAUDE.md` brand): "Quiet hour — try a wider window."
+Not "No results found."
+
+## URL state
+
+Page reads `sort` and `period` from `useSearchParams`.
+
+- `sort` ∈ `{ hot, top, rising, classic, popular }`. Unknown / missing → `hot`.
+- `period` ∈ `{ now, today, week, month, all }`. Only consulted when `sort=popular`.
+  Unknown / missing → `today`.
+- `?sort=controversial` from older shared links → coerced to `hot` on read; URL is
+  rewritten via `replace` (no history entry).
+- Pill / tab clicks update the URL via `setSearchParams({ sort, period })` with `replace`
+  semantics so browser back goes to the page-before, not between sort flips.
+
+## Data flow
+
+```
+TrendingPage (sort, period from URL)
+   └─ VideoFeed { sortMode, period, ... }
+        └─ useVideoProvider { sortMode, period, ... }
+              └─ useInfiniteVideosFunnelcake { sortMode, period, ... }
+                    └─ getFetchOptions(feedType='trending', sortMode, period)
+                          └─ fetchVideosV2 (sort, period, ...)
+                                └─ /api/v2/videos?sort=popular&period=today
+```
+
+### Type changes
+
+`src/types/funnelcake.ts`:
+```ts
+export type FunnelcakePeriod = 'now' | 'today' | 'week' | 'month' | 'all';
+
+export interface FunnelcakeFetchOptions {
+  sort?: 'trending' | 'recent' | 'popular' | 'loops' | 'engagement'
+       | 'watching' | 'likes' | 'comments' | 'published';
+  period?: FunnelcakePeriod;   // NEW — only meaningful when sort='popular' (or 'trending')
+  // ...existing fields unchanged
+}
+```
+
+`src/hooks/useInfiniteVideosFunnelcake.ts`:
+```ts
+export type FunnelcakeSortMode =
+  | 'trending' | 'recent' | 'loops' | 'engagement'
+  | 'classic' | 'watching' | 'popular';   // 'popular' added
+```
+
+`src/types/nostr.ts`:
+- `SortMode` union keeps `'controversial'` literal (URL safety / coercion source).
+- Add `'popular'` to the union.
+
+### Hook wiring
+
+`useInfiniteVideosFunnelcake.getFetchOptions` for `feedType='trending'`:
+```ts
+case 'trending':
+  if (sortMode === 'classic') {
+    return { ...base, classic: true, platform: 'vine', sort: 'loops' };
+  }
+  if (sortMode === 'popular') {
+    return { ...base, sort: 'popular', period: period ?? 'today' };
+  }
+  return { ...base, sort: sortMode || 'watching' };
+```
+
+`fetchVideosV2` (and `fetchVideos` v1 for parity) appends `period` to query params when
+present. Param is omitted (not sent as empty) when undefined.
+
+`mapToFunnelcakeSortMode` (`useVideoProvider.ts`) gets a new branch:
+```ts
+case 'popular': return 'popular';
+```
+
+### `VideoFeed` props
+
+Add `period?: FunnelcakePeriod` prop. Plumb through `useVideoProvider` → hook. No-op for
+non-trending feed types.
+
+### Query key
+
+`useInfiniteQuery` queryKey gains `period` so cache invalidates when window changes:
+```ts
+queryKey: ['funnelcake-videos', feedType, effectiveApiUrl, sortMode, period, hashtag, ...]
+```
+
+### `SORT_MODES` constants
+
+`src/lib/constants/sortModes.ts`:
+- `EXTENDED_SORT_MODES`: drop `controversial`, add `popular` (slotted before `classic`).
+- `SEARCH_SORT_MODES`: drop `controversial`. (Search page out of scope for period; no
+  period control added there.)
+- New constant `POPULAR_PERIODS: { value: FunnelcakePeriod; label: string }[]`
+  with `{ now: 'Now', today: 'Today', week: 'This Week', month: 'This Month', all: 'All Time' }`.
+
+## Edge cases
+
+- **Old `?sort=controversial` link:** coerced to `hot`, URL rewritten via `replace`.
+- **`?sort=popular` without `period`:** treated as `period=today`.
+- **`?period=today` without `sort=popular`:** `period` ignored; sort defaults to `hot`.
+- **Edge-injected feed:** `window.__DIVINE_FEED__` is only consumed for the default
+  trending feed (no sort param). Popular requests bypass the cache and hit the API
+  directly. (Future optimization could cache top periods at the edge — out of scope.)
+- **Empty `now` window:** see empty state above.
+- **i18n:** all new strings (`Popular`, `Now`, `Today`, `This Week`, `This Month`,
+  `All Time`, "Quiet hour — try a wider window") added under
+  `trendingPage.popular.*` keys; populated for the existing 14 non-fil locales by the
+  same AI-translation pass that did the prior batches.
+
+## Testing
+
+### Unit / hook
+
+- `useInfiniteVideosFunnelcake.test.ts`: assert that
+  `{ feedType: 'trending', sortMode: 'popular', period: 'week' }`
+  calls `fetchVideosV2` with `sort: 'popular', period: 'week'`.
+- `useInfiniteVideosFunnelcake.test.ts`: omitting `period` with `sortMode='popular'`
+  defaults to `period: 'today'`.
+- `funnelcakeClient.test.ts`: `fetchVideosV2` includes `period` in the query string when
+  passed; omits it when undefined.
+
+### Component
+
+- `TrendingPage.test.tsx`: period row hidden unless `sort=popular`. Selecting Popular
+  reveals the row. Clicking a period pill updates the URL and the feed query.
+- `TrendingPage.test.tsx`: `?sort=controversial` redirects to `?sort=hot`.
+- `TrendingPage.test.tsx`: `?sort=popular&period=week` initial render selects Popular +
+  This Week.
+
+### Brand guardrails
+
+Existing tests already cover: no Tailwind `uppercase`, no gradients on layout, no
+`lucide-react`. New code must not introduce any.
+
+### A11y
+
+- Tabs use `role="tablist"` / `role="tab"` (or button equivalents already in use).
+- Period pills are buttons with clear `aria-pressed` state.
+- Axe sweep on `/trending?sort=popular&period=today` added to
+  `tests/visual/a11y.spec.ts`.
+
+## Rollout
+
+Single PR, behind no flag. Period defaults are conservative; failure mode is "API ignores
+period" (current behavior), which silently degrades to current Top/Hot semantics.
+
+## Open questions
+
+None blocking. Future work: edge-cache popular feeds per period; add period to hashtag
+page; reconsider RSS per-period feeds.

--- a/src/components/VideoFeed.test.tsx
+++ b/src/components/VideoFeed.test.tsx
@@ -175,4 +175,58 @@ describe('VideoFeed', () => {
       0,
     );
   });
+
+  it('renders the quiet-hour empty state for popular + now when feed is empty', async () => {
+    mockUseVideoProvider.mockReturnValue({
+      data: { pages: [{ videos: [] }] },
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+      dataSource: 'funnelcake',
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/trending?sort=popular&period=now']}>
+        <VideoFeed
+          feedType="trending"
+          sortMode="popular"
+          period="now"
+          viewMode="feed"
+          mode="thumbnail"
+        />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/quiet hour/i)).toBeInTheDocument();
+    expect(screen.getByTestId('quiet-hour-action')).toBeInTheDocument();
+  });
+
+  it('does not render the quiet-hour empty state for popular + week', async () => {
+    mockUseVideoProvider.mockReturnValue({
+      data: { pages: [{ videos: [] }] },
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+      dataSource: 'funnelcake',
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/trending?sort=popular&period=week']}>
+        <VideoFeed
+          feedType="trending"
+          sortMode="popular"
+          period="week"
+          viewMode="feed"
+          mode="thumbnail"
+        />
+      </MemoryRouter>
+    );
+
+    // Renders the existing "Divine reclining" / "Divine needs a rest" branch instead
+    expect(screen.queryByTestId('quiet-hour-action')).not.toBeInTheDocument();
+  });
 });

--- a/src/components/VideoFeed.tsx
+++ b/src/components/VideoFeed.tsx
@@ -158,6 +158,9 @@ export function VideoFeed({
     });
   }, [allVideos, checkContent, verifiedOnly]);
 
+  const isQuietHour =
+    feedType === 'trending' && sortMode === 'popular' && period === 'now';
+
   useEffect(() => {
     if (!isLoading && filteredVideos.length > 0) {
       trackInitialRender({
@@ -378,8 +381,30 @@ export function VideoFeed({
         <Card className="border-dashed border-2 border-brand-light-green dark:border-brand-dark-green bg-brand-light-green dark:bg-brand-dark-green">
           <CardContent className="py-16 px-8 text-center">
             <div className="max-w-md mx-auto space-y-6">
-              {/* Show reclining Divine image for discovery/trending/classics feeds when no videos */}
-              {(feedType === 'discovery' || feedType === 'trending' || feedType === 'classics') && !allFiltered ? (
+              {/* Show quiet-hour state for popular + now when no videos */}
+              {isQuietHour ? (
+                <>
+                  <div className="w-16 h-16 rounded-full bg-brand-light-green dark:bg-brand-dark-green flex items-center justify-center mx-auto">
+                    <Video className="h-8 w-8 text-primary" />
+                  </div>
+                  <div className="space-y-2">
+                    <p className="text-lg font-medium text-foreground">
+                      {t('trendingPage.popular.emptyHeading')}
+                    </p>
+                    <p className="text-sm text-muted-foreground">
+                      {t('trendingPage.popular.emptyBody')}
+                    </p>
+                  </div>
+                  <Button
+                    variant="default"
+                    onClick={() => navigate('/trending?sort=popular&period=today', { replace: true })}
+                    data-testid="quiet-hour-action"
+                  >
+                    {t('trendingPage.popular.emptyAction')}
+                  </Button>
+                </>
+              ) : (feedType === 'discovery' || feedType === 'trending' || feedType === 'classics') && !allFiltered ? (
+                /* Show reclining Divine image for discovery/trending/classics feeds when no videos */
                 <>
                   <div className="mx-auto -mx-8 -mt-16">
                     <img

--- a/src/components/VideoFeed.tsx
+++ b/src/components/VideoFeed.tsx
@@ -20,6 +20,7 @@ import InfiniteScroll from 'react-infinite-scroll-component';
 import type { ParsedVideoData } from '@/types/video';
 import { debugLog, debugWarn } from '@/lib/debug';
 import type { SortMode } from '@/types/nostr';
+import type { FunnelcakePeriod } from '@/types/funnelcake';
 import { useSubdomainNavigate } from '@/hooks/useSubdomainNavigate';
 import { useCallback } from 'react';
 import { useFullscreenFeed } from '@/contexts/FullscreenFeedContext';
@@ -37,6 +38,7 @@ interface VideoFeedProps {
   pubkey?: string;
   limit?: number;
   sortMode?: SortMode; // NIP-50 sort mode (hot, top, rising, controversial)
+  period?: FunnelcakePeriod; // Time window — only meaningful when sortMode='popular' on a trending feed
   viewMode?: ViewMode; // Display mode: feed (full cards) or grid (thumbnails)
   className?: string;
   verifiedOnly?: boolean; // Filter to show only ProofMode verified videos
@@ -59,6 +61,7 @@ export function VideoFeed({
   pubkey,
   limit = 12, // Smaller first page improves initial paint on REST-backed feeds
   sortMode,
+  period,
   viewMode = 'feed',
   className,
   verifiedOnly = false,
@@ -94,6 +97,7 @@ export function VideoFeed({
     pubkey,
     pageSize: limit,
     sortMode,
+    period,
   });
   const { feedRootRef, trackInitialRender, trackFirstPlayback } = useFeedPerformanceInstrumentation({
     feedType,

--- a/src/hooks/useInfiniteVideosFunnelcake.test.ts
+++ b/src/hooks/useInfiniteVideosFunnelcake.test.ts
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 
 const mockFetchVideos = vi.fn();
+const mockFetchVideosV2 = vi.fn();
 const mockFetchRecommendations = vi.fn();
 const mockTransformToVideoPage = vi.fn();
 
@@ -15,6 +16,7 @@ vi.mock('@/hooks/useCurrentUser', () => ({
 
 vi.mock('@/lib/funnelcakeClient', () => ({
   fetchVideos: mockFetchVideos,
+  fetchVideosV2: mockFetchVideosV2,
   searchVideos: vi.fn(),
   fetchUserVideos: vi.fn(),
   fetchUserFeed: vi.fn(),
@@ -215,5 +217,95 @@ describe('useInfiniteVideosFunnelcake', () => {
     );
 
     expect(result.current.data?.pages[1]?.videos).toEqual(popularVideos);
+  });
+});
+
+describe('popular sort with period', () => {
+  it('passes sort=popular and the chosen period to fetchVideosV2', async () => {
+    mockFetchVideosV2.mockResolvedValueOnce({
+      videos: [{}],
+      has_more: false,
+      next_cursor: undefined,
+    });
+    mockTransformToVideoPage.mockReturnValueOnce({
+      videos: [{ id: 'v1', pubkey: 'p1', kind: 34236, createdAt: 1, vineId: 'd1' }],
+      nextCursor: undefined,
+      hasMore: false,
+    });
+
+    const { result } = renderHook(
+      () => useInfiniteVideosFunnelcake({
+        feedType: 'trending',
+        sortMode: 'popular',
+        period: 'week',
+        pageSize: 12,
+      }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockFetchVideosV2).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        sort: 'popular',
+        period: 'week',
+        limit: 12,
+      }),
+    );
+  });
+
+  it('defaults popular sort to period=today when period is omitted', async () => {
+    mockFetchVideosV2.mockResolvedValueOnce({ videos: [], has_more: false, next_cursor: undefined });
+    mockTransformToVideoPage.mockReturnValueOnce({ videos: [], nextCursor: undefined, hasMore: false });
+
+    renderHook(
+      () => useInfiniteVideosFunnelcake({
+        feedType: 'trending',
+        sortMode: 'popular',
+        pageSize: 12,
+      }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() =>
+      expect(mockFetchVideosV2).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ sort: 'popular', period: 'today' }),
+      ),
+    );
+  });
+
+  it('does not consume edge-injected feed when period is set', async () => {
+    // Simulate the real edge worker: it sets BOTH globals together.
+    // See compute-js/src/index.js:207 — `window.__DIVINE_FEED_TYPE__="trending"`.
+    type EdgeWindow = Window & { __DIVINE_FEED__?: unknown; __DIVINE_FEED_TYPE__?: string };
+    (window as EdgeWindow).__DIVINE_FEED__ = {
+      videos: [{ id: 'edge-video', pubkey: 'edge-p', kind: 34236, createdAt: 1, vineId: 'edge-d' }],
+    };
+    (window as EdgeWindow).__DIVINE_FEED_TYPE__ = 'trending';
+
+    mockFetchVideosV2.mockResolvedValueOnce({ videos: [{}], has_more: false, next_cursor: undefined });
+    mockTransformToVideoPage.mockReturnValueOnce({
+      videos: [{ id: 'api-video', pubkey: 'api-p', kind: 34236, createdAt: 2, vineId: 'api-d' }],
+      nextCursor: undefined,
+      hasMore: false,
+    });
+
+    const { result } = renderHook(
+      () => useInfiniteVideosFunnelcake({ feedType: 'trending', sortMode: 'popular', period: 'today', pageSize: 12 }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockFetchVideosV2).toHaveBeenCalled();
+    expect(result.current.data?.pages[0]?.videos[0]?.id).toBe('api-video');
+
+    expect((window as EdgeWindow).__DIVINE_FEED__).toBeDefined();
+    expect((window as EdgeWindow).__DIVINE_FEED_TYPE__).toBe('trending');
+
+    delete (window as EdgeWindow).__DIVINE_FEED__;
+    delete (window as EdgeWindow).__DIVINE_FEED_TYPE__;
   });
 });

--- a/src/hooks/useInfiniteVideosFunnelcake.test.ts
+++ b/src/hooks/useInfiniteVideosFunnelcake.test.ts
@@ -279,9 +279,15 @@ describe('popular sort with period', () => {
   it('does not consume edge-injected feed when period is set', async () => {
     // Simulate the real edge worker: it sets BOTH globals together.
     // See compute-js/src/index.js:207 — `window.__DIVINE_FEED_TYPE__="trending"`.
+    // The fixture mimics what the Fastly edge worker injects, but the hook is
+    // supposed to skip consumption when period is set — so the shape never
+    // gets parsed. Use a structural type that bypasses FunnelcakeResponse's
+    // required fields (id, pubkey, d_tag, video_url, etc.) to keep the test
+    // narrow.
     type EdgeWindow = Window & { __DIVINE_FEED__?: unknown; __DIVINE_FEED_TYPE__?: string };
     (window as EdgeWindow).__DIVINE_FEED__ = {
-      videos: [{ id: 'edge-video', pubkey: 'edge-p', kind: 34236, createdAt: 1, vineId: 'edge-d' }],
+      videos: [{ id: 'edge-video', pubkey: 'edge-p', kind: 34236, created_at: 1, d_tag: 'edge-d', video_url: 'https://example.com/edge.mp4' }],
+      has_more: false,
     };
     (window as EdgeWindow).__DIVINE_FEED_TYPE__ = 'trending';
 

--- a/src/hooks/useInfiniteVideosFunnelcake.ts
+++ b/src/hooks/useInfiniteVideosFunnelcake.ts
@@ -6,7 +6,7 @@ import { useState } from 'react';
 import { getFunnelcakeBaseUrl } from '@/config/api';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
 import type { ParsedVideoData } from '@/types/video';
-import type { FunnelcakeFetchOptions } from '@/types/funnelcake';
+import type { FunnelcakeFetchOptions, FunnelcakePeriod } from '@/types/funnelcake';
 import { fetchVideos, fetchVideosV2, searchVideos, fetchUserVideos, fetchUserFeed, fetchRecommendations } from '@/lib/funnelcakeClient';
 import { enrichAgeRestrictedVideos } from '@/lib/ageRestrictedVideos';
 import { transformToVideoPage } from '@/lib/funnelcakeTransform';
@@ -14,12 +14,13 @@ import { debugLog } from '@/lib/debug';
 import { performanceMonitor } from '@/lib/performanceMonitoring';
 
 export type FunnelcakeFeedType = 'trending' | 'recent' | 'classics' | 'hashtag' | 'profile' | 'home' | 'recommendations' | 'category';
-export type FunnelcakeSortMode = 'trending' | 'recent' | 'loops' | 'engagement' | 'classic' | 'watching';
+export type FunnelcakeSortMode = 'trending' | 'recent' | 'loops' | 'engagement' | 'classic' | 'watching' | 'popular';
 
 interface UseInfiniteVideosFunnelcakeOptions {
   feedType: FunnelcakeFeedType;
   apiUrl?: string;          // Override API URL (for classics always using Divine)
   sortMode?: FunnelcakeSortMode;
+  period?: FunnelcakePeriod;   // Time window for popular/trending sorts
   hashtag?: string;         // For hashtag feed
   category?: string;        // For category feed
   pubkey?: string;          // For profile and home feeds
@@ -92,7 +93,8 @@ function isRecommendationsCursorPageParam(
 function getFetchOptions(
   feedType: FunnelcakeFeedType,
   sortMode?: FunnelcakeSortMode,
-  pageSize: number = 20
+  pageSize: number = 20,
+  period?: FunnelcakePeriod,
 ): FunnelcakeFetchOptions {
   const baseOptions: FunnelcakeFetchOptions = {
     limit: pageSize,
@@ -111,10 +113,15 @@ function getFetchOptions(
     case 'trending':
       // Trending uses /api/v2/videos with sort=watching by default — 24h CDN view
       // count with no age decay, surfaces classic Vines getting current attention.
+      if (sortMode === 'classic') {
+        return { ...baseOptions, classic: true, platform: 'vine', sort: 'loops' };
+      }
+      if (sortMode === 'popular') {
+        return { ...baseOptions, sort: 'popular', period: period ?? 'today' };
+      }
       return {
         ...baseOptions,
-        sort: sortMode === 'classic' ? 'loops' : (sortMode || 'watching'),
-        ...(sortMode === 'classic' ? { classic: true, platform: 'vine' } : {}),
+        sort: sortMode || 'watching',
       };
 
     case 'recent':
@@ -178,6 +185,7 @@ export function useInfiniteVideosFunnelcake({
   feedType,
   apiUrl,
   sortMode,
+  period,
   hashtag,
   category,
   pubkey,
@@ -202,7 +210,7 @@ export function useInfiniteVideosFunnelcake({
     : (apiUrl || getFunnelcakeBaseUrl());
 
   return useInfiniteQuery<FunnelcakeVideoPage, Error>({
-    queryKey: ['funnelcake-videos', feedType, effectiveApiUrl, sortMode, hashtag, category, pubkey, pageSize, randomStartOffset],
+    queryKey: ['funnelcake-videos', feedType, effectiveApiUrl, sortMode, period, hashtag, category, pubkey, pageSize, randomStartOffset],
 
     queryFn: async ({ pageParam, signal }) => {
       const totalStart = performance.now();
@@ -211,7 +219,11 @@ export function useInfiniteVideosFunnelcake({
       // The Fastly edge worker injects window.__DIVINE_FEED__ to avoid a client round-trip
       const edgeFeedType = typeof window !== 'undefined' ? window.__DIVINE_FEED_TYPE__ : undefined;
       const edgeMatchesFeed = edgeFeedType === feedType || (edgeFeedType === undefined && feedType === 'trending');
-      if (!pageParam && edgeMatchesFeed && typeof window !== 'undefined' && window.__DIVINE_FEED__) {
+      // Edge-injected data only represents the default trending feed (sort=watching, no period).
+      // Skip it whenever the request specifies a period — those mean Popular, which the edge
+      // hasn't pre-cached.
+      const edgeUsable = edgeMatchesFeed && !period;
+      if (!pageParam && edgeUsable && typeof window !== 'undefined' && window.__DIVINE_FEED__) {
         const edgeData = window.__DIVINE_FEED__;
         delete window.__DIVINE_FEED__; // Consume once
         delete window.__DIVINE_FEED_TYPE__;
@@ -247,7 +259,7 @@ export function useInfiniteVideosFunnelcake({
           ? String(pageParam)
           : undefined;
 
-      const options = getFetchOptions(feedType, sortMode, pageSize);
+      const options = getFetchOptions(feedType, sortMode, pageSize, period);
       options.signal = signal;
 
       // For randomized feeds, use offset directly instead of before cursor

--- a/src/hooks/useVideoProvider.ts
+++ b/src/hooks/useVideoProvider.ts
@@ -10,6 +10,7 @@ import { hasFunnelcake, getFunnelcakeUrl } from '@/config/relays';
 import { debugLog } from '@/lib/debug';
 import type { RelayCapabilities } from '@/lib/relayCapabilities';
 import type { SortMode } from '@/types/nostr';
+import type { FunnelcakePeriod } from '@/types/funnelcake';
 
 // Feed types that can be provided
 export type VideoFeedType = 'discovery' | 'home' | 'trending' | 'hashtag' | 'profile' | 'recent' | 'classics' | 'foryou' | 'category';
@@ -18,6 +19,7 @@ type WebsocketVideoFeedType = 'discovery' | 'home' | 'trending' | 'hashtag' | 'p
 interface UseVideoProviderOptions {
   feedType: VideoFeedType;
   sortMode?: SortMode;
+  period?: FunnelcakePeriod;
   hashtag?: string;
   category?: string;
   pubkey?: string;
@@ -118,6 +120,8 @@ function mapToFunnelcakeSortMode(sortMode?: SortMode): FunnelcakeSortMode | unde
       return 'engagement';
     case 'classic':
       return 'classic';
+    case 'popular':
+      return 'popular';
     default:
       return 'trending';
   }
@@ -207,6 +211,7 @@ export function chooseVideoDataSource({
 export function useVideoProvider({
   feedType,
   sortMode,
+  period,
   hashtag,
   category,
   pubkey,
@@ -233,6 +238,7 @@ export function useVideoProvider({
     feedType: mapToFunnelcakeFeedType(feedType),
     apiUrl: decision.apiUrl,
     sortMode: mapToFunnelcakeSortMode(sortMode),
+    period,
     hashtag,
     category,
     pubkey,

--- a/src/lib/constants/sortModes.test.ts
+++ b/src/lib/constants/sortModes.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import {
+  EXTENDED_SORT_MODES,
+  SEARCH_SORT_MODES,
+  POPULAR_PERIODS,
+} from './sortModes';
+
+describe('sortModes constants', () => {
+  it('EXTENDED_SORT_MODES contains popular and not controversial', () => {
+    const values = EXTENDED_SORT_MODES.map(m => m.value);
+    expect(values).toContain('popular');
+    expect(values).not.toContain('controversial');
+  });
+
+  it('EXTENDED_SORT_MODES places popular between rising and classic', () => {
+    const values = EXTENDED_SORT_MODES.map(m => m.value);
+    const rising = values.indexOf('rising');
+    const popular = values.indexOf('popular');
+    const classic = values.indexOf('classic');
+    expect(rising).toBeGreaterThanOrEqual(0);
+    expect(popular).toBe(rising + 1);
+    expect(classic).toBe(popular + 1);
+  });
+
+  it('SEARCH_SORT_MODES does not contain controversial', () => {
+    const values = SEARCH_SORT_MODES.map(m => m.value);
+    expect(values).not.toContain('controversial');
+  });
+
+  it('POPULAR_PERIODS contains the five expected windows in order', () => {
+    expect(POPULAR_PERIODS.map(p => p.value)).toEqual(['now', 'today', 'week', 'month', 'all']);
+  });
+});

--- a/src/lib/constants/sortModes.ts
+++ b/src/lib/constants/sortModes.ts
@@ -1,9 +1,10 @@
 // ABOUTME: Centralized sort mode definitions for NIP-50 search
 // ABOUTME: Single source of truth for sort modes across all pages
 
-import { Flame, TrendUp as TrendingUp, Lightning as Zap, Scales as Scale, Clock, MagnifyingGlass as Search, FilmSlate as Clapperboard } from '@phosphor-icons/react';
+import { Flame, TrendUp as TrendingUp, Lightning as Zap, Clock, MagnifyingGlass as Search, FilmSlate as Clapperboard } from '@phosphor-icons/react';
 import type { Icon as LucideIcon } from '@phosphor-icons/react';
 import type { SortMode } from '@/types/nostr';
+import type { FunnelcakePeriod } from '@/types/funnelcake';
 
 export interface SortModeDefinition {
   value: SortMode | undefined;
@@ -57,46 +58,16 @@ export const SORT_MODES: SortModeDefinition[] = [
 ];
 
 /**
- * Extended sort modes including controversial
+ * Extended sort modes including popular
  * Used in: TrendingPage, HashtagPage
  */
 export const EXTENDED_SORT_MODES: SortModeDefinition[] = [
-  {
-    value: 'hot',
-    label: 'Hot',
-    description: 'Recent + high engagement',
-    icon: Flame
-  },
-  {
-    value: undefined,
-    label: 'New',
-    description: 'Latest videos',
-    icon: Clock
-  },
-  {
-    value: 'top',
-    label: 'Top',
-    description: 'Most viewed all-time',
-    icon: TrendingUp
-  },
-  {
-    value: 'rising',
-    label: 'Rising',
-    description: 'Gaining traction',
-    icon: Zap
-  },
-  {
-    value: 'classic',
-    label: 'Classic',
-    description: 'Vine archive favorites',
-    icon: Clapperboard
-  },
-  {
-    value: 'controversial',
-    label: 'Controversial',
-    description: 'Mixed reactions',
-    icon: Scale
-  }
+  { value: 'hot',     label: 'Hot',     description: 'Recent + high engagement', icon: Flame },
+  { value: undefined, label: 'New',     description: 'Latest videos',           icon: Clock },
+  { value: 'top',     label: 'Top',     description: 'Most viewed all-time',    icon: TrendingUp },
+  { value: 'rising',  label: 'Rising',  description: 'Gaining traction',        icon: Zap },
+  { value: 'popular', label: 'Popular', description: 'Trending in this window', icon: TrendingUp },
+  { value: 'classic', label: 'Classic', description: 'Vine archive favorites',  icon: Clapperboard },
 ];
 
 /**
@@ -152,11 +123,19 @@ export const SEARCH_SORT_MODES: SearchSortModeDefinition[] = [
     label: 'Classic',
     description: 'Vine archive favorites',
     icon: Clapperboard
-  },
-  {
-    value: 'controversial',
-    label: 'Controversial',
-    description: 'Mixed reactions',
-    icon: Scale
   }
+];
+
+export interface PopularPeriodDefinition {
+  value: FunnelcakePeriod;
+  label: string;            // i18n key: trendingPage.popular.period.<value>
+  shortLabel: string;       // for compact pills on mobile
+}
+
+export const POPULAR_PERIODS: PopularPeriodDefinition[] = [
+  { value: 'now',   label: 'Now',        shortLabel: 'Now' },
+  { value: 'today', label: 'Today',      shortLabel: 'Today' },
+  { value: 'week',  label: 'This Week',  shortLabel: 'Week' },
+  { value: 'month', label: 'This Month', shortLabel: 'Month' },
+  { value: 'all',   label: 'All Time',   shortLabel: 'All' },
 ];

--- a/src/lib/funnelcakeClient.test.ts
+++ b/src/lib/funnelcakeClient.test.ts
@@ -614,3 +614,76 @@ describe('funnelcakeClient', () => {
     });
   });
 });
+
+describe('fetchVideos / fetchVideosV2 period parameter', () => {
+  let fetchVideos: typeof import('./funnelcakeClient').fetchVideos;
+  let fetchVideosV2: typeof import('./funnelcakeClient').fetchVideosV2;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    global.fetch = vi.fn();
+    const client = await import('./funnelcakeClient');
+    fetchVideos = client.fetchVideos;
+    fetchVideosV2 = client.fetchVideosV2;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function lastFetchUrl(): string {
+    const mockFetch = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    const calls = mockFetch.mock.calls;
+    return String(calls[calls.length - 1][0]);
+  }
+
+  it('fetchVideos includes period when provided', async () => {
+    (global.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } })
+    );
+
+    await fetchVideos(API_URL, { sort: 'popular', period: 'week', limit: 12 });
+
+    const url = lastFetchUrl();
+    expect(url).toContain('sort=popular');
+    expect(url).toContain('period=week');
+  });
+
+  it('fetchVideos omits period when undefined', async () => {
+    (global.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } })
+    );
+
+    await fetchVideos(API_URL, { sort: 'popular', limit: 12 });
+
+    expect(lastFetchUrl()).not.toContain('period=');
+  });
+
+  it('fetchVideosV2 includes period when provided', async () => {
+    (global.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(JSON.stringify({ data: [], pagination: { has_more: false } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    await fetchVideosV2(API_URL, { sort: 'popular', period: 'today', limit: 12 });
+
+    const url = lastFetchUrl();
+    expect(url).toContain('sort=popular');
+    expect(url).toContain('period=today');
+  });
+
+  it('fetchVideosV2 omits period when undefined', async () => {
+    (global.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(JSON.stringify({ data: [], pagination: { has_more: false } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    await fetchVideosV2(API_URL, { sort: 'watching', limit: 12 });
+
+    expect(lastFetchUrl()).not.toContain('period=');
+  });
+});

--- a/src/lib/funnelcakeClient.ts
+++ b/src/lib/funnelcakeClient.ts
@@ -167,10 +167,11 @@ export async function fetchVideos(
   apiUrl: string = API_CONFIG.funnelcake.baseUrl,
   options: FunnelcakeFetchOptions = {}
 ): Promise<FunnelcakeResponse> {
-  const { sort = 'trending', limit = 20, before, offset, classic, platform, category, signal } = options;
+  const { sort = 'trending', period, limit = 20, before, offset, classic, platform, category, signal } = options;
 
   const params: Record<string, string | number | boolean | undefined> = {
     sort,
+    period,
     limit,
     classic,
     platform,
@@ -230,10 +231,11 @@ export async function fetchVideosV2(
   apiUrl: string = API_CONFIG.funnelcake.baseUrl,
   options: FunnelcakeFetchOptions = {}
 ): Promise<FunnelcakeResponse> {
-  const { sort = 'watching', limit = 20, before, offset, classic, platform, category, signal } = options;
+  const { sort = 'watching', period, limit = 20, before, offset, classic, platform, category, signal } = options;
 
   const params: Record<string, string | number | boolean | undefined> = {
     sort,
+    period,
     limit,
     classic,
     platform,

--- a/src/lib/i18n/locales/ar/common.json
+++ b/src/lib/i18n/locales/ar/common.json
@@ -64,6 +64,7 @@
     "forYou": "لك",
     "classic": "كلاسيكي",
     "hot": "رائج",
+    "popular": "شائع",
     "new": "جديد",
     "tags": "الوسوم",
     "verifiedOnly": "من صنع البشر",

--- a/src/lib/i18n/locales/ar/common.json
+++ b/src/lib/i18n/locales/ar/common.json
@@ -1100,7 +1100,20 @@
     "heading": "الرائج",
     "subheading": "اكتشف ما هو شائع في المجتمع",
     "rssTitle": "DiVine - الرائج",
-    "rssLink": "RSS"
+    "rssLink": "RSS",
+    "popular": {
+      "period": {
+        "label": "النافذة",
+        "now": "الآن",
+        "today": "اليوم",
+        "week": "هذا الأسبوع",
+        "month": "هذا الشهر",
+        "all": "الكل"
+      },
+      "emptyHeading": "ساعة هادئة",
+      "emptyBody": "جرّب نافذة زمنية أوسع.",
+      "emptyAction": "اعرض اليوم"
+    }
   },
   "merchPage": {
     "metaTitle": "منتجات — Divine",

--- a/src/lib/i18n/locales/de/common.json
+++ b/src/lib/i18n/locales/de/common.json
@@ -1096,7 +1096,20 @@
     "heading": "Trending",
     "subheading": "Schau, was in der Community gerade läuft",
     "rssTitle": "DiVine - Trending",
-    "rssLink": "RSS"
+    "rssLink": "RSS",
+    "popular": {
+      "period": {
+        "label": "Zeitraum",
+        "now": "Jetzt",
+        "today": "Heute",
+        "week": "Diese Woche",
+        "month": "Diesen Monat",
+        "all": "Alle"
+      },
+      "emptyHeading": "Stille Stunde",
+      "emptyBody": "Versuch ein größeres Zeitfenster.",
+      "emptyAction": "Heute anzeigen"
+    }
   },
   "merchPage": {
     "metaTitle": "Merch — Divine",

--- a/src/lib/i18n/locales/de/common.json
+++ b/src/lib/i18n/locales/de/common.json
@@ -64,6 +64,7 @@
     "forYou": "Fur dich",
     "classic": "Klassisch",
     "hot": "Heiss",
+    "popular": "Beliebt",
     "new": "Neu",
     "tags": "Tags",
     "verifiedOnly": "Von Menschen gemacht",

--- a/src/lib/i18n/locales/en/common.json
+++ b/src/lib/i18n/locales/en/common.json
@@ -64,6 +64,7 @@
     "forYou": "For You",
     "classic": "Classic",
     "hot": "Hot",
+    "popular": "Popular",
     "new": "New",
     "tags": "Tags",
     "verifiedOnly": "Human Made",

--- a/src/lib/i18n/locales/en/common.json
+++ b/src/lib/i18n/locales/en/common.json
@@ -1096,7 +1096,20 @@
     "heading": "Trending",
     "subheading": "Discover what's popular in the community",
     "rssTitle": "DiVine - Trending",
-    "rssLink": "RSS"
+    "rssLink": "RSS",
+    "popular": {
+      "period": {
+        "label": "Window",
+        "now": "Now",
+        "today": "Today",
+        "week": "This Week",
+        "month": "This Month",
+        "all": "All Time"
+      },
+      "emptyHeading": "Quiet hour",
+      "emptyBody": "Try a wider window.",
+      "emptyAction": "Show today"
+    }
   },
   "merchPage": {
     "metaTitle": "Merch — Divine",

--- a/src/lib/i18n/locales/es/common.json
+++ b/src/lib/i18n/locales/es/common.json
@@ -64,6 +64,7 @@
     "forYou": "Para ti",
     "classic": "Clasico",
     "hot": "Popular",
+    "popular": "Popular",
     "new": "Nuevo",
     "tags": "Etiquetas",
     "verifiedOnly": "Hecho por humanos",

--- a/src/lib/i18n/locales/es/common.json
+++ b/src/lib/i18n/locales/es/common.json
@@ -1096,7 +1096,20 @@
     "heading": "Tendencias",
     "subheading": "Descubre qué es popular en la comunidad",
     "rssTitle": "DiVine - Tendencias",
-    "rssLink": "RSS"
+    "rssLink": "RSS",
+    "popular": {
+      "period": {
+        "label": "Período",
+        "now": "Ahora",
+        "today": "Hoy",
+        "week": "Esta semana",
+        "month": "Este mes",
+        "all": "Todo"
+      },
+      "emptyHeading": "Hora tranquila",
+      "emptyBody": "Prueba un período más amplio.",
+      "emptyAction": "Mostrar hoy"
+    }
   },
   "merchPage": {
     "metaTitle": "Merch — Divine",

--- a/src/lib/i18n/locales/fil/common.json
+++ b/src/lib/i18n/locales/fil/common.json
@@ -64,6 +64,7 @@
     "forYou": "Para Sayo",
     "classic": "Klasiko",
     "hot": "Sikat",
+    "popular": "Popular",
     "new": "Bago",
     "tags": "Mga Tag",
     "verifiedOnly": "Gawa ng Tao",

--- a/src/lib/i18n/locales/fil/common.json
+++ b/src/lib/i18n/locales/fil/common.json
@@ -1096,7 +1096,20 @@
     "heading": "Trending",
     "subheading": "Tuklasin kung ano ang sikat sa komunidad",
     "rssTitle": "DiVine - Trending",
-    "rssLink": "RSS"
+    "rssLink": "RSS",
+    "popular": {
+      "period": {
+        "label": "Window",
+        "now": "Now",
+        "today": "Today",
+        "week": "This Week",
+        "month": "This Month",
+        "all": "All Time"
+      },
+      "emptyHeading": "Quiet hour",
+      "emptyBody": "Try a wider window.",
+      "emptyAction": "Show today"
+    }
   },
   "merchPage": {
     "metaTitle": "Mga Merch — Divine",

--- a/src/lib/i18n/locales/fr/common.json
+++ b/src/lib/i18n/locales/fr/common.json
@@ -64,6 +64,7 @@
     "forYou": "Pour vous",
     "classic": "Classique",
     "hot": "Tendance",
+    "popular": "Populaire",
     "new": "Nouveau",
     "tags": "Tags",
     "verifiedOnly": "Cree par des humains",

--- a/src/lib/i18n/locales/fr/common.json
+++ b/src/lib/i18n/locales/fr/common.json
@@ -1096,7 +1096,20 @@
     "heading": "Tendances",
     "subheading": "Découvre ce qui cartonne dans la communauté",
     "rssTitle": "DiVine - Tendances",
-    "rssLink": "RSS"
+    "rssLink": "RSS",
+    "popular": {
+      "period": {
+        "label": "Fenêtre",
+        "now": "Maintenant",
+        "today": "Aujourd'hui",
+        "week": "Cette semaine",
+        "month": "Ce mois",
+        "all": "Tout"
+      },
+      "emptyHeading": "Heure calme",
+      "emptyBody": "Essaie une plage plus large.",
+      "emptyAction": "Afficher aujourd'hui"
+    }
   },
   "merchPage": {
     "metaTitle": "Merch — Divine",

--- a/src/lib/i18n/locales/id/common.json
+++ b/src/lib/i18n/locales/id/common.json
@@ -64,6 +64,7 @@
     "forYou": "Untuk Anda",
     "classic": "Klasik",
     "hot": "Populer",
+    "popular": "Populer",
     "new": "Baru",
     "tags": "Tag",
     "verifiedOnly": "Buatan manusia",

--- a/src/lib/i18n/locales/id/common.json
+++ b/src/lib/i18n/locales/id/common.json
@@ -1096,7 +1096,20 @@
     "heading": "Trending",
     "subheading": "Temukan apa yang lagi populer di komunitas",
     "rssTitle": "DiVine - Trending",
-    "rssLink": "RSS"
+    "rssLink": "RSS",
+    "popular": {
+      "period": {
+        "label": "Jendela",
+        "now": "Sekarang",
+        "today": "Hari ini",
+        "week": "Minggu ini",
+        "month": "Bulan ini",
+        "all": "Semua waktu"
+      },
+      "emptyHeading": "Jam tenang",
+      "emptyBody": "Coba jendela yang lebih lebar.",
+      "emptyAction": "Tampilkan hari ini"
+    }
   },
   "merchPage": {
     "metaTitle": "Merch — Divine",

--- a/src/lib/i18n/locales/it/common.json
+++ b/src/lib/i18n/locales/it/common.json
@@ -1096,7 +1096,20 @@
     "heading": "Di tendenza",
     "subheading": "Scopri cosa va forte nella community",
     "rssTitle": "DiVine - Di tendenza",
-    "rssLink": "RSS"
+    "rssLink": "RSS",
+    "popular": {
+      "period": {
+        "label": "Finestra",
+        "now": "Ora",
+        "today": "Oggi",
+        "week": "Questa settimana",
+        "month": "Questo mese",
+        "all": "Tutti"
+      },
+      "emptyHeading": "Ora tranquilla",
+      "emptyBody": "Prova una finestra più ampia.",
+      "emptyAction": "Mostra oggi"
+    }
   },
   "merchPage": {
     "metaTitle": "Merch — Divine",

--- a/src/lib/i18n/locales/it/common.json
+++ b/src/lib/i18n/locales/it/common.json
@@ -64,6 +64,7 @@
     "forYou": "Per te",
     "classic": "Classico",
     "hot": "Caldo",
+    "popular": "Popolare",
     "new": "Nuovo",
     "tags": "Tag",
     "verifiedOnly": "Creato da umani",

--- a/src/lib/i18n/locales/ja/common.json
+++ b/src/lib/i18n/locales/ja/common.json
@@ -64,6 +64,7 @@
     "forYou": "あなた向け",
     "classic": "クラシック",
     "hot": "人気",
+    "popular": "人気",
     "new": "新着",
     "tags": "タグ",
     "verifiedOnly": "人が作成",

--- a/src/lib/i18n/locales/ja/common.json
+++ b/src/lib/i18n/locales/ja/common.json
@@ -1096,7 +1096,20 @@
     "heading": "トレンド",
     "subheading": "コミュニティで人気のコンテンツをチェック",
     "rssTitle": "DiVine - トレンド",
-    "rssLink": "RSS"
+    "rssLink": "RSS",
+    "popular": {
+      "period": {
+        "label": "ウィンドウ",
+        "now": "いま",
+        "today": "今日",
+        "week": "今週",
+        "month": "今月",
+        "all": "すべて"
+      },
+      "emptyHeading": "静かな時間",
+      "emptyBody": "もっと広い期間で試してみて。",
+      "emptyAction": "今日を表示"
+    }
   },
   "merchPage": {
     "metaTitle": "グッズ — Divine",

--- a/src/lib/i18n/locales/ko/common.json
+++ b/src/lib/i18n/locales/ko/common.json
@@ -1096,7 +1096,20 @@
     "heading": "인기",
     "subheading": "커뮤니티에서 인기 있는 콘텐츠를 발견해요",
     "rssTitle": "DiVine - 인기",
-    "rssLink": "RSS"
+    "rssLink": "RSS",
+    "popular": {
+      "period": {
+        "label": "기간",
+        "now": "지금",
+        "today": "오늘",
+        "week": "이번 주",
+        "month": "이번 달",
+        "all": "전체"
+      },
+      "emptyHeading": "조용한 시간",
+      "emptyBody": "더 넓은 범위로 시도해 봐.",
+      "emptyAction": "오늘 보기"
+    }
   },
   "merchPage": {
     "metaTitle": "굿즈 — Divine",

--- a/src/lib/i18n/locales/ko/common.json
+++ b/src/lib/i18n/locales/ko/common.json
@@ -64,6 +64,7 @@
     "forYou": "추천",
     "classic": "클래식",
     "hot": "인기",
+    "popular": "인기",
     "new": "신규",
     "tags": "태그",
     "verifiedOnly": "사람이 만든 콘텐츠",

--- a/src/lib/i18n/locales/nl/common.json
+++ b/src/lib/i18n/locales/nl/common.json
@@ -64,6 +64,7 @@
     "forYou": "Voor jou",
     "classic": "Klassiek",
     "hot": "Heet",
+    "popular": "Populair",
     "new": "Nieuw",
     "tags": "Tags",
     "verifiedOnly": "Door mensen gemaakt",

--- a/src/lib/i18n/locales/nl/common.json
+++ b/src/lib/i18n/locales/nl/common.json
@@ -1096,7 +1096,20 @@
     "heading": "Trending",
     "subheading": "Ontdek wat populair is in de community",
     "rssTitle": "DiVine - Trending",
-    "rssLink": "RSS"
+    "rssLink": "RSS",
+    "popular": {
+      "period": {
+        "label": "Venster",
+        "now": "Nu",
+        "today": "Vandaag",
+        "week": "Deze week",
+        "month": "Deze maand",
+        "all": "Altijd"
+      },
+      "emptyHeading": "Stil uur",
+      "emptyBody": "Probeer een breder venster.",
+      "emptyAction": "Vandaag tonen"
+    }
   },
   "merchPage": {
     "metaTitle": "Merch — Divine",

--- a/src/lib/i18n/locales/pl/common.json
+++ b/src/lib/i18n/locales/pl/common.json
@@ -64,6 +64,7 @@
     "forYou": "Dla ciebie",
     "classic": "Klasyczne",
     "hot": "Gorace",
+    "popular": "Popularne",
     "new": "Nowe",
     "tags": "Tagi",
     "verifiedOnly": "Stworzone przez ludzi",

--- a/src/lib/i18n/locales/pl/common.json
+++ b/src/lib/i18n/locales/pl/common.json
@@ -1098,7 +1098,20 @@
     "heading": "Na czasie",
     "subheading": "Sprawdź, co jest popularne w społeczności",
     "rssTitle": "DiVine - Na czasie",
-    "rssLink": "RSS"
+    "rssLink": "RSS",
+    "popular": {
+      "period": {
+        "label": "Okno",
+        "now": "Teraz",
+        "today": "Dzisiaj",
+        "week": "Ten tydzień",
+        "month": "Ten miesiąc",
+        "all": "Cały czas"
+      },
+      "emptyHeading": "Cicha godzina",
+      "emptyBody": "Spróbuj szerszego okna.",
+      "emptyAction": "Pokaż dziś"
+    }
   },
   "merchPage": {
     "metaTitle": "Gadżety — Divine",

--- a/src/lib/i18n/locales/pt/common.json
+++ b/src/lib/i18n/locales/pt/common.json
@@ -64,6 +64,7 @@
     "forYou": "Para voce",
     "classic": "Classico",
     "hot": "Em alta",
+    "popular": "Popular",
     "new": "Novo",
     "tags": "Tags",
     "verifiedOnly": "Feito por humanos",

--- a/src/lib/i18n/locales/pt/common.json
+++ b/src/lib/i18n/locales/pt/common.json
@@ -1096,7 +1096,20 @@
     "heading": "Em alta",
     "subheading": "Descubra o que tá bombando na comunidade",
     "rssTitle": "DiVine - Em alta",
-    "rssLink": "RSS"
+    "rssLink": "RSS",
+    "popular": {
+      "period": {
+        "label": "Período",
+        "now": "Agora",
+        "today": "Hoje",
+        "week": "Esta semana",
+        "month": "Este mês",
+        "all": "Todos"
+      },
+      "emptyHeading": "Hora calma",
+      "emptyBody": "Tenta uma janela mais ampla.",
+      "emptyAction": "Mostrar hoje"
+    }
   },
   "merchPage": {
     "metaTitle": "Merch — Divine",

--- a/src/lib/i18n/locales/ro/common.json
+++ b/src/lib/i18n/locales/ro/common.json
@@ -64,6 +64,7 @@
     "forYou": "Pentru tine",
     "classic": "Clasic",
     "hot": "Popular",
+    "popular": "Popular",
     "new": "Nou",
     "tags": "Etichete",
     "verifiedOnly": "Creat de oameni",

--- a/src/lib/i18n/locales/ro/common.json
+++ b/src/lib/i18n/locales/ro/common.json
@@ -1097,7 +1097,20 @@
     "heading": "În tendințe",
     "subheading": "Descoperă ce e popular în comunitate",
     "rssTitle": "DiVine - În tendințe",
-    "rssLink": "RSS"
+    "rssLink": "RSS",
+    "popular": {
+      "period": {
+        "label": "Fereastră",
+        "now": "Acum",
+        "today": "Astăzi",
+        "week": "Săptămâna asta",
+        "month": "Luna asta",
+        "all": "Tot timpul"
+      },
+      "emptyHeading": "Oră liniștită",
+      "emptyBody": "Încearcă o fereastră mai largă.",
+      "emptyAction": "Arată astăzi"
+    }
   },
   "merchPage": {
     "metaTitle": "Merch — Divine",

--- a/src/lib/i18n/locales/sv/common.json
+++ b/src/lib/i18n/locales/sv/common.json
@@ -64,6 +64,7 @@
     "forYou": "For dig",
     "classic": "Klassiskt",
     "hot": "Hett",
+    "popular": "Populärt",
     "new": "Nytt",
     "tags": "Taggar",
     "verifiedOnly": "Skapad av manniskor",

--- a/src/lib/i18n/locales/sv/common.json
+++ b/src/lib/i18n/locales/sv/common.json
@@ -1096,7 +1096,20 @@
     "heading": "Populärt",
     "subheading": "Upptäck vad som är populärt i communityn",
     "rssTitle": "DiVine - Populärt",
-    "rssLink": "RSS"
+    "rssLink": "RSS",
+    "popular": {
+      "period": {
+        "label": "Fönster",
+        "now": "Nu",
+        "today": "Idag",
+        "week": "Denna vecka",
+        "month": "Denna månad",
+        "all": "Alltid"
+      },
+      "emptyHeading": "Tyst stund",
+      "emptyBody": "Pröva ett bredare fönster.",
+      "emptyAction": "Visa idag"
+    }
   },
   "merchPage": {
     "metaTitle": "Merch — Divine",

--- a/src/lib/i18n/locales/tr/common.json
+++ b/src/lib/i18n/locales/tr/common.json
@@ -64,6 +64,7 @@
     "forYou": "Senin icin",
     "classic": "Klasik",
     "hot": "Populer",
+    "popular": "Popüler",
     "new": "Yeni",
     "tags": "Etiketler",
     "verifiedOnly": "Insan yapimi",

--- a/src/lib/i18n/locales/tr/common.json
+++ b/src/lib/i18n/locales/tr/common.json
@@ -1096,7 +1096,20 @@
     "heading": "Trend",
     "subheading": "Toplulukta neyin popüler olduğunu keşfet",
     "rssTitle": "DiVine - Trend",
-    "rssLink": "RSS"
+    "rssLink": "RSS",
+    "popular": {
+      "period": {
+        "label": "Pencere",
+        "now": "Şimdi",
+        "today": "Bugün",
+        "week": "Bu hafta",
+        "month": "Bu ay",
+        "all": "Tüm zamanlar"
+      },
+      "emptyHeading": "Sakin saat",
+      "emptyBody": "Daha geniş bir pencere dene.",
+      "emptyAction": "Bugünü göster"
+    }
   },
   "merchPage": {
     "metaTitle": "Ürünler — Divine",

--- a/src/pages/DiscoveryPage.tsx
+++ b/src/pages/DiscoveryPage.tsx
@@ -2,25 +2,34 @@
 // ABOUTME: Each tab uses different sort modes; Classics uses Funnelcake REST API for pre-computed metrics
 // ABOUTME: For You tab shows personalized recommendations when user is logged in
 
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router-dom';
 import { useSubdomainNavigate } from '@/hooks/useSubdomainNavigate';
 import { VideoFeed } from '@/components/VideoFeed';
 import { VerifiedOnlyToggle } from '@/components/VerifiedOnlyToggle';
 import { HashtagExplorer } from '@/components/HashtagExplorer';
 import { ClassicVinersRow } from '@/components/ClassicVinersRow';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Star, Clock, Hash, Flame, Sparkle as Sparkles } from '@phosphor-icons/react';
+import { Star, Clock, Hash, Flame, Sparkle as Sparkles, TrendUp as TrendingUp } from '@phosphor-icons/react';
 // Zap temporarily unused - will be needed when Rising tab is re-enabled
 import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { useCategories } from '@/hooks/useCategories';
 import { getTranslatedCategoryLabel } from '@/lib/constants/categories';
+import { POPULAR_PERIODS } from '@/lib/constants/sortModes';
+import type { FunnelcakePeriod } from '@/types/funnelcake';
 
 // All possible tab values (foryou only shown when logged in)
-type AllowedTab = 'foryou' | 'classics' | 'hot' | 'new' | 'hashtags';
-const ALL_TABS: AllowedTab[] = ['foryou', 'classics', 'hot', 'new', 'hashtags'];
-const BASE_TABS: AllowedTab[] = ['classics', 'hot', 'new', 'hashtags'];
+type AllowedTab = 'foryou' | 'classics' | 'hot' | 'popular' | 'new' | 'hashtags';
+const ALL_TABS: AllowedTab[] = ['foryou', 'classics', 'hot', 'popular', 'new', 'hashtags'];
+const BASE_TABS: AllowedTab[] = ['classics', 'hot', 'popular', 'new', 'hashtags'];
+
+const VALID_PERIODS: ReadonlyArray<string> = ['now', 'today', 'week', 'month', 'all'];
+
+function parsePeriod(raw: string | null): FunnelcakePeriod {
+  if (raw && VALID_PERIODS.includes(raw)) return raw as FunnelcakePeriod;
+  return 'today';
+}
 
 export function DiscoveryPage() {
   const navigate = useSubdomainNavigate();
@@ -44,6 +53,15 @@ export function DiscoveryPage() {
   const initialTab: AllowedTab = allowedTabs.includes(normalizedTab as AllowedTab) ? (normalizedTab as AllowedTab) : defaultTab;
   const [activeTab, setActiveTab] = useState<AllowedTab>(initialTab);
   const [verifiedOnly, setVerifiedOnly] = useState(false);
+
+  // Period state for the Popular tab. Lives in URL so /discovery/popular?period=week is shareable.
+  const [searchParams, setSearchParams] = useSearchParams();
+  const period = parsePeriod(searchParams.get('period'));
+  const setPeriod = useCallback((next: FunnelcakePeriod) => {
+    const params = new URLSearchParams(searchParams);
+    params.set('period', next);
+    setSearchParams(params, { replace: true });
+  }, [searchParams, setSearchParams]);
 
   // Note: We no longer force relay changes here as it causes navigation delays
   // The default relay (relay.divine.video) is already configured in App.tsx
@@ -122,7 +140,7 @@ export function DiscoveryPage() {
           }}
           className="space-y-6"
         >
-          <TabsList className={`w-full grid gap-1 ${isLoggedIn ? 'grid-cols-5' : 'grid-cols-4'}`}>
+          <TabsList className={`w-full grid gap-1 ${isLoggedIn ? 'grid-cols-6' : 'grid-cols-5'}`}>
             {isLoggedIn && (
               <TabsTrigger value="foryou" className="gap-1.5 sm:gap-2">
                 <Sparkles className="h-4 w-4" />
@@ -136,6 +154,10 @@ export function DiscoveryPage() {
             <TabsTrigger value="hot" className="gap-1.5 sm:gap-2">
               <Flame className="h-4 w-4" />
               <span className="hidden sm:inline">{t('discovery.hot')}</span>
+            </TabsTrigger>
+            <TabsTrigger value="popular" className="gap-1.5 sm:gap-2">
+              <TrendingUp className="h-4 w-4" />
+              <span className="hidden sm:inline">{t('discovery.popular')}</span>
             </TabsTrigger>
             {/* Rising tab temporarily disabled
             <TabsTrigger value="rising" className="gap-1.5 sm:gap-2">
@@ -189,6 +211,45 @@ export function DiscoveryPage() {
               data-testid="video-feed-hot"
               className="space-y-6"
               key="hot"
+            />
+          </TabsContent>
+
+          <TabsContent value="popular" className="mt-0 space-y-6">
+            <div
+              role="group"
+              aria-label={t('trendingPage.popular.period.label')}
+              data-testid="period-row"
+              className="flex flex-wrap gap-2"
+            >
+              {POPULAR_PERIODS.map(p => {
+                const isSelected = period === p.value;
+                return (
+                  <button
+                    key={p.value}
+                    type="button"
+                    aria-pressed={isSelected}
+                    data-testid={`period-pill-${p.value}`}
+                    onClick={() => setPeriod(p.value)}
+                    className={`px-3 py-1.5 rounded-full text-sm font-medium transition-all min-h-[36px]
+                      ${isSelected
+                        ? 'bg-primary text-primary-foreground'
+                        : 'bg-brand-light-green dark:bg-brand-dark-green hover:bg-muted text-muted-foreground hover:text-foreground'
+                      }`}
+                  >
+                    {t(`trendingPage.popular.period.${p.value}`)}
+                  </button>
+                );
+              })}
+            </div>
+            <VideoFeed
+              feedType="trending"
+              sortMode="popular"
+              period={period}
+              verifiedOnly={verifiedOnly}
+              accent="pink"
+              data-testid="video-feed-popular"
+              className="space-y-6"
+              key={`popular-${period}`}
             />
           </TabsContent>
 

--- a/src/pages/TrendingPage.test.tsx
+++ b/src/pages/TrendingPage.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import TrendingPage from './TrendingPage';
+
+vi.mock('@/components/VideoFeed', () => ({
+  VideoFeed: (props: { sortMode?: string; period?: string }) => (
+    <div data-testid="video-feed" data-sort={props.sortMode ?? ''} data-period={props.period ?? ''} />
+  ),
+}));
+
+vi.mock('@/hooks/useRssFeedAvailable', () => ({ useRssFeedAvailable: () => false }));
+vi.mock('@unhead/react', () => ({ useHead: () => undefined }));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+function LocationProbe() {
+  const location = useLocation();
+  return <div data-testid="location-search">{location.search}</div>;
+}
+
+function renderAt(initial: string) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[initial]}>
+        <Routes>
+          <Route
+            path="/trending"
+            element={<>
+              <TrendingPage />
+              <LocationProbe />
+            </>}
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('TrendingPage URL state', () => {
+  it('defaults to sort=hot and renders no period row when no params', () => {
+    renderAt('/trending');
+    const feed = screen.getByTestId('video-feed');
+    expect(feed.dataset.sort).toBe('hot');
+    expect(screen.queryByTestId('period-row')).not.toBeInTheDocument();
+  });
+
+  it('shows the period row when sort=popular and defaults period to today', () => {
+    renderAt('/trending?sort=popular');
+    const feed = screen.getByTestId('video-feed');
+    expect(feed.dataset.sort).toBe('popular');
+    expect(feed.dataset.period).toBe('today');
+    expect(screen.getByTestId('period-row')).toBeInTheDocument();
+    expect(screen.getByTestId('period-pill-week')).toBeInTheDocument();
+  });
+
+  it('respects ?sort=popular&period=week', () => {
+    renderAt('/trending?sort=popular&period=week');
+    expect(screen.getByTestId('video-feed').dataset.period).toBe('week');
+    expect(screen.getByTestId('period-pill-week')).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('renders ?sort=controversial as the Hot tab (no API call uses controversial) and hides the period row', () => {
+    renderAt('/trending?sort=controversial');
+    expect(screen.getByTestId('video-feed').dataset.sort).toBe('hot');
+    expect(screen.queryByTestId('period-row')).not.toBeInTheDocument();
+  });
+
+  it('encodes the New tab as ?sort=new (round-trip stable)', () => {
+    renderAt('/trending?sort=new');
+    expect(screen.getByTestId('video-feed').dataset.sort).toBe('');
+    expect(screen.queryByTestId('period-row')).not.toBeInTheDocument();
+  });
+
+  it('updates the URL and feed when a period pill is clicked', async () => {
+    const user = userEvent.setup();
+    renderAt('/trending?sort=popular');
+    await user.click(screen.getByTestId('period-pill-month'));
+    await waitFor(() => {
+      expect(screen.getByTestId('video-feed').dataset.period).toBe('month');
+    });
+    expect(screen.getByTestId('location-search').textContent).toContain('period=month');
+    expect(screen.getByTestId('location-search').textContent).toContain('sort=popular');
+  });
+
+  it('drops period from the URL when switching from Popular to Hot', async () => {
+    const user = userEvent.setup();
+    renderAt('/trending?sort=popular&period=week');
+    await user.click(screen.getByRole('tab', { name: /^Hot/i }));
+    await waitFor(() => {
+      expect(screen.getByTestId('video-feed').dataset.sort).toBe('hot');
+    });
+    expect(screen.getByTestId('location-search').textContent).not.toContain('period=');
+  });
+});

--- a/src/pages/TrendingPage.tsx
+++ b/src/pages/TrendingPage.tsx
@@ -1,32 +1,71 @@
-// ABOUTME: Trending feed page showing popular videos with multiple sort modes
-// ABOUTME: Supports NIP-50 search modes: hot, top, rising, controversial
+// ABOUTME: Trending feed page with sort tabs + Popular time-window selector
+// ABOUTME: Sort + period live in URL query params for shareable, refresh-safe views
 
-import { useState } from 'react';
+import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useSearchParams } from 'react-router-dom';
 import { Rss } from '@phosphor-icons/react';
 import { useHead } from '@unhead/react';
 import { VideoFeed } from '@/components/VideoFeed';
 import { feedUrls } from '@/lib/feedUrls';
 import { useRssFeedAvailable } from '@/hooks/useRssFeedAvailable';
 import type { SortMode } from '@/types/nostr';
-import { EXTENDED_SORT_MODES as SORT_MODES } from '@/lib/constants/sortModes';
+import type { FunnelcakePeriod } from '@/types/funnelcake';
+import { EXTENDED_SORT_MODES, POPULAR_PERIODS } from '@/lib/constants/sortModes';
+
+const VALID_SORTS: ReadonlyArray<string> = ['hot', 'top', 'rising', 'popular', 'classic', 'new'];
+const VALID_PERIODS: ReadonlyArray<string> = ['now', 'today', 'week', 'month', 'all'];
+
+// URL encoding rules:
+// - Missing sort param → 'hot' (default)
+// - 'new' (the New tab; sortMode undefined) → 'new' in URL, undefined in state
+// - 'controversial' (legacy) → coerced to 'hot' in state; URL not rewritten (cosmetic only)
+// - Unknown values → 'hot'
+function parseSort(raw: string | null): SortMode | undefined {
+  if (raw === null) return 'hot';
+  if (raw === 'new') return undefined;
+  if (raw === 'controversial') return 'hot';
+  return (VALID_SORTS.includes(raw) ? (raw as SortMode) : 'hot');
+}
+
+function parsePeriod(raw: string | null): FunnelcakePeriod {
+  if (raw && VALID_PERIODS.includes(raw)) return raw as FunnelcakePeriod;
+  return 'today';
+}
+
+function sortToUrl(sort: SortMode | undefined): string {
+  return sort ?? 'new';
+}
 
 export function TrendingPage() {
   const { t } = useTranslation();
-  const [sortMode, setSortMode] = useState<SortMode>('hot');
+  const [searchParams, setSearchParams] = useSearchParams();
 
-  // RSS auto-discovery link for feed readers (only if feed endpoints exist)
+  const sortMode = parseSort(searchParams.get('sort'));
+  const period = parsePeriod(searchParams.get('period'));
+
+  const setSort = useCallback((next: SortMode | undefined) => {
+    const params = new URLSearchParams(searchParams);
+    params.set('sort', sortToUrl(next));
+    if (next !== 'popular') params.delete('period');
+    setSearchParams(params, { replace: true });
+  }, [searchParams, setSearchParams]);
+
+  const setPeriod = useCallback((next: FunnelcakePeriod) => {
+    const params = new URLSearchParams(searchParams);
+    params.set('period', next);
+    params.set('sort', 'popular');
+    setSearchParams(params, { replace: true });
+  }, [searchParams, setSearchParams]);
+
   const rssFeedAvailable = useRssFeedAvailable();
   useHead({
-    link: rssFeedAvailable ? [
-      {
-        rel: 'alternate',
-        type: 'application/rss+xml',
-        title: t('trendingPage.rssTitle'),
-        href: feedUrls.trending(),
-      },
-    ] : [],
+    link: rssFeedAvailable
+      ? [{ rel: 'alternate', type: 'application/rss+xml', title: t('trendingPage.rssTitle'), href: feedUrls.trending() }]
+      : [],
   });
+
+  const showPeriodRow = sortMode === 'popular';
 
   return (
     <div className="container mx-auto px-4 py-6">
@@ -35,9 +74,7 @@ export function TrendingPage() {
           <div className="flex items-center justify-between">
             <div>
               <h1 className="text-2xl font-bold">{t('trendingPage.heading')}</h1>
-              <p className="text-muted-foreground">
-                {t('trendingPage.subheading')}
-              </p>
+              <p className="text-muted-foreground">{t('trendingPage.subheading')}</p>
             </div>
             {rssFeedAvailable && (
               <a
@@ -51,39 +88,66 @@ export function TrendingPage() {
             )}
           </div>
 
-          {/* Sort mode selector as prominent tabs/buttons */}
-          <div className="flex flex-wrap gap-2">
-            {SORT_MODES.map(mode => {
+          <div className="flex flex-wrap gap-2" role="tablist" aria-label={t('trendingPage.heading')}>
+            {EXTENDED_SORT_MODES.map(mode => {
               const ModeIcon = mode.icon;
               const isSelected = sortMode === mode.value;
               return (
                 <button
-                  key={mode.value}
-                  onClick={() => setSortMode(mode.value as SortMode)}
-                  className={`
-                    flex items-center gap-2 px-4 py-2 rounded-lg font-medium transition-all
+                  key={String(mode.value ?? 'new')}
+                  role="tab"
+                  aria-selected={isSelected}
+                  onClick={() => setSort(mode.value)}
+                  className={`flex items-center gap-2 px-4 py-2 rounded-lg font-medium transition-all
                     ${isSelected
                       ? 'bg-primary text-primary-foreground shadow-md'
                       : 'bg-brand-light-green dark:bg-brand-dark-green hover:bg-muted text-muted-foreground hover:text-foreground'
-                    }
-                  `}
+                    }`}
                 >
                   <ModeIcon className="h-4 w-4" />
                   <span>{mode.label}</span>
                   {isSelected && (
-                    <span className="text-xs opacity-80 hidden sm:inline">
-                      • {mode.description}
-                    </span>
+                    <span className="text-xs opacity-80 hidden sm:inline">• {mode.description}</span>
                   )}
                 </button>
               );
             })}
           </div>
+
+          {showPeriodRow && (
+            <div
+              role="group"
+              aria-label={t('trendingPage.popular.period.label')}
+              data-testid="period-row"
+              className="flex flex-wrap gap-2 pl-1"
+            >
+              {POPULAR_PERIODS.map(p => {
+                const isSelected = period === p.value;
+                return (
+                  <button
+                    key={p.value}
+                    type="button"
+                    aria-pressed={isSelected}
+                    data-testid={`period-pill-${p.value}`}
+                    onClick={() => setPeriod(p.value)}
+                    className={`px-3 py-1.5 rounded-full text-sm font-medium transition-all min-h-[36px]
+                      ${isSelected
+                        ? 'bg-primary text-primary-foreground'
+                        : 'bg-brand-light-green dark:bg-brand-dark-green hover:bg-muted text-muted-foreground hover:text-foreground'
+                      }`}
+                  >
+                    {t(`trendingPage.popular.period.${p.value}`)}
+                  </button>
+                );
+              })}
+            </div>
+          )}
         </header>
 
         <VideoFeed
           feedType="trending"
           sortMode={sortMode}
+          period={showPeriodRow ? period : undefined}
           accent="pink"
           data-testid="video-feed-trending"
           className="space-y-6"

--- a/src/types/funnelcake.ts
+++ b/src/types/funnelcake.ts
@@ -119,10 +119,17 @@ export interface FunnelcakeError {
 }
 
 /**
+ * Time window for popular/trending sorts on /api/videos and /api/v2/videos.
+ * Maps directly to the API's `period` query parameter.
+ */
+export type FunnelcakePeriod = 'now' | 'today' | 'week' | 'month' | 'all';
+
+/**
  * Options for fetching videos from Funnelcake
  */
 export interface FunnelcakeFetchOptions {
   sort?: 'trending' | 'recent' | 'popular' | 'loops' | 'engagement' | 'watching' | 'likes' | 'comments' | 'published';
+  period?: FunnelcakePeriod;   // Window for popular/trending; ignored by other sorts
   limit?: number;
   before?: string;        // Cursor for pagination (timestamp)
   offset?: number;        // Offset for page-based pagination (0-indexed)

--- a/src/types/nostr.ts
+++ b/src/types/nostr.ts
@@ -31,7 +31,7 @@ export interface NIP50Filter extends NostrFilter {
  * - controversial: Events with mixed positive/negative reactions
  * - classic: Classic Vine archive content sorted by loops
  */
-export type SortMode = 'hot' | 'top' | 'rising' | 'controversial' | 'classic';
+export type SortMode = 'hot' | 'top' | 'rising' | 'controversial' | 'classic' | 'popular';
 
 /**
  * Pagination options for cursor-based queries

--- a/tests/visual/a11y.spec.ts
+++ b/tests/visual/a11y.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';
 
-const ROUTES = ['/', '/discovery', '/search', '/merch', '/__brand-preview'];
+const ROUTES = ['/', '/discovery', '/search', '/merch', '/trending?sort=popular&period=today', '/__brand-preview'];
 
 for (const route of ROUTES) {
   test(`a11y: ${route} has no WCAG 2 A/AA violations`, async ({ page }) => {


### PR DESCRIPTION
## Summary

Adds a **Popular** tab to `/trending` that calls `api.divine.video` with `sort=popular` and a user-selected period (`now / today / week / month / all`). Sort + period live in the URL (`?sort=popular&period=…`) so views are shareable, refresh-safe, and bookmarkable.

Drops **Controversial** from visible tabs (off-brand engagement-bait per `CLAUDE.md`); legacy `?sort=controversial` URLs render as Hot (render-only coercion — URL not rewritten).

Adds a "Quiet hour — try a wider window" empty state for `popular + now` when the feed is empty (off-hours).

**Real bug fix included**: the Fastly edge worker injects `__DIVINE_FEED__` for the default trending feed (sort=watching), and the hook was unconditionally consuming it on page 1 regardless of sortMode/period. Deep-links to `/trending?sort=popular&period=today` would have shown wrong videos on page 1 and right videos starting on page 2. Fix: skip edge consumption when `period` is set. Existing Hot/Top/Rising sorts keep their current behavior (production already accepts that mismatch).

## What changed

- `src/types/funnelcake.ts` — new `FunnelcakePeriod` type, `period?` field on `FunnelcakeFetchOptions`
- `src/lib/funnelcakeClient.ts` — thread `period` through `fetchVideos` and `fetchVideosV2`
- `src/hooks/useInfiniteVideosFunnelcake.ts` — add `'popular'` sort, accept period, edge-cache guard
- `src/types/nostr.ts` — add `'popular'` to `SortMode` (kept `'controversial'` for URL coercion)
- `src/hooks/useVideoProvider.ts` — map `SortMode 'popular'` and pass period through
- `src/components/VideoFeed.tsx` — `period` prop + quiet-hour empty state for popular + now
- `src/lib/constants/sortModes.ts` — drop Controversial from visible tabs, add Popular tab + `POPULAR_PERIODS`
- `src/pages/TrendingPage.tsx` — full rewrite: URL-driven sort + period, period pill row when sort=popular
- `src/lib/i18n/locales/*/common.json` — add `trendingPage.popular.*` keys to en + 14 translated locales + fil placeholders
- `tests/visual/a11y.spec.ts` — add `/trending?sort=popular&period=today` to axe sweep

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` passes (747/747 tests)
- [x] `npx vitest run tests/brand` passes (no Tailwind `uppercase`, no `lucide-react`, no gradient bgs)
- [ ] Manual: `/trending` defaults to Hot, no period row, Controversial tab gone
- [ ] Manual: `/trending?sort=popular` shows period row, defaults to Today
- [ ] Manual: each period pill issues `/api/v2/videos?sort=popular&period=…`
- [ ] Manual: `/trending?sort=controversial` renders Hot tab (URL stays as-is by design)
- [ ] Manual: `/trending?sort=popular&period=week` deep-link survives refresh
- [ ] Manual: quiet-hour empty state appears for empty `now` window with one-tap fix
- [ ] **Edge-cache deep-link smoke test**: open a fresh tab to `/trending?sort=popular&period=week`, verify the first `/api/v2/videos?...` request includes `sort=popular&period=week` (not `sort=watching`), and `window.__DIVINE_FEED__` remains defined in the console (proving the hook saw it but skipped it)
- [ ] Axe a11y sweep green on `/trending?sort=popular&period=today`

## Notes

- **Base**: PR targets `feat/i18n-filipino` because that's the in-flight branch this work was based on. Once `feat/i18n-filipino` merges, this PR auto-rebases against `main`.
- **Spec**: `docs/superpowers/specs/2026-05-09-popular-time-window-design.md`
- **Plan**: `docs/superpowers/plans/2026-05-09-popular-time-window.md` (12 tasks, executed via subagent-driven-development with two-stage review per task)
- **Out of scope**: Period support on hashtag/search/profile/category feeds; edge-caching popular feeds per period; per-period RSS feeds; renaming `/trending` → `/popular`; Leaderboard period changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)