### PR TITLE
fix(analytics): keep route mounted while auth restores

### DIFF
--- a/src/AppRouter.test.tsx
+++ b/src/AppRouter.test.tsx
@@ -1,0 +1,63 @@
+import { Outlet } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import AppRouter from './AppRouter';
+
+const { mockUseCurrentUser } = vi.hoisted(() => ({
+  mockUseCurrentUser: vi.fn(() => ({
+    user: undefined,
+    isSessionLoading: true,
+  })),
+}));
+
+vi.mock('./hooks/useCurrentUser', () => ({
+  useCurrentUser: () => mockUseCurrentUser(),
+}));
+
+vi.mock('./hooks/useSubdomainUser', () => ({
+  getSubdomainUser: () => null,
+}));
+
+vi.mock('./components/ScrollToTop', () => ({
+  ScrollToTop: () => null,
+}));
+
+vi.mock('./components/AnalyticsPageTracker', () => ({
+  AnalyticsPageTracker: () => null,
+}));
+
+vi.mock('./components/AnalyticsUserTracker', () => ({
+  AnalyticsUserTracker: () => null,
+}));
+
+vi.mock('@/components/AppLayout', () => ({
+  AppLayout: () => <Outlet />,
+}));
+
+vi.mock('./pages/AnalyticsPage', () => ({
+  default: () => <div data-testid="analytics-page" />,
+}));
+
+vi.mock('./pages/NIP19Page', () => ({
+  NIP19Page: () => <div data-testid="nip19-page" />,
+}));
+
+describe('AppRouter', () => {
+  beforeEach(() => {
+    mockUseCurrentUser.mockReset();
+    mockUseCurrentUser.mockReturnValue({
+      user: undefined,
+      isSessionLoading: true,
+    });
+    window.history.pushState({}, '', '/');
+  });
+
+  it('keeps analytics routed while a saved session is restoring', () => {
+    window.history.pushState({}, '', '/analytics');
+
+    render(<AppRouter />);
+
+    expect(screen.getByTestId('analytics-page')).toBeInTheDocument();
+    expect(screen.queryByTestId('nip19-page')).not.toBeInTheDocument();
+  });
+});

