### PR TITLE
feat: family + age-review + kids — three sister pages for parents, teens, moderation, and policy

### DIFF
--- a/.ai-ack
+++ b/.ai-ack
@@ -1,1 +1,0 @@
-yes i understood

--- a/.ai-ack
+++ b/.ai-ack
@@ -1,0 +1,1 @@
+yes i understood

--- a/compute-js/src/index.js
+++ b/compute-js/src/index.js
@@ -219,6 +219,30 @@ async function handleRequest(event) {
       const ogResponse = await handleDiscoveryOgTags(type);
       if (ogResponse) return ogResponse;
     }
+
+    // Family resource hub at /family on apex.
+    if (url.pathname === '/family') {
+      const ogResponse = handleFamilyOgTags(url, hostnameToUse);
+      if (ogResponse) {
+        return ogResponse;
+      }
+    }
+
+    // Age-review page at /age-review on apex.
+    if (url.pathname === '/age-review') {
+      const ogResponse = handleAgeReviewOgTags(url, hostnameToUse);
+      if (ogResponse) {
+        return ogResponse;
+      }
+    }
+
+    // Kids policy page at /kids on apex.
+    if (url.pathname === '/kids') {
+      const ogResponse = handleKidsPolicyOgTags(url, hostnameToUse);
+      if (ogResponse) {
+        return ogResponse;
+      }
+    }
   }
 
   // 7. Serve sw.js with no-cache to ensure browsers always get the latest service worker
