### PR TITLE
fix(legal): render headings at brand-correct Extra Bold weight

### DIFF
--- a/src/pages/DMCAPage.tsx
+++ b/src/pages/DMCAPage.tsx
@@ -12,13 +12,13 @@ export function DMCAPage() {
     <MarketingLayout>
       <div className="container mx-auto px-4 py-8 max-w-4xl">
         <ZendeskWidget />
-        <h1 className="text-4xl font-bold mb-4">{t('title')}</h1>
+        <h1 className="text-4xl font-extrabold mb-4">{t('title')}</h1>
         <p className="text-muted-foreground mb-8">{t('updated')}</p>
 
         <div className="space-y-8 text-muted-foreground leading-relaxed">
           {/* 1. Overview */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">{t('sections.overview')}</h2>
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">{t('sections.overview')}</h2>
             <p className="mb-3">
               Verse Communications PBC dba Divine (&ldquo;Divine&rdquo;) respects intellectual property rights
               and complies with the Digital Millennium Copyright Act (&ldquo;DMCA&rdquo;). This policy describes
@@ -35,7 +35,7 @@ export function DMCAPage() {
 
           {/* 2. Definitions */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">{t('sections.definitions')}</h2>
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">{t('sections.definitions')}</h2>
             <p className="mb-3">
               <strong className="text-foreground">&ldquo;Divine-controlled infrastructure&rdquo;</strong> means
               websites, apps, relays, media storage, APIs, and other systems owned or controlled by Divine.
@@ -78,7 +78,7 @@ export function DMCAPage() {
 
           {/* 3. Submitting a Notice */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">{t('sections.notice')}</h2>
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">{t('sections.notice')}</h2>
             <p className="mb-3">
               If you believe that content available through Divine-controlled infrastructure infringes your
               copyright, you may submit a notice to{' '}
@@ -96,7 +96,7 @@ export function DMCAPage() {
 
           {/* 4. Response to Notices */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">{t('sections.response')}</h2>
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">{t('sections.response')}</h2>
             <p className="mb-3">
               Upon receipt of a facially valid notice, Divine may remove or disable access to the allegedly
               infringing material on Divine-controlled infrastructure and may take additional action, including
@@ -114,7 +114,7 @@ export function DMCAPage() {
 
           {/* 5. Counter-Notifications */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">{t('sections.counter')}</h2>
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">{t('sections.counter')}</h2>
             <p className="mb-3">
               Users may submit counter-notifications as permitted by law. A valid counter-notification must
               include identification of the removed material, a statement under penalty of perjury, consent to
@@ -129,7 +129,7 @@ export function DMCAPage() {
 
           {/* 6. Repeat Infringers */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">{t('sections.repeat')}</h2>
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">{t('sections.repeat')}</h2>
             <p>
               Divine maintains a policy of addressing repeat infringement and may restrict or terminate access for
               users who repeatedly infringe intellectual property rights.
@@ -138,7 +138,7 @@ export function DMCAPage() {
 
           {/* 7. Scope of Control */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">{t('sections.control')}</h2>
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">{t('sections.control')}</h2>
             <p>
               Divine can remove or disable access to content only on systems it owns or controls. If the
               underlying material is stored on independent relays, third-party hosts, or archives, requests to
@@ -148,7 +148,7 @@ export function DMCAPage() {
 
           {/* 8. User Responsibility */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">{t('sections.responsibility')}</h2>
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">{t('sections.responsibility')}</h2>
             <p>
               Users are responsible for ensuring that they have the rights, licenses, and permissions necessary to
               publish or reference content through the Service.
@@ -157,7 +157,7 @@ export function DMCAPage() {
 
           {/* 9. Good Faith Requirement */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">{t('sections.goodFaith')}</h2>
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">{t('sections.goodFaith')}</h2>
             <p>
               Submitting false or misleading claims may result in liability under applicable law.
             </p>
@@ -165,7 +165,7 @@ export function DMCAPage() {
 
           {/* 10. User Controls */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">{t('sections.userControls')}</h2>
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">{t('sections.userControls')}</h2>
             <p>
               The Service may provide tools such as blocking, muting, filtering, and moderation lists that allow
               users to manage their experience. These controls apply within Divine-operated interfaces as
@@ -175,7 +175,7 @@ export function DMCAPage() {
 
           {/* 11. Relationship to Terms */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">{t('sections.relation')}</h2>
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">{t('sections.relation')}</h2>
             <p>
               This policy operates alongside the Terms of Service. Users retain ownership of their content but
               grant Divine a license to use that content as described in the Terms.
@@ -184,7 +184,7 @@ export function DMCAPage() {
 
           {/* 12. Contact */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">{t('sections.contact')}</h2>
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">{t('sections.contact')}</h2>
             <p>
               <a href="mailto:contact@divine.video" className="text-primary hover:underline">
                 contact@divine.video

--- a/src/pages/PrivacyPage.tsx
+++ b/src/pages/PrivacyPage.tsx
@@ -11,13 +11,13 @@ export function PrivacyPage() {
     <MarketingLayout>
       <div className="container mx-auto px-4 py-8 max-w-4xl">
         <ZendeskWidget />
-        <h1 className="text-4xl font-bold mb-4">{t('privacyPage.title')}</h1>
+        <h1 className="text-4xl font-extrabold mb-4">{t('privacyPage.title')}</h1>
         <p className="text-muted-foreground mb-8">{t('privacyPage.lastUpdated', { date: 'March 30, 2026' })}</p>
 
         <div className="space-y-8 text-muted-foreground leading-relaxed">
           {/* 1. Overview */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">1. Overview</h2>
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">1. Overview</h2>
             <p className="mb-3">
               This Privacy Policy explains how Verse Communications PBC dba Divine (&ldquo;Divine,&rdquo;
               &ldquo;we,&rdquo; &ldquo;us,&rdquo; or &ldquo;our&rdquo;) collects, uses, and discloses
@@ -38,7 +38,7 @@ export function PrivacyPage() {
 
           {/* 2. Definitions */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">2. Definitions</h2>
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">2. Definitions</h2>
             <p className="mb-3">
               <strong className="text-foreground">&ldquo;Divine-controlled infrastructure&rdquo;</strong> means
               websites, apps, relays, media storage, APIs, and other systems owned or controlled by Divine.
@@ -81,7 +81,7 @@ export function PrivacyPage() {
 
           {/* 3. Non-Custodial and Custodial Use */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">
               3. Non-Custodial and Custodial Use
             </h2>
             <p className="mb-3">
@@ -102,7 +102,7 @@ export function PrivacyPage() {
 
           {/* 4. Information We Collect */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">4. Information We Collect</h2>
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">4. Information We Collect</h2>
             <p className="mb-3">
               Divine may collect and process information in several categories. The categories of personal
               information collected may include identifiers (such as public keys or IP addresses), internet or
@@ -129,7 +129,7 @@ export function PrivacyPage() {
 
           {/* 5. Public, Divine-Controlled, and Third-Party Data */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">
               5. Public, Divine-Controlled, and Third-Party Data
             </h2>
             <p className="mb-3">
@@ -155,7 +155,7 @@ export function PrivacyPage() {
 
           {/* 6. How We Use Information */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">6. How We Use Information</h2>
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">6. How We Use Information</h2>
             <p className="mb-3">
               Divine processes information as reasonably necessary to operate, secure, maintain, and improve the
               Service.
@@ -173,7 +173,7 @@ export function PrivacyPage() {
 
           {/* 7. Legal Bases for Processing */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">
               7. Legal Bases for Processing
             </h2>
             <p className="mb-3">
@@ -208,7 +208,7 @@ export function PrivacyPage() {
 
           {/* 8. Disclosure of Information */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">8. Disclosure of Information</h2>
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">8. Disclosure of Information</h2>
             <p className="mb-3">
               Divine may disclose information to service providers that process data on our behalf and under our
               instructions to support the operation of Divine-controlled infrastructure, to comply with legal
@@ -224,7 +224,7 @@ export function PrivacyPage() {
 
           {/* 9. International Data Transfers */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">
               9. International Data Transfers
             </h2>
             <p className="mb-3">
@@ -239,7 +239,7 @@ export function PrivacyPage() {
 
           {/* 10. Data Retention */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">10. Data Retention</h2>
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">10. Data Retention</h2>
             <p className="mb-3">
               Divine retains information for as long as reasonably necessary to operate the Service, comply with
               legal obligations, enforce its Terms and Safety Standards, and prevent abuse.
@@ -257,7 +257,7 @@ export function PrivacyPage() {
 
           {/* 11. Your Rights */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">11. Your Rights</h2>
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">11. Your Rights</h2>
             <p className="mb-3">
               Depending on your jurisdiction, you may have the right to:
             </p>
@@ -288,7 +288,7 @@ export function PrivacyPage() {
 
           {/* 12. Automated Decision Making */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">12. Automated Decision Making</h2>
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">12. Automated Decision Making</h2>
             <p>
               Divine does not engage in automated decision-making or profiling that produces legal or similarly
               significant effects on users within the meaning of applicable data protection law.
@@ -297,7 +297,7 @@ export function PrivacyPage() {
 
           {/* 13. Security */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">13. Security</h2>
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">13. Security</h2>
             <p>
               Divine implements reasonable technical and organizational measures to protect information processed
               on Divine-controlled infrastructure. However, no system is completely secure, and Divine does not
@@ -307,7 +307,7 @@ export function PrivacyPage() {
 
           {/* 14. Children */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">14. Children</h2>
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">14. Children</h2>
             <p>
               Individuals under the age of 16 may use the Service only with the involvement and consent of a
               parent or legal guardian, where permitted by applicable law. If Divine becomes aware that such
@@ -318,7 +318,7 @@ export function PrivacyPage() {
 
           {/* 15. Decentralized System Notice */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">
               15. Decentralized System Notice
             </h2>
             <p>
@@ -330,7 +330,7 @@ export function PrivacyPage() {
 
           {/* 16. Changes to This Policy */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">16. Changes to This Policy</h2>
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">16. Changes to This Policy</h2>
             <p>
               Divine may update this Privacy Policy from time to time. Updated versions will be posted with a
               revised &ldquo;Last Updated&rdquo; date. Unless a different effective date is stated, changes will
@@ -341,7 +341,7 @@ export function PrivacyPage() {
 
           {/* 17. California Privacy Rights */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">17. California Privacy Rights</h2>
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">17. California Privacy Rights</h2>
             <p className="mb-3">
               If you are a California resident, you may have certain rights under the California Consumer Privacy
               Act (CCPA), as amended by the California Privacy Rights Act (CPRA), subject to applicable
@@ -371,7 +371,7 @@ export function PrivacyPage() {
 
           {/* 18. Contact */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">18. Contact</h2>
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">18. Contact</h2>
             <p className="mb-3">
               For questions about this Privacy Policy, contact:
             </p>

--- a/src/pages/SafetyPage.tsx
+++ b/src/pages/SafetyPage.tsx
@@ -12,13 +12,13 @@ export function SafetyPage() {
     <MarketingLayout>
       <div className="container mx-auto px-4 py-8 max-w-4xl">
         <ZendeskWidget />
-        <h1 className="text-4xl font-bold mb-4">{t('title')}</h1>
+        <h1 className="text-4xl font-extrabold mb-4">{t('title')}</h1>
         <p className="text-muted-foreground mb-8">{t('updated')}</p>
 
         <div className="space-y-8 text-muted-foreground leading-relaxed">
           {/* 1. Overview */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">{t('sections.overview')}</h2>
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">{t('sections.overview')}</h2>
             <p className="mb-3">
               These Safety Standards describe the rules and enforcement practices that apply to use of the
               Divine&trade; app (the &ldquo;Service&rdquo;). The Service is provided by Verse Communications PBC
@@ -34,7 +34,7 @@ export function SafetyPage() {
 
           {/* 2. Definitions */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">{t('sections.definitions')}</h2>
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">{t('sections.definitions')}</h2>
             <p className="mb-3">
               <strong className="text-foreground">&ldquo;Divine-controlled infrastructure&rdquo;</strong> means
               websites, apps, relays, media storage, APIs, and other systems owned or controlled by Divine.
@@ -77,7 +77,7 @@ export function SafetyPage() {
 
           {/* 3. Prohibited Content and Conduct */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">{t('sections.prohibited')}</h2>
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">{t('sections.prohibited')}</h2>
             <p className="mb-3">
               Users may not use the Service to create, publish, distribute, or facilitate content or activity
               that is unlawful, harmful, violates applicable law, or violates the Terms of Service.
@@ -95,7 +95,7 @@ export function SafetyPage() {
 
           {/* 4. Child Safety */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">{t('sections.childSafety')}</h2>
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">{t('sections.childSafety')}</h2>
             <p>
               Divine maintains a zero-tolerance policy for child sexual abuse material and related exploitation.
               Divine may remove such content from Divine-controlled infrastructure, restrict access, preserve
@@ -105,7 +105,7 @@ export function SafetyPage() {
 
           {/* 5. Mature Content */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">{t('sections.matureContent')}</h2>
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">{t('sections.matureContent')}</h2>
             <p>
               Certain mature content may be restricted, hidden by default, or made available only to users who
               meet applicable age requirements. Users are responsible for complying with all age restrictions.
@@ -114,7 +114,7 @@ export function SafetyPage() {
 
           {/* 6. Platform Integrity and Abuse */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">{t('sections.integrity')}</h2>
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">{t('sections.integrity')}</h2>
             <p>
               Users may not interfere with the operation or integrity of the Service, including by circumventing
               safeguards, engaging in coordinated manipulation, or using automation or bulk activity in ways that
@@ -124,7 +124,7 @@ export function SafetyPage() {
 
           {/* 7. Enforcement */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">{t('sections.enforcement')}</h2>
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">{t('sections.enforcement')}</h2>
             <p className="mb-3">
               Divine may take action in response to violations of these Safety Standards, including removing or
               limiting content within Divine-controlled infrastructure, restricting or suspending access, disabling
@@ -143,7 +143,7 @@ export function SafetyPage() {
 
           {/* 8. Moderation Methods */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">{t('sections.moderation')}</h2>
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">{t('sections.moderation')}</h2>
             <p>
               Divine may use automated tools, third-party systems, human review, and other methods to identify
               and address violations. These systems are not perfect, and Divine does not guarantee that all
@@ -154,7 +154,7 @@ export function SafetyPage() {
 
           {/* 9. Reporting */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">{t('sections.reporting')}</h2>
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">{t('sections.reporting')}</h2>
             <p>
               Users may report content or accounts through tools made available in the Service. Divine aims to
               review reports of objectionable content promptly and generally within 24 hours, although response
@@ -164,7 +164,7 @@ export function SafetyPage() {
 
           {/* 10. User Controls */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">{t('sections.userControls')}</h2>
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">{t('sections.userControls')}</h2>
             <p>
               The Service may provide tools such as blocking, muting, filtering, and moderation lists that allow
               users to manage their experience. These controls apply within Divine-operated interfaces as
@@ -174,7 +174,7 @@ export function SafetyPage() {
 
           {/* 11. Decentralization Limitation */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">{t('sections.decentralization')}</h2>
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">{t('sections.decentralization')}</h2>
             <p>
               Enforcement actions apply only within Divine-controlled infrastructure and do not extend to
               independent relays, clients, or third-party systems. Because the Service interacts with
@@ -186,7 +186,7 @@ export function SafetyPage() {
 
           {/* 12. Automated Decision-Making */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">{t('sections.automated')}</h2>
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">{t('sections.automated')}</h2>
             <p>
               Divine does not engage in automated decision-making or profiling that produces legal or similarly
               significant effects on users within the meaning of applicable data protection law.
@@ -195,7 +195,7 @@ export function SafetyPage() {
 
           {/* 13. Appeals */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">{t('sections.appeals')}</h2>
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">{t('sections.appeals')}</h2>
             <p>
               Divine may, but is not obligated to, review requests to reconsider moderation decisions.
             </p>
@@ -203,7 +203,7 @@ export function SafetyPage() {
 
           {/* 14. Updates */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">{t('sections.updates')}</h2>
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">{t('sections.updates')}</h2>
             <p>
               These Safety Standards may be updated from time to time. When we do, we will post the updated
               version and revise the &ldquo;Last Updated&rdquo; date above. Unless a different effective date is

--- a/src/pages/TermsPage.tsx
+++ b/src/pages/TermsPage.tsx
@@ -12,13 +12,13 @@ export function TermsPage() {
     <MarketingLayout>
       <div className="container mx-auto px-4 py-8 max-w-4xl">
         <ZendeskWidget />
-        <h1 className="text-4xl font-bold mb-4">{t('termsPage.title')}</h1>
+        <h1 className="text-4xl font-extrabold mb-4">{t('termsPage.title')}</h1>
         <p className="text-muted-foreground mb-8">{t('termsPage.lastUpdated', { date: 'March 30, 2026' })}</p>
 
         <div className="space-y-8 text-muted-foreground leading-relaxed">
           {/* 1. Acceptance of Terms */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">1. Acceptance of Terms</h2>
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">1. Acceptance of Terms</h2>
             <p className="mb-3">
               By accessing or using Divine&trade; (the &ldquo;Service&rdquo;), you agree to these Terms of Service
               (&ldquo;Terms&rdquo;). If you do not agree, do not use the Service.
@@ -39,7 +39,7 @@ export function TermsPage() {
 
           {/* 2. Definitions */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">2. Definitions</h2>
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">2. Definitions</h2>
             <p className="mb-3">
               <strong className="text-foreground">&ldquo;Divine-controlled infrastructure&rdquo;</strong> means
               websites, apps, relays, media storage, APIs, and other systems owned or controlled by Divine.
@@ -82,7 +82,7 @@ export function TermsPage() {
 
           {/* 3. Nature of the Service */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">3. Nature of the Service</h2>
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">3. Nature of the Service</h2>
             <p className="mb-3">
               Divine primarily operates as a non-custodial interface for reading, writing, and interacting with
               Nostr events, although certain optional authentication, signing, backup, or recovery features may
@@ -106,7 +106,7 @@ export function TermsPage() {
 
           {/* 4. Eligibility, Accounts, and Authentication */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">
               4. Eligibility, Accounts, and Authentication
             </h2>
             <p className="mb-3">
@@ -145,7 +145,7 @@ export function TermsPage() {
 
           {/* 5. User Content, Representations, and License */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">
               5. User Content, Representations, and License
             </h2>
             <p className="mb-3">
@@ -177,7 +177,7 @@ export function TermsPage() {
 
           {/* 6. Prohibited Content and Conduct */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">
               6. Prohibited Content and Conduct
             </h2>
             <p className="mb-3">
@@ -216,7 +216,7 @@ export function TermsPage() {
 
           {/* 7. Moderation, Reporting, and User Controls */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">
               7. Moderation, Reporting, and User Controls
             </h2>
             <p className="mb-3">
@@ -247,7 +247,7 @@ export function TermsPage() {
 
           {/* 8. Intellectual Property Complaints */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">
               8. Intellectual Property Complaints
             </h2>
             <p className="mb-3">
@@ -274,7 +274,7 @@ export function TermsPage() {
 
           {/* 9. Usernames, Verification, and Identity Handles */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">
               9. Usernames, Verification, and Identity Handles
             </h2>
             <p className="mb-3">
@@ -320,7 +320,7 @@ export function TermsPage() {
 
           {/* 10. Divine Intellectual Property and Service License */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">
               10. Divine Intellectual Property and Service License
             </h2>
             <p className="mb-3">
@@ -343,7 +343,7 @@ export function TermsPage() {
 
           {/* 11. Service Operations and Platform Rights */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">
               11. Service Operations and Platform Rights
             </h2>
             <p className="mb-3">
@@ -365,7 +365,7 @@ export function TermsPage() {
 
           {/* 12. Termination and Deletion Requests */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">
               12. Termination and Deletion Requests
             </h2>
             <p className="mb-3">
@@ -391,7 +391,7 @@ export function TermsPage() {
 
           {/* 13. Decentralization and Content Persistence */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">
               13. Decentralization and Content Persistence
             </h2>
             <p className="mb-3">
@@ -411,7 +411,7 @@ export function TermsPage() {
 
           {/* 14. Third-Party Systems and External Links */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">
               14. Third-Party Systems and External Links
             </h2>
             <p className="mb-3">
@@ -433,7 +433,7 @@ export function TermsPage() {
 
           {/* 15. Beta and Experimental Features */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">
               15. Beta and Experimental Features
             </h2>
             <p>
@@ -445,7 +445,7 @@ export function TermsPage() {
 
           {/* 16. Disclaimers About User Content and Monitoring */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">
               16. Disclaimers About User Content and Monitoring
             </h2>
             <p className="mb-3">
@@ -463,7 +463,7 @@ export function TermsPage() {
 
           {/* 17. Indemnification */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">17. Indemnification</h2>
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">17. Indemnification</h2>
             <p>
               You agree to indemnify, defend, and hold harmless Divine and its officers, directors, employees,
               contractors, service providers, and affiliates from and against any claims, liabilities, damages,
@@ -484,7 +484,7 @@ export function TermsPage() {
             * legal review.
             */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">
               18. Disclaimer of Warranties and Limitation of Liability
             </h2>
             <p className="mb-3" style={{ textTransform: 'uppercase' }}>
@@ -520,7 +520,7 @@ export function TermsPage() {
 
           {/* 19. Dispute Resolution; Governing Law; Class Action Waiver */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">
               19. Dispute Resolution; Governing Law; Class Action Waiver
             </h2>
             <p className="mb-3">
@@ -541,7 +541,7 @@ export function TermsPage() {
 
           {/* 20. Changes to These Terms */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">20. Changes to These Terms</h2>
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">20. Changes to These Terms</h2>
             <p>
               We may modify these Terms from time to time. When we do, we will post the updated version and revise
               the &ldquo;Last Updated&rdquo; date above. Unless a different effective date is stated, changes will
@@ -552,7 +552,7 @@ export function TermsPage() {
 
           {/* 21. Entire Agreement; Severability; Contact Information */}
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-3">
+            <h2 className="text-2xl font-extrabold text-foreground mb-3">
               21. Entire Agreement; Severability; Contact Information
             </h2>
             <p className="mb-3">


### PR DESCRIPTION
## Summary
- Brand rule at \`src/index.css:215\` declares \`h1, h2 { font-weight: 800 }\`, but the legal pages used Tailwind's \`font-bold\` (700) on \`<h1>\` and \`font-semibold\` (600) on \`<h2>\`.
- Utility classes have higher CSS specificity than bare element selectors, so the page-level classes clobbered the brand intent and every section heading rendered ~200 weight units lighter than the rest of the site.
- Swapped \`font-bold\` → \`font-extrabold\` on each \`<h1>\` and \`font-semibold\` → \`font-extrabold\` on each \`<h2>\` across Terms, Privacy, DMCA, and Safety pages.
- Verified computed weight is now 800 across all four routes.

## Test plan
- [ ] Visit \`/terms\`, \`/privacy\`, \`/dmca\`, \`/safety\` and confirm h1 + section h2 headings render at Extra Bold, visually matching the section-header treatment elsewhere on the site
- [ ] No layout regressions (font-weight change only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)