### PR TITLE
feat(about): thank Miss Australiana, ArchiveTeam, and the Internet Archive

### DIFF
--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -179,6 +179,21 @@ export function AboutPage() {
               pre-AI era videos a new home on the decentralized web. We're committed to restoring creator ownership
               and attribution when possible, honoring those who created these cultural artifacts.
             </p>
+            <p className="text-muted-foreground">
+              Huge thanks to{" "}
+              <a href="https://missaustraliana.net/" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">
+                Miss Australiana
+              </a>{" "}
+              for sharing more recovered Vines with us, the volunteer archivists at{" "}
+              <a href="https://wiki.archiveteam.org/index.php/Vine" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">
+                ArchiveTeam
+              </a>{" "}
+              who raced to save the platform before it went dark, and{" "}
+              <a href="https://archive.org/" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">
+                the Internet Archive
+              </a>{" "}
+              for keeping the lights on so these videos still have a home.
+            </p>
             <blockquote className="border-l-4 border-primary pl-4 italic text-muted-foreground">
               "Do it for the Vine!" — A motto from the creative community, circa 2015
             </blockquote>


### PR DESCRIPTION
## Summary

Adds a credits paragraph in the "Preserving Archived Videos" section of the About page (`/about`), recognizing the people and projects responsible for keeping the Vine archive alive:

- **[Miss Australiana](https://missaustraliana.net/)** — for sharing newly recovered Vines we're folding into the Divine archive
- **[ArchiveTeam](https://wiki.archiveteam.org/index.php/Vine)** — for racing to preserve Vine before it went dark in 2017
- **[The Internet Archive](https://archive.org/)** — for hosting these videos so they don't disappear again

Slots in between the existing import-explanation paragraph and the "Do it for the Vine!" blockquote in `src/pages/AboutPage.tsx`. ArchiveTeam was already linked in the section intro; the new paragraph re-mentions them in the thanks-context with the same link, which reads natural.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint src/pages/AboutPage.tsx` clean
- [ ] Visual check on /about — three links open in new tabs, prose flows naturally before the blockquote

🤖 Generated with [Claude Code](https://claude.com/claude-code)