@@ -676,8 +700,12 @@ function getSubdomain(hostname) {
     }
     if (hostname.endsWith('.' + apex)) {
       const subdomain = hostname.slice(0, -(apex.length + 1));
-      // Skip reserved subdomains
-      if (subdomain === 'www' || subdomain === 'admin' || subdomain === 'api') {
+      // Skip reserved subdomains.
+      if (
+        subdomain === 'www' ||
+        subdomain === 'admin' ||
+        subdomain === 'api'
+      ) {
         return null;
       }
       // Skip multi-level subdomains (e.g., names.admin.divine.video)
@@ -1172,6 +1200,93 @@ async function handleCategoryOgTags(request, url, funnelcakeTarget) {
   } catch (err) {
     console.error('handleCategoryOgTags error:', err.message, err.stack);
     return await publisherServer.serveRequest(request);
+  }
+}
+
+function handleFamilyOgTags(url, hostnameToUse) {
+  try {
+    const canonical = `https://${hostnameToUse}${url.pathname}`;
+    const html = buildCrawlerHtml({
+      title: 'For families on Divine — Conversation-first guidance for parents and teens',
+      description:
+        'A practical guide for families on Divine: how to talk with your teen about social media, what Divine can and can’t do, content settings, healthy feed habits, and trusted outside resources.',
+      image: DEFAULT_OG_IMAGE,
+      url: canonical,
+      ogType: 'website',
+      twitterCard: 'summary_large_image',
+      imageWidth: 1200,
+      imageHeight: 630,
+    });
+
+    return new Response(html, {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/html; charset=utf-8',
+        'Cache-Control': 'public, max-age=300',
+        'Vary': 'User-Agent',
+      },
+    });
+  } catch (err) {
+    console.error('handleFamilyOgTags error:', err.message, err.stack);
+    return null;
+  }
+}
+
+function handleAgeReviewOgTags(url, hostnameToUse) {
+  try {
+    const canonical = `https://${hostnameToUse}${url.pathname}`;
+    const html = buildCrawlerHtml({
+      title: 'Account review — Divine',
+      description:
+        'If your Divine account was flagged as possibly belonging to someone under 16, this page explains what to do — and the 15-day window for responding.',
+      image: DEFAULT_OG_IMAGE,
+      url: canonical,
+      ogType: 'website',
+      twitterCard: 'summary_large_image',
+      imageWidth: 1200,
+      imageHeight: 630,
+    });
+
+    return new Response(html, {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/html; charset=utf-8',
+        'Cache-Control': 'public, max-age=300',
+        'Vary': 'User-Agent',
+      },
+    });
+  } catch (err) {
+    console.error('handleAgeReviewOgTags error:', err.message, err.stack);
+    return null;
+  }
+}
+
+function handleKidsPolicyOgTags(url, hostnameToUse) {
+  try {
+    const canonical = `https://${hostnameToUse}${url.pathname}`;
+    const html = buildCrawlerHtml({
+      title: 'Kids on Divine — How accounts work for under-16s',
+      description:
+        'How Divine handles accounts for people under 16 — the rules, the reasoning, and what families can do together regardless of age.',
+      image: DEFAULT_OG_IMAGE,
+      url: canonical,
+      ogType: 'website',
+      twitterCard: 'summary_large_image',
+      imageWidth: 1200,
+      imageHeight: 630,
+    });
+
+    return new Response(html, {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/html; charset=utf-8',
+        'Cache-Control': 'public, max-age=300',
+        'Vary': 'User-Agent',
+      },
+    });
+  } catch (err) {
+    console.error('handleKidsPolicyOgTags error:', err.message, err.stack);
+    return null;
   }
 }
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,7 +8,7 @@ import htmlParser from "@html-eslint/parser";
 import customRules from "./eslint-rules/index.js";
 
 export default tseslint.config(
-  { ignores: ["dist", "old_files", "public/proofmode-spec.html", "public/unregister-sw.html", "public/embed.html", "scripts/prerender-content/*.html"] },
+  { ignores: ["dist", "old_files", "playwright-report", "test-results", "public/proofmode-spec.html", "public/unregister-sw.html", "public/embed.html", "scripts/prerender-content/*.html"] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ["**/*.{ts,tsx}"],

--- a/functions/[[path]].test.ts
+++ b/functions/[[path]].test.ts
@@ -184,6 +184,55 @@ describe('functions/[[path]]', () => {
     expect(html).toContain('property="og:image" content="https://media.divine.video/545aff83f83b4643f340747213e86520fac83596f899e8ea3117e0aa8b260f7b"');
   });
 
+  it('injects family-hub metadata for /family on apex', async () => {
+    const response = await onRequest({
+      request: new Request('https://divine.video/family'),
+      next: async () => new Response('not found', { status: 404 }),
+      env: {},
+    });
+
+    const html = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(html).toContain('<title>For families on Divine — Conversation-first guidance for parents and teens</title>');
+    expect(html).toContain('property="og:url" content="https://divine.video/family"');
+    expect(html).toContain('property="og:title" content="For families on Divine');
+    expect(html).toContain('name="twitter:title" content="For families on Divine');
+  });
+
+  it('injects age-review metadata for /age-review on apex', async () => {
+    const response = await onRequest({
+      request: new Request('https://divine.video/age-review'),
+      next: async () => new Response('not found', { status: 404 }),
+      env: {},
+    });
+
+    const html = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(html).toContain('<title>Account review — Divine</title>');
+    expect(html).toContain('property="og:url" content="https://divine.video/age-review"');
+    expect(html).toContain('property="og:title" content="Account review — Divine"');
+    expect(html).toContain('name="twitter:title" content="Account review — Divine"');
+    expect(html).toContain('15-day window');
+  });
+
+  it('injects kids-policy metadata for /kids on apex', async () => {
+    const response = await onRequest({
+      request: new Request('https://divine.video/kids'),
+      next: async () => new Response('not found', { status: 404 }),
+      env: {},
+    });
+
+    const html = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(html).toContain('<title>Kids on Divine — How accounts work for under-16s</title>');
+    expect(html).toContain('property="og:url" content="https://divine.video/kids"');
+    expect(html).toContain('property="og:title" content="Kids on Divine');
+    expect(html).toContain('name="twitter:title" content="Kids on Divine');
+  });
+
   it('injects category metadata for category routes', async () => {
     const response = await onRequest({
       request: new Request('https://divine.video/category/dance'),

--- a/functions/[[path]].ts
+++ b/functions/[[path]].ts
@@ -2,8 +2,11 @@
 // ABOUTME: Returns index.html with a 200 status for SPA routes and injects per-video OG/Twitter tags for bots
 
 import {
+  buildAgeReviewPageMeta,
   buildCategoriesIndexMeta,
   buildCategoryPageMeta,
+  buildFamilyPageMeta,
+  buildKidsPolicyPageMeta,
   buildProfilePageMeta,
   buildVideoPageMeta,
   decodeNpubToHex,
@@ -205,6 +208,21 @@ async function fetchRouteMeta(url: URL): Promise<PageMeta | null> {
     return fetchProfileMeta(url);
   }
 
+  // Family resource hub at /family on apex.
+  if (url.pathname === '/family') {
+    return buildFamilyPageMeta(url);
+  }
+
+  // Age-review page at /age-review on apex.
+  if (url.pathname === '/age-review') {
+    return buildAgeReviewPageMeta(url);
+  }
+
+  // Kids policy page at /kids on apex.
+  if (url.pathname === '/kids') {
+    return buildKidsPolicyPageMeta(url);
+  }
+
   return null;
 }
 
@@ -223,6 +241,18 @@ export async function onRequest(context: {
 
   // Try to serve the requested asset first
   const response = await context.next();
+  const meta = await fetchRouteMeta(url);
+
+  if (meta && response.ok && response.headers.get('content-type')?.includes('text/html')) {
+    const html = injectMetaTags(await response.text(), meta);
+    const headers = new Headers(response.headers);
+    headers.set('content-type', 'text/html; charset=UTF-8');
+
+    return new Response(html, {
+      status: response.status,
+      headers,
+    });
+  }
 
   // If the response is a 404 and not a file request (no extension or is .html),
   // serve index.html with a 200 status code
@@ -234,7 +264,6 @@ export async function onRequest(context: {
       // Fetch index.html from the static assets
       const indexUrl = new URL('/index.html', context.request.url);
       const indexResponse = await fetch(indexUrl);
-      const meta = await fetchRouteMeta(url);
 
       if (meta) {
         const html = injectMetaTags(await indexResponse.text(), meta, path);

--- a/functions/[[path]].ts
+++ b/functions/[[path]].ts
@@ -244,7 +244,7 @@ export async function onRequest(context: {
   const meta = await fetchRouteMeta(url);
 
   if (meta && response.ok && response.headers.get('content-type')?.includes('text/html')) {
-    const html = injectMetaTags(await response.text(), meta);
+    const html = injectMetaTags(await response.text(), meta, path);
     const headers = new Headers(response.headers);
     headers.set('content-type', 'text/html; charset=UTF-8');
 

--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -40,6 +40,9 @@ import AuthenticityPage from "./pages/AuthenticityPage";
 import DMCAPage from "./pages/DMCAPage";
 import HumanCreatedPage from "./pages/HumanCreatedPage";
 import { SafetyPage } from "./pages/SafetyPage";
+import { FamilyPage } from "./pages/FamilyPage";
+import { AgeReviewPage } from "./pages/AgeReviewPage";
+import { KidsPolicyPage } from "./pages/KidsPolicyPage";
 import { Support } from "./pages/Support";
 import { FAQPage } from "./pages/FAQPage";
 import MerchPage from "./pages/MerchPage";
@@ -72,6 +75,53 @@ export function AppRouter() {
   // Check if we're on a subdomain profile (username.divine.video)
   const subdomainUser = getSubdomainUser();
 
+  const appShellRoutes = (
+    <>
+      {/* Public browsing routes - accessible without login */}
+      <Route path="/discovery" element={<DiscoveryPage />} />
+      <Route path="/discovery/:tab" element={<DiscoveryPage />} />
+      <Route path="/trending" element={<TrendingPage />} />
+      <Route path="/popular" element={<PopularPage />} />
+      <Route path="/hashtags" element={<HashtagDiscoveryPage />} />
+      <Route path="/hashtag/:tag" element={<HashtagPage />} />
+      <Route path="/category" element={<CategoriesIndexPage />} />
+      <Route path="/category/:name" element={<CategoryPage />} />
+      <Route path="/t/:tag" element={<TagPage />} />
+      <Route path="/profile/:npub" element={<ProfilePage />} />
+      <Route path="/video/:id" element={<VideoPage />} />
+      <Route path="/search" element={<SearchPage />} />
+      <Route path="/leaderboard" element={<LeaderboardPage />} />
+      <Route path="/merch" element={<MerchPage />} />
+      <Route path="/u/:userId" element={<UniversalUserPage />} />
+      <Route path="/list/:pubkey/:listId" element={<ListDetailPage />} />
+      <Route path="/event/:eventId" element={<EventPage />} />
+      <Route path="/event/a/:kind/:pubkey/:identifier" element={<EventPage />} />
+      <Route path="/:nip19" element={<NIP19Page />} />
+
+      {/* Protected routes - require login */}
+      {canUseProtectedRoutes && (
+        <>
+          <Route path="/home" element={<HomePage />} />
+          <Route path="/notifications" element={<NotificationsPage />} />
+          <Route path="/messages" element={<MessagesPage />} />
+          <Route path="/messages/:conversationId" element={<ConversationPage />} />
+          <Route path="/analytics" element={<AnalyticsPage />} />
+          <Route path="/lists" element={<ListsPage />} />
+          {/* DISABLED: Upload route - not supported on web at this time
+          <Route path="/upload" element={<UploadPage />} />
+          */}
+          <Route path="/settings/moderation" element={<ModerationSettingsPage />} />
+          <Route path="/settings/linked-accounts" element={<LinkedAccountsSettingsPage />} />
+          {/* Test pages for debugging */}
+          <Route path="/debug-video" element={<DebugVideoPage />} />
+        </>
+      )}
+
+      {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+      <Route path="*" element={<NotFound />} />
+    </>
+  );
+
   return (
     <BrowserRouter>
       <ScrollToTop />
@@ -88,6 +138,9 @@ export function AppRouter() {
         <Route path="/human-created" element={<HumanCreatedPage />} />
         <Route path="/dmca" element={<DMCAPage />} />
         <Route path="/safety" element={<SafetyPage />} />
+        <Route path="/family" element={<FamilyPage />} />
+        <Route path="/age-review" element={<AgeReviewPage />} />
+        <Route path="/kids" element={<KidsPolicyPage />} />
         <Route path="/support" element={<Support />} />
         <Route path="/faq" element={<FAQPage />} />
         <Route path="/get-embed" element={<GetEmbedPage />} />
@@ -106,57 +159,10 @@ export function AppRouter() {
           />
         )}
 
-        {/* App routes - with AppLayout */}
         <Route element={<AppLayout />}>
           {/* Home/landing route - render profile directly on subdomain */}
-          <Route path="/" element={
-            subdomainUser
-              ? <ProfilePage />
-              : <Index />
-          } />
-
-          {/* Public browsing routes - accessible without login */}
-          <Route path="/discovery" element={<DiscoveryPage />} />
-          <Route path="/discovery/:tab" element={<DiscoveryPage />} />
-          <Route path="/trending" element={<TrendingPage />} />
-          <Route path="/popular" element={<PopularPage />} />
-          <Route path="/hashtags" element={<HashtagDiscoveryPage />} />
-          <Route path="/hashtag/:tag" element={<HashtagPage />} />
-          <Route path="/category" element={<CategoriesIndexPage />} />
-          <Route path="/category/:name" element={<CategoryPage />} />
-          <Route path="/t/:tag" element={<TagPage />} />
-          <Route path="/profile/:npub" element={<ProfilePage />} />
-          <Route path="/video/:id" element={<VideoPage />} />
-          <Route path="/search" element={<SearchPage />} />
-          <Route path="/leaderboard" element={<LeaderboardPage />} />
-          <Route path="/merch" element={<MerchPage />} />
-          <Route path="/u/:userId" element={<UniversalUserPage />} />
-          <Route path="/list/:pubkey/:listId" element={<ListDetailPage />} />
-          <Route path="/event/:eventId" element={<EventPage />} />
-          <Route path="/event/a/:kind/:pubkey/:identifier" element={<EventPage />} />
-          <Route path="/:nip19" element={<NIP19Page />} />
-
-          {/* Protected routes - require login */}
-          {canUseProtectedRoutes && (
-            <>
-              <Route path="/home" element={<HomePage />} />
-              <Route path="/notifications" element={<NotificationsPage />} />
-              <Route path="/messages" element={<MessagesPage />} />
-              <Route path="/messages/:conversationId" element={<ConversationPage />} />
-              <Route path="/analytics" element={<AnalyticsPage />} />
-              <Route path="/lists" element={<ListsPage />} />
-              {/* DISABLED: Upload route - not supported on web at this time
-              <Route path="/upload" element={<UploadPage />} />
-              */}
-              <Route path="/settings/moderation" element={<ModerationSettingsPage />} />
-              <Route path="/settings/linked-accounts" element={<LinkedAccountsSettingsPage />} />
-              {/* Test pages for debugging */}
-              <Route path="/debug-video" element={<DebugVideoPage />} />
-            </>
-          )}
-
-          {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-          <Route path="*" element={<NotFound />} />
+          <Route path="/" element={subdomainUser ? <ProfilePage /> : <Index />} />
+          {appShellRoutes}
         </Route>
       </Routes>
     </BrowserRouter>

--- a/src/components/AppFooter.tsx
+++ b/src/components/AppFooter.tsx
@@ -88,11 +88,11 @@ export function AppFooter() {
                 </SmartLink>
                 <span>•</span>
                 <SmartLink to="/family" className="hover:text-brand-off-white transition-colors">
-                  Family Resources
+                  {t('menu.familyResources')}
                 </SmartLink>
                 <span>•</span>
                 <SmartLink to="/kids" className="hover:text-brand-off-white transition-colors">
-                  Kids Policy
+                  {t('menu.kidsPolicy')}
                 </SmartLink>
                 <span>•</span>
                 <SmartLink to="/dmca" className="hover:text-brand-off-white transition-colors">

--- a/src/components/AppFooter.tsx
+++ b/src/components/AppFooter.tsx
@@ -87,6 +87,14 @@ export function AppFooter() {
                   Safety
                 </SmartLink>
                 <span>•</span>
+                <SmartLink to="/family" className="hover:text-brand-off-white transition-colors">
+                  Family Resources
+                </SmartLink>
+                <span>•</span>
+                <SmartLink to="/kids" className="hover:text-brand-off-white transition-colors">
+                  Kids Policy
+                </SmartLink>
+                <span>•</span>
                 <SmartLink to="/dmca" className="hover:text-brand-off-white transition-colors">
                   DMCA & Copyright
                 </SmartLink>

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -509,6 +509,18 @@ export function AppSidebar({ className }: { className?: string }) {
                 {t('menu.safety')}
               </button>
               <button
+                onClick={() => navigate('/family')}
+                className="transition-colors hover:text-primary"
+              >
+                Family Resources
+              </button>
+              <button
+                onClick={() => navigate('/kids')}
+                className="transition-colors hover:text-primary"
+              >
+                Kids Policy
+              </button>
+              <button
                 onClick={() => navigate('/dmca')}
                 className="transition-colors hover:text-primary"
               >

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -512,13 +512,13 @@ export function AppSidebar({ className }: { className?: string }) {
                 onClick={() => navigate('/family')}
                 className="transition-colors hover:text-primary"
               >
-                Family Resources
+                {t('menu.familyResources')}
               </button>
               <button
                 onClick={() => navigate('/kids')}
                 className="transition-colors hover:text-primary"
               >
-                Kids Policy
+                {t('menu.kidsPolicy')}
               </button>
               <button
                 onClick={() => navigate('/dmca')}

--- a/src/components/MarketingHeader.tsx
+++ b/src/components/MarketingHeader.tsx
@@ -54,7 +54,7 @@ export function MarketingHeader() {
             </Link>
             <Link
               to="/discovery"
-              className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-semibold bg-primary text-white rounded-full hover:brightness-110 transition-colors"
+              className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-semibold bg-primary text-primary-foreground rounded-full hover:brightness-110 transition-colors"
             >
               Try it
               <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/components/ScrollToTop.test.tsx
+++ b/src/components/ScrollToTop.test.tsx
@@ -1,7 +1,12 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { Link, MemoryRouter, Route, Routes } from 'react-router-dom';
+import { Link, MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ScrollToTop } from './ScrollToTop';
+
+function BackButton() {
+  const navigate = useNavigate();
+  return <button onClick={() => navigate(-1)}>Back</button>;
+}
 
 function TestApp() {
   return (
@@ -23,6 +28,7 @@ function TestApp() {
             <div>
               <h1>Details</h1>
               <Link to="/feed">Feed</Link>
+              <BackButton />
             </div>
           }
         />
@@ -45,7 +51,7 @@ describe('ScrollToTop', () => {
     });
   });
 
-  it('restores the saved scroll position when returning to a route', () => {
+  it('scrolls to the top on forward (PUSH) navigation, even with a saved position', () => {
     render(<TestApp />);
 
     expect(window.scrollTo).toHaveBeenLastCalledWith(0, 0);
@@ -56,8 +62,26 @@ describe('ScrollToTop', () => {
     expect(screen.getByRole('heading', { name: 'Details' })).toBeInTheDocument();
     expect(window.scrollTo).toHaveBeenLastCalledWith(0, 0);
 
+    // Returning to /feed via a link is a PUSH — it should land at the top,
+    // not restore the 420 position saved when we left.
     scrollY = 125;
     fireEvent.click(screen.getByRole('link', { name: 'Feed' }));
+
+    expect(screen.getByRole('heading', { name: 'Feed' })).toBeInTheDocument();
+    expect(window.scrollTo).toHaveBeenLastCalledWith(0, 0);
+  });
+
+  it('restores the saved scroll position on back (POP) navigation', () => {
+    render(<TestApp />);
+
+    // Leave /feed at y=420; that position is saved for /feed.
+    scrollY = 420;
+    fireEvent.click(screen.getByRole('link', { name: 'Details' }));
+    expect(screen.getByRole('heading', { name: 'Details' })).toBeInTheDocument();
+
+    // Browser back (navigate(-1)) is a POP — restore the saved /feed position.
+    scrollY = 0;
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }));
 
     expect(screen.getByRole('heading', { name: 'Feed' })).toBeInTheDocument();
     expect(window.scrollTo).toHaveBeenLastCalledWith(0, 420);

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useLayoutEffect, useRef } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigationType } from 'react-router-dom';
 
 const scrollPositions = new Map<string, number>();
 
@@ -9,6 +9,7 @@ function getScrollKey(pathname: string, search: string) {
 
 export function ScrollToTop() {
   const { pathname, search, hash } = useLocation();
+  const navigationType = useNavigationType();
   const scrollKey = getScrollKey(pathname, search);
   const timeoutRef = useRef<number | null>(null);
 
@@ -62,13 +63,17 @@ export function ScrollToTop() {
       };
     }
 
-    const savedPosition = scrollPositions.get(scrollKey) ?? 0;
+    // Only restore the saved position on browser back/forward (POP) — including
+    // in-app `navigate(-1)`. Forward link clicks (PUSH/REPLACE) start at the top
+    // so footer/sidebar/nav links always land at the top of the destination.
+    const savedPosition =
+      navigationType === 'POP' ? (scrollPositions.get(scrollKey) ?? 0) : 0;
     window.scrollTo(0, savedPosition);
 
     return () => {
       scrollPositions.set(scrollKey, window.scrollY);
     };
-  }, [scrollKey, hash]);
+  }, [scrollKey, hash, navigationType]);
 
   return null;
 }

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -575,9 +575,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
 
       const failedUrl = allUrls[currentUrlIndex] || hlsUrl || src;
       if (failedUrl && isProtectedDivineMediaUrl(failedUrl)) {
-        const authResult = await checkMediaAuth(failedUrl);
-        const authorized = authResult?.authorized ?? true;
-        const status = authResult?.status ?? 0;
+        const { authorized, status } = await checkMediaAuth(failedUrl);
         if (!authorized && (status === 401 || status === 403)) {
           debugError(`[VideoPlayer ${videoId}] Media auth required after load failure (${status})`);
 
@@ -757,9 +755,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
       const checkAuth = async () => {
         const urlToCheck = hlsUrl || allUrls[currentUrlIndex];
         if (urlToCheck && !isAdultVerified) {
-          const authResult = await checkMediaAuth(urlToCheck);
-          const authorized = authResult?.authorized ?? true;
-          const status = authResult?.status ?? 0;
+          const { authorized, status } = await checkMediaAuth(urlToCheck);
           setAuthCheckPending(false);
           if (!authorized && (status === 401 || status === 403)) {
             verboseLog(`[VideoPlayer ${videoId}] Preflight check: auth required (${status})`);

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -575,7 +575,9 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
 
       const failedUrl = allUrls[currentUrlIndex] || hlsUrl || src;
       if (failedUrl && isProtectedDivineMediaUrl(failedUrl)) {
-        const { authorized, status } = await checkMediaAuth(failedUrl);
+        const authResult = await checkMediaAuth(failedUrl);
+        const authorized = authResult?.authorized ?? true;
+        const status = authResult?.status ?? 0;
         if (!authorized && (status === 401 || status === 403)) {
           debugError(`[VideoPlayer ${videoId}] Media auth required after load failure (${status})`);
 
@@ -755,7 +757,9 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
       const checkAuth = async () => {
         const urlToCheck = hlsUrl || allUrls[currentUrlIndex];
         if (urlToCheck && !isAdultVerified) {
-          const { authorized, status } = await checkMediaAuth(urlToCheck);
+          const authResult = await checkMediaAuth(urlToCheck);
+          const authorized = authResult?.authorized ?? true;
+          const status = authResult?.status ?? 0;
           setAuthCheckPending(false);
           if (!authorized && (status === 401 || status === 403)) {
             verboseLog(`[VideoPlayer ${videoId}] Preflight check: auth required (${status})`);

--- a/src/components/static-pages/Anchor.tsx
+++ b/src/components/static-pages/Anchor.tsx
@@ -1,0 +1,12 @@
+// ABOUTME: Anchor wrapper with consistent scroll offset for static pages
+// ABOUTME: Keeps hero anchor navigation aligned below the fixed header
+
+import type { ReactNode } from "react";
+
+export function Anchor({ id, children }: { id: string; children: ReactNode }) {
+  return (
+    <section id={id} className="scroll-mt-24">
+      {children}
+    </section>
+  );
+}

--- a/src/components/static-pages/AnchorNav.tsx
+++ b/src/components/static-pages/AnchorNav.tsx
@@ -1,0 +1,33 @@
+// ABOUTME: Shared "On this page" anchor navigation for static pages
+// ABOUTME: Renders a grid of in-page jump links from a list of section anchors
+
+import { cn } from "@/lib/utils";
+
+export interface SectionAnchor {
+  id: string;
+  title: string;
+}
+
+interface AnchorNavProps {
+  sections: SectionAnchor[];
+  className?: string;
+}
+
+export function AnchorNav({ sections, className }: AnchorNavProps) {
+  return (
+    <nav
+      aria-label="On this page"
+      className={cn("mt-10 grid gap-2 sm:grid-cols-3 text-sm", className)}
+    >
+      {sections.map((s) => (
+        <a
+          key={s.id}
+          href={`#${s.id}`}
+          className="rounded-xl border border-brand-green/40 bg-brand-dark-green/40 px-4 py-3 text-brand-light-green hover:bg-brand-green/10 hover:border-brand-green transition-colors"
+        >
+          {s.title}
+        </a>
+      ))}
+    </nav>
+  );
+}

--- a/src/components/static-pages/BackToTopButton.tsx
+++ b/src/components/static-pages/BackToTopButton.tsx
@@ -1,0 +1,41 @@
+// ABOUTME: Floating back-to-top button for long static pages
+// ABOUTME: Appears after scrolling and respects reduced-motion preferences
+
+import { useEffect, useState } from "react";
+import { ArrowUp } from "@phosphor-icons/react";
+
+import { cn } from "@/lib/utils";
+
+export function BackToTopButton() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setVisible(window.scrollY > 600);
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  const goTop = () => {
+    const reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    window.scrollTo({ top: 0, behavior: reduced ? "auto" : "smooth" });
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={goTop}
+      aria-label="Back to top"
+      aria-hidden={!visible}
+      tabIndex={visible ? 0 : -1}
+      className={cn(
+        "fixed right-5 bottom-[calc(1.25rem+env(safe-area-inset-bottom))] z-40 h-12 w-12 rounded-full bg-brand-green text-brand-dark-green border-2 border-brand-dark-green brand-offset-shadow-sm-dark flex items-center justify-center transition-all duration-200 hover:-translate-x-[2px] hover:-translate-y-[2px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-dark-green focus-visible:ring-offset-2",
+        visible
+          ? "opacity-100 translate-y-0 pointer-events-auto"
+          : "opacity-0 translate-y-2 pointer-events-none",
+      )}
+    >
+      <ArrowUp weight="bold" className="h-5 w-5" />
+    </button>
+  );
+}

--- a/src/components/static-pages/SectionHero.tsx
+++ b/src/components/static-pages/SectionHero.tsx
@@ -1,0 +1,33 @@
+// ABOUTME: Reusable section heading block for long static pages
+// ABOUTME: Pairs eyebrow icons, display headings, and lead copy consistently
+
+import type { ReactNode } from "react";
+
+import { SectionHeader } from "@/components/brand/SectionHeader";
+
+export function SectionHero({
+  eyebrow,
+  icon,
+  title,
+  lead,
+}: {
+  eyebrow: string;
+  icon: ReactNode;
+  title: string;
+  lead: string;
+}) {
+  return (
+    <div className="mb-8">
+      <div className="flex items-center gap-2 text-xs font-semibold tracking-wide text-brand-dark-green dark:text-brand-green mb-3">
+        {icon}
+        <span>{eyebrow}</span>
+      </div>
+      <SectionHeader as="h2" className="text-3xl md:text-4xl mb-4">
+        {title}
+      </SectionHeader>
+      <p className="text-lg leading-relaxed text-muted-foreground max-w-3xl">
+        {lead}
+      </p>
+    </div>
+  );
+}

--- a/src/components/static-pages/SupportEmailButton.tsx
+++ b/src/components/static-pages/SupportEmailButton.tsx
@@ -1,0 +1,23 @@
+// ABOUTME: Sticker-style support email link for static policy pages
+// ABOUTME: Standardizes mailto CTA presentation across family and review pages
+
+import { EnvelopeSimple } from "@phosphor-icons/react";
+
+import { Button } from "@/components/ui/button";
+
+export function SupportEmailButton({
+  href,
+  label,
+}: {
+  href: string;
+  label: string;
+}) {
+  return (
+    <Button asChild variant="sticker" size="lg">
+      <a href={href} className="inline-flex items-center gap-2">
+        <EnvelopeSimple weight="fill" className="h-4 w-4" />
+        {label}
+      </a>
+    </Button>
+  );
+}

--- a/src/components/static-pages/index.ts
+++ b/src/components/static-pages/index.ts
@@ -1,4 +1,5 @@
 export { Anchor } from "./Anchor";
+export { AnchorNav, type SectionAnchor } from "./AnchorNav";
 export { BackToTopButton } from "./BackToTopButton";
 export { SectionHero } from "./SectionHero";
 export { staticPageLinkCardClass } from "./staticPageLinkCardClass";

--- a/src/components/static-pages/index.ts
+++ b/src/components/static-pages/index.ts
@@ -1,0 +1,5 @@
+export { Anchor } from "./Anchor";
+export { BackToTopButton } from "./BackToTopButton";
+export { SectionHero } from "./SectionHero";
+export { staticPageLinkCardClass } from "./staticPageLinkCardClass";
+export { SupportEmailButton } from "./SupportEmailButton";

--- a/src/components/static-pages/staticPageLinkCardClass.ts
+++ b/src/components/static-pages/staticPageLinkCardClass.ts
@@ -1,0 +1,26 @@
+// ABOUTME: Shared class builder for static-page brand link cards
+// ABOUTME: Maps brand accents to utility classes with consistent hover behavior
+
+import { cn } from "@/lib/utils";
+
+const LINK_CARD_ACCENT_CLASS = {
+  blue: "brand-offset-shadow-blue brand-link-card-blue",
+  green: "brand-offset-shadow-green brand-link-card-green",
+  orange: "brand-offset-shadow-orange brand-link-card-orange",
+  pink: "brand-offset-shadow-pink brand-link-card-pink",
+  violet: "brand-offset-shadow-violet brand-link-card-violet",
+  yellow: "brand-offset-shadow-yellow brand-link-card-yellow",
+} as const;
+
+export type LinkCardAccent = keyof typeof LINK_CARD_ACCENT_CLASS;
+
+export function staticPageLinkCardClass(
+  accent: LinkCardAccent = "green",
+  className?: string,
+) {
+  return cn(
+    "group block brand-card brand-link-card p-6 transition-all",
+    LINK_CARD_ACCENT_CLASS[accent],
+    className,
+  );
+}

--- a/src/lib/i18n/locales/ar/common.json
+++ b/src/lib/i18n/locales/ar/common.json
@@ -28,7 +28,9 @@
     "openSource": "المصدر المفتوح",
     "donate": "تبرع",
     "help": "مساعدة",
-    "merch": "Merch"
+    "merch": "Merch",
+    "familyResources": "موارد العائلة",
+    "kidsPolicy": "سياسة الأطفال"
   },
   "theme": {
     "lightMode": "الوضع الفاتح",

--- a/src/lib/i18n/locales/de/common.json
+++ b/src/lib/i18n/locales/de/common.json
@@ -28,7 +28,9 @@
     "openSource": "Open Source",
     "donate": "Spenden",
     "help": "Hilfe",
-    "merch": "Merch"
+    "merch": "Merch",
+    "familyResources": "Familienressourcen",
+    "kidsPolicy": "Richtlinie für Kinder"
   },
   "theme": {
     "lightMode": "Heller Modus",

--- a/src/lib/i18n/locales/en/common.json
+++ b/src/lib/i18n/locales/en/common.json
@@ -28,7 +28,9 @@
     "openSource": "Open Source",
     "donate": "Donate",
     "help": "Help",
-    "merch": "Merch"
+    "merch": "Merch",
+    "familyResources": "Family Resources",
+    "kidsPolicy": "Kids Policy"
   },
   "theme": {
     "lightMode": "Light mode",

--- a/src/lib/i18n/locales/es/common.json
+++ b/src/lib/i18n/locales/es/common.json
@@ -28,7 +28,9 @@
     "openSource": "Codigo abierto",
     "donate": "Donar",
     "help": "Ayuda",
-    "merch": "Merch"
+    "merch": "Merch",
+    "familyResources": "Recursos familiares",
+    "kidsPolicy": "Politica para ninos"
   },
   "theme": {
     "lightMode": "Modo claro",

--- a/src/lib/i18n/locales/fil/common.json
+++ b/src/lib/i18n/locales/fil/common.json
@@ -28,7 +28,9 @@
     "openSource": "Open Source",
     "donate": "Mag-donate",
     "help": "Tulong",
-    "merch": "Merch"
+    "merch": "Merch",
+    "familyResources": "Mga resource para sa pamilya",
+    "kidsPolicy": "Patakaran para sa mga bata"
   },
   "theme": {
     "lightMode": "Maliwanag na mode",

--- a/src/lib/i18n/locales/fr/common.json
+++ b/src/lib/i18n/locales/fr/common.json
@@ -28,7 +28,9 @@
     "openSource": "Open source",
     "donate": "Faire un don",
     "help": "Aide",
-    "merch": "Merch"
+    "merch": "Merch",
+    "familyResources": "Ressources famille",
+    "kidsPolicy": "Politique enfants"
   },
   "theme": {
     "lightMode": "Mode clair",

--- a/src/lib/i18n/locales/id/common.json
+++ b/src/lib/i18n/locales/id/common.json
@@ -28,7 +28,9 @@
     "openSource": "Sumber terbuka",
     "donate": "Donasi",
     "help": "Bantuan",
-    "merch": "Merch"
+    "merch": "Merch",
+    "familyResources": "Sumber daya keluarga",
+    "kidsPolicy": "Kebijakan anak"
   },
   "theme": {
     "lightMode": "Mode terang",

--- a/src/lib/i18n/locales/it/common.json
+++ b/src/lib/i18n/locales/it/common.json
@@ -28,7 +28,9 @@
     "openSource": "Open source",
     "donate": "Dona",
     "help": "Aiuto",
-    "merch": "Merch"
+    "merch": "Merch",
+    "familyResources": "Risorse per famiglie",
+    "kidsPolicy": "Politica per bambini"
   },
   "theme": {
     "lightMode": "Modalita chiara",

--- a/src/lib/i18n/locales/ja/common.json
+++ b/src/lib/i18n/locales/ja/common.json
@@ -28,7 +28,9 @@
     "openSource": "オープンソース",
     "donate": "寄付",
     "help": "ヘルプ",
-    "merch": "Merch"
+    "merch": "Merch",
+    "familyResources": "家族向けリソース",
+    "kidsPolicy": "子どもポリシー"
   },
   "theme": {
     "lightMode": "ライトモード",

--- a/src/lib/i18n/locales/ko/common.json
+++ b/src/lib/i18n/locales/ko/common.json
@@ -28,7 +28,9 @@
     "openSource": "오픈 소스",
     "donate": "후원",
     "help": "도움말",
-    "merch": "Merch"
+    "merch": "Merch",
+    "familyResources": "가족 리소스",
+    "kidsPolicy": "어린이 정책"
   },
   "theme": {
     "lightMode": "라이트 모드",

--- a/src/lib/i18n/locales/nl/common.json
+++ b/src/lib/i18n/locales/nl/common.json
@@ -28,7 +28,9 @@
     "openSource": "Open source",
     "donate": "Doneren",
     "help": "Help",
-    "merch": "Merch"
+    "merch": "Merch",
+    "familyResources": "Gezinsbronnen",
+    "kidsPolicy": "Kinderbeleid"
   },
   "theme": {
     "lightMode": "Lichte modus",

--- a/src/lib/i18n/locales/pl/common.json
+++ b/src/lib/i18n/locales/pl/common.json
@@ -28,7 +28,9 @@
     "openSource": "Open source",
     "donate": "Wesprzyj",
     "help": "Pomoc",
-    "merch": "Merch"
+    "merch": "Merch",
+    "familyResources": "Zasoby dla rodzin",
+    "kidsPolicy": "Polityka dla dzieci"
   },
   "theme": {
     "lightMode": "Tryb jasny",

--- a/src/lib/i18n/locales/pt/common.json
+++ b/src/lib/i18n/locales/pt/common.json
@@ -28,7 +28,9 @@
     "openSource": "Codigo aberto",
     "donate": "Doar",
     "help": "Ajuda",
-    "merch": "Merch"
+    "merch": "Merch",
+    "familyResources": "Recursos para familias",
+    "kidsPolicy": "Politica para criancas"
   },
   "theme": {
     "lightMode": "Modo claro",

--- a/src/lib/i18n/locales/ro/common.json
+++ b/src/lib/i18n/locales/ro/common.json
@@ -28,7 +28,9 @@
     "openSource": "Sursa deschisa",
     "donate": "Doneaza",
     "help": "Ajutor",
-    "merch": "Merch"
+    "merch": "Merch",
+    "familyResources": "Resurse pentru familie",
+    "kidsPolicy": "Politica pentru copii"
   },
   "theme": {
     "lightMode": "Mod luminos",

--- a/src/lib/i18n/locales/sv/common.json
+++ b/src/lib/i18n/locales/sv/common.json
@@ -28,7 +28,9 @@
     "openSource": "Oppen kallkod",
     "donate": "Donera",
     "help": "Hjalp",
-    "merch": "Merch"
+    "merch": "Merch",
+    "familyResources": "Familjeresurser",
+    "kidsPolicy": "Policy for barn"
   },
   "theme": {
     "lightMode": "Ljust lage",

--- a/src/lib/i18n/locales/tr/common.json
+++ b/src/lib/i18n/locales/tr/common.json
@@ -28,7 +28,9 @@
     "openSource": "Acik kaynak",
     "donate": "Bagis yap",
     "help": "Yardim",
-    "merch": "Merch"
+    "merch": "Merch",
+    "familyResources": "Aile kaynaklari",
+    "kidsPolicy": "Cocuk politikasi"
   },
   "theme": {
     "lightMode": "Acik mod",

--- a/src/lib/mailto.ts
+++ b/src/lib/mailto.ts
@@ -1,0 +1,13 @@
+// ABOUTME: Utility helpers for building encoded mailto links
+// ABOUTME: Used by static pages with prefilled support email subjects and bodies
+
+export function buildMailtoLink(
+  email: string,
+  subject: string,
+  body?: string,
+): string {
+  const params = new URLSearchParams();
+  params.set("subject", subject);
+  if (body) params.set("body", body);
+  return `mailto:${email}?${params.toString().replace(/\+/g, "%20")}`;
+}

--- a/src/lib/serverSocialMeta.ts
+++ b/src/lib/serverSocialMeta.ts
@@ -295,6 +295,45 @@ export function buildCategoriesIndexMeta(url: URL): PageMeta {
   };
 }
 
+export function buildFamilyPageMeta(url: URL): PageMeta {
+  return {
+    title: 'For families on Divine — Conversation-first guidance for parents and teens',
+    description:
+      'A practical guide for families on Divine: how to talk with your teen about social media, what Divine can and can’t do, content settings, healthy feed habits, and trusted outside resources.',
+    ogType: 'website',
+    url: url.toString(),
+    image: DEFAULT_OG_IMAGE,
+    imageAlt: 'Divine — family resource hub for parents and teens',
+    twitterCard: 'summary_large_image',
+  };
+}
+
+export function buildAgeReviewPageMeta(url: URL): PageMeta {
+  return {
+    title: 'Account review — Divine',
+    description:
+      'If your Divine account was flagged as possibly belonging to someone under 16, this page explains what to do — and the 15-day window for responding.',
+    ogType: 'website',
+    url: url.toString(),
+    image: DEFAULT_OG_IMAGE,
+    imageAlt: 'Divine — account review information',
+    twitterCard: 'summary_large_image',
+  };
+}
+
+export function buildKidsPolicyPageMeta(url: URL): PageMeta {
+  return {
+    title: 'Kids on Divine — How accounts work for under-16s',
+    description:
+      'How Divine handles accounts for people under 16 — the rules, the reasoning, and what families can do together regardless of age.',
+    ogType: 'website',
+    url: url.toString(),
+    image: DEFAULT_OG_IMAGE,
+    imageAlt: 'Divine — how accounts work for kids and families',
+    twitterCard: 'summary_large_image',
+  };
+}
+
 export function getDefaultPageMeta(url: URL): PageMeta {
   return {
     title: 'Divine Web - Short-form Looping Videos on Nostr',

--- a/src/pages/AgeReviewPage.tsx
+++ b/src/pages/AgeReviewPage.tsx
@@ -69,7 +69,7 @@ export function AgeReviewPage() {
             of the in-app notice.
           </p>
           <p className="text-base md:text-lg text-brand-off-white/80 max-w-3xl leading-relaxed mt-4">
-            While the review is open, the account is suspended — you can read
+            While the review is open, the account is suspended—you can read
             this page and email Divine, but you can't post or engage publicly.
             After {REVIEW_WINDOW_DAYS} days with no response, support closes
             the account and deletes the personal information Divine holds
@@ -95,11 +95,11 @@ export function AgeReviewPage() {
       </section>
 
       <div className="container mx-auto px-4 py-14 md:py-16 max-w-4xl space-y-14">
-        {/* Honest note for under-13 readers — placed first so a kid
+        {/* Honest note for under-13 readers—placed first so a kid
             reading the page lands on this before scrolling through the
             13–15 instructions and assuming a parent video might apply.
             Intentionally not a path-shaped card (no CardHeader, no
-            mailto button) — the action paths below don't apply, and
+            mailto button)—the action paths below don't apply, and
             emailing doesn't pause the clock for under-13. */}
         <Card variant="brand">
           <CardContent className="pt-6 space-y-3 text-base leading-relaxed">
@@ -110,7 +110,7 @@ export function AgeReviewPage() {
             <p>
               We're sorry. Divine has to close under-13 accounts at the
               15-day mark and delete the data Divine holds. Emailing
-              won't pause the clock here — the rules around services for
+              won't pause the clock here—the rules around services for
               kids under 13 tie our hands. The same person can come back
               and create a new account when they're 13 or older.
             </p>
@@ -151,7 +151,7 @@ export function AgeReviewPage() {
                   </li>
                 </ul>
                 <p className="text-sm text-muted-foreground pt-1">
-                  Phone-camera quality is fine. There's no script — natural
+                  Phone-camera quality is fine. There's no script—natural
                   is better. Keep it short.
                 </p>
               </CardContent>
@@ -222,7 +222,7 @@ export function AgeReviewPage() {
                 <div className="pt-2">
                   <SupportEmailButton
                     href={mailtoLink(
-                      "Account review — 13 to 15",
+                      "Account review—13 to 15",
                       "Hi Divine support,\n\nI'm a parent or guardian. I'm attaching a short private video to confirm the account on Divine.\n\nAccount username or link:\n\nTeen's age (13, 14, or 15):\n\nThanks,",
                     )}
                     label={`Email ${SUPPORT_EMAIL}`}
@@ -317,7 +317,7 @@ export function AgeReviewPage() {
                     4.
                   </span>
                   <span>
-                    Add any context that might be helpful — anything you
+                    Add any context that might be helpful—anything you
                     think the team should know.
                   </span>
                 </li>
@@ -340,7 +340,7 @@ export function AgeReviewPage() {
           </Card>
         </Anchor>
 
-        {/* 3. No-response section — what happens when the clock runs out */}
+        {/* 3. No-response section—what happens when the clock runs out */}
         <Anchor id="no-response">
           <SectionHero
             eyebrow="If we don't hear from you"
@@ -354,7 +354,7 @@ export function AgeReviewPage() {
               <ul className="space-y-2 list-disc pl-5 marker:text-brand-orange">
                 <li>
                   Support closes the account and deletes everything tied to
-                  it from Divine's infrastructure — profile, videos,
+                  it from Divine's infrastructure—profile, videos,
                   comments, follow lists, and any email or IP-derived data
                   on file.
                 </li>
@@ -365,7 +365,7 @@ export function AgeReviewPage() {
                 </li>
                 <li>
                   The same person can create a new account later when they
-                  meet the age and consent conditions — but the closed
+                  meet the age and consent conditions—but the closed
                   account itself doesn't return.
                 </li>
               </ul>
@@ -390,7 +390,7 @@ export function AgeReviewPage() {
             eyebrow="More context"
             icon={<HouseLine weight="fill" className="h-7 w-7" />}
             title="Want to understand the broader policy?"
-            lead="The full picture — how families can use Divine together on a parent-held account, what happens to under-13 accounts, and why Divine works this way — lives on the kids policy page."
+            lead="The full picture—how families can use Divine together on a parent-held account, what happens to under-13 accounts, and why Divine works this way—lives on the kids policy page."
           />
 
           <a

--- a/src/pages/AgeReviewPage.tsx
+++ b/src/pages/AgeReviewPage.tsx
@@ -112,7 +112,8 @@ export function AgeReviewPage() {
               15-day mark and delete the data Divine holds. Emailing
               won't pause the clock here—the rules around services for
               kids under 13 tie our hands. The same person can come back
-              and create a new account when they're 13 or older.
+              and create a new account when they're 13 or older (with
+              parental consent required between ages 13-15).
             </p>
           </CardContent>
         </Card>

--- a/src/pages/AgeReviewPage.tsx
+++ b/src/pages/AgeReviewPage.tsx
@@ -1,0 +1,521 @@
+// ABOUTME: External moderation-flow page at /age-review for accounts flagged as possibly under 16
+// ABOUTME: Deadline-shaped: 15-day window, 13–15 parent video, 16+ mistake-flag; FAQ-style content lives at /family (see _AgeReviewFAQStaging.tsx)
+
+import { useEffect, useState } from "react";
+import {
+  Info,
+  VideoCamera,
+  EnvelopeSimple,
+  ShieldCheck,
+  Path,
+  HouseLine,
+  Heart,
+  ArrowSquareOut,
+  ArrowUp,
+  LockKey,
+} from "@phosphor-icons/react";
+
+import { MarketingLayout } from "@/components/MarketingLayout";
+import { SectionHeader } from "@/components/brand/SectionHeader";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+const SUPPORT_EMAIL = "support@divine.video";
+const REVIEW_WINDOW_DAYS = 15;
+
+interface SectionAnchor {
+  id: string;
+  title: string;
+}
+
+const SECTIONS: SectionAnchor[] = [
+  { id: "path-13-15", title: "If you're 13 to 15" },
+  { id: "path-mistake", title: "If you're 16 or older" },
+  { id: "no-response", title: "If no one responds" },
+];
+
+function mailtoLink(subject: string, body?: string): string {
+  const params = new URLSearchParams();
+  params.set("subject", subject);
+  if (body) params.set("body", body);
+  return `mailto:${SUPPORT_EMAIL}?${params.toString().replace(/\+/g, "%20")}`;
+}
+
+export function AgeReviewPage() {
+  return (
+    <MarketingLayout>
+      <BackToTopButton />
+
+      {/* Hero */}
+      <section className="bg-brand-dark-green text-brand-off-white">
+        <div className="container mx-auto px-4 py-16 md:py-20 max-w-4xl">
+          <div className="flex items-center gap-2 text-xs font-semibold tracking-wide text-brand-green mb-6">
+            <Info weight="fill" className="h-4 w-4" />
+            <span>Account review</span>
+          </div>
+          <h1
+            className="font-display font-extrabold tracking-tight text-4xl md:text-5xl leading-[1.05] text-brand-off-white mb-6"
+            style={{ fontFamily: "'Bricolage Grotesque', system-ui, sans-serif" }}
+          >
+            Your account is under review
+          </h1>
+          <p className="text-lg md:text-xl text-brand-light-green max-w-3xl leading-relaxed">
+            Divine flagged this account as possibly belonging to someone under
+            16. To keep the account open, the steps on this page need to happen
+            within{" "}
+            <strong className="text-brand-off-white">
+              {REVIEW_WINDOW_DAYS} days
+            </strong>{" "}
+            of the in-app notice.
+          </p>
+          <p className="text-base md:text-lg text-brand-off-white/80 max-w-3xl leading-relaxed mt-4">
+            While the review is open, the account is suspended — you can read
+            this page and email Divine, but you can't post or engage publicly.
+            After {REVIEW_WINDOW_DAYS} days with no response, support closes
+            the account and deletes the personal information Divine holds
+            about it.
+          </p>
+
+          {/* Anchor nav */}
+          <nav
+            aria-label="On this page"
+            className="mt-10 grid gap-2 sm:grid-cols-3 text-sm"
+          >
+            {SECTIONS.map((s) => (
+              <a
+                key={s.id}
+                href={`#${s.id}`}
+                className="rounded-xl border border-brand-green/40 bg-brand-dark-green/40 px-4 py-3 text-brand-light-green hover:bg-brand-green/10 hover:border-brand-green transition-colors"
+              >
+                {s.title}
+              </a>
+            ))}
+          </nav>
+        </div>
+      </section>
+
+      <div className="container mx-auto px-4 py-14 md:py-16 max-w-4xl space-y-14">
+        {/* Honest note for under-13 readers — placed first so a kid
+            reading the page lands on this before scrolling through the
+            13–15 instructions and assuming a parent video might apply.
+            Intentionally not a path-shaped card (no CardHeader, no
+            mailto button) — the action paths below don't apply, and
+            emailing doesn't pause the clock for under-13. */}
+        <Card variant="brand">
+          <CardContent className="pt-6 space-y-3 text-base leading-relaxed">
+            <div className="flex items-center gap-2 text-sm font-semibold text-brand-dark-green dark:text-brand-green">
+              <Heart weight="fill" className="h-4 w-4" />
+              <span>A note for anyone under 13 reading this</span>
+            </div>
+            <p>
+              We're sorry. Divine has to close under-13 accounts at the
+              15-day mark and delete the data Divine holds. Emailing
+              won't pause the clock here — the rules around services for
+              kids under 13 tie our hands. The same person can come back
+              and create a new account when they're 13 or older.
+            </p>
+          </CardContent>
+        </Card>
+
+        {/* 1. 13-15 path */}
+        <Anchor id="path-13-15">
+          <SectionHero
+            eyebrow="Step-by-step"
+            icon={<VideoCamera weight="fill" className="h-7 w-7" />}
+            title="If you're 13 to 15"
+            lead={`Teens 13 to 15 can use Divine with a parent or guardian who's aware and involved. To keep the account open, a parent or guardian sends a short private video confirming the situation. The email needs to land within ${REVIEW_WINDOW_DAYS} days of the in-app notice.`}
+          />
+
+          <div className="grid gap-6 md:grid-cols-2">
+            <Card variant="brand" accent="green">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-xl">
+                  <VideoCamera weight="fill" className="h-5 w-5 text-brand-green" />
+                  What the video should show
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3 text-base leading-relaxed">
+                <ul className="space-y-2 list-disc pl-5 marker:text-brand-green">
+                  <li>The teen, on camera.</li>
+                  <li>A parent or guardian, also on camera, speaking.</li>
+                  <li>
+                    A clear statement that the teen is between 13 and 15.
+                  </li>
+                  <li>
+                    A clear statement that the teen has permission to use
+                    Divine.
+                  </li>
+                  <li>
+                    A clear statement that the parent or guardian knows about
+                    the account and will supervise its use.
+                  </li>
+                </ul>
+                <p className="text-sm text-muted-foreground pt-1">
+                  Phone-camera quality is fine. There's no script — natural
+                  is better. Keep it short.
+                </p>
+              </CardContent>
+            </Card>
+
+            <Card variant="brand" accent="blue">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-xl">
+                  <EnvelopeSimple weight="fill" className="h-5 w-5 text-brand-blue" />
+                  How to send it
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3 text-base leading-relaxed">
+                <ol className="space-y-3 list-none pl-0">
+                  <li className="flex items-start gap-3">
+                    <span
+                      className="flex-shrink-0 font-extrabold text-brand-dark-green dark:text-brand-green w-6 leading-7 tabular-nums"
+                      aria-hidden="true"
+                    >
+                      1.
+                    </span>
+                    <span>
+                      Email{" "}
+                      <a
+                        href={`mailto:${SUPPORT_EMAIL}`}
+                        className="text-brand-dark-green dark:text-brand-green underline underline-offset-2 hover:opacity-80 break-all"
+                      >
+                        {SUPPORT_EMAIL}
+                      </a>{" "}
+                      from a parent or guardian's email address.
+                    </span>
+                  </li>
+                  <li className="flex items-start gap-3">
+                    <span
+                      className="flex-shrink-0 font-extrabold text-brand-dark-green dark:text-brand-green w-6 leading-7 tabular-nums"
+                      aria-hidden="true"
+                    >
+                      2.
+                    </span>
+                    <span>Attach the video, or include a private link to it.</span>
+                  </li>
+                  <li className="flex items-start gap-3">
+                    <span
+                      className="flex-shrink-0 font-extrabold text-brand-dark-green dark:text-brand-green w-6 leading-7 tabular-nums"
+                      aria-hidden="true"
+                    >
+                      3.
+                    </span>
+                    <span>
+                      Include the account's username so the team can match
+                      it up.
+                    </span>
+                  </li>
+                  <li className="flex items-start gap-3">
+                    <span
+                      className="flex-shrink-0 font-extrabold text-brand-dark-green dark:text-brand-green w-6 leading-7 tabular-nums"
+                      aria-hidden="true"
+                    >
+                      4.
+                    </span>
+                    <span>
+                      Don't post the video in the app. It stays between
+                      the family and Divine support.
+                    </span>
+                  </li>
+                </ol>
+
+                <div className="pt-2">
+                  <SupportEmailButton
+                    href={mailtoLink(
+                      "Account review — 13 to 15",
+                      "Hi Divine support,\n\nI'm a parent or guardian. I'm attaching a short private video to confirm the account on Divine.\n\nAccount username or link:\n\nTeen's age (13, 14, or 15):\n\nThanks,",
+                    )}
+                    label={`Email ${SUPPORT_EMAIL}`}
+                  />
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+
+          <Card variant="brand" className="mt-6">
+            <CardContent className="pt-6 space-y-3 text-base leading-relaxed">
+              <div className="flex items-center gap-2 text-sm font-semibold text-brand-dark-green dark:text-brand-green">
+                <LockKey weight="fill" className="h-4 w-4" />
+                <span>A note on privacy</span>
+              </div>
+              <p>
+                The video is used to confirm the situation and is handled by
+                Divine's support and trust &amp; safety team. It isn't
+                published anywhere on Divine and isn't shared with other
+                users.
+              </p>
+            </CardContent>
+          </Card>
+        </Anchor>
+
+        {/* 2. 16+ mistake path */}
+        <Anchor id="path-mistake">
+          <SectionHero
+            eyebrow="For users 16 or older"
+            icon={<ShieldCheck weight="fill" className="h-7 w-7" />}
+            title="If you're 16 or older and this is a mistake"
+            lead={`Reviews can be triggered by signals that don't always land on the right account. If you're 16 or older and the account was flagged in error, send a short email within ${REVIEW_WINDOW_DAYS} days and the team will take another look.`}
+          />
+
+          <Card variant="brand" accent="pink">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-xl">
+                <EnvelopeSimple weight="fill" className="h-5 w-5 text-brand-pink" />
+                What to send Divine support
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4 text-base leading-relaxed">
+              <ol className="space-y-3 list-none pl-0">
+                <li className="flex items-start gap-3">
+                  <span
+                    className="flex-shrink-0 font-extrabold text-brand-dark-green dark:text-brand-green w-6 leading-7 tabular-nums"
+                    aria-hidden="true"
+                  >
+                    1.
+                  </span>
+                  <span>
+                    Email{" "}
+                    <a
+                      href={`mailto:${SUPPORT_EMAIL}`}
+                      className="text-brand-dark-green dark:text-brand-green underline underline-offset-2 hover:opacity-80 break-all"
+                    >
+                      {SUPPORT_EMAIL}
+                    </a>{" "}
+                    with the subject line{" "}
+                    <span className="font-medium">
+                      "I am 16 or older and think this account was flagged
+                      by mistake."
+                    </span>
+                  </span>
+                </li>
+                <li className="flex items-start gap-3">
+                  <span
+                    className="flex-shrink-0 font-extrabold text-brand-dark-green dark:text-brand-green w-6 leading-7 tabular-nums"
+                    aria-hidden="true"
+                  >
+                    2.
+                  </span>
+                  <span>Say briefly that you are 16 or older.</span>
+                </li>
+                <li className="flex items-start gap-3">
+                  <span
+                    className="flex-shrink-0 font-extrabold text-brand-dark-green dark:text-brand-green w-6 leading-7 tabular-nums"
+                    aria-hidden="true"
+                  >
+                    3.
+                  </span>
+                  <span>
+                    Include the account's username or a link to its
+                    profile.
+                  </span>
+                </li>
+                <li className="flex items-start gap-3">
+                  <span
+                    className="flex-shrink-0 font-extrabold text-brand-dark-green dark:text-brand-green w-6 leading-7 tabular-nums"
+                    aria-hidden="true"
+                  >
+                    4.
+                  </span>
+                  <span>
+                    Add any context that might be helpful — anything you
+                    think the team should know.
+                  </span>
+                </li>
+              </ol>
+
+              <p className="text-muted-foreground">
+                Keep it short. The team will review and reply with next steps.
+              </p>
+
+              <div className="pt-2">
+                <SupportEmailButton
+                  href={mailtoLink(
+                    "I am 16 or older and think this account was flagged by mistake",
+                    "Hi Divine support,\n\nI'm 16 or older and I think this account was flagged by mistake.\n\nAccount username or link:\n\nAny helpful context:\n\nThanks,",
+                  )}
+                  label={`Email ${SUPPORT_EMAIL}`}
+                />
+              </div>
+            </CardContent>
+          </Card>
+        </Anchor>
+
+        {/* 3. No-response section — what happens when the clock runs out */}
+        <Anchor id="no-response">
+          <SectionHero
+            eyebrow="If we don't hear from you"
+            icon={<Path weight="fill" className="h-7 w-7" />}
+            title={`What happens after ${REVIEW_WINDOW_DAYS} days with no response`}
+            lead={`After ${REVIEW_WINDOW_DAYS} days with no email to support, the account is closed and the personal information Divine holds about it is deleted. The closed account doesn't come back.`}
+          />
+
+          <Card variant="brand" accent="orange">
+            <CardContent className="pt-6 space-y-3 text-base leading-relaxed">
+              <ul className="space-y-2 list-disc pl-5 marker:text-brand-orange">
+                <li>
+                  Support closes the account and deletes everything tied to
+                  it from Divine's infrastructure — profile, videos,
+                  comments, follow lists, and any email or IP-derived data
+                  on file.
+                </li>
+                <li>
+                  Divine issues a deletion request across the Nostr network.
+                  Copies of videos that propagated to relays Divine doesn't
+                  operate may persist outside Divine's reach.
+                </li>
+                <li>
+                  The same person can create a new account later when they
+                  meet the age and consent conditions — but the closed
+                  account itself doesn't return.
+                </li>
+              </ul>
+              <p className="text-sm text-muted-foreground pt-2">
+                Any email to{" "}
+                <a
+                  href={`mailto:${SUPPORT_EMAIL}`}
+                  className="text-brand-dark-green dark:text-brand-green underline underline-offset-2 hover:opacity-80 break-all"
+                >
+                  {SUPPORT_EMAIL}
+                </a>{" "}
+                from the account holder or a parent or guardian stops the
+                clock. A "we're working on it" reply counts.
+              </p>
+            </CardContent>
+          </Card>
+        </Anchor>
+
+        {/* 4. Link to broader policy at /kids */}
+        <Anchor id="more-context">
+          <SectionHero
+            eyebrow="More context"
+            icon={<HouseLine weight="fill" className="h-7 w-7" />}
+            title="Want to understand the broader policy?"
+            lead="The full picture — how families can use Divine together on a parent-held account, what happens to under-13 accounts, and why Divine works this way — lives on the kids policy page."
+          />
+
+          <a
+            href="/kids"
+            className="group block brand-card brand-offset-shadow-green p-6 hover:-translate-x-[2px] hover:-translate-y-[2px] hover:[box-shadow:8px_8px_0_0_hsl(var(--brand-green))] transition-all"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <h3 className="font-display font-extrabold tracking-tight text-xl text-brand-dark-green dark:text-brand-off-white">
+                  Open the kids policy page
+                </h3>
+                <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                  Policy explainer, family-account guidance, and the longer
+                  read at{" "}
+                  <span className="font-medium text-brand-dark-green dark:text-brand-green">
+                    divine.video/kids
+                  </span>
+                  .
+                </p>
+              </div>
+              <ArrowSquareOut className="h-5 w-5 flex-shrink-0 text-brand-dark-green dark:text-brand-green group-hover:translate-x-0.5 transition-transform" />
+            </div>
+          </a>
+        </Anchor>
+
+        {/* Closing note */}
+        <div className="pt-8 border-t border-brand-dark-green/10 dark:border-brand-green/20">
+          <p className="text-sm text-muted-foreground leading-relaxed">
+            If you sent an email and haven't heard back, email{" "}
+            <a
+              href={`mailto:${SUPPORT_EMAIL}`}
+              className="text-brand-dark-green dark:text-brand-green underline underline-offset-2 hover:opacity-80 break-all"
+            >
+              {SUPPORT_EMAIL}
+            </a>{" "}
+            again. The team would rather hear from you twice than miss a
+            message.
+          </p>
+        </div>
+      </div>
+    </MarketingLayout>
+  );
+}
+
+export default AgeReviewPage;
+
+// ——————————————————————————————————————————————————————————————
+// Local presentation helpers
+// ——————————————————————————————————————————————————————————————
+
+function SupportEmailButton({ href, label }: { href: string; label: string }) {
+  return (
+    <Button asChild variant="sticker" size="lg">
+      <a href={href} className="inline-flex items-center gap-2">
+        <EnvelopeSimple weight="fill" className="h-4 w-4" />
+        {label}
+      </a>
+    </Button>
+  );
+}
+
+function BackToTopButton() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setVisible(window.scrollY > 600);
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  const goTop = () => {
+    const reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    window.scrollTo({ top: 0, behavior: reduced ? "auto" : "smooth" });
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={goTop}
+      aria-label="Back to top"
+      aria-hidden={!visible}
+      tabIndex={visible ? 0 : -1}
+      className={`fixed right-5 bottom-[calc(1.25rem+env(safe-area-inset-bottom))] z-40 h-12 w-12 rounded-full bg-brand-green text-brand-dark-green border-2 border-brand-dark-green brand-offset-shadow-sm-dark flex items-center justify-center transition-all duration-200 hover:-translate-x-[2px] hover:-translate-y-[2px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-dark-green focus-visible:ring-offset-2 ${
+        visible
+          ? "opacity-100 translate-y-0 pointer-events-auto"
+          : "opacity-0 translate-y-2 pointer-events-none"
+      }`}
+    >
+      <ArrowUp weight="bold" className="h-5 w-5" />
+    </button>
+  );
+}
+
+function Anchor({ id, children }: { id: string; children: React.ReactNode }) {
+  return (
+    <section id={id} className="scroll-mt-24">
+      {children}
+    </section>
+  );
+}
+
+function SectionHero({
+  eyebrow,
+  icon,
+  title,
+  lead,
+}: {
+  eyebrow: string;
+  icon: React.ReactNode;
+  title: string;
+  lead: string;
+}) {
+  return (
+    <div className="mb-8">
+      <div className="flex items-center gap-2 text-xs font-semibold tracking-wide text-brand-dark-green dark:text-brand-green mb-3">
+        {icon}
+        <span>{eyebrow}</span>
+      </div>
+      <SectionHeader as="h2" className="text-3xl md:text-4xl mb-4">
+        {title}
+      </SectionHeader>
+      <p className="text-lg leading-relaxed text-muted-foreground max-w-3xl">
+        {lead}
+      </p>
+    </div>
+  );
+}

--- a/src/pages/AgeReviewPage.tsx
+++ b/src/pages/AgeReviewPage.tsx
@@ -95,7 +95,7 @@ export function AgeReviewPage() {
       </section>
 
       <div className="container mx-auto px-4 py-14 md:py-16 max-w-4xl space-y-14">
-        {/* Honest note for under-13 readers—placed first so a kid
+        {/* Note for under-13 readers—placed first so a kid
             reading the page lands on this before scrolling through the
             13–15 instructions and assuming a parent video might apply.
             Intentionally not a path-shaped card (no CardHeader, no
@@ -108,8 +108,7 @@ export function AgeReviewPage() {
               <span>A note for anyone under 13 reading this</span>
             </div>
             <p>
-              We're sorry. Divine has to close under-13 accounts when Divine confirms or has actual knowledge that the account holder is under 13, and in any event no later than the
-              15-day mark and delete the data Divine holds. Emailing
+              We're sorry. Divine must close an under-13 account and delete the data it holds once it confirms or has actual knowledge that the account holder is under 13, and in all cases no later than the 15-day mark. Emailing
               won't pause the clock here—the rules around services for
               kids under 13 tie our hands. The same person can come back
               and create a new account when they're 13 or older (with
@@ -319,7 +318,7 @@ export function AgeReviewPage() {
                   </span>
                   <span>
                     Add any context that might be helpful—anything you
-                    think the team should know.
+                    think the team should know. Please don't include government IDs, payment-card numbers, school records, medical information, passwords, Social Security numbers, or other sensitive documents.
                   </span>
                 </li>
               </ol>
@@ -347,7 +346,7 @@ export function AgeReviewPage() {
             eyebrow="If we don't hear from you"
             icon={<Path weight="fill" className="h-7 w-7" />}
             title={`What happens after ${REVIEW_WINDOW_DAYS} days with no response`}
-            lead={`After ${REVIEW_WINDOW_DAYS} days with no email to support, the account is closed and the personal information Divine holds about it is deleted. The closed account doesn't come back.`}
+            lead={`After ${REVIEW_WINDOW_DAYS} days with no email to Support, the account is closed and the personal information Divine holds about it is deleted. The closed account doesn't come back.`}
           />
 
           <Card variant="brand" accent="orange">
@@ -379,7 +378,7 @@ export function AgeReviewPage() {
                   {SUPPORT_EMAIL}
                 </a>{" "}
                 from a parent or guardian within the 15-day window stops the
-                clock while Divine reviews the submission. For accounts flagged in error as belonging to someone under 16, an email from the account holder stating that they are 16 or older stops the clock while Divine reviews the submission. An email does not pause closure of an account once Divine confirms or has actual knowledge that the account holder is under 13. A "we're working on it" reply counts.
+                clock while Divine reviews the submission. For accounts flagged in error as belonging to someone under 16, an email from the account holder stating that they are 16 or older stops the clock while Divine reviews the submission. A "we're working on it" reply counts. An email does not pause closure of an account once Divine confirms or has actual knowledge that the account holder is under 13.
               </p>
             </CardContent>
           </Card>
@@ -428,7 +427,7 @@ export function AgeReviewPage() {
               {SUPPORT_EMAIL}
             </a>{" "}
             again. The team would rather hear from you twice than miss a
-            message. If your first email was sent within the 15-day window, include the date and address you sent it from so Divine can confirm the timing.
+            message. If your first email was sent within the 15-day window, include the date and address you sent it so Divine can confirm the timing.
           </p>
         </div>
       </div>

--- a/src/pages/AgeReviewPage.tsx
+++ b/src/pages/AgeReviewPage.tsx
@@ -1,7 +1,6 @@
 // ABOUTME: External moderation-flow page at /age-review for accounts flagged as possibly under 16
-// ABOUTME: Deadline-shaped: 15-day window, 13–15 parent video, 16+ mistake-flag; FAQ-style content lives at /family (see _AgeReviewFAQStaging.tsx)
+// ABOUTME: Deadline-shaped: 15-day window, 13–15 parent video, 16+ mistake-flag; policy context lives at /kids
 
-import { useEffect, useState } from "react";
 import {
   Info,
   VideoCamera,
@@ -11,14 +10,19 @@ import {
   HouseLine,
   Heart,
   ArrowSquareOut,
-  ArrowUp,
   LockKey,
 } from "@phosphor-icons/react";
 
 import { MarketingLayout } from "@/components/MarketingLayout";
-import { SectionHeader } from "@/components/brand/SectionHeader";
+import {
+  Anchor,
+  BackToTopButton,
+  SectionHero,
+  staticPageLinkCardClass,
+  SupportEmailButton,
+} from "@/components/static-pages";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
+import { buildMailtoLink } from "@/lib/mailto";
 
 const SUPPORT_EMAIL = "support@divine.video";
 const REVIEW_WINDOW_DAYS = 15;
@@ -34,20 +38,14 @@ const SECTIONS: SectionAnchor[] = [
   { id: "no-response", title: "If we don't hear from you" },
 ];
 
-function mailtoLink(subject: string, body?: string): string {
-  const params = new URLSearchParams();
-  params.set("subject", subject);
-  if (body) params.set("body", body);
-  return `mailto:${SUPPORT_EMAIL}?${params.toString().replace(/\+/g, "%20")}`;
-}
-
 // Mirrors the 13-15 parent-consent email in divine-mobile
 // (minorAccountReviewParentConsentEmailSubject / ...Body) so the in-app flow
 // and this page open the same prefilled message.
 const TEEN_REVIEW_EMAIL_SUBJECT = "13-15 account review help";
 const TEEN_REVIEW_EMAIL_BODY =
   "Hi Divine support,\n\nI am contacting Divine about an account for a teen who is 13 to 15.\n\nI have attached a short private video that shows:\n- the teen\n- a parent or guardian speaking on camera\n- that the teen has permission to use Divine\n- that the parent or guardian knows about the account and will supervise its use\n\nCountry/ies of residence:\n\nHelpful context:\n\nThanks.";
-const TEEN_REVIEW_MAILTO = mailtoLink(
+const TEEN_REVIEW_MAILTO = buildMailtoLink(
+  SUPPORT_EMAIL,
   TEEN_REVIEW_EMAIL_SUBJECT,
   TEEN_REVIEW_EMAIL_BODY,
 );
@@ -58,7 +56,8 @@ const MISTAKE_REVIEW_EMAIL_SUBJECT =
   "I am 16 or older and think this account was flagged by mistake";
 const MISTAKE_REVIEW_EMAIL_BODY =
   "Hi Divine support,\n\nI'm 16 or older and I think this account was flagged by mistake.\n\nAccount username or link:\n\nAny helpful context:\n\nThanks,";
-const MISTAKE_REVIEW_MAILTO = mailtoLink(
+const MISTAKE_REVIEW_MAILTO = buildMailtoLink(
+  SUPPORT_EMAIL,
   MISTAKE_REVIEW_EMAIL_SUBJECT,
   MISTAKE_REVIEW_EMAIL_BODY,
 );
@@ -75,10 +74,7 @@ export function AgeReviewPage() {
             <Info weight="fill" className="h-4 w-4" />
             <span>Account review</span>
           </div>
-          <h1
-            className="font-display font-extrabold tracking-tight text-4xl md:text-5xl leading-[1.05] text-brand-off-white mb-6"
-            style={{ fontFamily: "'Bricolage Grotesque', system-ui, sans-serif" }}
-          >
+          <h1 className="font-display font-extrabold tracking-tight text-4xl md:text-5xl leading-[1.05] text-brand-off-white mb-6">
             Your account is under review
           </h1>
           <p className="text-lg md:text-xl text-brand-light-green max-w-3xl leading-relaxed">
@@ -411,7 +407,7 @@ export function AgeReviewPage() {
 
           <a
             href="/kids"
-            className="group block brand-card brand-offset-shadow-green p-6 hover:-translate-x-[2px] hover:-translate-y-[2px] hover:[box-shadow:8px_8px_0_0_hsl(var(--brand-green))] transition-all"
+            className={staticPageLinkCardClass("green")}
           >
             <div className="flex items-start justify-between gap-3">
               <div>
@@ -452,86 +448,3 @@ export function AgeReviewPage() {
 }
 
 export default AgeReviewPage;
-
-// ——————————————————————————————————————————————————————————————
-// Local presentation helpers
-// ——————————————————————————————————————————————————————————————
-
-function SupportEmailButton({ href, label }: { href: string; label: string }) {
-  return (
-    <Button asChild variant="sticker" size="lg">
-      <a href={href} className="inline-flex items-center gap-2">
-        <EnvelopeSimple weight="fill" className="h-4 w-4" />
-        {label}
-      </a>
-    </Button>
-  );
-}
-
-function BackToTopButton() {
-  const [visible, setVisible] = useState(false);
-
-  useEffect(() => {
-    const onScroll = () => setVisible(window.scrollY > 600);
-    onScroll();
-    window.addEventListener("scroll", onScroll, { passive: true });
-    return () => window.removeEventListener("scroll", onScroll);
-  }, []);
-
-  const goTop = () => {
-    const reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-    window.scrollTo({ top: 0, behavior: reduced ? "auto" : "smooth" });
-  };
-
-  return (
-    <button
-      type="button"
-      onClick={goTop}
-      aria-label="Back to top"
-      aria-hidden={!visible}
-      tabIndex={visible ? 0 : -1}
-      className={`fixed right-5 bottom-[calc(1.25rem+env(safe-area-inset-bottom))] z-40 h-12 w-12 rounded-full bg-brand-green text-brand-dark-green border-2 border-brand-dark-green brand-offset-shadow-sm-dark flex items-center justify-center transition-all duration-200 hover:-translate-x-[2px] hover:-translate-y-[2px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-dark-green focus-visible:ring-offset-2 ${
-        visible
-          ? "opacity-100 translate-y-0 pointer-events-auto"
-          : "opacity-0 translate-y-2 pointer-events-none"
-      }`}
-    >
-      <ArrowUp weight="bold" className="h-5 w-5" />
-    </button>
-  );
-}
-
-function Anchor({ id, children }: { id: string; children: React.ReactNode }) {
-  return (
-    <section id={id} className="scroll-mt-24">
-      {children}
-    </section>
-  );
-}
-
-function SectionHero({
-  eyebrow,
-  icon,
-  title,
-  lead,
-}: {
-  eyebrow: string;
-  icon: React.ReactNode;
-  title: string;
-  lead: string;
-}) {
-  return (
-    <div className="mb-8">
-      <div className="flex items-center gap-2 text-xs font-semibold tracking-wide text-brand-dark-green dark:text-brand-green mb-3">
-        {icon}
-        <span>{eyebrow}</span>
-      </div>
-      <SectionHeader as="h2" className="text-3xl md:text-4xl mb-4">
-        {title}
-      </SectionHeader>
-      <p className="text-lg leading-relaxed text-muted-foreground max-w-3xl">
-        {lead}
-      </p>
-    </div>
-  );
-}

--- a/src/pages/AgeReviewPage.tsx
+++ b/src/pages/AgeReviewPage.tsx
@@ -108,7 +108,7 @@ export function AgeReviewPage() {
               <span>A note for anyone under 13 reading this</span>
             </div>
             <p>
-              We're sorry. Divine has to close under-13 accounts at the
+              We're sorry. Divine has to close under-13 accounts when Divine confirms or has actual knowledge that the account holder is under 13, and in any event no later than the
               15-day mark and delete the data Divine holds. Emailing
               won't pause the clock here—the rules around services for
               kids under 13 tie our hands. The same person can come back
@@ -192,7 +192,7 @@ export function AgeReviewPage() {
                     >
                       2.
                     </span>
-                    <span>Attach the video, or include a private link to it.</span>
+                    <span>Attach the video, or include a private link to it that is not posted publicly and does not require the teen to share a password or account login with Divine.</span>
                   </li>
                   <li className="flex items-start gap-3">
                     <span
@@ -215,7 +215,7 @@ export function AgeReviewPage() {
                     </span>
                     <span>
                       Don't post the video in the app. It stays between
-                      the family and Divine support.
+                      the family and Divine support. Please don't include government IDs, payment-card numbers, school records, medical information, passwords, Social Security numbers, or other sensitive documents. Divine only needs the short video and the account username for this review.
                     </span>
                   </li>
                 </ol>
@@ -241,7 +241,7 @@ export function AgeReviewPage() {
               </div>
               <p>
                 The video is used to confirm the situation and is handled by
-                Divine's support and trust &amp; safety team. It isn't
+                Divine's support and trust &amp; safety team. Divine uses the video only for account review, safety, legal, and compliance purposes, and keeps it only as long as reasonably necessary for those purposes unless a longer retention period is required or permitted by law. It isn't
                 published anywhere on Divine and isn't shared with other
                 users.
               </p>
@@ -357,7 +357,7 @@ export function AgeReviewPage() {
                   Support closes the account and deletes everything tied to
                   it from Divine's infrastructure—profile, videos,
                   comments, follow lists, and any email or IP-derived data
-                  on file.
+                  on file, except information Divine is required or permitted to keep for legal, safety, security, fraud-prevention, dispute-resolution, or compliance purposes.
                 </li>
                 <li>
                   Divine issues a deletion request across the Nostr network.
@@ -371,15 +371,15 @@ export function AgeReviewPage() {
                 </li>
               </ul>
               <p className="text-sm text-muted-foreground pt-2">
-                Any email to{" "}
+                For 13-to-15 accounts, an email to{" "}
                 <a
                   href={`mailto:${SUPPORT_EMAIL}`}
                   className="text-brand-dark-green dark:text-brand-green underline underline-offset-2 hover:opacity-80 break-all"
                 >
                   {SUPPORT_EMAIL}
                 </a>{" "}
-                from the account holder or a parent or guardian stops the
-                clock. A "we're working on it" reply counts.
+                from a parent or guardian within the 15-day window stops the
+                clock while Divine reviews the submission. For accounts flagged in error as belonging to someone under 16, an email from the account holder stating that they are 16 or older stops the clock while Divine reviews the submission. An email does not pause closure of an account once Divine confirms or has actual knowledge that the account holder is under 13. A "we're working on it" reply counts.
               </p>
             </CardContent>
           </Card>
@@ -428,7 +428,7 @@ export function AgeReviewPage() {
               {SUPPORT_EMAIL}
             </a>{" "}
             again. The team would rather hear from you twice than miss a
-            message.
+            message. If your first email was sent within the 15-day window, include the date and address you sent it from so Divine can confirm the timing.
           </p>
         </div>
       </div>

--- a/src/pages/AgeReviewPage.tsx
+++ b/src/pages/AgeReviewPage.tsx
@@ -16,21 +16,18 @@ import {
 import { MarketingLayout } from "@/components/MarketingLayout";
 import {
   Anchor,
+  AnchorNav,
   BackToTopButton,
   SectionHero,
   staticPageLinkCardClass,
   SupportEmailButton,
+  type SectionAnchor,
 } from "@/components/static-pages";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { buildMailtoLink } from "@/lib/mailto";
 
 const SUPPORT_EMAIL = "support@divine.video";
 const REVIEW_WINDOW_DAYS = 15;
-
-interface SectionAnchor {
-  id: string;
-  title: string;
-}
 
 const SECTIONS: SectionAnchor[] = [
   { id: "path-13-15", title: "If you're 13 to 15" },
@@ -94,21 +91,7 @@ export function AgeReviewPage() {
             about it.
           </p>
 
-          {/* Anchor nav */}
-          <nav
-            aria-label="On this page"
-            className="mt-10 grid gap-2 sm:grid-cols-3 text-sm"
-          >
-            {SECTIONS.map((s) => (
-              <a
-                key={s.id}
-                href={`#${s.id}`}
-                className="rounded-xl border border-brand-green/40 bg-brand-dark-green/40 px-4 py-3 text-brand-light-green hover:bg-brand-green/10 hover:border-brand-green transition-colors"
-              >
-                {s.title}
-              </a>
-            ))}
-          </nav>
+          <AnchorNav sections={SECTIONS} />
         </div>
       </section>
 

--- a/src/pages/AgeReviewPage.tsx
+++ b/src/pages/AgeReviewPage.tsx
@@ -123,7 +123,7 @@ export function AgeReviewPage() {
             eyebrow="If you're 13 to 15"
             icon={<VideoCamera weight="fill" className="h-7 w-7" />}
             title="A guided start"
-            lead={`Teens 13 to 15 can use Divine with a parent or guardian who's aware and involved. To keep the account open, a parent or guardian sends a short private video confirming the situation. The email needs to land within ${REVIEW_WINDOW_DAYS} days of the in-app notice.`}
+            lead={`Where local rules allow it, teens 13 to 15 can use Divine with a parent or guardian who's aware and involved. To keep the account open, a parent or guardian sends a short private video confirming the situation. The email needs to land within ${REVIEW_WINDOW_DAYS} days of the in-app notice.`}
           />
 
           <div className="grid gap-6 md:grid-cols-2">

--- a/src/pages/AgeReviewPage.tsx
+++ b/src/pages/AgeReviewPage.tsx
@@ -31,7 +31,7 @@ interface SectionAnchor {
 const SECTIONS: SectionAnchor[] = [
   { id: "path-13-15", title: "If you're 13 to 15" },
   { id: "path-mistake", title: "If you're 16 or older" },
-  { id: "no-response", title: "If no one responds" },
+  { id: "no-response", title: "If we don't hear from you" },
 ];
 
 function mailtoLink(subject: string, body?: string): string {
@@ -120,9 +120,9 @@ export function AgeReviewPage() {
         {/* 1. 13-15 path */}
         <Anchor id="path-13-15">
           <SectionHero
-            eyebrow="Step-by-step"
+            eyebrow="If you're 13 to 15"
             icon={<VideoCamera weight="fill" className="h-7 w-7" />}
-            title="If you're 13 to 15"
+            title="A guided start"
             lead={`Teens 13 to 15 can use Divine with a parent or guardian who's aware and involved. To keep the account open, a parent or guardian sends a short private video confirming the situation. The email needs to land within ${REVIEW_WINDOW_DAYS} days of the in-app notice.`}
           />
 

--- a/src/pages/AgeReviewPage.tsx
+++ b/src/pages/AgeReviewPage.tsx
@@ -41,6 +41,28 @@ function mailtoLink(subject: string, body?: string): string {
   return `mailto:${SUPPORT_EMAIL}?${params.toString().replace(/\+/g, "%20")}`;
 }
 
+// Mirrors the 13-15 parent-consent email in divine-mobile
+// (minorAccountReviewParentConsentEmailSubject / ...Body) so the in-app flow
+// and this page open the same prefilled message.
+const TEEN_REVIEW_EMAIL_SUBJECT = "13-15 account review help";
+const TEEN_REVIEW_EMAIL_BODY =
+  "Hi Divine support,\n\nI am contacting Divine about an account for a teen who is 13 to 15.\n\nI have attached a short private video that shows:\n- the teen\n- a parent or guardian speaking on camera\n- that the teen has permission to use Divine\n- that the parent or guardian knows about the account and will supervise its use\n\nCountry/ies of residence:\n\nHelpful context:\n\nThanks.";
+const TEEN_REVIEW_MAILTO = mailtoLink(
+  TEEN_REVIEW_EMAIL_SUBJECT,
+  TEEN_REVIEW_EMAIL_BODY,
+);
+
+// 16-or-older "flagged by mistake" path. Shared so the inline link and the
+// button below it open the same prefilled message.
+const MISTAKE_REVIEW_EMAIL_SUBJECT =
+  "I am 16 or older and think this account was flagged by mistake";
+const MISTAKE_REVIEW_EMAIL_BODY =
+  "Hi Divine support,\n\nI'm 16 or older and I think this account was flagged by mistake.\n\nAccount username or link:\n\nAny helpful context:\n\nThanks,";
+const MISTAKE_REVIEW_MAILTO = mailtoLink(
+  MISTAKE_REVIEW_EMAIL_SUBJECT,
+  MISTAKE_REVIEW_EMAIL_BODY,
+);
+
 export function AgeReviewPage() {
   return (
     <MarketingLayout>
@@ -110,9 +132,9 @@ export function AgeReviewPage() {
             <p>
               We're sorry. Divine must close an under-13 account and delete the data it holds once it confirms or has actual knowledge that the account holder is under 13, and in all cases no later than the 15-day mark. Emailing
               won't pause the clock here—the rules around services for
-              kids under 13 tie our hands. The same person can come back
-              and create a new account when they're 13 or older (with
-              parental consent required between ages 13-15).
+              kids under 13 tie our hands. Where the rules allow, the same
+              person can come back and create a new account when they're 13
+              or older (with parental consent required between ages 13-15).
             </p>
           </CardContent>
         </Card>
@@ -176,7 +198,7 @@ export function AgeReviewPage() {
                     <span>
                       Email{" "}
                       <a
-                        href={`mailto:${SUPPORT_EMAIL}`}
+                        href={TEEN_REVIEW_MAILTO}
                         className="text-brand-dark-green dark:text-brand-green underline underline-offset-2 hover:opacity-80 break-all"
                       >
                         {SUPPORT_EMAIL}
@@ -221,10 +243,7 @@ export function AgeReviewPage() {
 
                 <div className="pt-2">
                   <SupportEmailButton
-                    href={mailtoLink(
-                      "Account review—13 to 15",
-                      "Hi Divine support,\n\nI'm a parent or guardian. I'm attaching a short private video to confirm the account on Divine.\n\nAccount username or link:\n\nTeen's age (13, 14, or 15):\n\nThanks,",
-                    )}
+                    href={TEEN_REVIEW_MAILTO}
                     label={`Email ${SUPPORT_EMAIL}`}
                   />
                 </div>
@@ -240,7 +259,7 @@ export function AgeReviewPage() {
               </div>
               <p>
                 The video is used to confirm the situation and is handled by
-                Divine's support and trust &amp; safety team. Divine uses the video only for account review, safety, legal, and compliance purposes, and keeps it only as long as reasonably necessary for those purposes unless a longer retention period is required or permitted by law. It isn't
+                Divine's Support and Trust &amp; Safety teams. Divine uses the video only for account review, safety, legal, and compliance purposes, and keeps it only as long as reasonably necessary for those purposes unless a longer retention period is required or permitted by law. It isn't
                 published anywhere on Divine and isn't shared with other
                 users.
               </p>
@@ -276,7 +295,7 @@ export function AgeReviewPage() {
                   <span>
                     Email{" "}
                     <a
-                      href={`mailto:${SUPPORT_EMAIL}`}
+                      href={MISTAKE_REVIEW_MAILTO}
                       className="text-brand-dark-green dark:text-brand-green underline underline-offset-2 hover:opacity-80 break-all"
                     >
                       {SUPPORT_EMAIL}
@@ -329,10 +348,7 @@ export function AgeReviewPage() {
 
               <div className="pt-2">
                 <SupportEmailButton
-                  href={mailtoLink(
-                    "I am 16 or older and think this account was flagged by mistake",
-                    "Hi Divine support,\n\nI'm 16 or older and I think this account was flagged by mistake.\n\nAccount username or link:\n\nAny helpful context:\n\nThanks,",
-                  )}
+                  href={MISTAKE_REVIEW_MAILTO}
                   label={`Email ${SUPPORT_EMAIL}`}
                 />
               </div>

--- a/src/pages/FamilyPage.tsx
+++ b/src/pages/FamilyPage.tsx
@@ -139,7 +139,7 @@ const RESOURCE_GROUPS: ResourceGroup[] = [
         name: "Thorn for Parents",
         url: "https://parents.thorn.org/",
         description:
-          "Conversation-first guidance from Thorn for keeping kids safer from online exploitation.",
+          "Thorn is a nonprofit that builds technology and research to defend children from online sexual abuse. Their parents' site offers conversation-first guidance on tough topics like sextortion, grooming, and nudes.",
       },
     ],
   },

--- a/src/pages/FamilyPage.tsx
+++ b/src/pages/FamilyPage.tsx
@@ -67,16 +67,16 @@ const RESOURCE_GROUPS: ResourceGroup[] = [
           "American Academy of Pediatrics tool for building a household plan together, room by room and screen by screen.",
       },
       {
-        name: "eSafety Commissioner (Australia) — Family Tech Agreement",
+        name: "eSafety Commissioner (Australia)—Family Tech Agreement",
         url: "https://www.esafety.gov.au/parents/resources/family-tech-agreement",
         description:
-          "A downloadable family tech-agreement template from Australia's online-safety regulator — same shape as the AAP plan, written to work for any household.",
+          "A downloadable family tech-agreement template from Australia's online-safety regulator—same shape as the AAP plan, written to work for any household.",
       },
       {
-        name: "WHO — Helping Adolescents Thrive",
+        name: "WHO—Helping Adolescents Thrive",
         url: "https://www.who.int/publications/i/item/9789240025554",
         description:
-          "The World Health Organization's framework for adolescent well-being — strategies for parents, educators, and health workers, written for a global audience.",
+          "The World Health Organization's framework for adolescent well-being—strategies for parents, educators, and health workers, written for a global audience.",
       },
     ],
   },
@@ -84,7 +84,7 @@ const RESOURCE_GROUPS: ResourceGroup[] = [
     heading: "Family guidance and conversation tools",
     links: [
       {
-        name: "Common Sense Media — Parents' Guide to Social Media",
+        name: "Common Sense Media—Parents' Guide to Social Media",
         url: "https://www.commonsensemedia.org/articles/parents-ultimate-guide-to-social-media",
         description:
           "Plain-language explainers, age-by-age guidance, and reviews of the apps teens actually use.",
@@ -93,7 +93,7 @@ const RESOURCE_GROUPS: ResourceGroup[] = [
         name: "Internet Matters (UK)",
         url: "https://www.internetmatters.org/",
         description:
-          "UK-based equivalent of Common Sense Media — app-by-app guides, age-by-age advice, and practical online-safety tools for parents.",
+          "UK-based equivalent of Common Sense Media—app-by-app guides, age-by-age advice, and practical online-safety tools for parents.",
       },
       {
         name: "ConnectSafely Parent Guides",
@@ -117,7 +117,7 @@ const RESOURCE_GROUPS: ResourceGroup[] = [
         name: "Screen Sanity",
         url: "https://screensanity.org/",
         description:
-          "Parent-to-parent guidance — conversation starters, family templates, and decision frameworks for navigating screens at every age.",
+          "Parent-to-parent guidance—conversation starters, family templates, and decision frameworks for navigating screens at every age.",
       },
     ],
   },
@@ -128,13 +128,13 @@ const RESOURCE_GROUPS: ResourceGroup[] = [
         name: "INHOPE",
         url: "https://www.inhope.org/",
         description:
-          "Global network of reporting hotlines — find the right place to report illegal online content in your country.",
+          "Global network of reporting hotlines—find the right place to report illegal online content in your country.",
       },
       {
         name: "Child Helpline International",
         url: "https://childhelplineinternational.org/",
         description:
-          "Directory of crisis helplines for kids and teens by country — for the moments when your child needs to talk to someone right now.",
+          "Directory of crisis helplines for kids and teens by country—for the moments when your child needs to talk to someone right now.",
       },
       {
         name: "Thorn for Parents",
@@ -171,9 +171,9 @@ export function FamilyPage() {
             conversation, supervision, and thoughtful boundaries at home.
           </p>
           <p className="text-base md:text-lg text-brand-off-white/80 max-w-3xl leading-relaxed mt-4">
-            This page is a starting point for parents, guardians, and teens —
-            not a contract, not a control panel. It's the stuff we wish more
-            apps said out loud.
+            This page is a starting point for parents, guardians, and
+            teens—not a contract, not a control panel. It's the stuff we wish
+            more apps said out loud.
           </p>
 
           {/* Anchor nav */}
@@ -214,7 +214,7 @@ export function FamilyPage() {
             <FrameStep
               icon={<Compass weight="fill" className="h-6 w-6" />}
               label="Redirect"
-              body="Pick the next step together — a setting to try, a person to mute, a break to take, a thing to do off the app."
+              body="Pick the next step together—a setting to try, a person to mute, a break to take, a thing to do off the app."
             />
           </div>
         </div>
@@ -300,7 +300,7 @@ export function FamilyPage() {
             eyebrow="Honest app limits"
             icon={<ShieldCheck weight="fill" className="h-7 w-7" />}
             title="What Divine can and can't do"
-            lead="We'd rather be useful than impressive. Here's the real picture of what the app side can help with — and where conversation, supervision, and human judgment still have to do the work."
+            lead="We'd rather be useful than impressive. Here's the real picture of what the app side can help with—and where conversation, supervision, and human judgment still have to do the work."
           />
 
           <div className="grid gap-6 md:grid-cols-2">
@@ -353,7 +353,7 @@ export function FamilyPage() {
               <CardContent className="space-y-3 text-base leading-relaxed">
                 <ul className="space-y-2 list-disc pl-5 marker:text-brand-orange">
                   <li>
-                    No app — including Divine — can guarantee a teen will
+                    No app—including Divine—can guarantee a teen will
                     never see adult, upsetting, or harmful content.
                   </li>
                   <li>
@@ -371,7 +371,7 @@ export function FamilyPage() {
                   </li>
                   <li>
                     Settings and tools work best as part of a household
-                    conversation — not as a substitute for one.
+                    conversation—not as a substitute for one.
                   </li>
                 </ul>
               </CardContent>
@@ -407,7 +407,7 @@ export function FamilyPage() {
               />
               <SettingsRow
                 title="Moderation lists and filters"
-                body="Users can apply moderation lists, mute words, and filter creators they don't want to see. These can be revisited any time — they're not one-time decisions."
+                body="Users can apply moderation lists, mute words, and filter creators they don't want to see. These can be revisited any time—they're not one-time decisions."
               />
               <SettingsRow
                 title="Blocking and muting"
@@ -422,7 +422,7 @@ export function FamilyPage() {
                   <strong className="text-foreground">A note on settings:</strong>{" "}
                   even good settings can be turned off, worked around, or simply
                   not catch every edge case. Treat them as one helpful layer of
-                  several — alongside conversation, check-ins, and the off
+                  several—alongside conversation, check-ins, and the off
                   switch.
                 </p>
               </div>
@@ -436,7 +436,7 @@ export function FamilyPage() {
             eyebrow="Healthier habits, not just restrictions"
             icon={<Path weight="fill" className="h-7 w-7" />}
             title="Feed habits and healthy stopping points"
-            lead="Most short-form feeds are designed to keep going. The healthier skill isn't blocking the feed — it's noticing when you've had enough and choosing to stop. That's a skill adults are still learning too."
+            lead="Most short-form feeds are designed to keep going. The healthier skill isn't blocking the feed—it's noticing when you've had enough and choosing to stop. That's a skill adults are still learning too."
           />
 
           <div className="grid gap-6 md:grid-cols-2">
@@ -446,7 +446,7 @@ export function FamilyPage() {
               </CardHeader>
               <CardContent className="space-y-3 text-base leading-relaxed">
                 <p>
-                  Pick a natural stop together — end of a video, end of a song,
+                  Pick a natural stop together—end of a video, end of a song,
                   end of a meal. The point isn't a hard timer. It's noticing
                   the moment to put the phone down and meaning it.
                 </p>
@@ -495,17 +495,17 @@ export function FamilyPage() {
             eyebrow="Make it together"
             icon={<UsersThree weight="fill" className="h-7 w-7" />}
             title="Build a family media plan"
-            lead="A plan that everyone helped write is a plan that everyone is more likely to follow. Plans are also living documents — expect to revisit them every few months as kids get older and apps change."
+            lead="A plan that everyone helped write is a plan that everyone is more likely to follow. Plans are also living documents—expect to revisit them every few months as kids get older and apps change."
           />
 
           <div className="grid gap-6 md:grid-cols-2">
             <PlanColumn
               title="Where and when use makes sense"
               items={[
-                "Phones at the dinner table — yes or no, decided together.",
-                "Bedrooms overnight — where do devices charge?",
-                "Homework time — what counts as a focus block?",
-                "Long car rides, family events, hangouts — any shared norms?",
+                "Phones at the dinner table—yes or no, decided together.",
+                "Bedrooms overnight—where do devices charge?",
+                "Homework time—what counts as a focus block?",
+                "Long car rides, family events, hangouts—any shared norms?",
               ]}
             />
             <PlanColumn
@@ -536,8 +536,8 @@ export function FamilyPage() {
           </div>
 
           <p className="mt-6 text-base text-muted-foreground leading-relaxed">
-            Looking for a template? A few household-plan starting points — from
-            the AAP, Australia's eSafety Commissioner, and the WHO — are in the{" "}
+            Looking for a template? A few household-plan starting points—from
+            the AAP, Australia's eSafety Commissioner, and the WHO—are in the{" "}
             <a
               href="#resources"
               className="text-brand-dark-green dark:text-brand-green underline underline-offset-2 hover:opacity-80"
@@ -554,7 +554,7 @@ export function FamilyPage() {
             eyebrow="When something goes wrong"
             icon={<Lifebuoy weight="fill" className="h-7 w-7" />}
             title="What to do if your child saw something upsetting"
-            lead="Most kids will see something they wish they hadn't at some point — on any app. What helps most isn't a perfect filter. It's a parent who reacts in a way that makes the next conversation possible."
+            lead="Most kids will see something they wish they hadn't at some point—on any app. What helps most isn't a perfect filter. It's a parent who reacts in a way that makes the next conversation possible."
           />
 
           <div className="grid gap-6 md:grid-cols-2">
@@ -584,7 +584,7 @@ export function FamilyPage() {
                 <p>
                   Ask what they saw, how they came across it, and how it felt.
                   Try to listen for longer than you talk. Punishment can come
-                  later if it's actually warranted — disclosure has to come
+                  later if it's actually warranted—disclosure has to come
                   first.
                 </p>
               </CardContent>
@@ -641,7 +641,7 @@ export function FamilyPage() {
             eyebrow="Why this approach"
             icon={<Microphone weight="fill" className="h-7 w-7" />}
             title="Rabble + Pam Wisniewski / STIR"
-            lead="The framing on this page — conversation over punishment, co-navigation over surveillance, pause and redirect over hard control — comes out of years of research from teams like the Socio-Technical Interaction Research (STIR) Lab."
+            lead="The framing on this page—conversation over punishment, co-navigation over surveillance, pause and redirect over hard control—comes out of years of research from teams like the Socio-Technical Interaction Research (STIR) Lab."
           />
 
           <Card variant="brand" accent="violet">
@@ -665,7 +665,7 @@ export function FamilyPage() {
                 conversation through the rough patches.
               </p>
               <p>
-                Rabble — Divine's founder — talks with researchers like Pam
+                Rabble—Divine's co-founder—talks with researchers like Pam
                 Wisniewski about what non-punitive, conversation-first online
                 safety actually looks like in practice. The values on this page
                 are why we build the way we do.
@@ -744,7 +744,7 @@ export function FamilyPage() {
             eyebrow="Don't just take our word for it"
             icon={<BookOpenText weight="fill" className="h-7 w-7" />}
             title="Outside resources"
-            lead="These are some resources we recommend. Inclusion here doesn't imply endorsement of every recommendation from these organizations. Read them with the same critical eye you'd bring to any single source — including this one. A few are global; most are from North American or UK sources."
+            lead="These are some resources we recommend. Inclusion here doesn't imply endorsement of every recommendation from these organizations. Read them with the same critical eye you'd bring to any single source—including this one. A few are global; most are from North American or UK sources."
           />
 
           <div className="space-y-10">
@@ -779,7 +779,7 @@ export function FamilyPage() {
           </div>
         </Anchor>
 
-        {/* Cross-link to the kids policy page — separate audience and
+        {/* Cross-link to the kids policy page—separate audience and
             tone, but the same household is likely interested in both. */}
         <div className="pt-12 border-t border-brand-dark-green/10 dark:border-brand-green/20">
           <div className="flex items-center gap-2 text-xs font-semibold tracking-wide text-brand-dark-green dark:text-brand-green mb-4">
@@ -835,7 +835,7 @@ export function FamilyPage() {
 export default FamilyPage;
 
 // ——————————————————————————————————————————————————————————————
-// Local presentation helpers — kept in-file so this page is easy to update.
+// Local presentation helpers—kept in-file so this page is easy to update.
 // ——————————————————————————————————————————————————————————————
 
 function BackToTopButton() {

--- a/src/pages/FamilyPage.tsx
+++ b/src/pages/FamilyPage.tsx
@@ -1,0 +1,958 @@
+// ABOUTME: Family resource hub for parents, guardians, and teens at /family
+// ABOUTME: Conversation-first guidance, honest app limits, and trusted outside resources
+
+import { useEffect, useState } from "react";
+import {
+  ChatsCircle,
+  Pause,
+  HandHeart,
+  Compass,
+  ListChecks,
+  Lifebuoy,
+  Microphone,
+  BookOpenText,
+  ArrowSquareOut,
+  Path,
+  ShieldCheck,
+  HouseLine,
+  UsersThree,
+  Eye,
+  Heart,
+  Lightbulb,
+  Flag,
+  ArrowUp,
+} from "@phosphor-icons/react";
+
+import { MarketingLayout } from "@/components/MarketingLayout";
+import { SectionHeader } from "@/components/brand/SectionHeader";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ZendeskWidget } from "@/components/ZendeskWidget";
+
+interface SectionAnchor {
+  id: string;
+  title: string;
+}
+
+const SECTIONS: SectionAnchor[] = [
+  { id: "talking", title: "Talking with your teen" },
+  { id: "limits", title: "What Divine can and can't do" },
+  { id: "settings", title: "How content settings work" },
+  { id: "habits", title: "Feed habits and stopping points" },
+  { id: "plan", title: "Build a family media plan" },
+  { id: "upset", title: "If your child saw something upsetting" },
+  { id: "stir", title: "Rabble + Pam Wisniewski / STIR" },
+  { id: "resources", title: "Outside resources" },
+];
+
+interface ResourceLink {
+  name: string;
+  url: string;
+  description: string;
+}
+
+interface ResourceGroup {
+  heading: string;
+  links: ResourceLink[];
+}
+
+const RESOURCE_GROUPS: ResourceGroup[] = [
+  {
+    heading: "Plans you can fill out together",
+    links: [
+      {
+        name: "AAP Family Media Plan",
+        url: "https://www.healthychildren.org/English/fmp/Pages/MediaPlan.aspx",
+        description:
+          "American Academy of Pediatrics tool for building a household plan together, room by room and screen by screen.",
+      },
+      {
+        name: "eSafety Commissioner (Australia) — Family Tech Agreement",
+        url: "https://www.esafety.gov.au/parents/resources/family-tech-agreement",
+        description:
+          "A downloadable family tech-agreement template from Australia's online-safety regulator — same shape as the AAP plan, written to work for any household.",
+      },
+      {
+        name: "WHO — Helping Adolescents Thrive",
+        url: "https://www.who.int/publications/i/item/9789240025554",
+        description:
+          "The World Health Organization's framework for adolescent well-being — strategies for parents, educators, and health workers, written for a global audience.",
+      },
+    ],
+  },
+  {
+    heading: "Family guidance and conversation tools",
+    links: [
+      {
+        name: "Common Sense Media — Parents' Guide to Social Media",
+        url: "https://www.commonsensemedia.org/articles/parents-ultimate-guide-to-social-media",
+        description:
+          "Plain-language explainers, age-by-age guidance, and reviews of the apps teens actually use.",
+      },
+      {
+        name: "Internet Matters (UK)",
+        url: "https://www.internetmatters.org/",
+        description:
+          "UK-based equivalent of Common Sense Media — app-by-app guides, age-by-age advice, and practical online-safety tools for parents.",
+      },
+      {
+        name: "ConnectSafely Parent Guides",
+        url: "https://connectsafely.org/parentguides/",
+        description:
+          "Short, practical guides to specific apps and online-safety topics, written for non-technical caregivers.",
+      },
+      {
+        name: "Family Online Safety Institute (FOSI)",
+        url: "https://fosi.org/",
+        description:
+          "Research, policy work, and family resources focused on a culture of responsibility in the connected world.",
+      },
+      {
+        name: "Children and Screens",
+        url: "https://www.childrenandscreens.org/",
+        description:
+          "Research-backed resources from the Institute of Digital Media and Child Development on how screens shape child development, with practical guidance for parents and educators.",
+      },
+      {
+        name: "Screen Sanity",
+        url: "https://screensanity.org/",
+        description:
+          "Parent-to-parent guidance — conversation starters, family templates, and decision frameworks for navigating screens at every age.",
+      },
+    ],
+  },
+  {
+    heading: "Reporting harms or getting help",
+    links: [
+      {
+        name: "INHOPE",
+        url: "https://www.inhope.org/",
+        description:
+          "Global network of reporting hotlines — find the right place to report illegal online content in your country.",
+      },
+      {
+        name: "Child Helpline International",
+        url: "https://childhelplineinternational.org/",
+        description:
+          "Directory of crisis helplines for kids and teens by country — for the moments when your child needs to talk to someone right now.",
+      },
+      {
+        name: "Thorn for Parents",
+        url: "https://parents.thorn.org/",
+        description:
+          "Conversation-first guidance from Thorn for keeping kids safer from online exploitation.",
+      },
+    ],
+  },
+];
+
+export function FamilyPage() {
+  return (
+    <MarketingLayout>
+      <ZendeskWidget />
+      <BackToTopButton />
+
+      {/* Hero */}
+      <section className="bg-brand-dark-green text-brand-off-white">
+        <div className="container mx-auto px-4 py-16 md:py-24 max-w-5xl">
+          <div className="flex items-center gap-2 text-xs font-semibold tracking-wide text-brand-green mb-6">
+            <HouseLine weight="fill" className="h-4 w-4" />
+            <span>For families on Divine</span>
+          </div>
+          <h1
+            className="font-display font-extrabold tracking-tight text-4xl md:text-6xl leading-[1.05] text-brand-off-white mb-6"
+            style={{ fontFamily: "'Bricolage Grotesque', system-ui, sans-serif" }}
+          >
+            Safer social media use starts with conversation.
+          </h1>
+          <p className="text-lg md:text-xl text-brand-light-green max-w-3xl leading-relaxed">
+            Divine can help families reduce some risks and build healthier
+            habits around social media use, but no app can replace
+            conversation, supervision, and thoughtful boundaries at home.
+          </p>
+          <p className="text-base md:text-lg text-brand-off-white/80 max-w-3xl leading-relaxed mt-4">
+            This page is a starting point for parents, guardians, and teens —
+            not a contract, not a control panel. It's the stuff we wish more
+            apps said out loud.
+          </p>
+
+          {/* Anchor nav */}
+          <nav
+            aria-label="On this page"
+            className="mt-10 grid gap-2 sm:grid-cols-2 lg:grid-cols-4 text-sm"
+          >
+            {SECTIONS.map((s) => (
+              <a
+                key={s.id}
+                href={`#${s.id}`}
+                className="rounded-xl border border-brand-green/40 bg-brand-dark-green/40 px-4 py-3 text-brand-light-green hover:bg-brand-green/10 hover:border-brand-green transition-colors"
+              >
+                {s.title}
+              </a>
+            ))}
+          </nav>
+        </div>
+      </section>
+
+      {/* Pause • Reflect • Redirect framing band */}
+      <section className="bg-brand-light-green/30 dark:bg-brand-dark-green/40 border-y border-brand-dark-green/10 dark:border-brand-green/20">
+        <div className="container mx-auto px-4 py-10 max-w-5xl">
+          <p className="text-xs font-semibold tracking-wide text-brand-dark-green dark:text-brand-green mb-4">
+            A simple framing
+          </p>
+          <div className="grid gap-6 md:grid-cols-3">
+            <FrameStep
+              icon={<Pause weight="fill" className="h-6 w-6" />}
+              label="Pause"
+              body="Notice what's happening before you react. For teens, that's catching the urge to scroll. For parents, that's catching the urge to confiscate."
+            />
+            <FrameStep
+              icon={<Lightbulb weight="fill" className="h-6 w-6" />}
+              label="Reflect"
+              body="Ask, don't assume. What did you see? How did it land? Is something here worth paying attention to?"
+            />
+            <FrameStep
+              icon={<Compass weight="fill" className="h-6 w-6" />}
+              label="Redirect"
+              body="Pick the next step together — a setting to try, a person to mute, a break to take, a thing to do off the app."
+            />
+          </div>
+        </div>
+      </section>
+
+      <div className="container mx-auto px-4 py-16 max-w-4xl space-y-16">
+        {/* 2. Talking with your teen */}
+        <Anchor id="talking">
+          <SectionHero
+            eyebrow="Conversation over punishment"
+            icon={<ChatsCircle weight="fill" className="h-7 w-7" />}
+            title="How to talk with your teen about social media"
+            lead="The goal isn't to win the conversation. It's to keep having one. Teens who feel heard stay open. Teens who feel surveilled go quiet."
+          />
+
+          <div className="grid gap-6 md:grid-cols-2">
+            <Card variant="brand" accent="green">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-xl">
+                  <HandHeart weight="fill" className="h-5 w-5 text-brand-green" />
+                  Co-navigate, don't surveil
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3 text-base leading-relaxed">
+                <p>
+                  Sit next to them on the app sometimes. Ask who they follow.
+                  Ask what's funny right now. You'll learn more in five minutes
+                  of scrolling together than in a month of monitoring software.
+                </p>
+                <p className="text-muted-foreground">
+                  Surveillance shifts the dynamic. Curiosity keeps it open.
+                </p>
+              </CardContent>
+            </Card>
+
+            <Card variant="brand" accent="violet">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-xl">
+                  <Pause weight="fill" className="h-5 w-5 text-brand-violet" />
+                  Respond, don't punish first
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3 text-base leading-relaxed">
+                <p>
+                  If you find something concerning, lead with a question. "Tell
+                  me what was happening when you saw this" gets you more than
+                  "you're grounded."
+                </p>
+                <p className="text-muted-foreground">
+                  Big consequences for the first disclosure usually buy you
+                  silence on the second one.
+                </p>
+              </CardContent>
+            </Card>
+          </div>
+
+          <div className="mt-6">
+            <Card variant="brand" accent="pink">
+              <CardHeader>
+                <CardTitle className="text-xl">Conversation starters</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3 text-base leading-relaxed">
+                <ul className="space-y-2 list-disc pl-5 marker:text-brand-pink">
+                  <li>What's the funniest thing you've seen on your feed this week?</li>
+                  <li>Who are the three creators you actually look forward to?</li>
+                  <li>Has anything online ever made you feel weird or stuck with you afterwards?</li>
+                  <li>If you saw a friend getting piled on in comments, what would you do?</li>
+                  <li>What's something you wish your feed had less of?</li>
+                  <li>If we built a "phones-away" hour together, when would it make most sense?</li>
+                </ul>
+                <p className="text-sm text-muted-foreground pt-2">
+                  Use these as warm-up questions, not interrogations. One good
+                  question per car ride is plenty.
+                </p>
+              </CardContent>
+            </Card>
+          </div>
+        </Anchor>
+
+        {/* 3. What Divine can / can't do */}
+        <Anchor id="limits">
+          <SectionHero
+            eyebrow="Honest app limits"
+            icon={<ShieldCheck weight="fill" className="h-7 w-7" />}
+            title="What Divine can and can't do"
+            lead="We'd rather be useful than impressive. Here's the real picture of what the app side can help with — and where conversation, supervision, and human judgment still have to do the work."
+          />
+
+          <div className="grid gap-6 md:grid-cols-2">
+            <Card variant="brand" accent="green">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-xl">
+                  <ShieldCheck weight="fill" className="h-5 w-5 text-brand-green" />
+                  What Divine offers
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3 text-base leading-relaxed">
+                <ul className="space-y-2 list-disc pl-5 marker:text-brand-green">
+                  <li>
+                    Moderation tools that remove clearly prohibited content
+                    from Divine-controlled surfaces.
+                  </li>
+                  <li>
+                    Reporting tools inside the app so anyone can flag content
+                    or accounts for review.
+                  </li>
+                  <li>
+                    Content settings that gate adult and sensitive content for
+                    accounts that haven't opted in.
+                  </li>
+                  <li>
+                    Blocking, muting, and filtering controls so users can shape
+                    their own experience.
+                  </li>
+                  <li>
+                    A support path for families and a published{" "}
+                    <a
+                      href="/safety"
+                      className="text-brand-green underline underline-offset-2 hover:text-brand-dark-green dark:hover:text-brand-light-green"
+                    >
+                      safety standards
+                    </a>{" "}
+                    page that documents what we will and won't do.
+                  </li>
+                </ul>
+              </CardContent>
+            </Card>
+
+            <Card variant="brand" accent="orange">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-xl">
+                  <Eye weight="fill" className="h-5 w-5 text-brand-orange" />
+                  What Divine can't promise
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3 text-base leading-relaxed">
+                <ul className="space-y-2 list-disc pl-5 marker:text-brand-orange">
+                  <li>
+                    No app — including Divine — can guarantee a teen will
+                    never see adult, upsetting, or harmful content.
+                  </li>
+                  <li>
+                    Automated systems and human review both miss things. We
+                    don't claim to catch every violation.
+                  </li>
+                  <li>
+                    Bad language and conflict happen in human communities. We
+                    don't promise a filter that removes all of it.
+                  </li>
+                  <li>
+                    Divine is built on an open protocol (Nostr). Content
+                    removed from Divine-controlled surfaces can still exist
+                    elsewhere on the network.
+                  </li>
+                  <li>
+                    Settings and tools work best as part of a household
+                    conversation — not as a substitute for one.
+                  </li>
+                </ul>
+              </CardContent>
+            </Card>
+          </div>
+
+          <p className="mt-6 text-base text-muted-foreground leading-relaxed">
+            For the full policy view, see our{" "}
+            <a
+              href="/safety"
+              className="text-brand-dark-green dark:text-brand-green underline underline-offset-2 hover:opacity-80"
+            >
+              Safety Standards
+            </a>
+            .
+          </p>
+        </Anchor>
+
+        {/* 4. How content settings work */}
+        <Anchor id="settings">
+          <SectionHero
+            eyebrow="Practical setup"
+            icon={<ListChecks weight="fill" className="h-7 w-7" />}
+            title="How content settings work on Divine"
+            lead="Settings are a useful layer. They are not a guarantee. The most important step is for the adult in the household to actually open them, read them, and adjust them together with the teen who'll use the account."
+          />
+
+          <Card variant="brand" accent="violet">
+            <CardContent className="pt-6 space-y-4 text-base leading-relaxed">
+              <SettingsRow
+                title="Adult content gating"
+                body="Adult and sensitive content is hidden by default and gated behind an age-affirmation step. Accounts that don't meet the requirements don't see that content on Divine-controlled surfaces."
+              />
+              <SettingsRow
+                title="Moderation lists and filters"
+                body="Users can apply moderation lists, mute words, and filter creators they don't want to see. These can be revisited any time — they're not one-time decisions."
+              />
+              <SettingsRow
+                title="Blocking and muting"
+                body="Blocking removes someone from your view on Divine. Muting hides their posts without notifying them. Both are reversible."
+              />
+              <SettingsRow
+                title="Reporting"
+                body="The report button is inside the app and on every video and profile. Reports go to a human review queue."
+              />
+              <div className="pt-2 border-t border-brand-dark-green/15 dark:border-brand-green/20">
+                <p className="text-sm text-muted-foreground">
+                  <strong className="text-foreground">A note on settings:</strong>{" "}
+                  even good settings can be turned off, worked around, or simply
+                  not catch every edge case. Treat them as one helpful layer of
+                  several — alongside conversation, check-ins, and the off
+                  switch.
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+        </Anchor>
+
+        {/* 5. Feed habits */}
+        <Anchor id="habits">
+          <SectionHero
+            eyebrow="Healthier habits, not just restrictions"
+            icon={<Path weight="fill" className="h-7 w-7" />}
+            title="Feed habits and healthy stopping points"
+            lead="Most short-form feeds are designed to keep going. The healthier skill isn't blocking the feed — it's noticing when you've had enough and choosing to stop. That's a skill adults are still learning too."
+          />
+
+          <div className="grid gap-6 md:grid-cols-2">
+            <Card variant="brand" accent="blue">
+              <CardHeader>
+                <CardTitle className="text-xl">Practice intentional stopping points</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3 text-base leading-relaxed">
+                <p>
+                  Pick a natural stop together — end of a video, end of a song,
+                  end of a meal. The point isn't a hard timer. It's noticing
+                  the moment to put the phone down and meaning it.
+                </p>
+                <p className="text-muted-foreground">
+                  Modeling matters. If adults in the house never stop scrolling,
+                  the lesson lands differently.
+                </p>
+              </CardContent>
+            </Card>
+
+            <Card variant="brand" accent="yellow">
+              <CardHeader>
+                <CardTitle className="text-xl">Build redirect routines</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3 text-base leading-relaxed">
+                <p>
+                  After a long session, redirect attention on purpose: a walk,
+                  music, food, a stretch, a friend, anything offline. The
+                  redirect matters as much as the pause.
+                </p>
+                <p className="text-muted-foreground">
+                  This isn't about declaring social media bad. It's about
+                  making sure it's not the only thing on the menu.
+                </p>
+              </CardContent>
+            </Card>
+          </div>
+
+          <Card variant="brand" accent="dark" className="mt-6 bg-brand-dark-green/95 text-brand-off-white">
+            <CardContent className="pt-6 text-base leading-relaxed">
+              <p className="text-brand-light-green text-sm font-semibold mb-2">
+                Talking points for the next car ride
+              </p>
+              <ul className="space-y-2 list-disc pl-5 marker:text-brand-green">
+                <li>What does "enough scrolling for now" feel like in your body?</li>
+                <li>What's the first thing you'd rather do when you put the phone down?</li>
+                <li>Is there a creator or topic that always leaves you feeling worse? What would it take to mute it?</li>
+              </ul>
+            </CardContent>
+          </Card>
+        </Anchor>
+
+        {/* 6. Family media plan */}
+        <Anchor id="plan">
+          <SectionHero
+            eyebrow="Make it together"
+            icon={<UsersThree weight="fill" className="h-7 w-7" />}
+            title="Build a family media plan"
+            lead="A plan that everyone helped write is a plan that everyone is more likely to follow. Plans are also living documents — expect to revisit them every few months as kids get older and apps change."
+          />
+
+          <div className="grid gap-6 md:grid-cols-2">
+            <PlanColumn
+              title="Where and when use makes sense"
+              items={[
+                "Phones at the dinner table — yes or no, decided together.",
+                "Bedrooms overnight — where do devices charge?",
+                "Homework time — what counts as a focus block?",
+                "Long car rides, family events, hangouts — any shared norms?",
+              ]}
+            />
+            <PlanColumn
+              title="What we do when things get hard"
+              items={[
+                "If something upsetting comes up, we talk before we punish.",
+                "We use the report and mute tools instead of arguing in comments.",
+                "If a creator or trend stops feeling good, we mute or move on.",
+                "Adults follow the same rules they ask teens to follow.",
+              ]}
+            />
+            <PlanColumn
+              title="Regular check-ins"
+              items={[
+                "A short, monthly check-in beats a once-a-year blow-up.",
+                "Ask: what's working, what's not, what should we change?",
+                "Adjust the plan in writing so it's clear what changed.",
+              ]}
+            />
+            <PlanColumn
+              title="Boundaries that are collaborative, not punitive"
+              items={[
+                "Boundaries are about the household, not just the teen.",
+                "Explain the why, not just the rule.",
+                "When trust grows, the plan gets more room. That's the deal.",
+              ]}
+            />
+          </div>
+
+          <p className="mt-6 text-base text-muted-foreground leading-relaxed">
+            Looking for a template? A few household-plan starting points — from
+            the AAP, Australia's eSafety Commissioner, and the WHO — are in the{" "}
+            <a
+              href="#resources"
+              className="text-brand-dark-green dark:text-brand-green underline underline-offset-2 hover:opacity-80"
+            >
+              outside resources
+            </a>{" "}
+            at the bottom of this page.
+          </p>
+        </Anchor>
+
+        {/* 7. What to do if upset */}
+        <Anchor id="upset">
+          <SectionHero
+            eyebrow="When something goes wrong"
+            icon={<Lifebuoy weight="fill" className="h-7 w-7" />}
+            title="What to do if your child saw something upsetting"
+            lead="Most kids will see something they wish they hadn't at some point — on any app. What helps most isn't a perfect filter. It's a parent who reacts in a way that makes the next conversation possible."
+          />
+
+          <div className="grid gap-6 md:grid-cols-2">
+            <Card variant="brand" accent="green">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-xl">
+                  <Pause weight="fill" className="h-5 w-5 text-brand-green" />
+                  1. Pause first
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3 text-base leading-relaxed">
+                <p>
+                  Take a breath before reacting. Your first response sets
+                  whether your teen tells you the next time something happens.
+                </p>
+              </CardContent>
+            </Card>
+
+            <Card variant="brand" accent="pink">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-xl">
+                  <ChatsCircle weight="fill" className="h-5 w-5 text-brand-pink" />
+                  2. Talk before punishing
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3 text-base leading-relaxed">
+                <p>
+                  Ask what they saw, how they came across it, and how it felt.
+                  Try to listen for longer than you talk. Punishment can come
+                  later if it's actually warranted — disclosure has to come
+                  first.
+                </p>
+              </CardContent>
+            </Card>
+
+            <Card variant="brand" accent="violet">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-xl">
+                  <Flag weight="fill" className="h-5 w-5 text-brand-violet" />
+                  3. Use the in-app tools
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3 text-base leading-relaxed">
+                <p>
+                  Report the content or account in the app. Mute or block the
+                  source. Walk through the steps together so your teen knows
+                  how to do it next time without you.
+                </p>
+              </CardContent>
+            </Card>
+
+            <Card variant="brand" accent="orange">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-xl">
+                  <Heart weight="fill" className="h-5 w-5 text-brand-orange" />
+                  4. Know when to escalate
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3 text-base leading-relaxed">
+                <p>
+                  If something looks illegal, involves a minor, or feels like
+                  it's escalating offline, contact Divine support and, when
+                  appropriate, local authorities. Trust your gut on this one.
+                </p>
+                <p className="text-sm text-muted-foreground">
+                  For serious or time-sensitive reports, use the report flow
+                  in the app and reach out via{" "}
+                  <a
+                    href="/support"
+                    className="text-brand-dark-green dark:text-brand-green underline underline-offset-2 hover:opacity-80"
+                  >
+                    Divine support
+                  </a>
+                  .
+                </p>
+              </CardContent>
+            </Card>
+          </div>
+        </Anchor>
+
+        {/* 8. Rabble + STIR */}
+        <Anchor id="stir">
+          <SectionHero
+            eyebrow="Why this approach"
+            icon={<Microphone weight="fill" className="h-7 w-7" />}
+            title="Rabble + Pam Wisniewski / STIR"
+            lead="The framing on this page — conversation over punishment, co-navigation over surveillance, pause and redirect over hard control — comes out of years of research from teams like the Socio-Technical Interaction Research (STIR) Lab."
+          />
+
+          <Card variant="brand" accent="violet">
+            <CardContent className="pt-6 space-y-4 text-base leading-relaxed">
+              <p>
+                Dr. Pamela Wisniewski and the{" "}
+                <a
+                  href="https://stirlab.org/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-brand-dark-green dark:text-brand-green underline underline-offset-2 hover:opacity-80 inline-flex items-center gap-1"
+                >
+                  STIR Lab
+                  <ArrowSquareOut className="h-3.5 w-3.5" />
+                </a>{" "}
+                study how teens, families, and online services actually
+                interact. Their consistent finding: heavy-handed monitoring and
+                punitive control tend to push teens away from the adults who
+                want to help them. Teens fare better when they're trusted
+                enough to participate in the rules, and when caregivers stay in
+                conversation through the rough patches.
+              </p>
+              <p>
+                Rabble — Divine's founder — talks with researchers like Pam
+                Wisniewski about what non-punitive, conversation-first online
+                safety actually looks like in practice. The values on this page
+                are why we build the way we do.
+              </p>
+
+              <div className="rounded-2xl border-2 border-brand-dark-green dark:border-brand-green/40 bg-brand-light-green/30 dark:bg-brand-dark-green/40 p-5 mt-2">
+                <p className="text-sm font-semibold text-brand-dark-green dark:text-brand-green mb-3">
+                  Watch: Rabble + Pam Wisniewski on non-punitive online safety
+                </p>
+                <div className="relative w-full overflow-hidden rounded-xl border-2 border-brand-dark-green/80 dark:border-brand-green/30 bg-black aspect-video">
+                  <iframe
+                    src="https://www.youtube-nocookie.com/embed/8Zfvyj40GTM?si=RUDHdp-Z8BA-9I_p"
+                    title="Rabble and Pam Wisniewski on conversation-first online safety"
+                    loading="lazy"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                    referrerPolicy="strict-origin-when-cross-origin"
+                    allowFullScreen
+                    className="absolute inset-0 w-full h-full"
+                  />
+                </div>
+                <p className="mt-3 text-sm text-muted-foreground">
+                  Prefer to read?{" "}
+                  <a
+                    href="https://www.youtube.com/watch?v=8Zfvyj40GTM"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-brand-dark-green dark:text-brand-green underline underline-offset-2 hover:opacity-80 inline-flex items-center gap-1"
+                  >
+                    Open the episode on YouTube
+                    <ArrowSquareOut className="h-3.5 w-3.5" />
+                  </a>
+                  .
+                </p>
+                <p className="mt-5 text-sm font-semibold text-brand-dark-green dark:text-brand-green">
+                  More from the STIR Lab
+                </p>
+                <ul className="mt-2 space-y-2 text-sm">
+                  <li>
+                    <a
+                      href="https://stirlab.org/team/"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-brand-dark-green dark:text-brand-green underline underline-offset-2 hover:opacity-80 inline-flex items-center gap-1"
+                    >
+                      Meet the STIR Lab team
+                      <ArrowSquareOut className="h-3.5 w-3.5" />
+                    </a>
+                  </li>
+                  <li>
+                    <a
+                      href="https://stirlab.org/wisniewski-speaks-on-gps-tracking/"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-brand-dark-green dark:text-brand-green underline underline-offset-2 hover:opacity-80 inline-flex items-center gap-1"
+                    >
+                      Wisniewski on GPS tracking and the case against
+                      surveillance-first parenting
+                      <ArrowSquareOut className="h-3.5 w-3.5" />
+                    </a>
+                  </li>
+                </ul>
+              </div>
+
+              <blockquote className="border-l-4 border-brand-green pl-4 italic text-muted-foreground">
+                The most effective online-safety strategy is rarely a tougher
+                filter. It's a household where it's safe to bring something
+                weird, scary, or embarrassing back to the adults.
+              </blockquote>
+            </CardContent>
+          </Card>
+        </Anchor>
+
+        {/* 9. Outside resources */}
+        <Anchor id="resources">
+          <SectionHero
+            eyebrow="Don't just take our word for it"
+            icon={<BookOpenText weight="fill" className="h-7 w-7" />}
+            title="Outside resources"
+            lead="These are some resources we recommend. Inclusion here doesn't imply endorsement of every recommendation from these organizations. Read them with the same critical eye you'd bring to any single source — including this one. A few are global; most are from North American or UK sources."
+          />
+
+          <div className="space-y-10">
+            {RESOURCE_GROUPS.map((group) => (
+              <div key={group.heading}>
+                <h3 className="font-display font-extrabold tracking-tight text-xl text-brand-dark-green dark:text-brand-off-white mb-4">
+                  {group.heading}
+                </h3>
+                <div className="grid gap-5 md:grid-cols-2">
+                  {group.links.map((r) => (
+                    <a
+                      key={r.url}
+                      href={r.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="group block brand-card brand-offset-shadow-green p-6 hover:-translate-x-[2px] hover:-translate-y-[2px] hover:[box-shadow:8px_8px_0_0_hsl(var(--brand-green))] transition-all"
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <h4 className="font-display font-extrabold tracking-tight text-lg text-brand-dark-green dark:text-brand-off-white">
+                          {r.name}
+                        </h4>
+                        <ArrowSquareOut className="h-5 w-5 flex-shrink-0 text-brand-dark-green dark:text-brand-green group-hover:translate-x-0.5 transition-transform" />
+                      </div>
+                      <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+                        {r.description}
+                      </p>
+                    </a>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </Anchor>
+
+        {/* Cross-link to the kids policy page — separate audience and
+            tone, but the same household is likely interested in both. */}
+        <div className="pt-12 border-t border-brand-dark-green/10 dark:border-brand-green/20">
+          <div className="flex items-center gap-2 text-xs font-semibold tracking-wide text-brand-dark-green dark:text-brand-green mb-4">
+            <HouseLine weight="fill" className="h-4 w-4" />
+            <span>More from Divine</span>
+          </div>
+          <a
+            href="/kids"
+            className="group block brand-card brand-offset-shadow-violet p-6 hover:-translate-x-[2px] hover:-translate-y-[2px] hover:[box-shadow:8px_8px_0_0_hsl(var(--brand-violet))] transition-all"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <h3 className="font-display font-extrabold tracking-tight text-xl text-brand-dark-green dark:text-brand-off-white">
+                  Looking for the account rules for kids and teens?
+                </h3>
+                <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                  The policy page covers how accounts work for under-16s,
+                  the family-account carve-out, and what happens to
+                  under-13 accounts at{" "}
+                  <span className="font-medium text-brand-dark-green dark:text-brand-green">
+                    divine.video/kids
+                  </span>
+                  .
+                </p>
+              </div>
+              <ArrowSquareOut className="h-5 w-5 flex-shrink-0 text-brand-dark-green dark:text-brand-green group-hover:translate-x-0.5 transition-transform" />
+            </div>
+          </a>
+        </div>
+
+        {/* Closing note */}
+        <div className="pt-8 border-t border-brand-dark-green/10 dark:border-brand-green/20">
+          <p className="text-sm text-muted-foreground leading-relaxed">
+            This page is part of Divine's commitment to being honest about
+            what apps can and can't do for families. It's not legal
+            advice, clinical advice, or a substitute for talking to the people
+            in your home. If you have feedback or want to suggest a resource,
+            reach out through{" "}
+            <a
+              href="/support"
+              className="text-brand-dark-green dark:text-brand-green underline underline-offset-2 hover:opacity-80"
+            >
+              Divine support
+            </a>
+            .
+          </p>
+        </div>
+      </div>
+    </MarketingLayout>
+  );
+}
+
+export default FamilyPage;
+
+// ——————————————————————————————————————————————————————————————
+// Local presentation helpers — kept in-file so this page is easy to update.
+// ——————————————————————————————————————————————————————————————
+
+function BackToTopButton() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setVisible(window.scrollY > 600);
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  const goTop = () => {
+    const reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    window.scrollTo({ top: 0, behavior: reduced ? "auto" : "smooth" });
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={goTop}
+      aria-label="Back to top"
+      aria-hidden={!visible}
+      tabIndex={visible ? 0 : -1}
+      className={`fixed right-5 bottom-[calc(1.25rem+env(safe-area-inset-bottom))] z-40 h-12 w-12 rounded-full bg-brand-green text-brand-dark-green border-2 border-brand-dark-green brand-offset-shadow-sm-dark flex items-center justify-center transition-all duration-200 hover:-translate-x-[2px] hover:-translate-y-[2px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-dark-green focus-visible:ring-offset-2 ${
+        visible
+          ? "opacity-100 translate-y-0 pointer-events-auto"
+          : "opacity-0 translate-y-2 pointer-events-none"
+      }`}
+    >
+      <ArrowUp weight="bold" className="h-5 w-5" />
+    </button>
+  );
+}
+
+function Anchor({ id, children }: { id: string; children: React.ReactNode }) {
+  return (
+    <section id={id} className="scroll-mt-24">
+      {children}
+    </section>
+  );
+}
+
+function SectionHero({
+  eyebrow,
+  icon,
+  title,
+  lead,
+}: {
+  eyebrow: string;
+  icon: React.ReactNode;
+  title: string;
+  lead: string;
+}) {
+  return (
+    <div className="mb-8">
+      <div className="flex items-center gap-2 text-xs font-semibold tracking-wide text-brand-dark-green dark:text-brand-green mb-3">
+        {icon}
+        <span>{eyebrow}</span>
+      </div>
+      <SectionHeader as="h2" className="text-3xl md:text-4xl mb-4">
+        {title}
+      </SectionHeader>
+      <p className="text-lg leading-relaxed text-muted-foreground max-w-3xl">
+        {lead}
+      </p>
+    </div>
+  );
+}
+
+function FrameStep({
+  icon,
+  label,
+  body,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  body: string;
+}) {
+  return (
+    <div className="flex gap-4 items-start">
+      <div className="flex-shrink-0 w-11 h-11 rounded-full bg-brand-green text-brand-dark-green flex items-center justify-center">
+        {icon}
+      </div>
+      <div>
+        <h3 className="font-display font-extrabold tracking-tight text-xl text-brand-dark-green dark:text-brand-off-white mb-1">
+          {label}
+        </h3>
+        <p className="text-base text-foreground/80 leading-relaxed">{body}</p>
+      </div>
+    </div>
+  );
+}
+
+function SettingsRow({ title, body }: { title: string; body: string }) {
+  return (
+    <div>
+      <h3 className="font-display font-extrabold tracking-tight text-lg text-brand-dark-green dark:text-brand-off-white mb-1">
+        {title}
+      </h3>
+      <p className="text-base leading-relaxed text-foreground/80">{body}</p>
+    </div>
+  );
+}
+
+function PlanColumn({ title, items }: { title: string; items: string[] }) {
+  return (
+    <Card variant="brand">
+      <CardHeader>
+        <CardTitle className="text-xl">{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ul className="space-y-2 list-disc pl-5 marker:text-brand-green text-base leading-relaxed">
+          {items.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/pages/FamilyPage.tsx
+++ b/src/pages/FamilyPage.tsx
@@ -34,6 +34,7 @@ interface SectionAnchor {
 }
 
 const SECTIONS: SectionAnchor[] = [
+  { id: "framing", title: "A simple framing" },
   { id: "talking", title: "Talking with your teen" },
   { id: "limits", title: "What Divine can and can't do" },
   { id: "settings", title: "How content settings work" },
@@ -178,7 +179,7 @@ export function FamilyPage() {
           {/* Anchor nav */}
           <nav
             aria-label="On this page"
-            className="mt-10 grid gap-2 sm:grid-cols-2 lg:grid-cols-4 text-sm"
+            className="mt-10 grid gap-2 sm:grid-cols-3 text-sm"
           >
             {SECTIONS.map((s) => (
               <a
@@ -194,7 +195,7 @@ export function FamilyPage() {
       </section>
 
       {/* Pause • Reflect • Redirect framing band */}
-      <section className="bg-brand-light-green/30 dark:bg-brand-dark-green/40 border-y border-brand-dark-green/10 dark:border-brand-green/20">
+      <section id="framing" className="scroll-mt-24 bg-brand-light-green/30 dark:bg-brand-dark-green/40 border-y border-brand-dark-green/10 dark:border-brand-green/20">
         <div className="container mx-auto px-4 py-10 max-w-5xl">
           <p className="text-xs font-semibold tracking-wide text-brand-dark-green dark:text-brand-green mb-4">
             A simple framing

--- a/src/pages/FamilyPage.tsx
+++ b/src/pages/FamilyPage.tsx
@@ -505,7 +505,7 @@ export function FamilyPage() {
                 "Phones at the dinner table—yes or no, decided together.",
                 "Bedrooms overnight—where do devices charge?",
                 "Homework time—what counts as a focus block?",
-                "Long car rides, family events, hangouts—any shared norms?"
+                "Long car rides, family events, hangouts—any shared norms?",
                 "Public posts—what details stay out of videos, like school names, home addresses, daily routines, location clues, or other information that could identify where a child lives, studies, or spends time?",
               ]}
             />

--- a/src/pages/FamilyPage.tsx
+++ b/src/pages/FamilyPage.tsx
@@ -218,15 +218,14 @@ export function FamilyPage() {
             />
           </div>
           <p className="mt-5 text-xs leading-relaxed text-muted-foreground/80">
-            Grounded in peer-reviewed research on youth online safety —
-            Sweigart, Valliani, and Wisniewski,{" "}
+            This framing is drawn from{" "}
             <a
               href="https://doi.org/10.3390/socsci14050302"
               className="underline underline-offset-2 hover:text-brand-dark-green dark:hover:text-brand-green"
             >
-              “Pause, reflect, and redirect”
+              peer-reviewed research on youth online safety
             </a>
-            {" "}(<em>Social Sciences</em> 14:5).
+            .
           </p>
         </div>
       </section>

--- a/src/pages/FamilyPage.tsx
+++ b/src/pages/FamilyPage.tsx
@@ -1,7 +1,6 @@
 // ABOUTME: Family resource hub for parents, guardians, and teens at /family
 // ABOUTME: Conversation-first guidance, honest app limits, and trusted outside resources
 
-import { useEffect, useState } from "react";
 import {
   ChatsCircle,
   Pause,
@@ -20,11 +19,15 @@ import {
   Heart,
   Lightbulb,
   Flag,
-  ArrowUp,
 } from "@phosphor-icons/react";
 
 import { MarketingLayout } from "@/components/MarketingLayout";
-import { SectionHeader } from "@/components/brand/SectionHeader";
+import {
+  Anchor,
+  BackToTopButton,
+  SectionHero,
+  staticPageLinkCardClass,
+} from "@/components/static-pages";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ZendeskWidget } from "@/components/ZendeskWidget";
 
@@ -159,10 +162,7 @@ export function FamilyPage() {
             <HouseLine weight="fill" className="h-4 w-4" />
             <span>For families on Divine</span>
           </div>
-          <h1
-            className="font-display font-extrabold tracking-tight text-4xl md:text-6xl leading-[1.05] text-brand-off-white mb-6"
-            style={{ fontFamily: "'Bricolage Grotesque', system-ui, sans-serif" }}
-          >
+          <h1 className="font-display font-extrabold tracking-tight text-4xl md:text-6xl leading-[1.05] text-brand-off-white mb-6">
             Safer social media use starts with conversation.
           </h1>
           <p className="text-lg md:text-xl text-brand-light-green max-w-3xl leading-relaxed">
@@ -800,7 +800,7 @@ export function FamilyPage() {
                       href={r.url}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="group block brand-card brand-offset-shadow-green p-6 hover:-translate-x-[2px] hover:-translate-y-[2px] hover:[box-shadow:8px_8px_0_0_hsl(var(--brand-green))] transition-all"
+                      className={staticPageLinkCardClass("green")}
                     >
                       <div className="flex items-start justify-between gap-3">
                         <h4 className="font-display font-extrabold tracking-tight text-lg text-brand-dark-green dark:text-brand-off-white">
@@ -828,7 +828,7 @@ export function FamilyPage() {
           </div>
           <a
             href="/kids"
-            className="group block brand-card brand-offset-shadow-violet p-6 hover:-translate-x-[2px] hover:-translate-y-[2px] hover:[box-shadow:8px_8px_0_0_hsl(var(--brand-violet))] transition-all"
+            className={staticPageLinkCardClass("violet")}
           >
             <div className="flex items-start justify-between gap-3">
               <div>
@@ -873,78 +873,6 @@ export function FamilyPage() {
 }
 
 export default FamilyPage;
-
-// ——————————————————————————————————————————————————————————————
-// Local presentation helpers—kept in-file so this page is easy to update.
-// ——————————————————————————————————————————————————————————————
-
-function BackToTopButton() {
-  const [visible, setVisible] = useState(false);
-
-  useEffect(() => {
-    const onScroll = () => setVisible(window.scrollY > 600);
-    onScroll();
-    window.addEventListener("scroll", onScroll, { passive: true });
-    return () => window.removeEventListener("scroll", onScroll);
-  }, []);
-
-  const goTop = () => {
-    const reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-    window.scrollTo({ top: 0, behavior: reduced ? "auto" : "smooth" });
-  };
-
-  return (
-    <button
-      type="button"
-      onClick={goTop}
-      aria-label="Back to top"
-      aria-hidden={!visible}
-      tabIndex={visible ? 0 : -1}
-      className={`fixed right-5 bottom-[calc(1.25rem+env(safe-area-inset-bottom))] z-40 h-12 w-12 rounded-full bg-brand-green text-brand-dark-green border-2 border-brand-dark-green brand-offset-shadow-sm-dark flex items-center justify-center transition-all duration-200 hover:-translate-x-[2px] hover:-translate-y-[2px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-dark-green focus-visible:ring-offset-2 ${
-        visible
-          ? "opacity-100 translate-y-0 pointer-events-auto"
-          : "opacity-0 translate-y-2 pointer-events-none"
-      }`}
-    >
-      <ArrowUp weight="bold" className="h-5 w-5" />
-    </button>
-  );
-}
-
-function Anchor({ id, children }: { id: string; children: React.ReactNode }) {
-  return (
-    <section id={id} className="scroll-mt-24">
-      {children}
-    </section>
-  );
-}
-
-function SectionHero({
-  eyebrow,
-  icon,
-  title,
-  lead,
-}: {
-  eyebrow: string;
-  icon: React.ReactNode;
-  title: string;
-  lead: string;
-}) {
-  return (
-    <div className="mb-8">
-      <div className="flex items-center gap-2 text-xs font-semibold tracking-wide text-brand-dark-green dark:text-brand-green mb-3">
-        {icon}
-        <span>{eyebrow}</span>
-      </div>
-      <SectionHeader as="h2" className="text-3xl md:text-4xl mb-4">
-        {title}
-      </SectionHeader>
-      <p className="text-lg leading-relaxed text-muted-foreground max-w-3xl">
-        {lead}
-      </p>
-    </div>
-  );
-}
 
 function FrameStep({
   icon,

--- a/src/pages/FamilyPage.tsx
+++ b/src/pages/FamilyPage.tsx
@@ -36,12 +36,12 @@ interface SectionAnchor {
 const SECTIONS: SectionAnchor[] = [
   { id: "framing", title: "A simple framing" },
   { id: "talking", title: "Talking with your teen" },
-  { id: "limits", title: "What Divine can and can't do" },
-  { id: "settings", title: "How content settings work" },
-  { id: "habits", title: "Feed habits and stopping points" },
-  { id: "plan", title: "Build a family media plan" },
-  { id: "upset", title: "If your child saw something upsetting" },
-  { id: "stir", title: "Rabble + Pam Wisniewski / STIR" },
+  { id: "limits", title: "Divine’s role" },
+  { id: "settings", title: "Understanding content settings" },
+  { id: "habits", title: "Building healthier feed habits" },
+  { id: "plan", title: "Creating a family media plan" },
+  { id: "upset", title: "When something goes wrong" },
+  { id: "stir", title: "Hear from the experts" },
   { id: "resources", title: "Outside resources" },
 ];
 
@@ -224,7 +224,7 @@ export function FamilyPage() {
         {/* 2. Talking with your teen */}
         <Anchor id="talking">
           <SectionHero
-            eyebrow="Conversation over punishment"
+            ="Talking with your teen"
             icon={<ChatsCircle weight="fill" className="h-7 w-7" />}
             title="How to talk with your teen about social media"
             lead="The goal isn't to win the conversation. It's to keep having one. Teens who feel heard stay open. Teens who feel surveilled go quiet."
@@ -297,7 +297,7 @@ export function FamilyPage() {
         {/* 3. What Divine can / can't do */}
         <Anchor id="limits">
           <SectionHero
-            eyebrow="Honest app limits"
+            ="Divine’s role"
             icon={<ShieldCheck weight="fill" className="h-7 w-7" />}
             title="What Divine can and can't do"
             lead="We'd rather be useful than impressive. Here's the real picture of what the app side can help with—and where conversation, supervision, and human judgment still have to do the work."
@@ -393,7 +393,7 @@ export function FamilyPage() {
         {/* 4. How content settings work */}
         <Anchor id="settings">
           <SectionHero
-            eyebrow="Practical setup"
+            ="Understanding content settings"
             icon={<ListChecks weight="fill" className="h-7 w-7" />}
             title="How content settings work on Divine"
             lead="Settings are a useful layer. They are not a guarantee. The most important step is for the adult in the household to actually open them, read them, and adjust them together with the teen who'll use the account. For accounts used by teens, start with the most protective settings that still let the account work for your family, then loosen settings only after you have (a) talked through why the change makes sense, and (b) made the decision, as parents, to make that change."
@@ -433,7 +433,7 @@ export function FamilyPage() {
         {/* 5. Feed habits */}
         <Anchor id="habits">
           <SectionHero
-            eyebrow="Healthier habits, not just restrictions"
+            ="Building healthier feed habits"
             icon={<Path weight="fill" className="h-7 w-7" />}
             title="Feed habits and healthy stopping points"
             lead="Most short-form feeds are designed to keep going. The healthier skill isn't blocking the feed—it's noticing when you've had enough and choosing to stop. That's a skill adults are still learning too."
@@ -492,9 +492,9 @@ export function FamilyPage() {
         {/* 6. Family media plan */}
         <Anchor id="plan">
           <SectionHero
-            eyebrow="Make it together"
+            ="Creating a family media plan"
             icon={<UsersThree weight="fill" className="h-7 w-7" />}
-            title="Build a family media plan"
+            title="Building a plan for how your family uses media—including Divine"
             lead="A plan that everyone helped write is a plan that everyone is more likely to follow. Plans are also living documents—expect to revisit them every few months as kids get older and apps change."
           />
 
@@ -552,7 +552,7 @@ export function FamilyPage() {
         {/* 7. What to do if upset */}
         <Anchor id="upset">
           <SectionHero
-            eyebrow="When something goes wrong"
+            ="When something goes wrong"
             icon={<Lifebuoy weight="fill" className="h-7 w-7" />}
             title="What to do if your child saw something upsetting"
             lead="Most kids will see something they wish they hadn't at some point—on any app. What helps most isn't a perfect filter. It's a parent who reacts in a way that makes the next conversation possible."
@@ -639,7 +639,7 @@ export function FamilyPage() {
         {/* 8. Rabble + STIR */}
         <Anchor id="stir">
           <SectionHero
-            eyebrow="Why this approach"
+            eyebrow="Hear from the experts"
             icon={<Microphone weight="fill" className="h-7 w-7" />}
             title="Rabble + Pam Wisniewski / STIR"
             lead="The framing on this page—conversation over punishment, co-navigation over surveillance, pause and redirect over hard control—comes out of years of research from teams like the Socio-Technical Interaction Research (STIR) Lab."
@@ -742,9 +742,9 @@ export function FamilyPage() {
         {/* 9. Outside resources */}
         <Anchor id="resources">
           <SectionHero
-            eyebrow="Don't just take our word for it"
+            eyebrow="Outside resources"
             icon={<BookOpenText weight="fill" className="h-7 w-7" />}
-            title="Outside resources"
+            title="But you don't have to take our word for it"
             lead="These are some resources we recommend. Inclusion here doesn't imply endorsement of every recommendation from these organizations. Read them with the same critical eye you'd bring to any single source—including this one. A few are global; most are from North American or UK sources."
           />
 

--- a/src/pages/FamilyPage.tsx
+++ b/src/pages/FamilyPage.tsx
@@ -41,7 +41,7 @@ const SECTIONS: SectionAnchor[] = [
   { id: "habits", title: "Building healthier feed habits" },
   { id: "plan", title: "Creating a family media plan" },
   { id: "upset", title: "When something goes wrong" },
-  { id: "stir", title: "Hear from the experts" },
+  { id: "stir", title: "Hear from experts" },
   { id: "resources", title: "Outside resources" },
 ];
 
@@ -639,7 +639,7 @@ export function FamilyPage() {
         {/* 8. Rabble + STIR */}
         <Anchor id="stir">
           <SectionHero
-            eyebrow="Hear from the experts"
+            eyebrow="Hear from experts"
             icon={<Microphone weight="fill" className="h-7 w-7" />}
             title="Rabble + Pam Wisniewski / STIR"
             lead="The framing on this page—conversation over punishment, co-navigation over surveillance, pause and redirect over hard control—comes out of years of research from teams like the Socio-Technical Interaction Research (STIR) Lab."

--- a/src/pages/FamilyPage.tsx
+++ b/src/pages/FamilyPage.tsx
@@ -172,8 +172,37 @@ export function FamilyPage() {
           </p>
           <p className="text-base md:text-lg text-brand-off-white/80 max-w-3xl leading-relaxed mt-4">
             This page is a starting point for parents, guardians, and
-            teens—not a contract, not a control panel, and not a replacement for Divine's Terms, Privacy Policy, Safety Standards, Kids Policy, or reporting tools. It's the stuff we wish
-            more apps said out loud.
+            teens—not a contract, not a control panel, and not a replacement
+            for Divine's{" "}
+            <a
+              href="/terms"
+              className="text-brand-green underline underline-offset-2 hover:text-brand-light-green"
+            >
+              Terms
+            </a>
+            ,{" "}
+            <a
+              href="/privacy"
+              className="text-brand-green underline underline-offset-2 hover:text-brand-light-green"
+            >
+              Privacy Policy
+            </a>
+            ,{" "}
+            <a
+              href="/safety"
+              className="text-brand-green underline underline-offset-2 hover:text-brand-light-green"
+            >
+              Safety Standards
+            </a>
+            ,{" "}
+            <a
+              href="/kids"
+              className="text-brand-green underline underline-offset-2 hover:text-brand-light-green"
+            >
+              Kids Policy
+            </a>
+            , or reporting tools. It's the stuff we wish more apps said out
+            loud.
           </p>
 
           {/* Anchor nav */}

--- a/src/pages/FamilyPage.tsx
+++ b/src/pages/FamilyPage.tsx
@@ -217,18 +217,16 @@ export function FamilyPage() {
               body="Pick the next step together—a setting to try, a person to mute, a break to take, a thing to do off the app."
             />
           </div>
-          <p className="mt-5 text-sm leading-relaxed text-muted-foreground">
-            Source for this framing: E. A. Sweigart, A. Valliani, and P. J.
-            Wisniewski, “Pause, reflect, and redirect: An approach to
-            empowering youth to be safer online by helping them make better
-            decisions,” <em>Social Sciences</em>, vol. 14, no. 5.{" "}
+          <p className="mt-5 text-xs leading-relaxed text-muted-foreground/80">
+            Grounded in peer-reviewed research on youth online safety —
+            Sweigart, Valliani, and Wisniewski,{" "}
             <a
               href="https://doi.org/10.3390/socsci14050302"
-              className="text-brand-dark-green dark:text-brand-green underline underline-offset-2 hover:opacity-80"
+              className="underline underline-offset-2 hover:text-brand-dark-green dark:hover:text-brand-green"
             >
-              doi:10.3390/socsci14050302
+              “Pause, reflect, and redirect”
             </a>
-            .
+            {" "}(<em>Social Sciences</em> 14:5).
           </p>
         </div>
       </section>

--- a/src/pages/FamilyPage.tsx
+++ b/src/pages/FamilyPage.tsx
@@ -24,17 +24,14 @@ import {
 import { MarketingLayout } from "@/components/MarketingLayout";
 import {
   Anchor,
+  AnchorNav,
   BackToTopButton,
   SectionHero,
   staticPageLinkCardClass,
+  type SectionAnchor,
 } from "@/components/static-pages";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ZendeskWidget } from "@/components/ZendeskWidget";
-
-interface SectionAnchor {
-  id: string;
-  title: string;
-}
 
 const SECTIONS: SectionAnchor[] = [
   { id: "framing", title: "A simple framing" },
@@ -205,21 +202,7 @@ export function FamilyPage() {
             loud.
           </p>
 
-          {/* Anchor nav */}
-          <nav
-            aria-label="On this page"
-            className="mt-10 grid gap-2 sm:grid-cols-3 text-sm"
-          >
-            {SECTIONS.map((s) => (
-              <a
-                key={s.id}
-                href={`#${s.id}`}
-                className="rounded-xl border border-brand-green/40 bg-brand-dark-green/40 px-4 py-3 text-brand-light-green hover:bg-brand-green/10 hover:border-brand-green transition-colors"
-              >
-                {s.title}
-              </a>
-            ))}
-          </nav>
+          <AnchorNav sections={SECTIONS} />
         </div>
       </section>
 
@@ -372,7 +355,7 @@ export function FamilyPage() {
                     A support path for families and a published{" "}
                     <a
                       href="/safety"
-                      className="text-brand-green underline underline-offset-2 hover:text-brand-dark-green dark:hover:text-brand-light-green"
+                      className="text-brand-dark-green dark:text-brand-green underline underline-offset-2 hover:opacity-80"
                     >
                       safety standards
                     </a>{" "}

--- a/src/pages/FamilyPage.tsx
+++ b/src/pages/FamilyPage.tsx
@@ -224,7 +224,7 @@ export function FamilyPage() {
         {/* 2. Talking with your teen */}
         <Anchor id="talking">
           <SectionHero
-            ="Talking with your teen"
+            eyebrow="Talking with your teen"
             icon={<ChatsCircle weight="fill" className="h-7 w-7" />}
             title="How to talk with your teen about social media"
             lead="The goal isn't to win the conversation. It's to keep having one. Teens who feel heard stay open. Teens who feel surveilled go quiet."
@@ -297,7 +297,7 @@ export function FamilyPage() {
         {/* 3. What Divine can / can't do */}
         <Anchor id="limits">
           <SectionHero
-            ="Divine’s role"
+            eyebrow="Divine’s role"
             icon={<ShieldCheck weight="fill" className="h-7 w-7" />}
             title="What Divine can and can't do"
             lead="We'd rather be useful than impressive. Here's the real picture of what the app side can help with—and where conversation, supervision, and human judgment still have to do the work."
@@ -393,7 +393,7 @@ export function FamilyPage() {
         {/* 4. How content settings work */}
         <Anchor id="settings">
           <SectionHero
-            ="Understanding content settings"
+            eyebrow="Understanding content settings"
             icon={<ListChecks weight="fill" className="h-7 w-7" />}
             title="How content settings work on Divine"
             lead="Settings are a useful layer. They are not a guarantee. The most important step is for the adult in the household to actually open them, read them, and adjust them together with the teen who'll use the account. For accounts used by teens, start with the most protective settings that still let the account work for your family, then loosen settings only after you have (a) talked through why the change makes sense, and (b) made the decision, as parents, to make that change."
@@ -433,7 +433,7 @@ export function FamilyPage() {
         {/* 5. Feed habits */}
         <Anchor id="habits">
           <SectionHero
-            ="Building healthier feed habits"
+            eyebrow="Building healthier feed habits"
             icon={<Path weight="fill" className="h-7 w-7" />}
             title="Feed habits and healthy stopping points"
             lead="Most short-form feeds are designed to keep going. The healthier skill isn't blocking the feed—it's noticing when you've had enough and choosing to stop. That's a skill adults are still learning too."
@@ -492,7 +492,7 @@ export function FamilyPage() {
         {/* 6. Family media plan */}
         <Anchor id="plan">
           <SectionHero
-            ="Creating a family media plan"
+            eyebrow="Creating a family media plan"
             icon={<UsersThree weight="fill" className="h-7 w-7" />}
             title="Building a plan for how your family uses media—including Divine"
             lead="A plan that everyone helped write is a plan that everyone is more likely to follow. Plans are also living documents—expect to revisit them every few months as kids get older and apps change."
@@ -552,7 +552,7 @@ export function FamilyPage() {
         {/* 7. What to do if upset */}
         <Anchor id="upset">
           <SectionHero
-            ="When something goes wrong"
+            eyebrow="When something goes wrong"
             icon={<Lifebuoy weight="fill" className="h-7 w-7" />}
             title="What to do if your child saw something upsetting"
             lead="Most kids will see something they wish they hadn't at some point—on any app. What helps most isn't a perfect filter. It's a parent who reacts in a way that makes the next conversation possible."

--- a/src/pages/FamilyPage.tsx
+++ b/src/pages/FamilyPage.tsx
@@ -396,7 +396,7 @@ export function FamilyPage() {
             eyebrow="Practical setup"
             icon={<ListChecks weight="fill" className="h-7 w-7" />}
             title="How content settings work on Divine"
-            lead="Settings are a useful layer. They are not a guarantee. The most important step is for the adult in the household to actually open them, read them, and adjust them together with the teen who'll use the account."
+            lead="Settings are a useful layer. They are not a guarantee. The most important step is for the adult in the household to actually open them, read them, and adjust them together with the teen who'll use the account. For accounts used by teens, start with the most protective settings that still let the account work for your family, then loosen settings only after you have (a) talked through why the change makes sense, and (b) made the decision, as parents, to make that change."
           />
 
           <Card variant="brand" accent="violet">
@@ -505,14 +505,15 @@ export function FamilyPage() {
                 "Phones at the dinner table—yes or no, decided together.",
                 "Bedrooms overnight—where do devices charge?",
                 "Homework time—what counts as a focus block?",
-                "Long car rides, family events, hangouts—any shared norms?",
+                "Long car rides, family events, hangouts—any shared norms?"
+                "Public posts—what details stay out of videos, like school names, home addresses, daily routines, location clues, or other information that could identify where a child lives, studies, or spends time?",
               ]}
             />
             <PlanColumn
               title="What we do when things get hard"
               items={[
                 "If something upsetting comes up, we talk before we punish.",
-                "We use the report and mute tools instead of arguing in comments.",
+                "We use the report and mute tools instead of arguing in comments. We don't pile on, quote-post to shame someone, or send other people after an account.",
                 "If a creator or trend stops feeling good, we mute or move on.",
                 "Adults follow the same rules they ask teens to follow.",
               ]}
@@ -601,7 +602,7 @@ export function FamilyPage() {
                 <p>
                   Report the content or account in the app. Mute or block the
                   source. Walk through the steps together so your teen knows
-                  how to do it next time without you.
+                  how to do it next time without you. For serious reports, write down the username, approximate time, and what happened, but don't repost, forward, or save harmful content just to document it.
                 </p>
               </CardContent>
             </Card>
@@ -617,7 +618,7 @@ export function FamilyPage() {
                 <p>
                   If something looks illegal, involves a minor, or feels like
                   it's escalating offline, contact Divine support and, when
-                  appropriate, local authorities. Trust your gut on this one.
+                  appropriate, local authorities. Do not download, save, repost, forward, or share suspected child sexual abuse material (CSAM). Use the in-app report flow or Divine support so Divine can review and, where required, report apparent child sexual exploitation to the appropriate reporting channel or authority. Trust your gut on this one.
                 </p>
                 <p className="text-sm text-muted-foreground">
                   For serious or time-sensitive reports, use the report flow
@@ -628,7 +629,7 @@ export function FamilyPage() {
                   >
                     Divine support
                   </a>
-                  .
+                  , and call local emergency services if someone is in immediate danger.
                 </p>
               </CardContent>
             </Card>

--- a/src/pages/FamilyPage.tsx
+++ b/src/pages/FamilyPage.tsx
@@ -217,6 +217,19 @@ export function FamilyPage() {
               body="Pick the next step together—a setting to try, a person to mute, a break to take, a thing to do off the app."
             />
           </div>
+          <p className="mt-5 text-sm leading-relaxed text-muted-foreground">
+            Source for this framing: E. A. Sweigart, A. Valliani, and P. J.
+            Wisniewski, “Pause, reflect, and redirect: An approach to
+            empowering youth to be safer online by helping them make better
+            decisions,” <em>Social Sciences</em>, vol. 14, no. 5.{" "}
+            <a
+              href="https://doi.org/10.3390/socsci14050302"
+              className="text-brand-dark-green dark:text-brand-green underline underline-offset-2 hover:opacity-80"
+            >
+              doi:10.3390/socsci14050302
+            </a>
+            .
+          </p>
         </div>
       </section>
 

--- a/src/pages/FamilyPage.tsx
+++ b/src/pages/FamilyPage.tsx
@@ -172,7 +172,7 @@ export function FamilyPage() {
           </p>
           <p className="text-base md:text-lg text-brand-off-white/80 max-w-3xl leading-relaxed mt-4">
             This page is a starting point for parents, guardians, and
-            teens—not a contract, not a control panel. It's the stuff we wish
+            teens—not a contract, not a control panel, and not a replacement for Divine's Terms, Privacy Policy, Safety Standards, Kids Policy, or reporting tools. It's the stuff we wish
             more apps said out loud.
           </p>
 
@@ -628,7 +628,7 @@ export function FamilyPage() {
                 <p>
                   If something looks illegal, involves a minor, or feels like
                   it's escalating offline, contact Divine support and, when
-                  appropriate, local authorities. Do not download, save, repost, forward, or share suspected child sexual abuse material (CSAM). Use the in-app report flow or Divine support so Divine can review and, where required, report apparent child sexual exploitation to the appropriate reporting channel or authority. Trust your gut on this one.
+                  appropriate, local authorities. Do <b>not</b> download, save, repost, forward, or share suspected child sexual abuse material (CSAM). Use the in-app report flow or Divine support so Divine can review and, where required, report apparent child sexual exploitation to the appropriate reporting channel or authority. Trust your gut on this one.
                 </p>
                 <p className="text-sm text-muted-foreground">
                   For serious or time-sensitive reports, use the report flow

--- a/src/pages/FamilyPage.tsx
+++ b/src/pages/FamilyPage.tsx
@@ -494,7 +494,7 @@ export function FamilyPage() {
           <SectionHero
             eyebrow="Creating a family media plan"
             icon={<UsersThree weight="fill" className="h-7 w-7" />}
-            title="Building a plan for how your family uses media—including Divine"
+            title="Building a plan for how your family uses media—not just Divine"
             lead="A plan that everyone helped write is a plan that everyone is more likely to follow. Plans are also living documents—expect to revisit them every few months as kids get older and apps change."
           />
 

--- a/src/pages/KidsPolicyPage.tsx
+++ b/src/pages/KidsPolicyPage.tsx
@@ -1,0 +1,567 @@
+// ABOUTME: Policy page at /kids explaining how Divine handles accounts for under-16s
+// ABOUTME: Long-form FAQ-style page — paired with the deadline-shaped action page at /age-review
+
+import { useEffect, useState } from "react";
+import {
+  Info,
+  UsersThree,
+  VideoCamera,
+  ShieldCheck,
+  ChatsCircle,
+  HouseLine,
+  EnvelopeSimple,
+  ArrowSquareOut,
+  ArrowUp,
+} from "@phosphor-icons/react";
+
+import { MarketingLayout } from "@/components/MarketingLayout";
+import { SectionHeader } from "@/components/brand/SectionHeader";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+const SUPPORT_EMAIL = "support@divine.video";
+
+interface SectionAnchor {
+  id: string;
+  title: string;
+}
+
+const SECTIONS: SectionAnchor[] = [
+  { id: "tiers", title: "At a glance" },
+  { id: "why", title: "Why we work this way" },
+  { id: "under-13", title: "Under-13 accounts" },
+  { id: "13-15", title: "13 to 15 accounts" },
+  { id: "family-account", title: "Families on Divine" },
+  { id: "family-guidance", title: "More family guidance" },
+];
+
+function mailtoLink(subject: string, body?: string): string {
+  const params = new URLSearchParams();
+  params.set("subject", subject);
+  if (body) params.set("body", body);
+  return `mailto:${SUPPORT_EMAIL}?${params.toString().replace(/\+/g, "%20")}`;
+}
+
+export function KidsPolicyPage() {
+  return (
+    <MarketingLayout>
+      <BackToTopButton />
+
+      {/* Hero */}
+      <section className="bg-brand-dark-green text-brand-off-white">
+        <div className="container mx-auto px-4 py-16 md:py-24 max-w-5xl">
+          <div className="flex items-center gap-2 text-xs font-semibold tracking-wide text-brand-green mb-6">
+            <UsersThree weight="fill" className="h-4 w-4" />
+            <span>Kids on Divine</span>
+          </div>
+          <h1
+            className="font-display font-extrabold tracking-tight text-4xl md:text-6xl leading-[1.05] text-brand-off-white mb-6"
+            style={{ fontFamily: "'Bricolage Grotesque', system-ui, sans-serif" }}
+          >
+            How accounts work for kids on Divine
+          </h1>
+          <p className="text-lg md:text-xl text-brand-light-green max-w-3xl leading-relaxed">
+            Here's how Divine handles accounts for people under 16 — the
+            rules, the reasoning, and what families can do together
+            regardless of age.
+          </p>
+          <p className="text-base md:text-lg text-brand-off-white/80 max-w-3xl leading-relaxed mt-4">
+            This is the policy page, not a moderation page. If your account
+            was just flagged and you have steps to take within a deadline,
+            the action page is at{" "}
+            <a
+              href="/age-review"
+              className="underline underline-offset-2 text-brand-light-green hover:text-brand-off-white"
+            >
+              divine.video/age-review
+            </a>
+            .
+          </p>
+
+          {/* Anchor nav */}
+          <nav
+            aria-label="On this page"
+            className="mt-10 grid gap-2 sm:grid-cols-2 lg:grid-cols-3 text-sm"
+          >
+            {SECTIONS.map((s) => (
+              <a
+                key={s.id}
+                href={`#${s.id}`}
+                className="rounded-xl border border-brand-green/40 bg-brand-dark-green/40 px-4 py-3 text-brand-light-green hover:bg-brand-green/10 hover:border-brand-green transition-colors"
+              >
+                {s.title}
+              </a>
+            ))}
+          </nav>
+        </div>
+      </section>
+
+      <div className="container mx-auto px-4 py-14 md:py-16 max-w-4xl space-y-16">
+        {/* 1. At a glance — three tier cards */}
+        <Anchor id="tiers">
+          <SectionHero
+            eyebrow="At a glance"
+            icon={<Info weight="fill" className="h-7 w-7" />}
+            title="Three age tiers, three different paths"
+            lead="Divine handles accounts differently depending on who's holding them. The short version:"
+          />
+
+          <div className="grid gap-6 md:grid-cols-3">
+            <Card variant="brand" accent="violet">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-xl">
+                  <UsersThree weight="fill" className="h-5 w-5 text-brand-violet" />
+                  Under 13
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2 text-base leading-relaxed">
+                <p>
+                  No solo accounts for kids under 13.
+                </p>
+                <p className="text-muted-foreground text-sm">
+                  A parent or guardian can hold the account and do all the
+                  posting; kids of any age can appear in videos with them.
+                  If Divine learns of a solo under-13 account, it's closed
+                  and the data is deleted.
+                </p>
+              </CardContent>
+            </Card>
+
+            <Card variant="brand" accent="green">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-xl">
+                  <VideoCamera weight="fill" className="h-5 w-5 text-brand-green" />
+                  13 to 15
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2 text-base leading-relaxed">
+                <p>
+                  Teen-held accounts are allowed, with a short video from a
+                  parent or guardian.
+                </p>
+                <p className="text-muted-foreground text-sm">
+                  The video confirms the teen's age, that they have
+                  permission, and that the parent or guardian knows about
+                  the account and will supervise its use.
+                </p>
+              </CardContent>
+            </Card>
+
+            <Card variant="brand" accent="blue">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-xl">
+                  <ShieldCheck weight="fill" className="h-5 w-5 text-brand-blue" />
+                  16 or older
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2 text-base leading-relaxed">
+                <p>
+                  Standard adult account. No parent step.
+                </p>
+                <p className="text-muted-foreground text-sm">
+                  Same path as anyone else on Divine. The rest of this page
+                  is mostly relevant if a 16+ account is flagged in error —
+                  the mistake-flag path lives on the action page.
+                </p>
+              </CardContent>
+            </Card>
+          </div>
+        </Anchor>
+
+        {/* 2. Why we work this way */}
+        <Anchor id="why">
+          <SectionHero
+            eyebrow="Honest framing"
+            icon={<Info weight="fill" className="h-7 w-7" />}
+            title="Why we work this way"
+            lead="The age rules Divine follows weren't all our idea. Some of them are operational choices about what kind of app we want to be."
+          />
+
+          <Card variant="brand">
+            <CardContent className="pt-6 space-y-3 text-base leading-relaxed">
+              <p>
+                The rules for online services for children under 13 require
+                apps to verify parents through credit-card checks,
+                government-ID uploads, and similar intrusive steps. Those
+                rules were written with little grasp of how the open
+                internet actually works. In practice they push every
+                app toward collecting <em>more</em> personal data, not
+                less, and they're realistically only operable by the
+                biggest tech companies.
+              </p>
+              <p>
+                Divine isn't going to build that machinery. We'd rather
+                close an account cleanly than ask a parent to hand a credit
+                card and a government ID to a video app to prove who they
+                are.
+              </p>
+              <p>
+                The 13-to-15 path is a different shape: a short private
+                video with a parent or guardian on camera. It's a real
+                human check, but it doesn't require Divine to operate an
+                ID-and-payment verification pipeline, and it doesn't
+                require the family to hand over more data than the video
+                itself. Imperfect, but more honest than the alternative.
+              </p>
+            </CardContent>
+          </Card>
+        </Anchor>
+
+        {/* 3. Under-13 accounts */}
+        <Anchor id="under-13">
+          <SectionHero
+            eyebrow="The under-13 policy"
+            icon={<UsersThree weight="fill" className="h-7 w-7" />}
+            title="Under-13 accounts close and the data is deleted"
+            lead="Divine isn't built for people under 13. When Divine learns an account is held by someone under 13, the team closes the account and promptly deletes everything tied to it from Divine's infrastructure — even when a parent or guardian is okay with the account staying open. The account doesn't come back."
+          />
+
+          {/* Parent-discovery action card */}
+          <Card variant="brand" accent="green">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-xl">
+                <ChatsCircle weight="fill" className="h-5 w-5 text-brand-green" />
+                If you've discovered an under-13 account
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4 text-base leading-relaxed">
+              <p>
+                This is for a parent or guardian who has found out a child
+                in their care is using a Divine account. Email support and
+                the team will close the account and remove the data.
+              </p>
+              <ol className="space-y-3 list-none pl-0">
+                <li className="flex items-start gap-3">
+                  <span
+                    className="flex-shrink-0 font-extrabold text-brand-dark-green dark:text-brand-green w-6 leading-7 tabular-nums"
+                    aria-hidden="true"
+                  >
+                    1.
+                  </span>
+                  <span>
+                    Email Divine support at{" "}
+                    <a
+                      href={`mailto:${SUPPORT_EMAIL}`}
+                      className="text-brand-dark-green dark:text-brand-green underline underline-offset-2 hover:opacity-80 break-all"
+                    >
+                      {SUPPORT_EMAIL}
+                    </a>
+                    .
+                  </span>
+                </li>
+                <li className="flex items-start gap-3">
+                  <span
+                    className="flex-shrink-0 font-extrabold text-brand-dark-green dark:text-brand-green w-6 leading-7 tabular-nums"
+                    aria-hidden="true"
+                  >
+                    2.
+                  </span>
+                  <span>
+                    Say you've discovered a Divine account belonging to a
+                    child in your care who is under 13.
+                  </span>
+                </li>
+                <li className="flex items-start gap-3">
+                  <span
+                    className="flex-shrink-0 font-extrabold text-brand-dark-green dark:text-brand-green w-6 leading-7 tabular-nums"
+                    aria-hidden="true"
+                  >
+                    3.
+                  </span>
+                  <span>
+                    Include the account's username or a link to its
+                    profile, if you have it handy.
+                  </span>
+                </li>
+              </ol>
+
+              <p className="text-muted-foreground">
+                The team will review what you send, close the account,
+                promptly delete everything tied to it from Divine's
+                infrastructure, and reply confirming what was done. There's
+                no form to fill out — the email is enough.
+              </p>
+
+              <div className="pt-2">
+                <SupportEmailButton
+                  href={mailtoLink(
+                    "Account review — under 13",
+                    "Hi Divine support,\n\nI'm a parent or guardian. I've discovered a Divine account belonging to a child in my care who is under 13.\n\nAccount username or link:\n\nAnything else that might help:\n\nThanks,",
+                  )}
+                  label={`Email ${SUPPORT_EMAIL}`}
+                />
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Nostr-relay caveat */}
+          <Card variant="brand" className="mt-6">
+            <CardContent className="pt-6 space-y-3 text-base leading-relaxed">
+              <div className="flex items-center gap-2 text-sm font-semibold text-brand-dark-green dark:text-brand-green">
+                <Info weight="fill" className="h-4 w-4" />
+                <span>An honest note about copies on other relays</span>
+              </div>
+              <p>
+                Any videos already posted from the account may have been
+                copied to other Nostr relays that Divine doesn't operate.
+                When Divine deletes an account's content, it issues a
+                deletion request across the network, but we can't
+                guarantee every copy disappears. Deletion is only complete
+                on Divine itself.
+              </p>
+            </CardContent>
+          </Card>
+
+          <p className="mt-6 text-sm text-muted-foreground leading-relaxed">
+            When they're 13 or older, the same person can create a new
+            account from scratch. The closed account itself doesn't
+            return.
+          </p>
+        </Anchor>
+
+        {/* 4. 13-15 accounts */}
+        <Anchor id="13-15">
+          <SectionHero
+            eyebrow="The 13-to-15 policy"
+            icon={<VideoCamera weight="fill" className="h-7 w-7" />}
+            title="Teen-held accounts need a parent or guardian video"
+            lead="Teens 13 to 15 can use Divine with a parent or guardian who's aware and involved. The video is how Divine knows that consent and supervision are real, without running an intrusive verification system."
+          />
+
+          <Card variant="brand" accent="green">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-xl">
+                <VideoCamera weight="fill" className="h-5 w-5 text-brand-green" />
+                What the video should show
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3 text-base leading-relaxed">
+              <ul className="space-y-2 list-disc pl-5 marker:text-brand-green">
+                <li>The teen, on camera.</li>
+                <li>A parent or guardian, also on camera, speaking.</li>
+                <li>A clear statement that the teen is between 13 and 15.</li>
+                <li>
+                  A clear statement that the teen has permission to use
+                  Divine.
+                </li>
+                <li>
+                  A clear statement that the parent or guardian knows about
+                  the account and will supervise its use.
+                </li>
+              </ul>
+              <p className="text-sm text-muted-foreground pt-1">
+                Phone-camera quality is fine. There's no script — natural
+                is better. Keep it short. The video is handled by Divine's
+                support and trust &amp; safety team and isn't published or
+                shared with other users.
+              </p>
+            </CardContent>
+          </Card>
+
+          {/* Link out to the action page */}
+          <a
+            href="/age-review"
+            className="mt-6 group block brand-card brand-offset-shadow-green p-6 hover:-translate-x-[2px] hover:-translate-y-[2px] hover:[box-shadow:8px_8px_0_0_hsl(var(--brand-green))] transition-all"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <h3 className="font-display font-extrabold tracking-tight text-xl text-brand-dark-green dark:text-brand-off-white">
+                  If your account was just flagged
+                </h3>
+                <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                  The action page with the 15-day window, mailto buttons,
+                  and what happens if no one responds lives at{" "}
+                  <span className="font-medium text-brand-dark-green dark:text-brand-green">
+                    divine.video/age-review
+                  </span>
+                  .
+                </p>
+              </div>
+              <ArrowSquareOut className="h-5 w-5 flex-shrink-0 text-brand-dark-green dark:text-brand-green group-hover:translate-x-0.5 transition-transform" />
+            </div>
+          </a>
+        </Anchor>
+
+        {/* 5. Family-account carve-out */}
+        <Anchor id="family-account">
+          <SectionHero
+            eyebrow="Families together"
+            icon={<HouseLine weight="fill" className="h-7 w-7" />}
+            title="Families absolutely belong on Divine"
+            lead="None of the rules above are about pushing your family off Divine. Families enjoying social media together is a good thing, and welcome here. The piece that matters is who holds the account."
+          />
+
+          <Card variant="brand" accent="pink">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-xl">
+                <HouseLine weight="fill" className="h-5 w-5 text-brand-pink" />
+                A family-account setup looks like this
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4 text-base leading-relaxed">
+              <ul className="space-y-2 list-disc pl-5 marker:text-brand-pink">
+                <li>
+                  The account is created by, and held in the name of, the
+                  parent or guardian.
+                </li>
+                <li>
+                  The parent or guardian does the posting and the
+                  moderating, every time.
+                </li>
+                <li>
+                  Kids of any age can appear in videos with their parent or
+                  guardian's involvement.
+                </li>
+              </ul>
+              <p>
+                What Divine won't host is a solo account in a child's
+                hands. Under 13, the account has to be the parent or
+                guardian's. From 13 to 15, the account can be the teen's
+                with the video step above. Pick whichever path fits your
+                family.
+              </p>
+              <p className="text-muted-foreground">
+                Most family-channel use of Divine is just adults sharing
+                videos that include their kids. That's exactly the case
+                this carve-out is for, and the app side of it is the
+                same as any other adult account.
+              </p>
+            </CardContent>
+          </Card>
+        </Anchor>
+
+        {/* 6. More family guidance */}
+        <Anchor id="family-guidance">
+          <SectionHero
+            eyebrow="The broader conversation"
+            icon={<HouseLine weight="fill" className="h-7 w-7" />}
+            title="Looking for the wider family resources?"
+            lead="This page covers the account-policy side. The wider conversation — how to talk with your teen, content settings, healthy feed habits, trusted outside resources — lives separately."
+          />
+
+          <a
+            href="/family"
+            className="group block brand-card brand-offset-shadow-green p-6 hover:-translate-x-[2px] hover:-translate-y-[2px] hover:[box-shadow:8px_8px_0_0_hsl(var(--brand-green))] transition-all"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <h3 className="font-display font-extrabold tracking-tight text-xl text-brand-dark-green dark:text-brand-off-white">
+                  Open family resources
+                </h3>
+                <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                  Conversation starters, content settings, healthy feed
+                  habits, and trusted outside resources at{" "}
+                  <span className="font-medium text-brand-dark-green dark:text-brand-green">
+                    divine.video/family
+                  </span>
+                  .
+                </p>
+              </div>
+              <ArrowSquareOut className="h-5 w-5 flex-shrink-0 text-brand-dark-green dark:text-brand-green group-hover:translate-x-0.5 transition-transform" />
+            </div>
+          </a>
+        </Anchor>
+
+        {/* Closing note */}
+        <div className="pt-8 border-t border-brand-dark-green/10 dark:border-brand-green/20">
+          <p className="text-sm text-muted-foreground leading-relaxed">
+            Questions, edge cases, or anything else you'd want a real
+            person to read? Email{" "}
+            <a
+              href={`mailto:${SUPPORT_EMAIL}`}
+              className="text-brand-dark-green dark:text-brand-green underline underline-offset-2 hover:opacity-80 break-all"
+            >
+              {SUPPORT_EMAIL}
+            </a>
+            . The support and trust &amp; safety team reads these.
+          </p>
+        </div>
+      </div>
+    </MarketingLayout>
+  );
+}
+
+export default KidsPolicyPage;
+
+// ——————————————————————————————————————————————————————————————
+// Local presentation helpers
+// ——————————————————————————————————————————————————————————————
+
+function SupportEmailButton({ href, label }: { href: string; label: string }) {
+  return (
+    <Button asChild variant="sticker" size="lg">
+      <a href={href} className="inline-flex items-center gap-2">
+        <EnvelopeSimple weight="fill" className="h-4 w-4" />
+        {label}
+      </a>
+    </Button>
+  );
+}
+
+function BackToTopButton() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setVisible(window.scrollY > 600);
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  const goTop = () => {
+    const reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    window.scrollTo({ top: 0, behavior: reduced ? "auto" : "smooth" });
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={goTop}
+      aria-label="Back to top"
+      aria-hidden={!visible}
+      tabIndex={visible ? 0 : -1}
+      className={`fixed right-5 bottom-[calc(1.25rem+env(safe-area-inset-bottom))] z-40 h-12 w-12 rounded-full bg-brand-green text-brand-dark-green border-2 border-brand-dark-green brand-offset-shadow-sm-dark flex items-center justify-center transition-all duration-200 hover:-translate-x-[2px] hover:-translate-y-[2px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-dark-green focus-visible:ring-offset-2 ${
+        visible
+          ? "opacity-100 translate-y-0 pointer-events-auto"
+          : "opacity-0 translate-y-2 pointer-events-none"
+      }`}
+    >
+      <ArrowUp weight="bold" className="h-5 w-5" />
+    </button>
+  );
+}
+
+function Anchor({ id, children }: { id: string; children: React.ReactNode }) {
+  return (
+    <section id={id} className="scroll-mt-24">
+      {children}
+    </section>
+  );
+}
+
+function SectionHero({
+  eyebrow,
+  icon,
+  title,
+  lead,
+}: {
+  eyebrow: string;
+  icon: React.ReactNode;
+  title: string;
+  lead: string;
+}) {
+  return (
+    <div className="mb-8">
+      <div className="flex items-center gap-2 text-xs font-semibold tracking-wide text-brand-dark-green dark:text-brand-green mb-3">
+        {icon}
+        <span>{eyebrow}</span>
+      </div>
+      <SectionHeader as="h2" className="text-3xl md:text-4xl mb-4">
+        {title}
+      </SectionHeader>
+      <p className="text-lg leading-relaxed text-muted-foreground max-w-3xl">
+        {lead}
+      </p>
+    </div>
+  );
+}

--- a/src/pages/KidsPolicyPage.tsx
+++ b/src/pages/KidsPolicyPage.tsx
@@ -1,5 +1,5 @@
 // ABOUTME: Policy page at /kids explaining how Divine handles accounts for under-16s
-// ABOUTME: Long-form FAQ-style page — paired with the deadline-shaped action page at /age-review
+// ABOUTME: Long-form FAQ-style page—paired with the deadline-shaped action page at /age-review
 
 import { useEffect, useState } from "react";
 import {
@@ -61,7 +61,7 @@ export function KidsPolicyPage() {
             How accounts work for kids on Divine
           </h1>
           <p className="text-lg md:text-xl text-brand-light-green max-w-3xl leading-relaxed">
-            Here's how Divine handles accounts for people under 16 — the
+            Here's how Divine handles accounts for people under 16—the
             rules, the reasoning, and what families can do together
             regardless of age.
           </p>
@@ -97,7 +97,7 @@ export function KidsPolicyPage() {
       </section>
 
       <div className="container mx-auto px-4 py-14 md:py-16 max-w-4xl space-y-16">
-        {/* 1. At a glance — three tier cards */}
+        {/* 1. At a glance—three tier cards */}
         <Anchor id="tiers">
           <SectionHero
             eyebrow="At a glance"
@@ -116,7 +116,7 @@ export function KidsPolicyPage() {
               </CardHeader>
               <CardContent className="space-y-2 text-base leading-relaxed">
                 <p>
-                  No solo accounts for kids under 13.
+                  Parent-held family accounts.
                 </p>
                 <p className="text-muted-foreground text-sm">
                   A parent or guardian can hold the account and do all the
@@ -160,8 +160,8 @@ export function KidsPolicyPage() {
                 </p>
                 <p className="text-muted-foreground text-sm">
                   Same path as anyone else on Divine. The rest of this page
-                  is mostly relevant if a 16+ account is flagged in error —
-                  the mistake-flag path lives on the action page.
+                  is mostly relevant if a 16+ account is flagged in
+                  error—the mistake-flag path lives on the action page.
                 </p>
               </CardContent>
             </Card>
@@ -213,7 +213,7 @@ export function KidsPolicyPage() {
             eyebrow="The under-13 policy"
             icon={<UsersThree weight="fill" className="h-7 w-7" />}
             title="Under-13 accounts close and the data is deleted"
-            lead="Divine isn't built for people under 13. When Divine learns an account is held by someone under 13, the team closes the account and promptly deletes everything tied to it from Divine's infrastructure — even when a parent or guardian is okay with the account staying open. The account doesn't come back."
+            lead="Divine isn't built for people under 13. When Divine learns an account is held by someone under 13, the team closes the account and promptly deletes everything tied to it from Divine's infrastructure—even when a parent or guardian is okay with the account staying open. The account doesn't come back."
           />
 
           {/* Parent-discovery action card */}
@@ -279,13 +279,13 @@ export function KidsPolicyPage() {
                 The team will review what you send, close the account,
                 promptly delete everything tied to it from Divine's
                 infrastructure, and reply confirming what was done. There's
-                no form to fill out — the email is enough.
+                no form to fill out—the email is enough.
               </p>
 
               <div className="pt-2">
                 <SupportEmailButton
                   href={mailtoLink(
-                    "Account review — under 13",
+                    "Account review—under 13",
                     "Hi Divine support,\n\nI'm a parent or guardian. I've discovered a Divine account belonging to a child in my care who is under 13.\n\nAccount username or link:\n\nAnything else that might help:\n\nThanks,",
                   )}
                   label={`Email ${SUPPORT_EMAIL}`}
@@ -299,7 +299,7 @@ export function KidsPolicyPage() {
             <CardContent className="pt-6 space-y-3 text-base leading-relaxed">
               <div className="flex items-center gap-2 text-sm font-semibold text-brand-dark-green dark:text-brand-green">
                 <Info weight="fill" className="h-4 w-4" />
-                <span>An honest note about copies on other relays</span>
+                <span>A note about copies on other relays</span>
               </div>
               <p>
                 Any videos already posted from the account may have been
@@ -350,7 +350,7 @@ export function KidsPolicyPage() {
                 </li>
               </ul>
               <p className="text-sm text-muted-foreground pt-1">
-                Phone-camera quality is fine. There's no script — natural
+                Phone-camera quality is fine. There's no script—natural
                 is better. Keep it short. The video is handled by Divine's
                 support and trust &amp; safety team and isn't published or
                 shared with other users.
@@ -436,7 +436,7 @@ export function KidsPolicyPage() {
             eyebrow="The broader conversation"
             icon={<HouseLine weight="fill" className="h-7 w-7" />}
             title="Looking for the wider family resources?"
-            lead="This page covers the account-policy side. The wider conversation — how to talk with your teen, content settings, healthy feed habits, trusted outside resources — lives separately."
+            lead="This page covers the account-policy side. The wider conversation—how to talk with your teen, content settings, healthy feed habits, trusted outside resources—lives separately."
           />
 
           <a

--- a/src/pages/KidsPolicyPage.tsx
+++ b/src/pages/KidsPolicyPage.tsx
@@ -136,12 +136,10 @@ export function KidsPolicyPage() {
               </CardHeader>
               <CardContent className="space-y-2 text-base leading-relaxed">
                 <p>
-                  In places where the law allows it, teens 13 to 15 can have their own accounts with a short parent or guardian video.
+                  Where local rules allow it, Divine offers a parent-supported path for teens 13 to 15.
                 </p>
                 <p className="text-muted-foreground text-sm">
-                  The video confirms the teen's age, that they have
-                  permission, and that the parent or guardian knows about
-                  the account and will supervise its use.
+                  This path requires a short private video from the teen and a parent or guardian confirming the teen’s age, permission to use Divine, and parent or guardian awareness and supervision. In some places, including countries with under-16 social media restrictions or stricter age-assurance rules, this path may not be available or may require additional steps.
                 </p>
               </CardContent>
             </Card>

--- a/src/pages/KidsPolicyPage.tsx
+++ b/src/pages/KidsPolicyPage.tsx
@@ -156,7 +156,7 @@ export function KidsPolicyPage() {
               </CardHeader>
               <CardContent className="space-y-2 text-base leading-relaxed">
                 <p>
-                  Standard adult account. No parent step.
+                  Standard 16+ account. No teen-specific parent step, unless required by applicable law, Divine's policies, or the user's location.
                 </p>
                 <p className="text-muted-foreground text-sm">
                   Same path as anyone else on Divine. The rest of this page

--- a/src/pages/KidsPolicyPage.tsx
+++ b/src/pages/KidsPolicyPage.tsx
@@ -1,7 +1,6 @@
 // ABOUTME: Policy page at /kids explaining how Divine handles accounts for under-16s
 // ABOUTME: Long-form FAQ-style page—paired with the deadline-shaped action page at /age-review
 
-import { useEffect, useState } from "react";
 import {
   Info,
   UsersThree,
@@ -9,15 +8,19 @@ import {
   ShieldCheck,
   ChatsCircle,
   HouseLine,
-  EnvelopeSimple,
   ArrowSquareOut,
-  ArrowUp,
 } from "@phosphor-icons/react";
 
 import { MarketingLayout } from "@/components/MarketingLayout";
-import { SectionHeader } from "@/components/brand/SectionHeader";
+import {
+  Anchor,
+  BackToTopButton,
+  SectionHero,
+  staticPageLinkCardClass,
+  SupportEmailButton,
+} from "@/components/static-pages";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
+import { buildMailtoLink } from "@/lib/mailto";
 
 const SUPPORT_EMAIL = "support@divine.video";
 
@@ -35,16 +38,10 @@ const SECTIONS: SectionAnchor[] = [
   { id: "family-guidance", title: "More family guidance" },
 ];
 
-function mailtoLink(subject: string, body?: string): string {
-  const params = new URLSearchParams();
-  params.set("subject", subject);
-  if (body) params.set("body", body);
-  return `mailto:${SUPPORT_EMAIL}?${params.toString().replace(/\+/g, "%20")}`;
-}
-
 // Parent-discovery email for an under-13 account. Shared so the inline link
 // and the button below it open the same prefilled message.
-const UNDER13_DISCOVERY_MAILTO = mailtoLink(
+const UNDER13_DISCOVERY_MAILTO = buildMailtoLink(
+  SUPPORT_EMAIL,
   "Account review—under 13",
   "Hi Divine support,\n\nI'm a parent or guardian. I've discovered a Divine account belonging to a child in my care who is under 13.\n\nAccount username or link:\n\nAnything else that might help:\n\nThanks,",
 );
@@ -61,10 +58,7 @@ export function KidsPolicyPage() {
             <UsersThree weight="fill" className="h-4 w-4" />
             <span>Kids on Divine</span>
           </div>
-          <h1
-            className="font-display font-extrabold tracking-tight text-4xl md:text-6xl leading-[1.05] text-brand-off-white mb-6"
-            style={{ fontFamily: "'Bricolage Grotesque', system-ui, sans-serif" }}
-          >
+          <h1 className="font-display font-extrabold tracking-tight text-4xl md:text-6xl leading-[1.05] text-brand-off-white mb-6">
             How accounts work for kids on Divine
           </h1>
           <p className="text-lg md:text-xl text-brand-light-green max-w-3xl leading-relaxed">
@@ -357,7 +351,7 @@ export function KidsPolicyPage() {
           {/* Link out to the action page */}
           <a
             href="/age-review"
-            className="mt-6 group block brand-card brand-offset-shadow-green p-6 hover:-translate-x-[2px] hover:-translate-y-[2px] hover:[box-shadow:8px_8px_0_0_hsl(var(--brand-green))] transition-all"
+            className={staticPageLinkCardClass("green", "mt-6")}
           >
             <div className="flex items-start justify-between gap-3">
               <div>
@@ -437,7 +431,7 @@ export function KidsPolicyPage() {
 
           <a
             href="/family"
-            className="group block brand-card brand-offset-shadow-green p-6 hover:-translate-x-[2px] hover:-translate-y-[2px] hover:[box-shadow:8px_8px_0_0_hsl(var(--brand-green))] transition-all"
+            className={staticPageLinkCardClass("green")}
           >
             <div className="flex items-start justify-between gap-3">
               <div>
@@ -478,86 +472,3 @@ export function KidsPolicyPage() {
 }
 
 export default KidsPolicyPage;
-
-// ——————————————————————————————————————————————————————————————
-// Local presentation helpers
-// ——————————————————————————————————————————————————————————————
-
-function SupportEmailButton({ href, label }: { href: string; label: string }) {
-  return (
-    <Button asChild variant="sticker" size="lg">
-      <a href={href} className="inline-flex items-center gap-2">
-        <EnvelopeSimple weight="fill" className="h-4 w-4" />
-        {label}
-      </a>
-    </Button>
-  );
-}
-
-function BackToTopButton() {
-  const [visible, setVisible] = useState(false);
-
-  useEffect(() => {
-    const onScroll = () => setVisible(window.scrollY > 600);
-    onScroll();
-    window.addEventListener("scroll", onScroll, { passive: true });
-    return () => window.removeEventListener("scroll", onScroll);
-  }, []);
-
-  const goTop = () => {
-    const reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-    window.scrollTo({ top: 0, behavior: reduced ? "auto" : "smooth" });
-  };
-
-  return (
-    <button
-      type="button"
-      onClick={goTop}
-      aria-label="Back to top"
-      aria-hidden={!visible}
-      tabIndex={visible ? 0 : -1}
-      className={`fixed right-5 bottom-[calc(1.25rem+env(safe-area-inset-bottom))] z-40 h-12 w-12 rounded-full bg-brand-green text-brand-dark-green border-2 border-brand-dark-green brand-offset-shadow-sm-dark flex items-center justify-center transition-all duration-200 hover:-translate-x-[2px] hover:-translate-y-[2px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-dark-green focus-visible:ring-offset-2 ${
-        visible
-          ? "opacity-100 translate-y-0 pointer-events-auto"
-          : "opacity-0 translate-y-2 pointer-events-none"
-      }`}
-    >
-      <ArrowUp weight="bold" className="h-5 w-5" />
-    </button>
-  );
-}
-
-function Anchor({ id, children }: { id: string; children: React.ReactNode }) {
-  return (
-    <section id={id} className="scroll-mt-24">
-      {children}
-    </section>
-  );
-}
-
-function SectionHero({
-  eyebrow,
-  icon,
-  title,
-  lead,
-}: {
-  eyebrow: string;
-  icon: React.ReactNode;
-  title: string;
-  lead: string;
-}) {
-  return (
-    <div className="mb-8">
-      <div className="flex items-center gap-2 text-xs font-semibold tracking-wide text-brand-dark-green dark:text-brand-green mb-3">
-        {icon}
-        <span>{eyebrow}</span>
-      </div>
-      <SectionHeader as="h2" className="text-3xl md:text-4xl mb-4">
-        {title}
-      </SectionHeader>
-      <p className="text-lg leading-relaxed text-muted-foreground max-w-3xl">
-        {lead}
-      </p>
-    </div>
-  );
-}

--- a/src/pages/KidsPolicyPage.tsx
+++ b/src/pages/KidsPolicyPage.tsx
@@ -380,7 +380,7 @@ export function KidsPolicyPage() {
         {/* 5. Family-account carve-out */}
         <Anchor id="family-account">
           <SectionHero
-            eyebrow="Family-account carve-out"
+            eyebrow="Families on Divine"
             icon={<HouseLine weight="fill" className="h-7 w-7" />}
             title="Families absolutely belong on Divine"
             lead="None of the rules above are about pushing your family off Divine. Families enjoying social media together is a good thing, and welcome here. The piece that matters is who holds the account."

--- a/src/pages/KidsPolicyPage.tsx
+++ b/src/pages/KidsPolicyPage.tsx
@@ -14,20 +14,17 @@ import {
 import { MarketingLayout } from "@/components/MarketingLayout";
 import {
   Anchor,
+  AnchorNav,
   BackToTopButton,
   SectionHero,
   staticPageLinkCardClass,
   SupportEmailButton,
+  type SectionAnchor,
 } from "@/components/static-pages";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { buildMailtoLink } from "@/lib/mailto";
 
 const SUPPORT_EMAIL = "support@divine.video";
-
-interface SectionAnchor {
-  id: string;
-  title: string;
-}
 
 const SECTIONS: SectionAnchor[] = [
   { id: "tiers", title: "At a glance" },
@@ -79,21 +76,10 @@ export function KidsPolicyPage() {
             .
           </p>
 
-          {/* Anchor nav */}
-          <nav
-            aria-label="On this page"
-            className="mt-10 grid gap-2 sm:grid-cols-2 lg:grid-cols-3 text-sm"
-          >
-            {SECTIONS.map((s) => (
-              <a
-                key={s.id}
-                href={`#${s.id}`}
-                className="rounded-xl border border-brand-green/40 bg-brand-dark-green/40 px-4 py-3 text-brand-light-green hover:bg-brand-green/10 hover:border-brand-green transition-colors"
-              >
-                {s.title}
-              </a>
-            ))}
-          </nav>
+          <AnchorNav
+            sections={SECTIONS}
+            className="sm:grid-cols-2 lg:grid-cols-3"
+          />
         </div>
       </section>
 

--- a/src/pages/KidsPolicyPage.tsx
+++ b/src/pages/KidsPolicyPage.tsx
@@ -193,12 +193,12 @@ export function KidsPolicyPage() {
                 are.
               </p>
               <p>
-                The 13-to-15 path is a different shape: a short private
+                Where the rules allow, Divine offers a different path for teens 13 to 15: a short private
                 video with a parent or guardian on camera. It's a real
                 human check, but it doesn't require Divine to operate an
                 ID-and-payment verification pipeline, and it doesn't
                 require the family to hand over more data than the video
-                itself. Imperfect, but more honest than the alternative.
+                itself. It’s not perfect, but it is more aligned with the kind of internet we want to build.
               </p>
             </CardContent>
           </Card>

--- a/src/pages/KidsPolicyPage.tsx
+++ b/src/pages/KidsPolicyPage.tsx
@@ -103,7 +103,7 @@ export function KidsPolicyPage() {
             eyebrow="At a glance"
             icon={<Info weight="fill" className="h-7 w-7" />}
             title="Three age tiers, three different paths"
-            lead="Divine handles accounts differently depending on who's holding them. The short version:"
+            lead="Divine handles accounts differently depending on who's holding them and where they live. The short version:"
           />
 
           <div className="grid gap-6 md:grid-cols-3">
@@ -136,8 +136,7 @@ export function KidsPolicyPage() {
               </CardHeader>
               <CardContent className="space-y-2 text-base leading-relaxed">
                 <p>
-                  Teen-held accounts are allowed, with a short video from a
-                  parent or guardian.
+                  In places where the law allows it, teens 13 to 15 can have their own accounts with a short parent or guardian video.
                 </p>
                 <p className="text-muted-foreground text-sm">
                   The video confirms the teen's age, that they have
@@ -323,7 +322,7 @@ export function KidsPolicyPage() {
             eyebrow="13-15 accounts"
             icon={<VideoCamera weight="fill" className="h-7 w-7" />}
             title="Teen-held accounts need a parent or guardian video"
-            lead="Teens 13 to 15 can use Divine with a parent or guardian who's aware and involved. The video is how Divine knows that consent and supervision are real, without running an intrusive verification system. Depending on where the teen lives, Divine may require additional or different age-assurance, parental-consent, privacy, or account-safety steps before the account can stay open."
+            lead="Where permitted by law, teens 13 to 15 can use Divine with a parent or guardian who's aware and involved. The video is how Divine knows that consent and supervision are real, without running an intrusive verification system. Depending on where the teen lives, Divine may require additional or different age-assurance, parental-consent, privacy, or account-safety steps before the account can stay open."
           />
 
           <Card variant="brand" accent="green">

--- a/src/pages/KidsPolicyPage.tsx
+++ b/src/pages/KidsPolicyPage.tsx
@@ -180,9 +180,7 @@ export function KidsPolicyPage() {
           <Card variant="brand">
             <CardContent className="pt-6 space-y-3 text-base leading-relaxed">
               <p>
-                The rules for online services for children under 13 require
-                apps to verify parents through credit-card checks,
-                government-ID uploads, and similar intrusive steps. Those
+                The rules for online services for children under 13 can require online services to give parents direct notice and obtain verifiable parental consent before collecting, using, or disclosing personal information from children under 13; available consent methods can include credit-card checks, government-ID checks, and other methods permitted by law. Those
                 rules were written with little grasp of how the open
                 internet actually works. In practice they push every
                 app toward collecting <em>more</em> personal data, not
@@ -213,7 +211,7 @@ export function KidsPolicyPage() {
             eyebrow="The under-13 policy"
             icon={<UsersThree weight="fill" className="h-7 w-7" />}
             title="Under-13 accounts close and the data is deleted"
-            lead="Divine isn't built for people under 13. When Divine learns an account is held by someone under 13, the team closes the account and promptly deletes everything tied to it from Divine's infrastructure—even when a parent or guardian is okay with the account staying open. The account doesn't come back."
+            lead="Divine isn't built for people under 13. When Divine learns an account is held by someone under 13, the team closes the account and promptly deletes everything tied to it from Divine's infrastructure, except information Divine is required or permitted to keep for legal, safety, security, fraud-prevention, dispute-resolution, or compliance purposes—even when a parent or guardian is okay with the account staying open. The account doesn't come back."
           />
 
           {/* Parent-discovery action card */}
@@ -325,7 +323,7 @@ export function KidsPolicyPage() {
             eyebrow="The 13-to-15 policy"
             icon={<VideoCamera weight="fill" className="h-7 w-7" />}
             title="Teen-held accounts need a parent or guardian video"
-            lead="Teens 13 to 15 can use Divine with a parent or guardian who's aware and involved. The video is how Divine knows that consent and supervision are real, without running an intrusive verification system."
+            lead="Teens 13 to 15 can use Divine with a parent or guardian who's aware and involved. The video is how Divine knows that consent and supervision are real, without running an intrusive verification system. Depending on where the teen lives, Divine may require additional or different age-assurance, parental-consent, privacy, or account-safety steps before the account can stay open."
           />
 
           <Card variant="brand" accent="green">
@@ -350,10 +348,7 @@ export function KidsPolicyPage() {
                 </li>
               </ul>
               <p className="text-sm text-muted-foreground pt-1">
-                Phone-camera quality is fine. There's no script—natural
-                is better. Keep it short. The video is handled by Divine's
-                support and trust &amp; safety team and isn't published or
-                shared with other users.
+                Phone-camera quality is fine. There's no script—natural is better. Keep it short. Please don't include more information than Divine asks for here; the review is meant to confirm age, permission, and parent or guardian awareness, not to collect extra documents or background details. The video is handled by Divine's support and trust & safety team, used only for account review, safety, legal, and compliance purposes, kept only as long as reasonably necessary for those purposes unless a longer retention period is required or permitted by law, and isn't published or shared with other users.
               </p>
             </CardContent>
           </Card>
@@ -374,7 +369,7 @@ export function KidsPolicyPage() {
                   <span className="font-medium text-brand-dark-green dark:text-brand-green">
                     divine.video/age-review
                   </span>
-                  .
+                  . If Divine needs more information to finish the review, support will ask for it through the support email thread rather than asking the teen to post anything publicly.
                 </p>
               </div>
               <ArrowSquareOut className="h-5 w-5 flex-shrink-0 text-brand-dark-green dark:text-brand-green group-hover:translate-x-0.5 transition-transform" />
@@ -410,14 +405,14 @@ export function KidsPolicyPage() {
                 </li>
                 <li>
                   Kids of any age can appear in videos with their parent or
-                  guardian's involvement.
+                  guardian's involvement, as long as the parent or guardian has the rights and permissions needed to share the video and the video complies with Divine's policies and applicable law. The parent or guardian should not share the account password or hand off control of the account to a child under 13.
                 </li>
               </ul>
               <p>
                 What Divine won't host is a solo account in a child's
                 hands. Under 13, the account has to be the parent or
                 guardian's. From 13 to 15, the account can be the teen's
-                with the video step above. Pick whichever path fits your
+                with the video step above, subject to any additional requirements that apply based on the teen's location. Pick whichever path fits your
                 family.
               </p>
               <p className="text-muted-foreground">

--- a/src/pages/KidsPolicyPage.tsx
+++ b/src/pages/KidsPolicyPage.tsx
@@ -42,6 +42,13 @@ function mailtoLink(subject: string, body?: string): string {
   return `mailto:${SUPPORT_EMAIL}?${params.toString().replace(/\+/g, "%20")}`;
 }
 
+// Parent-discovery email for an under-13 account. Shared so the inline link
+// and the button below it open the same prefilled message.
+const UNDER13_DISCOVERY_MAILTO = mailtoLink(
+  "Account review—under 13",
+  "Hi Divine support,\n\nI'm a parent or guardian. I've discovered a Divine account belonging to a child in my care who is under 13.\n\nAccount username or link:\n\nAnything else that might help:\n\nThanks,",
+);
+
 export function KidsPolicyPage() {
   return (
     <MarketingLayout>
@@ -236,7 +243,7 @@ export function KidsPolicyPage() {
                   <span>
                     Email Divine support at{" "}
                     <a
-                      href={`mailto:${SUPPORT_EMAIL}`}
+                      href={UNDER13_DISCOVERY_MAILTO}
                       className="text-brand-dark-green dark:text-brand-green underline underline-offset-2 hover:opacity-80 break-all"
                     >
                       {SUPPORT_EMAIL}
@@ -279,10 +286,7 @@ export function KidsPolicyPage() {
 
               <div className="pt-2">
                 <SupportEmailButton
-                  href={mailtoLink(
-                    "Account review—under 13",
-                    "Hi Divine support,\n\nI'm a parent or guardian. I've discovered a Divine account belonging to a child in my care who is under 13.\n\nAccount username or link:\n\nAnything else that might help:\n\nThanks,",
-                  )}
+                  href={UNDER13_DISCOVERY_MAILTO}
                   label={`Email ${SUPPORT_EMAIL}`}
                 />
               </div>
@@ -308,9 +312,9 @@ export function KidsPolicyPage() {
           </Card>
 
           <p className="mt-6 text-sm text-muted-foreground leading-relaxed">
-            When they're 13 or older, the same person can create a new
-            account from scratch. The closed account itself doesn't
-            return.
+            When they're 13 or older, and local law permits, the same
+            person can create a new account from scratch. The closed account
+            itself doesn't return.
           </p>
         </Anchor>
 
@@ -345,7 +349,7 @@ export function KidsPolicyPage() {
                 </li>
               </ul>
               <p className="text-sm text-muted-foreground pt-1">
-                Phone-camera quality is fine. There's no script—natural is better. Keep it short. Please don't include more information than Divine asks for here; the review is meant to confirm age, permission, and parent or guardian awareness, not to collect extra documents or background details. The video is handled by Divine's support and trust & safety team, used only for account review, safety, legal, and compliance purposes, kept only as long as reasonably necessary for those purposes unless a longer retention period is required or permitted by law, and isn't published or shared with other users.
+                Phone-camera quality is fine. There's no script—natural is better. Keep it short. Please don't include more information than Divine asks for here; the review is meant to confirm age, permission, and parent or guardian awareness, not to collect extra documents or background details. The video is handled by Divine's Support and Trust & Safety teams, used only for account review, safety, legal, and compliance purposes, kept only as long as reasonably necessary for those purposes unless a longer retention period is required or permitted by law, and isn't published or shared with other users.
               </p>
             </CardContent>
           </Card>
@@ -465,7 +469,7 @@ export function KidsPolicyPage() {
             >
               {SUPPORT_EMAIL}
             </a>
-            . The support and trust &amp; safety team reads these.
+            . The Support and Trust &amp; Safety teams read these.
           </p>
         </div>
       </div>

--- a/src/pages/KidsPolicyPage.tsx
+++ b/src/pages/KidsPolicyPage.tsx
@@ -171,9 +171,9 @@ export function KidsPolicyPage() {
         {/* 2. Why we work this way */}
         <Anchor id="why">
           <SectionHero
-            eyebrow="Honest framing"
+            eyebrow="Why we work this way"
             icon={<Info weight="fill" className="h-7 w-7" />}
-            title="Why we work this way"
+            title="Our operating philosophy"
             lead="The age rules Divine follows weren't all our idea. Some of them are operational choices about what kind of app we want to be."
           />
 
@@ -208,7 +208,7 @@ export function KidsPolicyPage() {
         {/* 3. Under-13 accounts */}
         <Anchor id="under-13">
           <SectionHero
-            eyebrow="The under-13 policy"
+            eyebrow="Under-13 accounts"
             icon={<UsersThree weight="fill" className="h-7 w-7" />}
             title="Under-13 accounts close and the data is deleted"
             lead="Divine isn't built for people under 13. When Divine learns an account is held by someone under 13, the team closes the account and promptly deletes everything tied to it from Divine's infrastructure, except information Divine is required or permitted to keep for legal, safety, security, fraud-prevention, dispute-resolution, or compliance purposes—even when a parent or guardian is okay with the account staying open. The account doesn't come back."
@@ -320,7 +320,7 @@ export function KidsPolicyPage() {
         {/* 4. 13-15 accounts */}
         <Anchor id="13-15">
           <SectionHero
-            eyebrow="The 13-to-15 policy"
+            eyebrow="13-15 accounts"
             icon={<VideoCamera weight="fill" className="h-7 w-7" />}
             title="Teen-held accounts need a parent or guardian video"
             lead="Teens 13 to 15 can use Divine with a parent or guardian who's aware and involved. The video is how Divine knows that consent and supervision are real, without running an intrusive verification system. Depending on where the teen lives, Divine may require additional or different age-assurance, parental-consent, privacy, or account-safety steps before the account can stay open."
@@ -380,7 +380,7 @@ export function KidsPolicyPage() {
         {/* 5. Family-account carve-out */}
         <Anchor id="family-account">
           <SectionHero
-            eyebrow="Families together"
+            eyebrow="Family-account carve-out"
             icon={<HouseLine weight="fill" className="h-7 w-7" />}
             title="Families absolutely belong on Divine"
             lead="None of the rules above are about pushing your family off Divine. Families enjoying social media together is a good thing, and welcome here. The piece that matters is who holds the account."
@@ -428,7 +428,7 @@ export function KidsPolicyPage() {
         {/* 6. More family guidance */}
         <Anchor id="family-guidance">
           <SectionHero
-            eyebrow="The broader conversation"
+            eyebrow="More family guidance"
             icon={<HouseLine weight="fill" className="h-7 w-7" />}
             title="Looking for the wider family resources?"
             lead="This page covers the account-policy side. The wider conversation—how to talk with your teen, content settings, healthy feed habits, trusted outside resources—lives separately."

--- a/src/pages/MerchPage.tsx
+++ b/src/pages/MerchPage.tsx
@@ -70,7 +70,7 @@ function ProductCard({ product, accent }: { product: Product; accent: (typeof AC
         </div>
         <div className="flex flex-1 flex-col gap-1 border-t-2 border-brand-dark-green bg-brand-off-white px-5 py-4 text-brand-dark-green">
           {showCampaignOverline ? (
-            <p className="text-xs font-semibold tracking-wide text-brand-dark-green/60">
+            <p className="text-xs font-semibold tracking-wide text-brand-dark-green/70">
               {product.campaignTitle}
             </p>
           ) : null}

--- a/src/styles/brand-utilities.css
+++ b/src/styles/brand-utilities.css
@@ -42,9 +42,25 @@
     color: hsl(var(--card-foreground));
   }
 
+  .brand-link-card {
+    transition: transform 150ms cubic-bezier(0.4, 0, 0.2, 1),
+                box-shadow 150ms cubic-bezier(0.4, 0, 0.2, 1);
+  }
+  .brand-link-card:hover {
+    transform: translate(-2px, -2px);
+  }
+  .brand-link-card-green:hover  { box-shadow: 8px 8px 0 0 hsl(var(--brand-green)); }
+  .brand-link-card-blue:hover   { box-shadow: 8px 8px 0 0 hsl(var(--brand-blue)); }
+  .brand-link-card-orange:hover { box-shadow: 8px 8px 0 0 hsl(var(--brand-orange)); }
+  .brand-link-card-pink:hover   { box-shadow: 8px 8px 0 0 hsl(var(--brand-pink)); }
+  .brand-link-card-violet:hover { box-shadow: 8px 8px 0 0 hsl(var(--brand-violet)); }
+  .brand-link-card-yellow:hover { box-shadow: 8px 8px 0 0 hsl(var(--brand-yellow)); }
+
   /* Respect reduced-motion */
   @media (prefers-reduced-motion: reduce) {
     .brand-sticker { transition: none; }
     .brand-sticker:hover { transform: none; }
+    .brand-link-card { transition: none; }
+    .brand-link-card:hover { transform: none; }
   }
 }

--- a/tests/visual/a11y.spec.ts
+++ b/tests/visual/a11y.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';
 
-const ROUTES = ['/', '/discovery', '/search', '/merch', '/__brand-preview'];
+const ROUTES = ['/', '/discovery', '/search', '/merch', '/family', '/age-review', '/kids', '/__brand-preview'];
 
 for (const route of ROUTES) {
   test(`a11y: ${route} has no WCAG 2 A/AA violations`, async ({ page }) => {

--- a/tests/visual/a11y.spec.ts
+++ b/tests/visual/a11y.spec.ts
@@ -6,8 +6,8 @@ const ROUTES = ['/', '/discovery', '/search', '/merch', '/__brand-preview'];
 for (const route of ROUTES) {
   test(`a11y: ${route} has no WCAG 2 A/AA violations`, async ({ page }) => {
     test.setTimeout(60_000); // discovery + search do a fair bit of fetching
-    await page.goto(route);
-    await page.waitForLoadState('networkidle');
+    await page.goto(route, { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('body')).toBeVisible();
     const builder = new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa']);
     // Color-swatch chips on the brand-preview page are reference tiles, not
     // content; their visible label is decorative. Axe's color-contrast rule


### PR DESCRIPTION
## Summary

Three sister static pages on the Divine apex, designed to be read together but each with a distinct audience and intent.

| Page | URL | Reader | Shape |
|---|---|---|---|
| Family resources | `divine.video/family` | Parents and guardians, conversation-first | Long-form guidance, anchor-nav, embedded STIR Lab interview |
| Account review | `divine.video/age-review` | Account holder whose account was just flagged | Short, deadline-shaped — 15-day window, two action paths, one no-response section |
| Kids policy | `divine.video/kids` | Curious parent, journalist, regulator, anyone looking up how Divine handles accounts for under-16s | Long-form FAQ explaining the under-13, 13–15, and 16+ tiers + the family-account carve-out + the policy stance |

The three are cross-linked:

- `/family` → `/kids` (for account policy specifics)
- `/age-review` → `/kids` (for context behind the rules)
- `/kids` → `/age-review` (for users with active reviews) and `/family` (for broader family guidance)

## divine.video/family — conversation-first guidance

Builds a polished static page at `/family` to support the in-app family-guide flow from the mobile app. Tone is direct, human, practical — conversation-first, not punitive or fear-based.

Covers, in order:

1. Hero — *"Safer social media use starts with conversation."*
2. Pause • Reflect • Redirect framing band
3. How to talk with your teen — co-navigate vs. surveil, respond before punishing, conversation starters
4. What Divine can and can't do — honest two-column ledger of moderation/reporting/support tools next to the things no app can guarantee
5. How content settings work — adult content gating, moderation lists, blocks/mutes, reporting
6. Feed habits and stopping points — habit framing, *not* "we eliminate infinite scroll"
7. Build a family media plan — collaborative, AAP-compatible
8. If your child saw something upsetting — pause → talk → tools → escalate
9. Rabble + Pam Wisniewski / STIR — embedded YouTube interview (lazy, `youtube-nocookie`) + STIR Lab links + pull quote
10. Trusted outside resources — Common Sense Media, AAP, HealthyChildren.org, ConnectSafely, FOSI, Thorn
11. Cross-link to `/kids` for account-rules specifics

## divine.video/age-review — the moderation action page

External page for accounts flagged in-app as possibly belonging to someone under 16. The reader is the flagged account holder, or a parent helping them resolve the review. Tight, deadline-forward, no policy ranting.

The 15-day window is the spine of the page. Sections:

1. Hero — *"Your account is under review"* + the 15-day window + suspension note + anchor nav
2. **Honest note for any under-13 reader** (placed before the action paths) — the account closes regardless because the rules around under-13 services tie our hands; the same person can create a new account when they're 13 or older
3. If you're 13 to 15 — two cards (what the video shows / how to send it) + privacy note + prefilled mailto to `support@divine.video`
4. If you're 16 or older and this is a mistake — single action card + prefilled mailto with the literal subject line *"I am 16 or older and think this account was flagged by mistake."*
5. What happens after 15 days with no response — orange card explaining closure + deletion mechanics; any email to support stops the clock
6. More context — single linked callout to `/kids`
7. Closing reassurance about re-emailing if no response

Body copy is ~620 words — reads in under a minute.

## divine.video/kids — the long-form policy page

Long-form FAQ-style policy explainer. The reader is a curious parent, journalist, regulator, or anyone trying to understand how Divine handles accounts for kids and teens.

Sections:

1. Hero — *"How accounts work for kids on Divine"* — explicitly routes flagged users to `/age-review` so they don't get stuck here
2. At a glance — three-card grid summarizing the under-13 / 13–15 / 16+ tiers
3. Why we work this way — policy stance (intrusive parent-verification critique, mass-data-collection critique, Big Tech moat point) + the 13–15 video as a different shape of consent check
4. Under-13 accounts — closure + deletion policy + parent-discovery action card with prefilled mailto + Nostr-relay caveat + come-back-as-a-new-account bridge
5. 13 to 15 accounts — video-requirement summary + linked callout to `/age-review` for active reviews
6. Families absolutely belong on Divine — the parent-held family-account carve-out (kids can appear in videos with their parent or guardian)
7. More family guidance — linked callout to `/family`

## Routing

- New routes: `/family`, `/age-review`, `/kids` on the apex — apex-only, no subdomain dispatch
- Per-page OG/Twitter meta on both Cloudflare Pages (`functions/[[path]].ts` via `serverSocialMeta.ts`) and Fastly (`compute-js/src/index.js` `handle*OgTags`), with crawler tests in `functions/[[path]].test.ts` for each apex path

## Copy refresh

Across `/family` and `/kids`, refer to Divine as an "app" not a "platform" — operational positioning the team uses going forward. The one academic-context exception is the STIR Lab research sentence, which says "online services" because that's the regulator-friendly term for the broader category their research covers.

## Brand / guardrails

- All three pages use `MarketingLayout`, `SectionHeader`, `Card variant="brand"` with accent shadows
- No `uppercase` classes, no gradients on layout surfaces, no `lucide-react` — Phosphor only
- Numbered lists across the new pages render as `font-extrabold` dark-green spans rather than native `::marker` (`::marker` font-weight is unreliable cross-browser); `aria-hidden` on the manual number spans preserves `<ol>` semantics for screen readers
- `tsc --noEmit`, ESLint, brand guardrail tests, and static-pages i18n test pass; production build succeeds; full suite is 138 files / 774 tests green

## Out of scope (intentional, needs follow-up)

- **Backend for the 15-day clock** — `/age-review` commits to behavior (signed Nostr-event notice delivery as the timestamp, account suspension during review, support's manual-close workflow at day 15, NIP-09 deletion request on closure) that the backend has yet to implement. Worth flagging to engineering before announcing the URLs.
- **Terms** — currently says *"may restrict or terminate."* Worth a one-line legal pass to acknowledge suspension as a real state alongside termination, now that the page commits publicly to it.
- **i18n** — all three pages are English-only on first landing. Locale JSON files + `useTranslation` + adding the new pages to `static-pages-i18n.test.tsx` are a single follow-up pass once stakeholders sign off on copy.

## Test plan

### /family

- [ ] Visit `/family` on the local dev server — verify hero, anchor nav, framing band, all 9 sections render
- [ ] Toggle dark mode — check hero, framing band, card accents, body copy all read well
- [ ] Scroll past ~600px — back-to-top button fades in bottom-right; clicking returns to top with smooth scroll
- [ ] Hover the resource cards (bottom of page) — chunky lift animation
- [ ] Lazy YouTube embed in the STIR section — 16:9, doesn't load until scrolled into view
- [ ] New cross-link card near the bottom — *"Looking for the account rules for kids and teens?"* — opens `/kids`

### /age-review

- [ ] Visit `/age-review` on the local dev server — verify hero (15-day window mentioned twice), anchor nav, all 4 main sections render
- [ ] **Honest note for under-13** is the first thing under the hero, before the 13–15 section
- [ ] 13–15 cards — bold readable numbers (not thin native markers); mailto button opens with prefilled subject + body to `support@divine.video`
- [ ] 16+ mistake card — same bold-number treatment; mailto button opens with the literal subject line in the brief
- [ ] "What happens after 15 days" section — orange card listing closure + deletion mechanics
- [ ] *"More context"* link card — opens `/kids`
- [ ] Slack/Twitter unfurl of `divine.video/age-review` shows the *"15-day window for responding"* description (crawler test in `functions/[[path]].test.ts` locks this in)

### /kids

- [ ] Visit `/kids` on the local dev server — verify hero, "this is the policy page, not the moderation page" callout (links to `/age-review`), and all 6 anchor sections render
- [ ] **At a glance** three-card grid — under-13 (violet), 13–15 (green), 16+ (blue) — readable in both light and dark mode
- [ ] **Why we work this way** card — the policy stance reads as intentional, not aggrieved
- [ ] Under-13 section — bold-numbered action steps; mailto opens with the parent-discovery prefilled body to `support@divine.video`
- [ ] Families absolutely belong on Divine — pink-accent card with the family-account carve-out
- [ ] Both linked callouts at the bottom resolve to the right pages (`/age-review`, `/family`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
