### PR TITLE
feat(search): default to Hot sort and surface sort pills above results

### DIFF
--- a/src/pages/SearchPage.test.tsx
+++ b/src/pages/SearchPage.test.tsx
@@ -574,6 +574,65 @@ describe('SearchPage', () => {
     expect(screen.getByTestId('search-sort-top')).toHaveAttribute('aria-checked', 'true');
   });
 
+  it('canonicalizes an invalid sort URL param back to hot', async () => {
+    mockUseInfiniteSearchVideos.mockReturnValue({
+      data: { pages: [{ videos: [] }] },
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+      isLoading: false,
+      error: null,
+    });
+
+    renderPage(['/search?q=dogs&sort=garbage']);
+
+    const lastCall = mockUseInfiniteSearchVideos.mock.calls.at(-1)?.[0];
+    expect(lastCall?.sortMode).toBe('hot');
+    expect(screen.getByTestId('search-sort-hot')).toHaveAttribute('aria-checked', 'true');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location-display').textContent).not.toContain('sort=');
+    });
+  });
+
+  it('supports roving keyboard navigation for sort radios', async () => {
+    const user = userEvent.setup();
+    mockUseInfiniteSearchVideos.mockReturnValue({
+      data: { pages: [{ videos: [] }] },
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+      isLoading: false,
+      error: null,
+    });
+
+    renderPage(['/search?q=dogs']);
+
+    const relevancePill = screen.getByTestId('search-sort-relevance');
+    const hotPill = screen.getByTestId('search-sort-hot');
+    const topPill = screen.getByTestId('search-sort-top');
+    const controversialPill = screen.getByTestId('search-sort-controversial');
+
+    expect(hotPill).toHaveAttribute('tabIndex', '0');
+    expect(relevancePill).toHaveAttribute('tabIndex', '-1');
+
+    hotPill.focus();
+    await user.keyboard('{ArrowRight}');
+
+    expect(topPill).toHaveFocus();
+    expect(topPill).toHaveAttribute('aria-checked', 'true');
+    expect(hotPill).toHaveAttribute('tabIndex', '-1');
+    expect(topPill).toHaveAttribute('tabIndex', '0');
+
+    await user.keyboard('{Home}');
+
+    expect(relevancePill).toHaveFocus();
+    expect(relevancePill).toHaveAttribute('aria-checked', 'true');
+
+    await user.keyboard('{End}');
+
+    expect(controversialPill).toHaveFocus();
+    expect(controversialPill).toHaveAttribute('aria-checked', 'true');
+  });
+
   it('writes sort to URL when user picks a non-default mode and omits it when hot is chosen', async () => {
     const user = userEvent.setup();
     mockUseInfiniteSearchVideos.mockReturnValue({

--- a/src/pages/SearchPage.test.tsx
+++ b/src/pages/SearchPage.test.tsx
@@ -538,4 +538,64 @@ describe('SearchPage', () => {
     expect(screen.getAllByTestId('video-card-video-2').length).toBeGreaterThan(0);
     expect(screen.queryAllByTestId('bare-video-card-video-2')).toHaveLength(0);
   });
+
+  it('defaults to hot sort when no sort param is in the URL and passes it to useInfiniteSearchVideos', () => {
+    mockUseInfiniteSearchVideos.mockReturnValue({
+      data: { pages: [{ videos: [] }] },
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+      isLoading: false,
+      error: null,
+    });
+
+    renderPage(['/search?q=dogs']);
+
+    const lastCall = mockUseInfiniteSearchVideos.mock.calls.at(-1)?.[0];
+    expect(lastCall?.sortMode).toBe('hot');
+
+    const hotPill = screen.getByTestId('search-sort-hot');
+    expect(hotPill).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByTestId('search-sort-relevance')).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('honors the sort URL param on initial load', () => {
+    mockUseInfiniteSearchVideos.mockReturnValue({
+      data: { pages: [{ videos: [] }] },
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+      isLoading: false,
+      error: null,
+    });
+
+    renderPage(['/search?q=dogs&sort=top']);
+
+    const lastCall = mockUseInfiniteSearchVideos.mock.calls.at(-1)?.[0];
+    expect(lastCall?.sortMode).toBe('top');
+    expect(screen.getByTestId('search-sort-top')).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('writes sort to URL when user picks a non-default mode and omits it when hot is chosen', async () => {
+    const user = userEvent.setup();
+    mockUseInfiniteSearchVideos.mockReturnValue({
+      data: { pages: [{ videos: [] }] },
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+      isLoading: false,
+      error: null,
+    });
+
+    renderPage(['/search?q=dogs']);
+
+    await user.click(screen.getByTestId('search-sort-top'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location-display').textContent).toContain('sort=top');
+    });
+
+    await user.click(screen.getByTestId('search-sort-hot'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location-display').textContent).not.toContain('sort=');
+    });
+  });
 });

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -13,7 +13,6 @@ import { trackSearch } from '@/lib/analytics';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Badge } from '@/components/ui/badge';
@@ -61,7 +60,7 @@ export function SearchPage() {
   const { config } = useAppContext();
   const [searchQuery, setSearchQuery] = useState(searchParams.get('q') || '');
   const [sortMode, setSortMode] = useState<SortMode | 'relevance'>(
-    (searchParams.get('sort') as SortMode | 'relevance') || 'relevance'
+    (searchParams.get('sort') as SortMode | 'relevance') || 'hot'
   );
   const [activeFilter, setActiveFilter] = useState<SearchFilter>(
     (searchParams.get('filter') as SearchFilter) || 'all'
@@ -150,7 +149,7 @@ export function SearchPage() {
       debouncedSearchQuery.current = searchQuery;
       const params = new URLSearchParams();
       if (searchQuery) params.set('q', searchQuery);
-      if (sortMode !== 'relevance') params.set('sort', sortMode);
+      if (sortMode !== 'hot') params.set('sort', sortMode);
       if (activeFilter !== 'all') params.set('filter', activeFilter);
       if (compilationRequest.play) {
         params.set('play', 'compilation');
@@ -349,7 +348,7 @@ export function SearchPage() {
     const trimmedQuery = searchQuery.trim();
 
     if (trimmedQuery) params.set('q', trimmedQuery);
-    if (sortMode !== 'relevance') params.set('sort', sortMode);
+    if (sortMode !== 'hot') params.set('sort', sortMode);
     if (activeFilter !== 'all') params.set('filter', activeFilter);
 
     const query = params.toString();
@@ -412,23 +411,36 @@ export function SearchPage() {
 
           {/* Sort mode selector for video results */}
           {(activeFilter === 'all' || activeFilter === 'videos') && searchQuery.trim() && (
-            <div className="flex items-center gap-2 justify-end">
-              <span className="text-sm text-muted-foreground">Sort:</span>
-              <Select value={sortMode} onValueChange={(value) => setSortMode(value as SortMode)}>
-                <SelectTrigger className="w-[160px]">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {SORT_MODES.map(mode => (
-                    <SelectItem key={mode.value} value={mode.value}>
-                      <div className="flex items-center gap-2">
-                        <mode.icon className="h-4 w-4" />
-                        {mode.label}
-                      </div>
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+            <div
+              role="radiogroup"
+              aria-label="Sort search results"
+              data-testid="search-sort-pills"
+              className="flex flex-wrap gap-2"
+            >
+              {SORT_MODES.map(mode => {
+                const ModeIcon = mode.icon;
+                const isSelected = sortMode === mode.value;
+                return (
+                  <button
+                    key={mode.value}
+                    type="button"
+                    role="radio"
+                    aria-checked={isSelected}
+                    data-testid={`search-sort-${mode.value}`}
+                    onClick={() => setSortMode(mode.value as SortMode | 'relevance')}
+                    className={`
+                      flex items-center gap-2 px-4 py-2 rounded-lg font-medium transition-all
+                      ${isSelected
+                        ? 'bg-primary text-primary-foreground shadow-md'
+                        : 'bg-brand-light-green dark:bg-brand-dark-green hover:bg-muted text-muted-foreground hover:text-foreground'
+                      }
+                    `}
+                  >
+                    <ModeIcon className="h-4 w-4" />
+                    <span>{mode.label}</span>
+                  </button>
+                );
+              })}
             </div>
           )}
 

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -1,7 +1,7 @@
 // ABOUTME: Comprehensive search page with debounced input, filter tabs, infinite scroll, and sort modes
 // ABOUTME: Supports searching videos, users, hashtags with NIP-50 full-text search
 
-import { useState, useEffect, useRef, useMemo, type ClipboardEvent } from 'react';
+import { useState, useEffect, useRef, useMemo, type ClipboardEvent, type KeyboardEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSearchParams } from 'react-router-dom';
 import { useNostr } from '@nostrify/react';
@@ -48,6 +48,12 @@ import {
 
 type SearchFilter = 'all' | 'videos' | 'users' | 'hashtags';
 
+function getValidSearchSortMode(sortParam: string | null): SortMode | 'relevance' {
+  return SORT_MODES.some(mode => mode.value === sortParam)
+    ? (sortParam as SortMode | 'relevance')
+    : 'hot';
+}
+
 export function SearchPage() {
   const { t } = useTranslation();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -59,8 +65,8 @@ export function SearchPage() {
   const navigate = useSubdomainNavigate();
   const { config } = useAppContext();
   const [searchQuery, setSearchQuery] = useState(searchParams.get('q') || '');
-  const [sortMode, setSortMode] = useState<SortMode | 'relevance'>(
-    (searchParams.get('sort') as SortMode | 'relevance') || 'hot'
+  const [sortMode, setSortMode] = useState<SortMode | 'relevance'>(() =>
+    getValidSearchSortMode(searchParams.get('sort'))
   );
   const [activeFilter, setActiveFilter] = useState<SearchFilter>(
     (searchParams.get('filter') as SearchFilter) || 'all'
@@ -295,6 +301,31 @@ export function SearchPage() {
     setActiveFilter(filter);
   };
 
+  const handleSortRadioKeyDown = (
+    event: KeyboardEvent<HTMLButtonElement>,
+    index: number,
+  ) => {
+    const lastIndex = SORT_MODES.length - 1;
+    const nextIndexByKey: Partial<Record<string, number>> = {
+      ArrowRight: index === lastIndex ? 0 : index + 1,
+      ArrowDown: index === lastIndex ? 0 : index + 1,
+      ArrowLeft: index === 0 ? lastIndex : index - 1,
+      ArrowUp: index === 0 ? lastIndex : index - 1,
+      Home: 0,
+      End: lastIndex,
+    };
+    const nextIndex = nextIndexByKey[event.key];
+
+    if (nextIndex === undefined) return;
+
+    event.preventDefault();
+    setSortMode(SORT_MODES[nextIndex].value);
+    event.currentTarget.parentElement
+      ?.querySelectorAll<HTMLButtonElement>('[role="radio"]')
+      .item(nextIndex)
+      ?.focus();
+  };
+
   // Loading state based on active filter
   const isLoading = (() => {
     switch (activeFilter) {
@@ -417,7 +448,7 @@ export function SearchPage() {
               data-testid="search-sort-pills"
               className="flex flex-wrap gap-2"
             >
-              {SORT_MODES.map(mode => {
+              {SORT_MODES.map((mode, index) => {
                 const ModeIcon = mode.icon;
                 const isSelected = sortMode === mode.value;
                 return (
@@ -426,8 +457,10 @@ export function SearchPage() {
                     type="button"
                     role="radio"
                     aria-checked={isSelected}
+                    tabIndex={isSelected ? 0 : -1}
                     data-testid={`search-sort-${mode.value}`}
-                    onClick={() => setSortMode(mode.value as SortMode | 'relevance')}
+                    onClick={() => setSortMode(mode.value)}
+                    onKeyDown={(event) => handleSortRadioKeyDown(event, index)}
                     className={`
                       flex items-center gap-2 px-4 py-2 rounded-lg font-medium transition-all
                       ${isSelected


### PR DESCRIPTION
## Summary

- The sort selector on `/search` was a small `<Select>` dropdown next to the search bar that users were missing. Promote it to a prominent pill row above the results, matching the Trending/Discovery feed pattern.
- Default sort changes from `relevance` to `hot` (recent + high engagement). Fresh `/search?q=X` URLs now land on lively videos instead of pure lexical-match order.
- URL canonicalization stays consistent: the default (`hot`) is omitted from the URL; any other mode (`relevance`, `top`, `rising`, `classic`, `controversial`) is written. Existing shared `?sort=top` links still resolve.

## ⚠️ Depends on funnelcake backend PR

This PR's sort pills change UI state and URL, but the **REST API silently ignores the `sort` param on `/api/search` and `/api/v2/search`** today. The backend fix is in: **divinevideo/divine-funnelcake#371**.

Evidence (same 3 IDs returned in same order regardless of sort value, on both prod and staging):
```
$ for s in trending loops engagement GARBAGE; do
    curl -s "https://api.divine.video/api/v2/search?q=dog&sort=$s&limit=3" \
      | jq -r '.data[] | "  id=\(.id[0:10]) loops=\(.loops)"'
  done
# all four produce identical output
```

OpenAPI confirms it: `/api/search` parameters are `tag, q, limit, offset, label, exclude_label, content_safety, nsfw, moderation_profile, type` — no `sort`. Root cause in funnelcake: `VIDEO_SORT_BY` hardcoded at `crates/api/src/search.rs:14`.

**Land funnelcake#371 first. Then this PR works end-to-end.** Until then, this PR is harmless — the param is just URL state and the existing hashtag/NIP-50 fallback paths already honor sort.

## What changed (web)

- `src/pages/SearchPage.tsx`: replaced `<Select>` + 6 imports with a `flex flex-wrap gap-2` button row reusing `SEARCH_SORT_MODES`, same icon set, brand-green tab styling from `TrendingPage`. Buttons accessible (`role="radio"` inside `role="radiogroup"`, `aria-checked`, `data-testid`).
- Default `useState` flipped from `'relevance'` to `'hot'`. Both URL writes (debounced sync + compilation-return path) gate on `sortMode !== 'hot'`.
- `src/pages/SearchPage.test.tsx`: 3 new tests cover default-hot initialization, `?sort=top` URL honoring, and round-trip URL write/erase on toggle.

## Test plan

- [x] `npx vitest run src/pages/SearchPage.test.tsx` — 17/17 passing
- [x] `npx vitest run tests/brand/` — brand guardrails clean
- [x] `npx vitest run` — 824/824 passing
- [x] `npx eslint src/pages/SearchPage.tsx src/pages/SearchPage.test.tsx` — 0 issues
- [ ] After funnelcake#371 deploys: live `curl https://api.divine.video/api/v2/search?q=dog&sort=loops` returns different ordering than `sort=trending`
- [ ] Visual: `/search?q=child&filter=videos`, confirm pill row above grid with Hot selected; click Top, verify URL `?sort=top` and grid re-sorts

🤖 Generated with [Claude Code](https://claude.com/claude-code)