### PR TITLE
fix(media): handle age-gated media 401s

### DIFF
--- a/src/components/VideoGrid.test.tsx
+++ b/src/components/VideoGrid.test.tsx
@@ -24,6 +24,7 @@ vi.mock('@/hooks/useCurrentUser', () => ({
 
 vi.mock('@/hooks/useAdultVerification', () => ({
   useAdultVerification: () => mockUseAdultVerification(),
+  checkMediaAuth: vi.fn().mockResolvedValue({ authorized: true, status: 200 }),
   fetchWithAuth: vi.fn(async (url: string, authHeader: string | null) => fetch(url, {
     headers: authHeader ? { Authorization: authHeader } : {},
   })),
@@ -99,6 +100,35 @@ describe('VideoGrid age-restricted gating', () => {
 
     expect(mockOpenLoginDialog).toHaveBeenCalledTimes(1);
     expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('shows the age-restricted gate when a thumbnail media error probes as 401', async () => {
+    const { checkMediaAuth } = await import('@/hooks/useAdultVerification');
+    (checkMediaAuth as ReturnType<typeof vi.fn>).mockResolvedValue({
+      authorized: false,
+      status: 401,
+    });
+
+    render(
+      <VideoGrid
+        videos={[
+          makeVideo({
+            id: 'unknown-restricted-video',
+            ageRestricted: false,
+          }),
+        ]}
+      />
+    );
+
+    fireEvent.error(screen.getByTestId('video-thumbnail-unknown-restricted-video'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Log in to view')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Age-restricted')).toBeInTheDocument();
+    expect(screen.queryByTestId('video-thumbnail-unknown-restricted-video')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('video-player-unknown-restricted-video')).not.toBeInTheDocument();
   });
 
   it('renders unrestricted videos with their thumbnail media as before', () => {

--- a/src/components/VideoGrid.tsx
+++ b/src/components/VideoGrid.tsx
@@ -9,7 +9,7 @@ import { Badge } from '@/components/ui/badge';
 import { AgeRestrictedMediaPlaceholder } from '@/components/AgeRestrictedMediaPlaceholder';
 import { useLoginDialog } from '@/contexts/LoginDialogContext';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
-import { useAdultVerification } from '@/hooks/useAdultVerification';
+import { checkMediaAuth, useAdultVerification } from '@/hooks/useAdultVerification';
 import { useAuthenticatedMediaUrl } from '@/hooks/useAuthenticatedMediaUrl';
 import { cn } from '@/lib/utils';
 import type { ParsedVideoData } from '@/types/video';
@@ -143,6 +143,7 @@ export function VideoGrid({ videos, loading = false, className, navigationContex
   const { openLoginDialog } = useLoginDialog();
   const [hoveredVideo, setHoveredVideo] = useState<string | null>(null);
   const [failedThumbnails, setFailedThumbnails] = useState<Set<string>>(new Set());
+  const [discoveredAgeRestrictedVideos, setDiscoveredAgeRestrictedVideos] = useState<Set<string>>(new Set());
   const videoRefs = useRef<Map<string, HTMLVideoElement>>(new Map());
 
   const handleVideoClick = (videoId: string, index: number) => {
@@ -164,8 +165,18 @@ export function VideoGrid({ videos, loading = false, className, navigationContex
     }
   };
 
-  const handleThumbnailError = (videoId: string) => {
-    setFailedThumbnails((prev) => new Set(prev).add(videoId));
+  const handleThumbnailError = async (video: ParsedVideoData) => {
+    const urlToCheck = video.thumbnailUrl || video.videoUrl;
+
+    if (urlToCheck) {
+      const { authorized, status } = await checkMediaAuth(urlToCheck);
+      if (!authorized && (status === 401 || status === 403)) {
+        setDiscoveredAgeRestrictedVideos((prev) => new Set(prev).add(video.id));
+        return;
+      }
+    }
+
+    setFailedThumbnails((prev) => new Set(prev).add(video.id));
   };
 
   const handleAgeGateAction = () => {
@@ -248,7 +259,9 @@ export function VideoGrid({ videos, loading = false, className, navigationContex
       {videos.map((video, index) => {
         const isHovered = hoveredVideo === video.id;
         const thumbnailFailed = failedThumbnails.has(video.id);
-        const isAgeGated = video.ageRestricted === true && (!user || !isAdultVerified);
+        const isKnownAgeRestricted = video.ageRestricted === true || discoveredAgeRestrictedVideos.has(video.id);
+        const gridVideo = isKnownAgeRestricted ? { ...video, ageRestricted: true } : video;
+        const isAgeGated = isKnownAgeRestricted && (!user || !isAdultVerified);
 
         return (
           <Card
@@ -279,9 +292,9 @@ export function VideoGrid({ videos, loading = false, className, navigationContex
                 />
               ) : (
                 <VideoGridMedia
-                  video={video}
+                  video={gridVideo}
                   thumbnailFailed={thumbnailFailed}
-                  onThumbnailError={handleThumbnailError}
+                  onThumbnailError={() => void handleThumbnailError(gridVideo)}
                   videoRefs={videoRefs}
                 />
               )}

--- a/src/components/VideoPlayer.test.tsx
+++ b/src/components/VideoPlayer.test.tsx
@@ -41,6 +41,12 @@ vi.mock('@/hooks/useCurrentUser', () => ({
   })),
 }));
 
+vi.mock('@/contexts/LoginDialogContext', () => ({
+  useLoginDialog: () => ({
+    openLoginDialog: vi.fn(),
+  }),
+}));
+
 vi.mock('@/hooks/useAdultVerification', () => ({
   useAdultVerification: vi.fn(() => ({
     isVerified: false,
@@ -398,6 +404,116 @@ describe('VideoPlayer', () => {
   });
 
   describe('protected media auth failures', () => {
+    it('shows age verification when an unverified direct media error probes as 401', async () => {
+      const { checkMediaAuth } = await import('@/hooks/useAdultVerification');
+      (checkMediaAuth as ReturnType<typeof vi.fn>).mockResolvedValue({
+        authorized: true,
+        status: 200,
+      });
+
+      const { container } = render(
+        <VideoPlayer
+          videoId="unknown-age-restricted"
+          src="https://media.divine.video/protected-video"
+          videoData={{
+            id: 'unknown-age-restricted',
+            pubkey: 'pub',
+            kind: 34236,
+            createdAt: 0,
+            content: '',
+            videoUrl: 'https://media.divine.video/protected-video',
+            hashtags: [],
+            vineId: null,
+            reposts: [],
+            isVineMigrated: false,
+            ageRestricted: false,
+          }}
+        />
+      );
+
+      const video = container.querySelector('video');
+      expect(video).not.toBeNull();
+      if (!video) {
+        throw new Error('expected rendered video element');
+      }
+
+      (checkMediaAuth as ReturnType<typeof vi.fn>).mockResolvedValue({
+        authorized: false,
+        status: 401,
+      });
+      fireEvent.error(video);
+
+      await waitFor(() => {
+        expect(screen.getByText(/age-restricted content/i)).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText('Failed to load video')).not.toBeInTheDocument();
+    });
+
+    it('retries unknown age-restricted media with auth for verified viewers after a 401 probe', async () => {
+      const getAuthHeader = vi.fn().mockResolvedValue('Nostr discovered-auth-header');
+      const fetchSpy = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        blob: () => Promise.resolve(new Blob(['test'], { type: 'video/mp4' })),
+      });
+
+      global.fetch = fetchSpy as typeof fetch;
+
+      const { useAdultVerification, checkMediaAuth } = await import('@/hooks/useAdultVerification');
+      (useAdultVerification as ReturnType<typeof vi.fn>).mockReturnValue({
+        isVerified: true,
+        isLoading: false,
+        hasSigner: true,
+        getAuthHeader,
+      });
+      (checkMediaAuth as ReturnType<typeof vi.fn>).mockResolvedValue({
+        authorized: true,
+        status: 200,
+      });
+
+      const { container } = render(
+        <VideoPlayer
+          videoId="verified-unknown-age-restricted"
+          src="https://media.divine.video/protected-video"
+          videoData={{
+            id: 'verified-unknown-age-restricted',
+            pubkey: 'pub',
+            kind: 34236,
+            createdAt: 0,
+            content: '',
+            videoUrl: 'https://media.divine.video/protected-video',
+            hashtags: [],
+            vineId: null,
+            reposts: [],
+            isVineMigrated: false,
+            ageRestricted: false,
+          }}
+        />
+      );
+
+      const video = container.querySelector('video');
+      expect(video).not.toBeNull();
+      if (!video) {
+        throw new Error('expected rendered video element');
+      }
+
+      (checkMediaAuth as ReturnType<typeof vi.fn>).mockResolvedValue({
+        authorized: false,
+        status: 401,
+      });
+      fireEvent.error(video);
+
+      await waitFor(() => {
+        expect(fetchSpy).toHaveBeenCalledWith(
+          'https://media.divine.video/protected-video',
+          expect.objectContaining({
+            headers: { Authorization: 'Nostr discovered-auth-header' },
+          }),
+        );
+      });
+    });
+
     it('does not retry age verification indefinitely for already verified viewers when media fetch returns 401', async () => {
       const getAuthHeader = vi.fn().mockResolvedValue('Nostr test-auth-header');
       const fetchSpy = vi.fn().mockResolvedValue({

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -127,14 +127,16 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
     const [currentUrlIndex, setCurrentUrlIndex] = useState(0);
     const [allUrls, setAllUrls] = useState<string[]>([]);
     const [triedHls, setTriedHls] = useState(false); // Track if we've fallen back to HLS
+    const [discoveredAgeRestricted, setDiscoveredAgeRestricted] = useState(false);
     const isChangingMuteState = useRef(false);
     const blobUrlRef = useRef<string | null>(null); // Track blob URL for cleanup to prevent memory leaks
 
     // Adult verification hook
     const { isVerified: isAdultVerified, getAuthHeader } = useAdultVerification();
+    const isKnownAgeRestricted = videoData?.ageRestricted === true || discoveredAgeRestricted;
     const { mediaUrl: authenticatedPosterUrl } = useAuthenticatedMediaUrl(poster, {
       enabled: !!poster && !requiresAuth && !authCheckPending,
-      ageRestricted: !!videoData?.ageRestricted,
+      ageRestricted: isKnownAgeRestricted,
     });
     const overlayPosterUrl = authenticatedPosterUrl ||
       (poster && !isProtectedDivineMediaUrl(poster) ? poster : undefined);
@@ -568,8 +570,29 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
       onLoadedData?.();
     };
 
-    const handleError = useCallback(() => {
+    const handleError = useCallback(async () => {
       debugError(`[VideoPlayer ${videoId}] Error loading video from URL index ${currentUrlIndex}: ${allUrls[currentUrlIndex]}`);
+
+      const failedUrl = allUrls[currentUrlIndex] || hlsUrl || src;
+      if (failedUrl && isProtectedDivineMediaUrl(failedUrl)) {
+        const { authorized, status } = await checkMediaAuth(failedUrl);
+        if (!authorized && (status === 401 || status === 403)) {
+          debugError(`[VideoPlayer ${videoId}] Media auth required after load failure (${status})`);
+
+          setHasError(false);
+          if (isAdultVerified) {
+            setDiscoveredAgeRestricted(true);
+            setIsLoading(true);
+            setAuthDeniedAfterVerification(false);
+            setAuthRetryCount(prev => prev + 1);
+            setCurrentUrlIndex(0);
+          } else {
+            setRequiresAuth(true);
+            setIsLoading(false);
+          }
+          return;
+        }
+      }
 
       // Try next fallback URL if available
       if (currentUrlIndex < allUrls.length - 1) {
@@ -589,7 +612,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
         setHasError(true);
         onError?.();
       }
-    }, [videoId, currentUrlIndex, allUrls, hlsUrl, triedHls, onError]);
+    }, [videoId, currentUrlIndex, allUrls, hlsUrl, src, triedHls, isAdultVerified, onError]);
 
     const handleEnded = () => {
       verboseLog(
@@ -777,7 +800,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
         // Add custom auth loader only when the video is age-restricted.
         // Public HLS streams must not carry an Authorization header — divine-blossom
         // rejects any malformed auth header with 401 even when the blob is public.
-        if (isAdultVerified && videoData?.ageRestricted) {
+        if (isAdultVerified && isKnownAgeRestricted) {
           verboseLog(`[VideoPlayer ${videoId}] Using NIP-98 auth loader for each HLS request`);
           hlsConfig.loader = createAuthLoader(getAuthHeader);
         }
@@ -845,7 +868,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
           // rejects any malformed auth header with 401 even when the blob is public,
           // so attaching auth optimistically locks users out of public content
           // whenever their signer produces an invalid event (e.g., JWT signer bugs).
-          if (isAdultVerified && videoData?.ageRestricted) {
+          if (isAdultVerified && isKnownAgeRestricted) {
             verboseLog(`[VideoPlayer ${videoId}] Fetching MP4 with NIP-98 auth`);
             (async () => {
               try {
@@ -929,7 +952,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
         }
       };
 
-    }, [hlsUrl, currentUrlIndex, allUrls, videoId, requiresAuth, isAdultVerified, authRetryCount, getAuthHeader, videoData?.ageRestricted]); // React to HLS URL, fallback, and auth changes
+    }, [hlsUrl, currentUrlIndex, allUrls, videoId, requiresAuth, isAdultVerified, authRetryCount, getAuthHeader, isKnownAgeRestricted]); // React to HLS URL, fallback, and auth changes
 
     // Cleanup on unmount
     useEffect(() => {

--- a/src/hooks/useAdultVerification.test.ts
+++ b/src/hooks/useAdultVerification.test.ts
@@ -4,9 +4,10 @@ import { useAdultVerification } from './useAdultVerification';
 import { createMediaViewerAuthHeader } from '@/lib/mediaViewerAuth';
 
 const mockSigner = { signEvent: vi.fn(), getPublicKey: vi.fn() };
+let currentSigner: typeof mockSigner | null = mockSigner;
 
 vi.mock('@/hooks/useCurrentUser', () => ({
-  useCurrentUser: () => ({ signer: mockSigner, pubkey: 'pub', user: { pubkey: 'pub' } }),
+  useCurrentUser: () => ({ signer: currentSigner, pubkey: currentSigner ? 'pub' : null, user: currentSigner ? { pubkey: 'pub' } : null }),
 }));
 
 vi.mock('@/lib/mediaViewerAuth', () => ({
@@ -37,6 +38,7 @@ function installMemoryStorage(): void {
 describe('useAdultVerification', () => {
   beforeEach(() => {
     installMemoryStorage();
+    currentSigner = mockSigner;
   });
 
   it('synchronizes confirmation across mounted hook instances', async () => {
@@ -58,6 +60,19 @@ describe('useAdultVerification', () => {
     await waitFor(() => {
       expect(second.result.current.isVerified).toBe(true);
     });
+  });
+
+  it('does not treat stored adult confirmation as verified without a signer', async () => {
+    currentSigner = null;
+    window.localStorage.setItem('adult-verification-confirmed', 'true');
+    window.localStorage.setItem('adult-verification-expiry', String(Date.now() + 60_000));
+
+    const { result } = renderHook(() => useAdultVerification());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.isVerified).toBe(false);
+    expect(result.current.hasSigner).toBe(false);
   });
 
   describe('getAuthHeader', () => {

--- a/src/hooks/useAdultVerification.ts
+++ b/src/hooks/useAdultVerification.ts
@@ -49,13 +49,14 @@ function notifyVerificationChange(): void {
 }
 
 export function useAdultVerification(): AdultVerificationState {
-  const [isVerified, setIsVerified] = useState(false);
+  const [storedIsVerified, setStoredIsVerified] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const { signer } = useCurrentUser();
+  const isVerified = storedIsVerified && !!signer;
 
   useEffect(() => {
     const syncFromStorage = () => {
-      setIsVerified(getStoredVerificationState());
+      setStoredIsVerified(getStoredVerificationState());
       setIsLoading(false);
     };
 
@@ -81,14 +82,14 @@ export function useAdultVerification(): AdultVerificationState {
     const expiryTime = Date.now() + VERIFICATION_DURATION_MS;
     localStorage.setItem(STORAGE_KEY, 'true');
     localStorage.setItem(STORAGE_EXPIRY_KEY, expiryTime.toString());
-    setIsVerified(true);
+    setStoredIsVerified(true);
     notifyVerificationChange();
   }, []);
 
   const revokeVerification = useCallback(() => {
     localStorage.removeItem(STORAGE_KEY);
     localStorage.removeItem(STORAGE_EXPIRY_KEY);
-    setIsVerified(false);
+    setStoredIsVerified(false);
     notifyVerificationChange();
   }, []);
 


### PR DESCRIPTION
## Summary
- Treat confirmed media 401/403 responses as age-restricted content in profile grids and video playback.
- Prevent logged-out viewers from reusing stale adult-verification localStorage without a signer.
- Retry discovered age-restricted video playback with authenticated media for verified viewers.

## Motivation
Age-gated media from `media.divine.video` can arrive as a 401 before the web client knows the item is age-restricted. That caused profile tiles to show generic media errors and play pages to stay black or show retry states instead of the existing login/age-confirmation flow.

## Visual change
Reuses the existing age-restricted login/verify UI. No new visual design was introduced.

## Test Plan
- [x] `npx vitest run src/hooks/useAdultVerification.test.ts src/components/VideoGrid.test.tsx src/components/VideoPlayer.test.tsx src/components/AgeVerificationOverlay.test.tsx src/components/ThumbnailPlayer.test.tsx`
- [x] `npm run test`