### PR TITLE
Link nostr mentions in video titles

### DIFF
--- a/src/components/InlineNostrText.test.tsx
+++ b/src/components/InlineNostrText.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import { nip19 } from 'nostr-tools';
 import { InlineNostrText } from './InlineNostrText';
 
@@ -13,25 +14,60 @@ vi.mock('@/hooks/useAuthor', () => ({
 const PUBKEY_HEX = 'a'.repeat(64);
 const NPUB = nip19.npubEncode(PUBKEY_HEX);
 
+function renderInlineText(text: string, props: Omit<React.ComponentProps<typeof InlineNostrText>, 'text'> = {}) {
+  return render(
+    <MemoryRouter>
+      <InlineNostrText text={text} {...props} />
+    </MemoryRouter>
+  );
+}
+
 describe('InlineNostrText', () => {
-  it('replaces a bare npub1... with @displayName', () => {
-    render(<InlineNostrText text={`hi ${NPUB}!`} />);
-    expect(screen.getByText(/@rabble/)).toBeInTheDocument();
+  it('replaces a bare npub1... with a profile link using the display name', () => {
+    renderInlineText(`hi ${NPUB}!`);
+    const link = screen.getByRole('link', { name: '@rabble' });
+    expect(link).toHaveAttribute('href', `/${NPUB}`);
   });
 
-  it('still replaces nostr:npub1... with @displayName (regression)', () => {
-    render(<InlineNostrText text={`hi nostr:${NPUB}!`} />);
-    expect(screen.getByText(/@rabble/)).toBeInTheDocument();
+  it('still replaces nostr:npub1... with a profile link using the display name (regression)', () => {
+    renderInlineText(`hi nostr:${NPUB}!`);
+    const link = screen.getByRole('link', { name: '@rabble' });
+    expect(link).toHaveAttribute('href', `/${NPUB}`);
   });
 
   it('renders plain text when no mention is present', () => {
-    render(<InlineNostrText text="hello world" />);
+    renderInlineText("hello world");
     expect(screen.getByText('hello world')).toBeInTheDocument();
   });
 
+  it('links non-mention text to the fallback target when provided', () => {
+    renderInlineText('hello world', { textLinkTo: '/video/video-1' });
+    expect(screen.getByRole('link', { name: 'hello world' })).toHaveAttribute('href', '/video/video-1');
+  });
+
+  it('keeps mention links separate from the fallback text link', () => {
+    renderInlineText(`hello ${NPUB}`, { textLinkTo: '/video/video-1' });
+    expect(screen.getByRole('link', { name: /hello/ })).toHaveAttribute('href', '/video/video-1');
+    expect(screen.getByRole('link', { name: '@rabble' })).toHaveAttribute('href', `/${NPUB}`);
+  });
+
+  it('still linkifies npub mentions when they are followed by adjacent nostr text', () => {
+    renderInlineText(`hi nostr:${NPUB}nostr:${NPUB}`);
+    const links = screen.getAllByRole('link', { name: '@rabble' });
+    expect(links).toHaveLength(2);
+    expect(links[0]).toHaveAttribute('href', `/${NPUB}`);
+    expect(links[1]).toHaveAttribute('href', `/${NPUB}`);
+  });
+
   it('does not match bech32-shaped strings mid-word', () => {
-    const { container } = render(<InlineNostrText text={`xxx${NPUB}yyy`} />);
+    const { container } = renderInlineText(`xxx${NPUB}yyy`);
     expect(container.textContent).toBe(`xxx${NPUB}yyy`);
     expect(container.textContent).not.toContain('@rabble');
+  });
+
+  it('does not match npub strings followed by an underscore word suffix', () => {
+    const { container } = renderInlineText(`${NPUB}_suffix`);
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(container.textContent).toBe(`${NPUB}_suffix`);
   });
 });

--- a/src/components/InlineNostrText.tsx
+++ b/src/components/InlineNostrText.tsx
@@ -1,14 +1,11 @@
-// ABOUTME: Renders text with nostr:npub1... references replaced by @displayName
-// ABOUTME: Plain text output (no links), safe to use inside <a> tags and titles
-
 import { useMemo } from 'react';
 import { nip19 } from 'nostr-tools';
+import { SmartLink } from '@/components/SmartLink';
 import { useAuthor } from '@/hooks/useAuthor';
 import { genUserName } from '@/lib/genUserName';
 
-// Matches both prefixed (nostr:npub1...) and bare (npub1...) forms.
-// Word boundary keeps `xxxnpub1...yyy` mid-word strings from matching.
-const NOSTR_MENTION_REGEX = /(?:nostr:)?\b(npub1[023456789acdefghjklmnpqrstuvwxyz]+)\b/g;
+const NIP19_CHARS = '023456789acdefghjklmnpqrstuvwxyz';
+const NOSTR_MENTION_REGEX = new RegExp(`(?:nostr:)?\\b(npub1[${NIP19_CHARS}]{58})(?=$|[^A-Za-z0-9_]|nostr:)`, 'g');
 
 /** Extract all npub pubkeys from a text string */
 function extractPubkeys(text: string): string[] {
@@ -31,31 +28,46 @@ function extractPubkeys(text: string): string[] {
 /** Resolves a single pubkey to a display name */
 function MentionName({ pubkey }: { pubkey: string }) {
   const author = useAuthor(pubkey);
+  const npub = nip19.npubEncode(pubkey);
   const displayName = author.data?.metadata?.name || author.data?.metadata?.display_name || genUserName(pubkey);
-  return <>@{displayName}</>;
+
+  return (
+    <SmartLink to={`/${npub}`} ownerPubkey={pubkey} className="hover:underline">
+      @{displayName}
+    </SmartLink>
+  );
 }
 
 interface InlineNostrTextProps {
   text: string;
+  textLinkTo?: string;
+  textLinkOwnerPubkey?: string | null;
+  textLinkClassName?: string;
 }
 
-/**
- * Renders text with nostr:npub1... mentions replaced by @displayName.
- * Does NOT render links — safe to use inside other clickable elements.
- */
-export function InlineNostrText({ text }: InlineNostrTextProps) {
+export function InlineNostrText({ text, textLinkTo, textLinkOwnerPubkey, textLinkClassName }: InlineNostrTextProps) {
   const pubkeys = useMemo(() => extractPubkeys(text), [text]);
 
-  // No mentions — render as plain text (no hooks called conditionally)
   if (pubkeys.length === 0) {
-    return <>{text}</>;
+    return <TextPart text={text} linkTo={textLinkTo} ownerPubkey={textLinkOwnerPubkey} className={textLinkClassName} />;
   }
 
-  return <InlineNostrTextResolved text={text} />;
+  return <InlineNostrTextResolved text={text} textLinkTo={textLinkTo} textLinkOwnerPubkey={textLinkOwnerPubkey} textLinkClassName={textLinkClassName} />;
 }
 
-/** Inner component that renders text with resolved mentions */
-function InlineNostrTextResolved({ text }: { text: string }) {
+function TextPart({ text, linkTo, ownerPubkey, className }: { text: string; linkTo?: string; ownerPubkey?: string | null; className?: string }) {
+  if (!linkTo || text.trim() === '') {
+    return <span>{text}</span>;
+  }
+
+  return (
+    <SmartLink to={linkTo} ownerPubkey={ownerPubkey} className={className}>
+      {text}
+    </SmartLink>
+  );
+}
+
+function InlineNostrTextResolved({ text, textLinkTo, textLinkOwnerPubkey, textLinkClassName }: InlineNostrTextProps) {
   const parts = useMemo(() => {
     const result: { type: 'text' | 'mention'; value: string }[] = [];
     let lastIndex = 0;
@@ -92,7 +104,7 @@ function InlineNostrTextResolved({ text }: { text: string }) {
         part.type === 'mention' ? (
           <MentionName key={i} pubkey={part.value} />
         ) : (
-          <span key={i}>{part.value}</span>
+          <TextPart key={i} text={part.value} linkTo={textLinkTo} ownerPubkey={textLinkOwnerPubkey} className={textLinkClassName} />
         )
       )}
     </>

--- a/src/components/NoteContent.test.tsx
+++ b/src/components/NoteContent.test.tsx
@@ -7,7 +7,7 @@ import type { NostrEvent } from '@nostrify/nostrify';
 
 vi.mock('@/hooks/useAuthor', () => ({
   useAuthor: () => ({
-    data: { metadata: { name: 'rabble' } },
+    data: { metadata: { display_name: 'rabble' } },
     isLoading: false,
   }),
 }));
@@ -86,11 +86,24 @@ describe('NoteContent — prefixed nostr: form (regression)', () => {
     const link = screen.getByRole('link');
     expect(link).toHaveAttribute('href', `/${NOTE}`);
   });
+
+  it('still linkifies adjacent nostr:npub1... mentions as profile links', () => {
+    renderContent(`hello nostr:${NPUB}nostr:${NPUB}`);
+    const links = screen.getAllByRole('link', { name: '@rabble' });
+    expect(links).toHaveLength(2);
+    expect(links[0]).toHaveAttribute('href', `/${NPUB}`);
+    expect(links[1]).toHaveAttribute('href', `/${NPUB}`);
+  });
 });
 
 describe('NoteContent — non-matches', () => {
   it('does not linkify a bech32-shaped id mid-word', () => {
     renderContent(`xxx${NPUB}yyy`);
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('does not linkify npub strings followed by an underscore word suffix', () => {
+    renderContent(`${NPUB}_suffix`);
     expect(screen.queryByRole('link')).not.toBeInTheDocument();
   });
 

--- a/src/components/NoteContent.tsx
+++ b/src/components/NoteContent.tsx
@@ -20,9 +20,8 @@ export function NoteContent({
   const content = useMemo(() => {
     const text = event.content;
     
-    // Regex to find URLs, Nostr references (with optional `nostr:` prefix), and hashtags.
-    // Word boundaries (\b) prevent mid-word false positives like `xxxnpub1...yyy`.
-    const regex = /(https?:\/\/[^\s]+)|(?:nostr:)?\b((?:npub1|note1|nprofile1|nevent1|naddr1)[023456789acdefghjklmnpqrstuvwxyz]+)\b|(#\w+)/g;
+    const nip19Chars = '023456789acdefghjklmnpqrstuvwxyz';
+    const regex = new RegExp(`(https?:\\/\\/[^\\s]+)|(?:nostr:)?\\b((?:npub1|note1)[${nip19Chars}]{58}|(?:nprofile1|nevent1|naddr1)[${nip19Chars}]+)(?=$|[^A-Za-z0-9_]|nostr:)|(#\\w+)`, 'g');
 
     const parts: React.ReactNode[] = [];
     let lastIndex = 0;
@@ -119,8 +118,8 @@ export function NoteContent({
 function NostrMention({ pubkey }: { pubkey: string }) {
   const author = useAuthor(pubkey);
   const npub = nip19.npubEncode(pubkey);
-  const hasRealName = !!author.data?.metadata?.name;
-  const displayName = author.data?.metadata?.name ?? genUserName(pubkey);
+  const hasRealName = !!(author.data?.metadata?.name || author.data?.metadata?.display_name);
+  const displayName = author.data?.metadata?.name || author.data?.metadata?.display_name || genUserName(pubkey);
 
   return (
     <SmartLink

--- a/src/components/VideoCard.tsx
+++ b/src/components/VideoCard.tsx
@@ -805,9 +805,9 @@ export function VideoCard({
             isHorizontal ? "space-y-1" : "p-4 space-y-2"
           )}>
             {video.title && (
-              <SmartLink to={`/video/${video.id}`} ownerPubkey={video.pubkey}>
-                <h3 className={cn("font-semibold line-clamp-2 hover:underline", isHorizontal ? "text-sm" : "text-lg")}><InlineNostrText text={video.title} /></h3>
-              </SmartLink>
+              <h3 className={cn("font-semibold line-clamp-2", isHorizontal ? "text-sm" : "text-lg")}>
+                <InlineNostrText text={video.title} textLinkTo={`/video/${video.id}`} textLinkOwnerPubkey={video.pubkey} textLinkClassName="hover:underline" />
+              </h3>
             )}
 
             {video.content && video.content.trim() !== video.title?.trim() && (


### PR DESCRIPTION
## Summary
- Render `npub` and `nostr:npub` mentions as clickable profile links in inline video-title text
- Preserve video-title navigation for non-mention text without nesting anchors
- Tighten NIP-19 parsing so adjacent `nostr:` tokens split correctly while underscore suffixes remain non-matches

## Test plan
- [x] `npx vitest run src/components/InlineNostrText.test.tsx src/components/NoteContent.test.tsx src/components/VideoCard.test.tsx`
- [x] `npx tsc --noEmit`
- [x] `git diff --check`
- [x] `npm run build`
- [x] Browser smoke test for title text link + profile links with no nested anchors

🤖 Generated with [Claude Code](https://claude.com/claude-code)