--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -63,10 +63,10 @@ const BrandPreview = import.meta.env.DEV
   : null;
 
 export function AppRouter() {
-  const { user } = useCurrentUser();
+  const { user, isSessionLoading } = useCurrentUser();
 
   // Check if user is logged in
-  const isLoggedIn = Boolean(user);
+  const canUseProtectedRoutes = Boolean(user) || isSessionLoading;
 
   // Check if we're on a subdomain profile (username.divine.video)
   const subdomainUser = getSubdomainUser();
@@ -135,7 +135,7 @@ export function AppRouter() {
           <Route path="/:nip19" element={<NIP19Page />} />
 
           {/* Protected routes - require login */}
-          {isLoggedIn && (
+          {canUseProtectedRoutes && (
             <>
               <Route path="/home" element={<HomePage />} />
               <Route path="/notifications" element={<NotificationsPage />} />

--- a/src/hooks/useCurrentUser.test.ts
+++ b/src/hooks/useCurrentUser.test.ts
@@ -136,6 +136,7 @@ describe('useCurrentUser', () => {
     expect(result.current.user).toBeUndefined();
     expect(result.current.users).toEqual([]);
     expect(result.current.signer).toBeUndefined();
+    expect(result.current.isSessionLoading).toBe(true);
   });
 
   it('skips extension logins when no browser extension is available', () => {

--- a/src/hooks/useCurrentUser.ts
+++ b/src/hooks/useCurrentUser.ts
@@ -19,6 +19,7 @@ export function useCurrentUser() {
   const { getValidToken } = useDivineSession();
   const token = getValidToken();
   const [jwtPubkey, setJwtPubkey] = useState<string>();
+  const [jwtPubkeyStatus, setJwtPubkeyStatus] = useState<'idle' | 'loading' | 'settled'>('idle');
   const jwtSigner = useMemo(() => (
     token ? new DivineJWTSigner({ token }) : null
   ), [token]);
@@ -32,21 +33,25 @@ export function useCurrentUser() {
 
     if (!jwtSigner) {
       setJwtPubkey(undefined);
+      setJwtPubkeyStatus('idle');
       return;
     }
 
     setJwtPubkey(undefined);
+    setJwtPubkeyStatus('loading');
 
     jwtSigner.getPublicKey()
       .then((pubkey) => {
         if (!isCancelled) {
           setJwtPubkey(pubkey);
+          setJwtPubkeyStatus('settled');
         }
       })
       .catch((error) => {
         if (!isCancelled) {
           console.warn('Skipped invalid JWT session', error);
           setJwtPubkey(undefined);
+          setJwtPubkeyStatus('settled');
         }
       });
 
@@ -88,11 +93,13 @@ export function useCurrentUser() {
   const user = users[0];
   const signer = useMemo(() => getSafeUserSigner(user), [user]);
   const author = useAuthor(user?.pubkey);
+  const isSessionLoading = Boolean(jwtSigner && !jwtPubkey && jwtPubkeyStatus !== 'settled');
 
   return {
     user,
     users,
     signer,
+    isSessionLoading,
     ...author.data,
   };
 }

--- a/src/pages/AnalyticsPage.test.tsx
+++ b/src/pages/AnalyticsPage.test.tsx
@@ -1,0 +1,58 @@
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import AnalyticsPage from './AnalyticsPage';
+
+const { mockUseCurrentUser } = vi.hoisted(() => ({
+  mockUseCurrentUser: vi.fn(() => ({
+    user: undefined,
+    isSessionLoading: true,
+  })),
+}));
+
+vi.mock('@/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => mockUseCurrentUser(),
+}));
+
+vi.mock('@/hooks/useCreatorAnalytics', () => ({
+  useCreatorAnalytics: () => ({
+    data: undefined,
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+}));
+
+vi.mock('@unhead/react', () => ({
+  useSeoMeta: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe('AnalyticsPage', () => {
+  beforeEach(() => {
+    mockUseCurrentUser.mockReset();
+    mockUseCurrentUser.mockReturnValue({
+      user: undefined,
+      isSessionLoading: true,
+    });
+  });
+
+  it('waits for a saved session to restore instead of redirecting home', () => {
+    render(
+      <MemoryRouter initialEntries={['/analytics']}>
+        <Routes>
+          <Route path="/" element={<div data-testid="home-page" />} />
+          <Route path="/analytics" element={<AnalyticsPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId('analytics-auth-loading')).toBeInTheDocument();
+    expect(screen.queryByTestId('home-page')).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/AnalyticsPage.tsx
+++ b/src/pages/AnalyticsPage.tsx
@@ -213,7 +213,7 @@ function ErrorState({ message, onRetry }: { message: string; onRetry: () => void
 // --- Main Page ---
 
 export function AnalyticsPage() {
-  const { user } = useCurrentUser();
+  const { user, isSessionLoading } = useCurrentUser();
   const { t } = useTranslation();
 
   useSeoMeta({
@@ -222,6 +222,31 @@ export function AnalyticsPage() {
     ogTitle: t('analyticsPage.seoTitle'),
     ogDescription: t('analyticsPage.seoOgDescription'),
   });
+
+  if (isSessionLoading) {
+    return (
+      <div className="container mx-auto px-4 py-6" data-testid="analytics-auth-loading">
+        <div className="mx-auto max-w-3xl space-y-6">
+          <div className="flex items-center gap-3">
+            <Skeleton className="h-8 w-8 rounded-lg" />
+            <div className="space-y-2">
+              <Skeleton className="h-7 w-32" />
+              <Skeleton className="h-4 w-48" />
+            </div>
+          </div>
+          <KpiGridSkeleton />
+          <Card>
+            <CardHeader>
+              <Skeleton className="h-6 w-28" />
+            </CardHeader>
+            <CardContent>
+              <TopContentSkeleton />
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    );
+  }
 
   // Redirect to home if not logged in
   if (!user?.pubkey) {


### PR DESCRIPTION
## Summary
- Keep protected routes mounted while a saved JWT session is still resolving.
- Show the analytics loading skeleton during auth restoration instead of redirecting home.
- Add regression coverage for auth loading state, `/analytics` route matching, and analytics redirect behavior.

## Motivation
The Analytics sidebar link could appear broken because `/analytics` was only registered after `useCurrentUser()` had a resolved user. During saved-session restoration, the route could fall through to the `/:nip19` catch-all or redirect away before auth finished.

## Linked issue
None.

## Visual change
No intended visual change after auth resolves. During saved-session restoration, analytics now shows the existing skeleton/loading treatment instead of redirecting away.

## Test plan
- [x] `npx vitest run src/hooks/useCurrentUser.test.ts src/AppRouter.test.tsx src/pages/AnalyticsPage.test.tsx`
- [x] `npm run test`
