### PR TITLE
feat(popular): add popular feed page

### DIFF
--- a/docs/superpowers/plans/2026-05-15-popular-page.md
+++ b/docs/superpowers/plans/2026-05-15-popular-page.md
@@ -1,0 +1,820 @@
+# Popular Page Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a dedicated `/popular` page that defaults to New + Now and lets people switch source and period using Funnelcake v2 popular feeds.
+
+**Architecture:** Extend the existing `VideoFeed -> useVideoProvider -> useInfiniteVideosFunnelcake -> fetchVideosV2` path with a `popular` feed type and explicit popular options. Add a `PopularPage` that owns URL-backed source and period controls, then add route/sidebar/i18n wiring.
+
+**Tech Stack:** React 18, TypeScript, React Router, TanStack Query, Vitest, Testing Library, Funnelcake REST API, Phosphor Icons, i18next locale JSON.
+
+---
+
+## File Structure
+
+- Modify `src/types/funnelcake.ts`: add v2 `period` and `exclude_platform` fetch options.
+- Modify `src/lib/funnelcakeClient.ts`: pass `period` and `exclude_platform` through `fetchVideosV2`.
+- Modify `src/hooks/useInfiniteVideosFunnelcake.ts`: add `popular` feed type and `popularSource`/`popularPeriod` options, map them to v2 params, and keep opaque cursor pagination.
+- Modify `src/hooks/useVideoProvider.ts`: add `popular` to provider feed types and route it to Funnelcake only.
+- Modify `src/components/VideoFeed.tsx`: accept `feedType="popular"` and popular options, pass them to provider.
+- Create `src/pages/PopularPage.tsx`: parse URL params, render pill controls, and render `VideoFeed`.
+- Create `src/pages/PopularPage.test.tsx`: page state and URL tests.
+- Modify `src/hooks/useInfiniteVideosFunnelcake.test.ts`: popular API mapping and cursor tests.
+- Modify `src/hooks/useVideoProvider.test.ts`: provider routing test for popular.
+- Modify `src/AppRouter.tsx`: add `/popular`.
+- Modify `src/components/AppSidebar.tsx`: add Popular nav item near Discover.
+- Modify `src/lib/i18n/locales/*/common.json`: add `nav.popular` and `popularPage` keys. Use English fallback copy for non-English locales to preserve key consistency.
+
+## Task 1: Funnelcake Popular Options
+
+**Files:**
+- Modify: `src/types/funnelcake.ts`
+- Modify: `src/lib/funnelcakeClient.ts`
+
+- [ ] **Step 1: Write failing type/client coverage by adding a test case to `src/hooks/useInfiniteVideosFunnelcake.test.ts`**
+
+Add `mockFetchVideosV2` to the hoisted mocks and the Funnelcake client mock:
+
+```ts
+const mockFetchVideosV2 = vi.fn();
+
+vi.mock('@/lib/funnelcakeClient', () => ({
+  fetchVideos: mockFetchVideos,
+  fetchVideosV2: mockFetchVideosV2,
+  searchVideos: vi.fn(),
+  fetchUserVideos: vi.fn(),
+  fetchUserFeed: vi.fn(),
+  fetchRecommendations: mockFetchRecommendations,
+}));
+```
+
+Then add this test inside `describe('useInfiniteVideosFunnelcake', ...)`:
+
+```ts
+it('requests native popular videos with period and excludes classic Vines', async () => {
+  mockFetchVideosV2.mockResolvedValueOnce({
+    videos: [{}],
+    has_more: true,
+    next_cursor: 'o:12',
+  });
+  mockTransformToVideoPage.mockReturnValueOnce({
+    videos: [{ id: 'video-1', pubkey: 'p1', kind: 34236, createdAt: 101, vineId: 'd-1' }],
+    nextCursor: undefined,
+    rawCursor: 'o:12',
+    hasMore: true,
+  });
+
+  const { result } = renderHook(
+    () => useInfiniteVideosFunnelcake({
+      feedType: 'popular',
+      popularSource: 'new',
+      popularPeriod: 'now',
+      pageSize: 12,
+    }),
+    { wrapper: createWrapper() }
+  );
+
+  await waitFor(() => {
+    expect(result.current.isSuccess).toBe(true);
+  });
+
+  expect(mockFetchVideosV2).toHaveBeenCalledWith(
+    'https://api.divine.video',
+    expect.objectContaining({
+      sort: 'popular',
+      period: 'now',
+      exclude_platform: 'vine',
+      limit: 12,
+      signal: expect.any(AbortSignal),
+    })
+  );
+  expect(result.current.hasNextPage).toBe(true);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+npx vitest run src/hooks/useInfiniteVideosFunnelcake.test.ts
+```
+
+Expected: FAIL because `fetchVideosV2` is not mocked in the hook test and/or `popular` is not assignable to `FunnelcakeFeedType`.
+
+- [ ] **Step 3: Add Funnelcake option types and v2 param pass-through**
+
+In `src/types/funnelcake.ts`, update `FunnelcakeFetchOptions`:
+
+```ts
+export type FunnelcakePopularPeriod = 'now' | 'today' | 'week' | 'month' | 'all';
+
+export interface FunnelcakeFetchOptions {
+  sort?: 'trending' | 'recent' | 'popular' | 'loops' | 'engagement' | 'watching' | 'likes' | 'comments' | 'published';
+  period?: FunnelcakePopularPeriod;
+  limit?: number;
+  before?: string;
+  offset?: number;
+  classic?: boolean;
+  platform?: string;
+  exclude_platform?: string;
+  category?: string;
+  signal?: AbortSignal;
+}
+```
+
+In `src/lib/funnelcakeClient.ts`, update the destructuring and params in `fetchVideosV2`:
+
+```ts
+const {
+  sort = 'watching',
+  period,
+  limit = 20,
+  before,
+  offset,
+  classic,
+  platform,
+  exclude_platform,
+  category,
+  signal,
+} = options;
+
+const params: Record<string, string | number | boolean | undefined> = {
+  sort,
+  period,
+  limit,
+  classic,
+  platform,
+  exclude_platform,
+  category,
+};
+```
+
+- [ ] **Step 4: Run test to confirm remaining failure moves to hook support**
+
+Run:
+
+```bash
+npx vitest run src/hooks/useInfiniteVideosFunnelcake.test.ts
+```
+
+Expected: still FAIL until Task 2 adds `popular` support.
+
+## Task 2: Hook And Provider Plumbing
+
+**Files:**
+- Modify: `src/hooks/useInfiniteVideosFunnelcake.ts`
+- Modify: `src/hooks/useVideoProvider.ts`
+- Modify: `src/components/VideoFeed.tsx`
+- Test: `src/hooks/useInfiniteVideosFunnelcake.test.ts`
+- Test: `src/hooks/useVideoProvider.test.ts`
+
+- [ ] **Step 1: Add failing provider routing test**
+
+In `src/hooks/useVideoProvider.test.ts`, add:
+
+```ts
+it('routes popular feeds to Funnelcake with popular options and no WebSocket fallback', () => {
+  const { result } = renderHook(() =>
+    useVideoProvider({
+      feedType: 'popular',
+      popularSource: 'classic',
+      popularPeriod: 'week',
+    })
+  );
+
+  expect(mockUseInfiniteVideosFunnelcake).toHaveBeenCalledWith(expect.objectContaining({
+    feedType: 'popular',
+    apiUrl: 'https://api.divine.video',
+    popularSource: 'classic',
+    popularPeriod: 'week',
+    enabled: true,
+  }));
+  expect(mockUseInfiniteVideos).toHaveBeenCalledWith(expect.objectContaining({
+    enabled: false,
+  }));
+  expect(result.current.dataSource).toBe('funnelcake');
+});
+```
+
+- [ ] **Step 2: Run provider test to verify it fails**
+
+Run:
+
+```bash
+npx vitest run src/hooks/useVideoProvider.test.ts
+```
+
+Expected: FAIL because `popular` is not a valid `VideoFeedType` and provider options do not include popular state.
+
+- [ ] **Step 3: Add popular types and mapping to `useInfiniteVideosFunnelcake.ts`**
+
+Add exported types near the existing feed/sort types:
+
+```ts
+export type FunnelcakeFeedType = 'trending' | 'recent' | 'classics' | 'hashtag' | 'profile' | 'home' | 'recommendations' | 'category' | 'popular';
+export type FunnelcakeSortMode = 'trending' | 'recent' | 'loops' | 'engagement' | 'classic' | 'watching';
+export type PopularSource = 'new' | 'classic' | 'all';
+export type PopularPeriod = 'now' | 'today' | 'week' | 'month' | 'all';
+```
+
+Add options:
+
+```ts
+interface UseInfiniteVideosFunnelcakeOptions {
+  feedType: FunnelcakeFeedType;
+  apiUrl?: string;
+  sortMode?: FunnelcakeSortMode;
+  popularSource?: PopularSource;
+  popularPeriod?: PopularPeriod;
+  hashtag?: string;
+  category?: string;
+  pubkey?: string;
+  pageSize?: number;
+  enabled?: boolean;
+  randomizeWithinTop?: number;
+}
+```
+
+Update `getFetchOptions` signature and popular case:
+
+```ts
+function getFetchOptions(
+  feedType: FunnelcakeFeedType,
+  sortMode?: FunnelcakeSortMode,
+  pageSize: number = 20,
+  popularSource?: PopularSource,
+  popularPeriod?: PopularPeriod
+): FunnelcakeFetchOptions {
+  const baseOptions: FunnelcakeFetchOptions = {
+    limit: pageSize,
+  };
+
+  switch (feedType) {
+    case 'popular':
+      return {
+        ...baseOptions,
+        sort: 'popular',
+        period: popularPeriod ?? 'now',
+        ...(popularSource === 'new' ? { exclude_platform: 'vine' } : {}),
+        ...(popularSource === 'classic' ? { platform: 'vine' } : {}),
+      };
+```
+
+Destructure `popularSource = 'new'` and `popularPeriod = 'now'` in the hook args. Include them in the query key and `getFetchOptions` call:
+
+```ts
+queryKey: ['funnelcake-videos', feedType, effectiveApiUrl, sortMode, popularSource, popularPeriod, hashtag, category, pubkey, pageSize, randomStartOffset],
+```
+
+```ts
+const options = getFetchOptions(feedType, sortMode, pageSize, popularSource, popularPeriod);
+```
+
+Route popular through v2:
+
+```ts
+case 'popular':
+case 'trending':
+  response = await fetchVideosV2(effectiveApiUrl, options);
+  break;
+```
+
+Use v2 cursor pagination for popular:
+
+```ts
+let cursorType: 'timestamp' | 'offset' | 'cursor' =
+  feedType === 'recommendations' || feedType === 'trending' || feedType === 'popular' ? 'cursor' : 'timestamp';
+```
+
+```ts
+v2Cursor: feedType === 'trending' || feedType === 'popular' ? page.rawCursor : undefined,
+```
+
+```ts
+if (feedType === 'trending' || feedType === 'popular') {
+  return lastPage.v2Cursor;
+}
+```
+
+- [ ] **Step 4: Add provider and VideoFeed plumbing**
+
+In `src/hooks/useVideoProvider.ts`, import popular types:
+
+```ts
+import { useInfiniteVideosFunnelcake, type FunnelcakeFeedType, type FunnelcakeSortMode, type PopularPeriod, type PopularSource } from '@/hooks/useInfiniteVideosFunnelcake';
+```
+
+Update types:
+
+```ts
+export type VideoFeedType = 'discovery' | 'home' | 'trending' | 'hashtag' | 'profile' | 'recent' | 'classics' | 'foryou' | 'category' | 'popular';
+
+interface UseVideoProviderOptions {
+  feedType: VideoFeedType;
+  sortMode?: SortMode;
+  popularSource?: PopularSource;
+  popularPeriod?: PopularPeriod;
+  hashtag?: string;
+  category?: string;
+  pubkey?: string;
+  pageSize?: number;
+  enabled?: boolean;
+}
+```
+
+Add `popular` to `canServeFeedViaFunnelcake`, `mapToFunnelcakeFeedType`, and `canServeFeedViaWebsocket`:
+
+```ts
+case 'popular':
+  return true;
+```
+
+```ts
+case 'popular':
+  return 'popular';
+```
+
+```ts
+case 'popular':
+  return false;
+```
+
+Destructure and pass popular options:
+
+```ts
+popularSource,
+popularPeriod,
+```
+
+```ts
+popularSource,
+popularPeriod,
+```
+
+In `src/components/VideoFeed.tsx`, import types and extend props:
+
+```ts
+import type { PopularPeriod, PopularSource } from '@/hooks/useInfiniteVideosFunnelcake';
+```
+
+```ts
+feedType?: 'discovery' | 'home' | 'trending' | 'hashtag' | 'profile' | 'recent' | 'classics' | 'foryou' | 'category' | 'popular';
+popularSource?: PopularSource;
+popularPeriod?: PopularPeriod;
+```
+
+Destructure and pass `popularSource`/`popularPeriod` into `useVideoProvider`.
+
+- [ ] **Step 5: Run hook/provider tests**
+
+Run:
+
+```bash
+npx vitest run src/hooks/useInfiniteVideosFunnelcake.test.ts src/hooks/useVideoProvider.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit hook plumbing**
+
+Run:
+
+```bash
+git add src/types/funnelcake.ts src/lib/funnelcakeClient.ts src/hooks/useInfiniteVideosFunnelcake.ts src/hooks/useInfiniteVideosFunnelcake.test.ts src/hooks/useVideoProvider.ts src/hooks/useVideoProvider.test.ts src/components/VideoFeed.tsx
+git commit -m "feat(popular): add Funnelcake popular feed plumbing"
+```
+
+## Task 3: Popular Page
+
+**Files:**
+- Create: `src/pages/PopularPage.tsx`
+- Create: `src/pages/PopularPage.test.tsx`
+
+- [ ] **Step 1: Write failing page tests**
+
+Create `src/pages/PopularPage.test.tsx`:
+
+```tsx
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+import { initializeI18n } from '@/lib/i18n';
+import PopularPage from './PopularPage';
+
+const mockVideoFeed = vi.fn();
+
+vi.mock('@/components/VideoFeed', () => ({
+  VideoFeed: (props: unknown) => {
+    mockVideoFeed(props);
+    return <div data-testid="popular-feed" />;
+  },
+}));
+
+function LocationDisplay() {
+  const location = useLocation();
+  return <div data-testid="location-display">{location.pathname}{location.search}</div>;
+}
+
+async function renderPage(initialEntry = '/popular') {
+  await initializeI18n({ force: true, languages: ['en-US'] });
+  mockVideoFeed.mockClear();
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <PopularPage />
+      <LocationDisplay />
+    </MemoryRouter>
+  );
+}
+
+describe('PopularPage', () => {
+  it('defaults to New and Now with canonical empty query params', async () => {
+    await renderPage('/popular');
+
+    expect(screen.getByRole('heading', { name: 'Popular' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'New' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'Now' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('location-display')).toHaveTextContent('/popular');
+    expect(mockVideoFeed).toHaveBeenCalledWith(expect.objectContaining({
+      feedType: 'popular',
+      popularSource: 'new',
+      popularPeriod: 'now',
+    }));
+  });
+
+  it('updates URL params when selecting Classic and Week', async () => {
+    const user = userEvent.setup();
+    await renderPage('/popular');
+
+    await user.click(screen.getByRole('button', { name: 'Classic' }));
+    await user.click(screen.getByRole('button', { name: 'Week' }));
+
+    expect(screen.getByRole('button', { name: 'Classic' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'Week' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('location-display')).toHaveTextContent('/popular?source=classic&period=week');
+    expect(mockVideoFeed).toHaveBeenLastCalledWith(expect.objectContaining({
+      feedType: 'popular',
+      popularSource: 'classic',
+      popularPeriod: 'week',
+    }));
+  });
+
+  it('normalizes invalid params to defaults', async () => {
+    await renderPage('/popular?source=bad&period=ancient');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location-display')).toHaveTextContent('/popular');
+    });
+    expect(screen.getByRole('button', { name: 'New' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'Now' })).toHaveAttribute('aria-pressed', 'true');
+  });
+});
+```
+
+- [ ] **Step 2: Run page test to verify it fails**
+
+Run:
+
+```bash
+npx vitest run src/pages/PopularPage.test.tsx
+```
+
+Expected: FAIL because `src/pages/PopularPage.tsx` does not exist.
+
+- [ ] **Step 3: Implement `PopularPage.tsx`**
+
+Create `src/pages/PopularPage.tsx`:
+
+```tsx
+// ABOUTME: Dedicated popular feed page with source and period controls
+// ABOUTME: Uses Funnelcake v2 popular period feeds through the shared VideoFeed stack
+
+import { useEffect, useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { Clock, FilmSlate, Fire, Sparkle, TrendUp } from '@phosphor-icons/react';
+import { VideoFeed } from '@/components/VideoFeed';
+import { cn } from '@/lib/utils';
+import type { PopularPeriod, PopularSource } from '@/hooks/useInfiniteVideosFunnelcake';
+
+const SOURCE_OPTIONS: Array<{ value: PopularSource; labelKey: string; icon: typeof Sparkle }> = [
+  { value: 'new', labelKey: 'popularPage.sources.new', icon: Sparkle },
+  { value: 'classic', labelKey: 'popularPage.sources.classic', icon: FilmSlate },
+  { value: 'all', labelKey: 'popularPage.sources.all', icon: TrendUp },
+];
+
+const PERIOD_OPTIONS: Array<{ value: PopularPeriod; labelKey: string; icon: typeof Clock }> = [
+  { value: 'now', labelKey: 'popularPage.periods.now', icon: Fire },
+  { value: 'today', labelKey: 'popularPage.periods.today', icon: Clock },
+  { value: 'week', labelKey: 'popularPage.periods.week', icon: Clock },
+  { value: 'month', labelKey: 'popularPage.periods.month', icon: Clock },
+  { value: 'all', labelKey: 'popularPage.periods.all', icon: TrendUp },
+];
+
+const SOURCE_VALUES = new Set<PopularSource>(SOURCE_OPTIONS.map(option => option.value));
+const PERIOD_VALUES = new Set<PopularPeriod>(PERIOD_OPTIONS.map(option => option.value));
+
+function parseSource(value: string | null): PopularSource {
+  return value && SOURCE_VALUES.has(value as PopularSource) ? (value as PopularSource) : 'new';
+}
+
+function parsePeriod(value: string | null): PopularPeriod {
+  return value && PERIOD_VALUES.has(value as PopularPeriod) ? (value as PopularPeriod) : 'now';
+}
+
+function buildCanonicalParams(source: PopularSource, period: PopularPeriod): URLSearchParams {
+  const params = new URLSearchParams();
+  if (source !== 'new') params.set('source', source);
+  if (period !== 'now') params.set('period', period);
+  return params;
+}
+
+export function PopularPage() {
+  const { t } = useTranslation();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const source = parseSource(searchParams.get('source'));
+  const period = parsePeriod(searchParams.get('period'));
+
+  const canonicalParams = useMemo(
+    () => buildCanonicalParams(source, period),
+    [source, period]
+  );
+  const canonicalSearch = canonicalParams.toString();
+
+  useEffect(() => {
+    const currentSearch = searchParams.toString();
+    if (currentSearch !== canonicalSearch) {
+      setSearchParams(canonicalParams, { replace: true });
+    }
+  }, [canonicalParams, canonicalSearch, searchParams, setSearchParams]);
+
+  const updateSource = (nextSource: PopularSource) => {
+    setSearchParams(buildCanonicalParams(nextSource, period));
+  };
+
+  const updatePeriod = (nextPeriod: PopularPeriod) => {
+    setSearchParams(buildCanonicalParams(source, nextPeriod));
+  };
+
+  const subheadingKey = `popularPage.subheadings.${source}.${period}`;
+
+  return (
+    <div className="container mx-auto px-4 py-6">
+      <div className="mx-auto max-w-2xl">
+        <header className="mb-6 space-y-4">
+          <div>
+            <h1 className="text-2xl font-bold">{t('popularPage.heading')}</h1>
+            <p className="text-muted-foreground">{t(subheadingKey)}</p>
+          </div>
+
+          <div className="space-y-3" aria-label={t('popularPage.controlsLabel')}>
+            <div className="flex flex-wrap gap-2" role="group" aria-label={t('popularPage.sourceLabel')}>
+              {SOURCE_OPTIONS.map(option => {
+                const Icon = option.icon;
+                const selected = source === option.value;
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    aria-pressed={selected}
+                    onClick={() => updateSource(option.value)}
+                    className={cn(
+                      'flex items-center gap-2 rounded-lg px-4 py-2 font-medium transition-all',
+                      selected
+                        ? 'bg-primary text-primary-foreground shadow-md'
+                        : 'bg-brand-light-green text-muted-foreground hover:bg-muted hover:text-foreground dark:bg-brand-dark-green'
+                    )}
+                  >
+                    <Icon className="h-4 w-4" />
+                    <span>{t(option.labelKey)}</span>
+                  </button>
+                );
+              })}
+            </div>
+
+            <div className="flex flex-wrap gap-2" role="group" aria-label={t('popularPage.periodLabel')}>
+              {PERIOD_OPTIONS.map(option => {
+                const Icon = option.icon;
+                const selected = period === option.value;
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    aria-pressed={selected}
+                    onClick={() => updatePeriod(option.value)}
+                    className={cn(
+                      'flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm font-medium transition-all sm:px-4 sm:py-2',
+                      selected
+                        ? 'bg-primary text-primary-foreground shadow-md'
+                        : 'bg-background text-muted-foreground ring-1 ring-border hover:bg-muted hover:text-foreground'
+                    )}
+                  >
+                    <Icon className="h-3.5 w-3.5" />
+                    <span>{t(option.labelKey)}</span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        </header>
+
+        <VideoFeed
+          feedType="popular"
+          popularSource={source}
+          popularPeriod={period}
+          accent="pink"
+          data-testid="video-feed-popular"
+          className="space-y-6"
+        />
+      </div>
+    </div>
+  );
+}
+
+export default PopularPage;
+```
+
+- [ ] **Step 4: Run page test**
+
+Run:
+
+```bash
+npx vitest run src/pages/PopularPage.test.tsx
+```
+
+Expected: PASS after adding i18n keys in Task 4. If it fails because i18n keys are missing, continue to Task 4 before re-running.
+
+## Task 4: Route, Sidebar, And I18n
+
+**Files:**
+- Modify: `src/AppRouter.tsx`
+- Modify: `src/components/AppSidebar.tsx`
+- Modify: `src/lib/i18n/locales/*/common.json`
+
+- [ ] **Step 1: Add route**
+
+In `src/AppRouter.tsx`, import the page:
+
+```ts
+import PopularPage from "./pages/PopularPage";
+```
+
+Add the route near other public browsing routes:
+
+```tsx
+<Route path="/popular" element={<PopularPage />} />
+```
+
+- [ ] **Step 2: Add sidebar nav**
+
+In `src/components/AppSidebar.tsx`, add `TrendUp` to the Phosphor import:
+
+```ts
+import { House as Home, Compass, MagnifyingGlass as Search, Bell, User, Sun, Moon, CaretDown as ChevronDown, Headphones, ChartBar as BarChart3, SquaresFour as LayoutGrid, Rss, ChatCircle as MessageCircle, TrendUp } from '@phosphor-icons/react';
+```
+
+Add active helper:
+
+```ts
+const isPopularActive = () => location.pathname === '/popular';
+```
+
+Add nav item after Discover:
+
+```tsx
+<NavItem
+  icon={<TrendUp className="h-[18px] w-[18px]" weight={isPopularActive() ? 'fill' : 'bold'} />}
+  label={t('nav.popular')}
+  onClick={() => navigate('/popular')}
+  isActive={isPopularActive()}
+/>
+```
+
+- [ ] **Step 3: Add English i18n keys**
+
+In `src/lib/i18n/locales/en/common.json`, add `"popular": "Popular"` to `nav`, and add this top-level block near `trendingPage`:
+
+```json
+"popularPage": {
+  "heading": "Popular",
+  "controlsLabel": "Popular feed filters",
+  "sourceLabel": "Source",
+  "periodLabel": "Period",
+  "sources": {
+    "new": "New",
+    "classic": "Classic",
+    "all": "All"
+  },
+  "periods": {
+    "now": "Now",
+    "today": "Today",
+    "week": "Week",
+    "month": "Month",
+    "all": "All time"
+  },
+  "subheadings": {
+    "new": {
+      "now": "Fresh Divine posts getting watched now.",
+      "today": "Fresh Divine posts getting watched today.",
+      "week": "Fresh Divine posts getting watched this week.",
+      "month": "Fresh Divine posts getting watched this month.",
+      "all": "Fresh Divine posts people keep coming back to."
+    },
+    "classic": {
+      "now": "Classic Vines getting watched now.",
+      "today": "Classic Vines getting watched today.",
+      "week": "Classic Vines getting watched this week.",
+      "month": "Classic Vines getting watched this month.",
+      "all": "Classic Vines people keep watching on Divine."
+    },
+    "all": {
+      "now": "Everything Divine is watching now.",
+      "today": "Everything Divine watched today.",
+      "week": "Everything Divine watched this week.",
+      "month": "Everything Divine watched this month.",
+      "all": "Everything people keep watching on Divine."
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Add fallback i18n keys to all other locales**
+
+For every `src/lib/i18n/locales/*/common.json` except `en`, add the same `nav.popular` and `popularPage` English strings. Keep JSON formatting valid.
+
+- [ ] **Step 5: Run locale consistency test and page test**
+
+Run:
+
+```bash
+npx vitest run src/lib/i18n/locales.test.ts src/pages/PopularPage.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit page and route**
+
+Run:
+
+```bash
+git add src/pages/PopularPage.tsx src/pages/PopularPage.test.tsx src/AppRouter.tsx src/components/AppSidebar.tsx src/lib/i18n/locales
+git commit -m "feat(popular): add popular page"
+```
+
+## Task 5: Final Verification
+
+**Files:**
+- No new files.
+
+- [ ] **Step 1: Run targeted tests**
+
+Run:
+
+```bash
+npx vitest run src/hooks/useInfiniteVideosFunnelcake.test.ts src/hooks/useVideoProvider.test.ts src/pages/PopularPage.test.tsx src/lib/i18n/locales.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run full project test**
+
+Run:
+
+```bash
+npm run test
+```
+
+Expected: PASS with existing warnings only.
+
+- [ ] **Step 3: Start dev server for browser verification**
+
+Run:
+
+```bash
+npm run dev
+```
+
+Expected: Vite serves the worktree on `http://localhost:8080` or another available port.
+
+- [ ] **Step 4: Verify `/popular` in browser**
+
+Open the dev URL at `/popular` and verify:
+
+- Page title is `Popular`.
+- New and Now pills are selected by default.
+- The sidebar includes Popular near Discover.
+- Clicking Classic and Week updates URL to `/popular?source=classic&period=week`.
+- Clicking New and Now returns URL to `/popular`.
+- The feed attempts a Funnelcake v2 request with `sort=popular`.
+
+- [ ] **Step 5: Confirm final git state**
+
+Run:
+
+```bash
+git status --short --branch
+```
+
+Expected: branch is ahead of `origin/main` with committed popular-page changes and no unstaged or untracked source files. If verification produced source changes, review them with `git diff`, stage only the changed popular-page files, and commit with `git commit -m "fix(popular): polish popular page verification issues"`.

--- a/docs/superpowers/specs/2026-05-15-popular-page-design.md
+++ b/docs/superpowers/specs/2026-05-15-popular-page-design.md
@@ -1,0 +1,131 @@
+# Popular Page Design
+
+## Context
+
+Divine Web needs a dedicated `/popular` destination for posts that are getting watched on Divine. Funnelcake now exposes the needed API surface on `/api/v2/videos`: `sort=popular`, `period=now|today|week|month|all`, `platform=vine`, and `exclude_platform=vine`.
+
+This page should default to fresh native Divine posts, while still letting people switch to classic Vine archive posts or a mixed feed. It should reuse the existing feed stack so playback, pagination, moderation filtering, author enrichment, ProofMode enrichment, and compilation navigation remain consistent with the rest of the app.
+
+## Goals
+
+- Add a shareable `/popular` app route.
+- Default `/popular` to New + Now.
+- Let users switch source: New, Classic, All.
+- Let users switch period: Now, Today, Week, Month, All time.
+- Use Funnelcake v2 popular period feeds rather than relay-side search sorting.
+- Keep `/trending` intact in this pass.
+
+## Non-Goals
+
+- Do not replace `/trending` or redirect it.
+- Do not change Search sort behavior from divine-web#365.
+- Do not rank classic all-time by original Vine archive loop counts on this page.
+- Do not add a separate popular API client/hook if the existing feed pipeline can be extended cleanly.
+
+## Route And State
+
+Add `PopularPage` at `/popular` under the normal `AppLayout`.
+
+The page owns two URL-backed controls:
+
+- `source`: `new | classic | all`, default `new`
+- `period`: `now | today | week | month | all`, default `now`
+
+Default values are omitted from the URL:
+
+- `/popular` means `source=new&period=now`
+- `/popular?source=classic` means `source=classic&period=now`
+- `/popular?period=week` means `source=new&period=week`
+- `/popular?source=all&period=month` means mixed source for the month period
+
+Invalid query params fall back to defaults and replace the URL with the canonical form.
+
+## API Mapping
+
+The page always uses `/api/v2/videos` through `fetchVideosV2`.
+
+Popular parameters map as follows:
+
+| UI state | API params |
+| --- | --- |
+| New + `<period>` | `sort=popular&period=<period>&exclude_platform=vine` |
+| Classic + `<period>` | `sort=popular&period=<period>&platform=vine` |
+| All + `<period>` | `sort=popular&period=<period>` |
+
+Classic + All time remains `sort=popular&period=all&platform=vine`. It means Divine-era popularity for archived Vines, not original Vine loop-count ordering. Original loop-count ordering belongs in existing classics/archive surfaces.
+
+Pagination uses the v2 envelope's opaque `pagination.next_cursor`, matching the current trending v2 implementation.
+
+## Feed Architecture
+
+Use option 1 from the design discussion: extend the existing feed stack.
+
+Data flow:
+
+1. `PopularPage` parses and controls `source` and `period`.
+2. `PopularPage` renders `VideoFeed feedType="popular"` with popular options.
+3. `VideoFeed` passes those options into `useVideoProvider`.
+4. `useVideoProvider` treats popular as Funnelcake-only canonical Divine API data.
+5. `useInfiniteVideosFunnelcake` maps popular options into `fetchVideosV2`.
+6. `transformToVideoPage` converts the v2 response into the shared video page shape.
+
+Popular should not silently widen an empty slice. If New + Now returns no videos, show the existing empty state and let the visible controls explain what slice is selected.
+
+## UI
+
+The page should be a feed page, not a dashboard.
+
+Header:
+
+- Title: `Popular`
+- Subheading changes with selected state, for example:
+  - New + Now: `Fresh Divine posts getting watched now.`
+  - Classic + Week: `Classic Vines getting watched this week.`
+  - All + Month: `Everything Divine watched this month.`
+
+Controls:
+
+- First pill row: New, Classic, All.
+- Second pill row: Now, Today, Week, Month, All time.
+- Use the prominent pill-row pattern from divine-web#365 and existing Trending/Discovery pages.
+- Avoid hiding period in a dropdown; both dimensions should be visible.
+
+Feed:
+
+- Render the standard `VideoFeed` card stack below the controls.
+- Use a distinct accent if useful, but stay within the existing brand component system.
+
+Navigation:
+
+- Add `Popular` to desktop sidebar near `Discover`.
+- Use a Phosphor icon such as `TrendUp` or `Flame`.
+- Add i18n keys for visible copy and nav text.
+
+## Error And Empty States
+
+Use existing `VideoFeed` loading, empty, and error behavior.
+
+Do not auto-switch to another source or period on error or empty results. The selected controls should remain stable so the URL, API request, and visible state always match.
+
+## Relationship To Existing Work
+
+divine-web#365 is related only as a UI pattern. It changes Search sort pills and defaults, but it does not touch `VideoFeed`, routes, Funnelcake video listing, or `/api/v2/videos`.
+
+This popular page uses `/api/v2/videos`, which has live support for `sort=popular`, `period`, `platform`, and `exclude_platform`. It is not blocked by the `/api/v2/search` backend sort issue called out in divine-web#365.
+
+## Testing
+
+Add focused tests for:
+
+- `PopularPage` defaults to New + Now when no query params exist.
+- Clicking source and period pills updates selection and URL params.
+- Default query params are omitted from the canonical URL.
+- Invalid query params normalize to New + Now.
+- Popular feed options map to `fetchVideosV2` params:
+  - New => `exclude_platform=vine`
+  - Classic => `platform=vine`
+  - All => no platform filter
+  - Period is passed through unchanged.
+- Pagination passes through v2 opaque cursors.
+
+Existing shared feed behavior should remain covered by current `VideoFeed` and provider tests.

--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -16,6 +16,7 @@ import NotFound from "./pages/NotFound";
 import HomePage from "./pages/HomePage";
 import DiscoveryPage from "./pages/DiscoveryPage";
 import TrendingPage from "./pages/TrendingPage";
+import PopularPage from "./pages/PopularPage";
 import HashtagPage from "./pages/HashtagPage";
 import CategoryPage from "./pages/CategoryPage";
 import CategoriesIndexPage from "./pages/CategoriesIndexPage";
@@ -118,6 +119,7 @@ export function AppRouter() {
           <Route path="/discovery" element={<DiscoveryPage />} />
           <Route path="/discovery/:tab" element={<DiscoveryPage />} />
           <Route path="/trending" element={<TrendingPage />} />
+          <Route path="/popular" element={<PopularPage />} />
           <Route path="/hashtags" element={<HashtagDiscoveryPage />} />
           <Route path="/hashtag/:tag" element={<HashtagPage />} />
           <Route path="/category" element={<CategoriesIndexPage />} />

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -2,7 +2,7 @@
 // ABOUTME: Shows main nav, login/signup, expandable Divine links section
 
 import { Link, useLocation } from 'react-router-dom';
-import { House as Home, Compass, MagnifyingGlass as Search, Bell, User, Sun, Moon, CaretDown as ChevronDown, Headphones, ChartBar as BarChart3, SquaresFour as LayoutGrid, Rss, ChatCircle as MessageCircle } from '@phosphor-icons/react';
+import { House as Home, Compass, MagnifyingGlass as Search, Bell, User, Sun, Moon, CaretDown as ChevronDown, Headphones, ChartBar as BarChart3, SquaresFour as LayoutGrid, Rss, ChatCircle as MessageCircle, TrendUp } from '@phosphor-icons/react';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useCategories } from '@/hooks/useCategories';
@@ -81,6 +81,7 @@ export function AppSidebar({ className }: { className?: string }) {
   const isActive = (path: string) => location.pathname === path;
   const isDiscoveryActive = () =>
     location.pathname === '/discovery' || location.pathname.startsWith('/discovery/');
+  const isPopularActive = () => location.pathname === '/popular';
   const isMessagesActive = () =>
     location.pathname === '/messages' || location.pathname.startsWith('/messages/');
   const isCategoryActive = (name: string) => location.pathname === `/category/${name}`;
@@ -194,6 +195,13 @@ export function AppSidebar({ className }: { className?: string }) {
             label={t('nav.discover')}
             onClick={() => navigate('/discovery')}
             isActive={isDiscoveryActive()}
+          />
+
+          <NavItem
+            icon={<TrendUp className="h-[18px] w-[18px]" weight={isPopularActive() ? 'fill' : 'bold'} />}
+            label={t('nav.popular')}
+            onClick={() => navigate('/popular')}
+            isActive={isPopularActive()}
           />
 
           {user && canUseDirectMessages && (

--- a/src/components/BottomNav.test.tsx
+++ b/src/components/BottomNav.test.tsx
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+import { initializeI18n } from '@/lib/i18n';
+import { BottomNav } from './BottomNav';
+
+vi.mock('@/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({ user: null }),
+}));
+
+vi.mock('@/hooks/useNotifications', () => ({
+  useUnreadNotificationCount: () => ({ data: 0 }),
+}));
+
+function LocationDisplay() {
+  const location = useLocation();
+  return <div data-testid="location-display">{location.pathname}</div>;
+}
+
+async function renderBottomNav(initialEntry = '/') {
+  await initializeI18n({ force: true, languages: ['en-US'] });
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <BottomNav />
+      <LocationDisplay />
+    </MemoryRouter>
+  );
+}
+
+describe('BottomNav', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const storage = new Map<string, string>();
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: (key: string) => storage.get(key) ?? null,
+        setItem: (key: string, value: string) => storage.set(key, value),
+        removeItem: (key: string) => storage.delete(key),
+        clear: () => storage.clear(),
+      } satisfies Pick<Storage, 'getItem' | 'setItem' | 'removeItem' | 'clear'>,
+    });
+  });
+
+  it('links mobile users to the popular page', async () => {
+    const user = userEvent.setup();
+    await renderBottomNav('/');
+
+    await user.click(screen.getByRole('button', { name: 'Popular' }));
+
+    expect(screen.getByTestId('location-display')).toHaveTextContent('/popular');
+  });
+});

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -1,4 +1,4 @@
-import { House as Home, Compass, MagnifyingGlass as Search, Bell, User } from '@phosphor-icons/react';
+import { House as Home, Compass, MagnifyingGlass as Search, Bell, User, TrendUp } from '@phosphor-icons/react';
 import { useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
@@ -53,6 +53,20 @@ export function BottomNav() {
         >
           <Compass className={cn("h-5 w-5", isActive('/discovery') && "text-primary")} weight={isActive('/discovery') ? 'fill' : 'bold'} />
           <span className={cn("text-xs", isActive('/discovery') && "text-primary")}>{t('nav.discover')}</span>
+        </Button>
+
+        {/* Popular */}
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => navigate('/popular')}
+          className={cn(
+            "flex flex-col items-center justify-center gap-1 h-full flex-1 rounded-none hover:bg-transparent",
+            isActive('/popular') && "text-primary"
+          )}
+        >
+          <TrendUp className={cn("h-5 w-5", isActive('/popular') && "text-primary")} weight={isActive('/popular') ? 'fill' : 'bold'} />
+          <span className={cn("text-xs", isActive('/popular') && "text-primary")}>{t('nav.popular')}</span>
         </Button>
 
         {/* Search */}

--- a/src/components/VideoFeed.tsx
+++ b/src/components/VideoFeed.tsx
@@ -27,16 +27,19 @@ import { useVideoPlayback } from '@/hooks/useVideoPlayback';
 import { useVideoPrefetch } from '@/hooks/useVideoPrefetch';
 import { useCompilationFullscreen } from '@/hooks/useCompilationFullscreen';
 import { buildCompilationPlaybackUrl } from '@/lib/compilationPlayback';
+import type { PopularPeriod, PopularSource } from '@/hooks/useInfiniteVideosFunnelcake';
 
 type ViewMode = 'feed' | 'grid';
 
 interface VideoFeedProps {
-  feedType?: 'discovery' | 'home' | 'trending' | 'hashtag' | 'profile' | 'recent' | 'classics' | 'foryou' | 'category';
+  feedType?: 'discovery' | 'home' | 'trending' | 'hashtag' | 'profile' | 'recent' | 'classics' | 'foryou' | 'category' | 'popular';
   hashtag?: string;
   category?: string;
   pubkey?: string;
   limit?: number;
   sortMode?: SortMode; // NIP-50 sort mode (hot, top, rising, controversial)
+  popularSource?: PopularSource;
+  popularPeriod?: PopularPeriod;
   viewMode?: ViewMode; // Display mode: feed (full cards) or grid (thumbnails)
   className?: string;
   verifiedOnly?: boolean; // Filter to show only ProofMode verified videos
@@ -59,6 +62,8 @@ export function VideoFeed({
   pubkey,
   limit = 12, // Smaller first page improves initial paint on REST-backed feeds
   sortMode,
+  popularSource,
+  popularPeriod,
   viewMode = 'feed',
   className,
   verifiedOnly = false,
@@ -94,6 +99,8 @@ export function VideoFeed({
     pubkey,
     pageSize: limit,
     sortMode,
+    popularSource,
+    popularPeriod,
   });
   const { feedRootRef, trackInitialRender, trackFirstPlayback } = useFeedPerformanceInstrumentation({
     feedType,

--- a/src/hooks/useInfiniteVideosFunnelcake.test.ts
+++ b/src/hooks/useInfiniteVideosFunnelcake.test.ts
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 
 const mockFetchVideos = vi.fn();
+const mockFetchVideosV2 = vi.fn();
 const mockFetchRecommendations = vi.fn();
 const mockTransformToVideoPage = vi.fn();
 
@@ -15,6 +16,7 @@ vi.mock('@/hooks/useCurrentUser', () => ({
 
 vi.mock('@/lib/funnelcakeClient', () => ({
   fetchVideos: mockFetchVideos,
+  fetchVideosV2: mockFetchVideosV2,
   searchVideos: vi.fn(),
   fetchUserVideos: vi.fn(),
   fetchUserFeed: vi.fn(),
@@ -58,6 +60,46 @@ beforeEach(async () => {
 });
 
 describe('useInfiniteVideosFunnelcake', () => {
+  it('requests native popular videos with period and excludes classic Vines', async () => {
+    mockFetchVideosV2.mockResolvedValueOnce({
+      videos: [{}],
+      has_more: true,
+      next_cursor: 'o:12',
+    });
+    mockTransformToVideoPage.mockReturnValueOnce({
+      videos: [{ id: 'video-1', pubkey: 'p1', kind: 34236, createdAt: 101, vineId: 'd-1' }],
+      nextCursor: undefined,
+      rawCursor: 'o:12',
+      hasMore: true,
+    });
+
+    const { result } = renderHook(
+      () => useInfiniteVideosFunnelcake({
+        feedType: 'popular',
+        popularSource: 'new',
+        popularPeriod: 'now',
+        pageSize: 12,
+      }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockFetchVideosV2).toHaveBeenCalledWith(
+      'https://api.divine.video',
+      expect.objectContaining({
+        sort: 'popular',
+        period: 'now',
+        exclude_platform: 'vine',
+        limit: 12,
+        signal: expect.any(AbortSignal),
+      })
+    );
+    expect(result.current.hasNextPage).toBe(true);
+  });
+
   it('uses cursor-based pagination for recommendations', async () => {
     // Page 1: server returns cursor for next page
     mockFetchRecommendations

--- a/src/hooks/useInfiniteVideosFunnelcake.ts
+++ b/src/hooks/useInfiniteVideosFunnelcake.ts
@@ -13,13 +13,17 @@ import { transformToVideoPage } from '@/lib/funnelcakeTransform';
 import { debugLog } from '@/lib/debug';
 import { performanceMonitor } from '@/lib/performanceMonitoring';
 
-export type FunnelcakeFeedType = 'trending' | 'recent' | 'classics' | 'hashtag' | 'profile' | 'home' | 'recommendations' | 'category';
+export type FunnelcakeFeedType = 'trending' | 'recent' | 'classics' | 'hashtag' | 'profile' | 'home' | 'recommendations' | 'category' | 'popular';
 export type FunnelcakeSortMode = 'trending' | 'recent' | 'loops' | 'engagement' | 'classic' | 'watching';
+export type PopularSource = 'new' | 'classic' | 'all';
+export type PopularPeriod = 'now' | 'today' | 'week' | 'month' | 'all';
 
 interface UseInfiniteVideosFunnelcakeOptions {
   feedType: FunnelcakeFeedType;
   apiUrl?: string;          // Override API URL (for classics always using Divine)
   sortMode?: FunnelcakeSortMode;
+  popularSource?: PopularSource;
+  popularPeriod?: PopularPeriod;
   hashtag?: string;         // For hashtag feed
   category?: string;        // For category feed
   pubkey?: string;          // For profile and home feeds
@@ -92,13 +96,24 @@ function isRecommendationsCursorPageParam(
 function getFetchOptions(
   feedType: FunnelcakeFeedType,
   sortMode?: FunnelcakeSortMode,
-  pageSize: number = 20
+  pageSize: number = 20,
+  popularSource?: PopularSource,
+  popularPeriod?: PopularPeriod
 ): FunnelcakeFetchOptions {
   const baseOptions: FunnelcakeFetchOptions = {
     limit: pageSize,
   };
 
   switch (feedType) {
+    case 'popular':
+      return {
+        ...baseOptions,
+        sort: 'popular',
+        period: popularPeriod ?? 'now',
+        ...(popularSource === 'new' ? { exclude_platform: 'vine' } : {}),
+        ...(popularSource === 'classic' ? { platform: 'vine' } : {}),
+      };
+
     case 'classics':
       // Classic Vines: filter by platform=vine, sort by loops
       return {
@@ -178,6 +193,8 @@ export function useInfiniteVideosFunnelcake({
   feedType,
   apiUrl,
   sortMode,
+  popularSource = 'new',
+  popularPeriod = 'now',
   hashtag,
   category,
   pubkey,
@@ -202,7 +219,7 @@ export function useInfiniteVideosFunnelcake({
     : (apiUrl || getFunnelcakeBaseUrl());
 
   return useInfiniteQuery<FunnelcakeVideoPage, Error>({
-    queryKey: ['funnelcake-videos', feedType, effectiveApiUrl, sortMode, hashtag, category, pubkey, pageSize, randomStartOffset],
+    queryKey: ['funnelcake-videos', feedType, effectiveApiUrl, sortMode, popularSource, popularPeriod, hashtag, category, pubkey, pageSize, randomStartOffset],
 
     queryFn: async ({ pageParam, signal }) => {
       const totalStart = performance.now();
@@ -247,7 +264,7 @@ export function useInfiniteVideosFunnelcake({
           ? String(pageParam)
           : undefined;
 
-      const options = getFetchOptions(feedType, sortMode, pageSize);
+      const options = getFetchOptions(feedType, sortMode, pageSize, popularSource, popularPeriod);
       options.signal = signal;
 
       // For randomized feeds, use offset directly instead of before cursor
@@ -269,7 +286,7 @@ export function useInfiniteVideosFunnelcake({
       let response;
       let responseMode: FunnelcakeVideoPage['mode'];
       let cursorType: 'timestamp' | 'offset' | 'cursor' =
-        feedType === 'recommendations' || feedType === 'trending' ? 'cursor' : 'timestamp';
+        feedType === 'recommendations' || feedType === 'trending' || feedType === 'popular' ? 'cursor' : 'timestamp';
 
       try {
         switch (feedType) {
@@ -342,6 +359,7 @@ export function useInfiniteVideosFunnelcake({
             });
             break;
 
+          case 'popular':
           case 'trending':
             // v2 endpoint with sort=watching default; opaque cursor pagination.
             response = await fetchVideosV2(effectiveApiUrl, options);
@@ -414,7 +432,7 @@ export function useInfiniteVideosFunnelcake({
         nextCursor: page.nextCursor,
         offset: page.offset,
         recommendationsCursor: responseMode === 'recommendations' ? page.rawCursor : undefined,
-        v2Cursor: feedType === 'trending' ? page.rawCursor : undefined,
+        v2Cursor: feedType === 'trending' || feedType === 'popular' ? page.rawCursor : undefined,
         mode: responseMode,
       };
     },
@@ -448,7 +466,7 @@ export function useInfiniteVideosFunnelcake({
         };
       }
       // Trending uses opaque v2 cursors — pass through as a string page param
-      if (feedType === 'trending') {
+      if (feedType === 'trending' || feedType === 'popular') {
         return lastPage.v2Cursor;
       }
       // Use offset for sorted pagination, timestamp for chronological

--- a/src/hooks/useVideoNavigation.ts
+++ b/src/hooks/useVideoNavigation.ts
@@ -8,7 +8,7 @@ import type { ParsedVideoData } from '@/types/video';
 import type { SortMode } from '@/types/nostr';
 
 export interface VideoNavigationContext {
-  source: 'hashtag' | 'profile' | 'discovery' | 'home' | 'trending' | 'recent' | 'classics' | 'foryou' | 'category' | 'search';
+  source: 'hashtag' | 'profile' | 'discovery' | 'home' | 'trending' | 'popular' | 'recent' | 'classics' | 'foryou' | 'category' | 'search';
   hashtag?: string;
   pubkey?: string;
   query?: string;
@@ -53,7 +53,7 @@ export function useVideoNavigation(videoId: string, options: UseVideoNavigationO
 
   // Fetch videos based on context
   // Map 'foryou' to 'trending' for WebSocket fallback (foryou only works via Funnelcake API)
-  const feedTypeForWebSocket = context?.source === 'foryou'
+  const feedTypeForWebSocket = context?.source === 'foryou' || context?.source === 'popular'
     ? 'trending'
     : context?.source === 'search'
       ? 'discovery'

--- a/src/hooks/useVideoProvider.test.ts
+++ b/src/hooks/useVideoProvider.test.ts
@@ -182,6 +182,28 @@ describe('useVideoProvider', () => {
     expect(result.current.dataSource).toBe('funnelcake');
   });
 
+  it('routes popular feeds to Funnelcake with popular options and no WebSocket fallback', () => {
+    const { result } = renderHook(() =>
+      useVideoProvider({
+        feedType: 'popular',
+        popularSource: 'classic',
+        popularPeriod: 'week',
+      })
+    );
+
+    expect(mockUseInfiniteVideosFunnelcake).toHaveBeenCalledWith(expect.objectContaining({
+      feedType: 'popular',
+      apiUrl: 'https://api.divine.video',
+      popularSource: 'classic',
+      popularPeriod: 'week',
+      enabled: true,
+    }));
+    expect(mockUseInfiniteVideos).toHaveBeenCalledWith(expect.objectContaining({
+      enabled: false,
+    }));
+    expect(result.current.dataSource).toBe('funnelcake');
+  });
+
   it('prefers Funnelcake for Divine hot feeds', () => {
     mockUseResolvedRelayCapabilities.mockReturnValue(makeCapabilities({
       supportsVideoSorts: true,

--- a/src/hooks/useVideoProvider.ts
+++ b/src/hooks/useVideoProvider.ts
@@ -5,19 +5,21 @@ import { useAppContext } from '@/hooks/useAppContext';
 import { getFunnelcakeBaseUrl } from '@/config/api';
 import { useInfiniteVideos } from '@/hooks/useInfiniteVideos';
 import { useResolvedRelayCapabilities } from '@/hooks/useRelayCapabilities';
-import { useInfiniteVideosFunnelcake, type FunnelcakeFeedType, type FunnelcakeSortMode } from '@/hooks/useInfiniteVideosFunnelcake';
+import { useInfiniteVideosFunnelcake, type FunnelcakeFeedType, type FunnelcakeSortMode, type PopularPeriod, type PopularSource } from '@/hooks/useInfiniteVideosFunnelcake';
 import { hasFunnelcake, getFunnelcakeUrl } from '@/config/relays';
 import { debugLog } from '@/lib/debug';
 import type { RelayCapabilities } from '@/lib/relayCapabilities';
 import type { SortMode } from '@/types/nostr';
 
 // Feed types that can be provided
-export type VideoFeedType = 'discovery' | 'home' | 'trending' | 'hashtag' | 'profile' | 'recent' | 'classics' | 'foryou' | 'category';
+export type VideoFeedType = 'discovery' | 'home' | 'trending' | 'hashtag' | 'profile' | 'recent' | 'classics' | 'foryou' | 'category' | 'popular';
 type WebsocketVideoFeedType = 'discovery' | 'home' | 'trending' | 'hashtag' | 'profile' | 'recent';
 
 interface UseVideoProviderOptions {
   feedType: VideoFeedType;
   sortMode?: SortMode;
+  popularSource?: PopularSource;
+  popularPeriod?: PopularPeriod;
   hashtag?: string;
   category?: string;
   pubkey?: string;
@@ -55,6 +57,7 @@ function canServeFeedViaFunnelcake(feedType: VideoFeedType): boolean {
     case 'classics':
     case 'foryou':
     case 'category':
+    case 'popular':
       return true;
   }
 }
@@ -82,6 +85,8 @@ function mapToFunnelcakeFeedType(feedType: VideoFeedType): FunnelcakeFeedType {
       return 'recommendations';
     case 'category':
       return 'category';
+    case 'popular':
+      return 'popular';
     default:
       return 'trending';
   }
@@ -132,6 +137,7 @@ export function canServeFeedViaWebsocket(
     case 'classics':
     case 'foryou':
     case 'category':
+    case 'popular':
       return false;
 
     case 'discovery':
@@ -207,6 +213,8 @@ export function chooseVideoDataSource({
 export function useVideoProvider({
   feedType,
   sortMode,
+  popularSource,
+  popularPeriod,
   hashtag,
   category,
   pubkey,
@@ -233,6 +241,8 @@ export function useVideoProvider({
     feedType: mapToFunnelcakeFeedType(feedType),
     apiUrl: decision.apiUrl,
     sortMode: mapToFunnelcakeSortMode(sortMode),
+    popularSource,
+    popularPeriod,
     hashtag,
     category,
     pubkey,

--- a/src/lib/funnelcakeClient.ts
+++ b/src/lib/funnelcakeClient.ts
@@ -230,13 +230,26 @@ export async function fetchVideosV2(
   apiUrl: string = API_CONFIG.funnelcake.baseUrl,
   options: FunnelcakeFetchOptions = {}
 ): Promise<FunnelcakeResponse> {
-  const { sort = 'watching', limit = 20, before, offset, classic, platform, category, signal } = options;
+  const {
+    sort = 'watching',
+    period,
+    limit = 20,
+    before,
+    offset,
+    classic,
+    platform,
+    exclude_platform,
+    category,
+    signal,
+  } = options;
 
   const params: Record<string, string | number | boolean | undefined> = {
     sort,
+    period,
     limit,
     classic,
     platform,
+    exclude_platform,
     category,
   };
 

--- a/src/lib/i18n/locales/ar/common.json
+++ b/src/lib/i18n/locales/ar/common.json
@@ -7,6 +7,7 @@
   "nav": {
     "home": "الرئيسية",
     "discover": "اكتشف",
+    "popular": "Popular",
     "search": "بحث",
     "messages": "الرسائل",
     "notifications": "الإشعارات",
@@ -1095,6 +1096,47 @@
     "previewEmpty": "أدخل npub أعلاه لرؤية المعاينة",
     "iframeTitle": "أداة فيديو Divine",
     "previewIframeTitle": "معاينة أداة فيديو Divine"
+  },
+  "popularPage": {
+    "heading": "Popular",
+    "controlsLabel": "Popular feed filters",
+    "sourceLabel": "Source",
+    "periodLabel": "Period",
+    "sources": {
+      "new": "New",
+      "classic": "Classic",
+      "all": "All"
+    },
+    "periods": {
+      "now": "Now",
+      "today": "Today",
+      "week": "Week",
+      "month": "Month",
+      "all": "All time"
+    },
+    "subheadings": {
+      "new": {
+        "now": "Fresh Divine posts getting watched now.",
+        "today": "Fresh Divine posts getting watched today.",
+        "week": "Fresh Divine posts getting watched this week.",
+        "month": "Fresh Divine posts getting watched this month.",
+        "all": "Fresh Divine posts people keep coming back to."
+      },
+      "classic": {
+        "now": "Classic Vines getting watched now.",
+        "today": "Classic Vines getting watched today.",
+        "week": "Classic Vines getting watched this week.",
+        "month": "Classic Vines getting watched this month.",
+        "all": "Classic Vines people keep watching on Divine."
+      },
+      "all": {
+        "now": "Everything Divine is watching now.",
+        "today": "Everything Divine watched today.",
+        "week": "Everything Divine watched this week.",
+        "month": "Everything Divine watched this month.",
+        "all": "Everything people keep watching on Divine."
+      }
+    }
   },
   "trendingPage": {
     "heading": "الرائج",

--- a/src/lib/i18n/locales/de/common.json
+++ b/src/lib/i18n/locales/de/common.json
@@ -7,6 +7,7 @@
   "nav": {
     "home": "Startseite",
     "discover": "Entdecken",
+    "popular": "Popular",
     "search": "Suchen",
     "messages": "Nachrichten",
     "notifications": "Benachrichtigungen",
@@ -1091,6 +1092,47 @@
     "previewEmpty": "Gib oben deinen npub ein, um eine Vorschau zu sehen",
     "iframeTitle": "Divine Video-Widget",
     "previewIframeTitle": "Divine Video-Widget Vorschau"
+  },
+  "popularPage": {
+    "heading": "Popular",
+    "controlsLabel": "Popular feed filters",
+    "sourceLabel": "Source",
+    "periodLabel": "Period",
+    "sources": {
+      "new": "New",
+      "classic": "Classic",
+      "all": "All"
+    },
+    "periods": {
+      "now": "Now",
+      "today": "Today",
+      "week": "Week",
+      "month": "Month",
+      "all": "All time"
+    },
+    "subheadings": {
+      "new": {
+        "now": "Fresh Divine posts getting watched now.",
+        "today": "Fresh Divine posts getting watched today.",
+        "week": "Fresh Divine posts getting watched this week.",
+        "month": "Fresh Divine posts getting watched this month.",
+        "all": "Fresh Divine posts people keep coming back to."
+      },
+      "classic": {
+        "now": "Classic Vines getting watched now.",
+        "today": "Classic Vines getting watched today.",
+        "week": "Classic Vines getting watched this week.",
+        "month": "Classic Vines getting watched this month.",
+        "all": "Classic Vines people keep watching on Divine."
+      },
+      "all": {
+        "now": "Everything Divine is watching now.",
+        "today": "Everything Divine watched today.",
+        "week": "Everything Divine watched this week.",
+        "month": "Everything Divine watched this month.",
+        "all": "Everything people keep watching on Divine."
+      }
+    }
   },
   "trendingPage": {
     "heading": "Trending",

--- a/src/lib/i18n/locales/en/common.json
+++ b/src/lib/i18n/locales/en/common.json
@@ -7,6 +7,7 @@
   "nav": {
     "home": "Home",
     "discover": "Discover",
+    "popular": "Popular",
     "search": "Search",
     "messages": "Messages",
     "notifications": "Notifications",
@@ -1091,6 +1092,47 @@
     "previewEmpty": "Enter your npub above to see a preview",
     "iframeTitle": "Divine Video Widget",
     "previewIframeTitle": "Divine Video Widget Preview"
+  },
+  "popularPage": {
+    "heading": "Popular",
+    "controlsLabel": "Popular feed filters",
+    "sourceLabel": "Source",
+    "periodLabel": "Period",
+    "sources": {
+      "new": "New",
+      "classic": "Classic",
+      "all": "All"
+    },
+    "periods": {
+      "now": "Now",
+      "today": "Today",
+      "week": "Week",
+      "month": "Month",
+      "all": "All time"
+    },
+    "subheadings": {
+      "new": {
+        "now": "Fresh Divine posts getting watched now.",
+        "today": "Fresh Divine posts getting watched today.",
+        "week": "Fresh Divine posts getting watched this week.",
+        "month": "Fresh Divine posts getting watched this month.",
+        "all": "Fresh Divine posts people keep coming back to."
+      },
+      "classic": {
+        "now": "Classic Vines getting watched now.",
+        "today": "Classic Vines getting watched today.",
+        "week": "Classic Vines getting watched this week.",
+        "month": "Classic Vines getting watched this month.",
+        "all": "Classic Vines people keep watching on Divine."
+      },
+      "all": {
+        "now": "Everything Divine is watching now.",
+        "today": "Everything Divine watched today.",
+        "week": "Everything Divine watched this week.",
+        "month": "Everything Divine watched this month.",
+        "all": "Everything people keep watching on Divine."
+      }
+    }
   },
   "trendingPage": {
     "heading": "Trending",

--- a/src/lib/i18n/locales/es/common.json
+++ b/src/lib/i18n/locales/es/common.json
@@ -7,6 +7,7 @@
   "nav": {
     "home": "Inicio",
     "discover": "Descubrir",
+    "popular": "Popular",
     "search": "Buscar",
     "messages": "Mensajes",
     "notifications": "Notificaciones",
@@ -1091,6 +1092,47 @@
     "previewEmpty": "Ingresa tu npub arriba para ver una vista previa",
     "iframeTitle": "Widget de video de Divine",
     "previewIframeTitle": "Vista previa del widget de video de Divine"
+  },
+  "popularPage": {
+    "heading": "Popular",
+    "controlsLabel": "Popular feed filters",
+    "sourceLabel": "Source",
+    "periodLabel": "Period",
+    "sources": {
+      "new": "New",
+      "classic": "Classic",
+      "all": "All"
+    },
+    "periods": {
+      "now": "Now",
+      "today": "Today",
+      "week": "Week",
+      "month": "Month",
+      "all": "All time"
+    },
+    "subheadings": {
+      "new": {
+        "now": "Fresh Divine posts getting watched now.",
+        "today": "Fresh Divine posts getting watched today.",
+        "week": "Fresh Divine posts getting watched this week.",
+        "month": "Fresh Divine posts getting watched this month.",
+        "all": "Fresh Divine posts people keep coming back to."
+      },
+      "classic": {
+        "now": "Classic Vines getting watched now.",
+        "today": "Classic Vines getting watched today.",
+        "week": "Classic Vines getting watched this week.",
+        "month": "Classic Vines getting watched this month.",
+        "all": "Classic Vines people keep watching on Divine."
+      },
+      "all": {
+        "now": "Everything Divine is watching now.",
+        "today": "Everything Divine watched today.",
+        "week": "Everything Divine watched this week.",
+        "month": "Everything Divine watched this month.",
+        "all": "Everything people keep watching on Divine."
+      }
+    }
   },
   "trendingPage": {
     "heading": "Tendencias",

--- a/src/lib/i18n/locales/fil/common.json
+++ b/src/lib/i18n/locales/fil/common.json
@@ -7,6 +7,7 @@
   "nav": {
     "home": "Tahanan",
     "discover": "Tuklasin",
+    "popular": "Popular",
     "search": "Hanapin",
     "messages": "Mga Mensahe",
     "notifications": "Mga Abiso",
@@ -1091,6 +1092,47 @@
     "previewEmpty": "Ilagay ang iyong npub sa itaas para makita ang preview",
     "iframeTitle": "Divine Video Widget",
     "previewIframeTitle": "Preview ng Divine Video Widget"
+  },
+  "popularPage": {
+    "heading": "Popular",
+    "controlsLabel": "Popular feed filters",
+    "sourceLabel": "Source",
+    "periodLabel": "Period",
+    "sources": {
+      "new": "New",
+      "classic": "Classic",
+      "all": "All"
+    },
+    "periods": {
+      "now": "Now",
+      "today": "Today",
+      "week": "Week",
+      "month": "Month",
+      "all": "All time"
+    },
+    "subheadings": {
+      "new": {
+        "now": "Fresh Divine posts getting watched now.",
+        "today": "Fresh Divine posts getting watched today.",
+        "week": "Fresh Divine posts getting watched this week.",
+        "month": "Fresh Divine posts getting watched this month.",
+        "all": "Fresh Divine posts people keep coming back to."
+      },
+      "classic": {
+        "now": "Classic Vines getting watched now.",
+        "today": "Classic Vines getting watched today.",
+        "week": "Classic Vines getting watched this week.",
+        "month": "Classic Vines getting watched this month.",
+        "all": "Classic Vines people keep watching on Divine."
+      },
+      "all": {
+        "now": "Everything Divine is watching now.",
+        "today": "Everything Divine watched today.",
+        "week": "Everything Divine watched this week.",
+        "month": "Everything Divine watched this month.",
+        "all": "Everything people keep watching on Divine."
+      }
+    }
   },
   "trendingPage": {
     "heading": "Trending",

--- a/src/lib/i18n/locales/fr/common.json
+++ b/src/lib/i18n/locales/fr/common.json
@@ -7,6 +7,7 @@
   "nav": {
     "home": "Accueil",
     "discover": "Decouvrir",
+    "popular": "Popular",
     "search": "Rechercher",
     "messages": "Messages",
     "notifications": "Notifications",
@@ -1091,6 +1092,47 @@
     "previewEmpty": "Entre ton npub ci-dessus pour voir un aperçu",
     "iframeTitle": "Widget vidéo Divine",
     "previewIframeTitle": "Aperçu du widget vidéo Divine"
+  },
+  "popularPage": {
+    "heading": "Popular",
+    "controlsLabel": "Popular feed filters",
+    "sourceLabel": "Source",
+    "periodLabel": "Period",
+    "sources": {
+      "new": "New",
+      "classic": "Classic",
+      "all": "All"
+    },
+    "periods": {
+      "now": "Now",
+      "today": "Today",
+      "week": "Week",
+      "month": "Month",
+      "all": "All time"
+    },
+    "subheadings": {
+      "new": {
+        "now": "Fresh Divine posts getting watched now.",
+        "today": "Fresh Divine posts getting watched today.",
+        "week": "Fresh Divine posts getting watched this week.",
+        "month": "Fresh Divine posts getting watched this month.",
+        "all": "Fresh Divine posts people keep coming back to."
+      },
+      "classic": {
+        "now": "Classic Vines getting watched now.",
+        "today": "Classic Vines getting watched today.",
+        "week": "Classic Vines getting watched this week.",
+        "month": "Classic Vines getting watched this month.",
+        "all": "Classic Vines people keep watching on Divine."
+      },
+      "all": {
+        "now": "Everything Divine is watching now.",
+        "today": "Everything Divine watched today.",
+        "week": "Everything Divine watched this week.",
+        "month": "Everything Divine watched this month.",
+        "all": "Everything people keep watching on Divine."
+      }
+    }
   },
   "trendingPage": {
     "heading": "Tendances",

--- a/src/lib/i18n/locales/id/common.json
+++ b/src/lib/i18n/locales/id/common.json
@@ -7,6 +7,7 @@
   "nav": {
     "home": "Beranda",
     "discover": "Jelajahi",
+    "popular": "Popular",
     "search": "Cari",
     "messages": "Pesan",
     "notifications": "Notifikasi",
@@ -1091,6 +1092,47 @@
     "previewEmpty": "Masukkan npub kamu di atas untuk melihat pratinjau",
     "iframeTitle": "Widget Video Divine",
     "previewIframeTitle": "Pratinjau Widget Video Divine"
+  },
+  "popularPage": {
+    "heading": "Popular",
+    "controlsLabel": "Popular feed filters",
+    "sourceLabel": "Source",
+    "periodLabel": "Period",
+    "sources": {
+      "new": "New",
+      "classic": "Classic",
+      "all": "All"
+    },
+    "periods": {
+      "now": "Now",
+      "today": "Today",
+      "week": "Week",
+      "month": "Month",
+      "all": "All time"
+    },
+    "subheadings": {
+      "new": {
+        "now": "Fresh Divine posts getting watched now.",
+        "today": "Fresh Divine posts getting watched today.",
+        "week": "Fresh Divine posts getting watched this week.",
+        "month": "Fresh Divine posts getting watched this month.",
+        "all": "Fresh Divine posts people keep coming back to."
+      },
+      "classic": {
+        "now": "Classic Vines getting watched now.",
+        "today": "Classic Vines getting watched today.",
+        "week": "Classic Vines getting watched this week.",
+        "month": "Classic Vines getting watched this month.",
+        "all": "Classic Vines people keep watching on Divine."
+      },
+      "all": {
+        "now": "Everything Divine is watching now.",
+        "today": "Everything Divine watched today.",
+        "week": "Everything Divine watched this week.",
+        "month": "Everything Divine watched this month.",
+        "all": "Everything people keep watching on Divine."
+      }
+    }
   },
   "trendingPage": {
     "heading": "Trending",

--- a/src/lib/i18n/locales/it/common.json
+++ b/src/lib/i18n/locales/it/common.json
@@ -7,6 +7,7 @@
   "nav": {
     "home": "Home",
     "discover": "Scopri",
+    "popular": "Popular",
     "search": "Cerca",
     "messages": "Messaggi",
     "notifications": "Notifiche",
@@ -1091,6 +1092,47 @@
     "previewEmpty": "Inserisci il tuo npub sopra per vedere un'anteprima",
     "iframeTitle": "Widget video Divine",
     "previewIframeTitle": "Anteprima widget video Divine"
+  },
+  "popularPage": {
+    "heading": "Popular",
+    "controlsLabel": "Popular feed filters",
+    "sourceLabel": "Source",
+    "periodLabel": "Period",
+    "sources": {
+      "new": "New",
+      "classic": "Classic",
+      "all": "All"
+    },
+    "periods": {
+      "now": "Now",
+      "today": "Today",
+      "week": "Week",
+      "month": "Month",
+      "all": "All time"
+    },
+    "subheadings": {
+      "new": {
+        "now": "Fresh Divine posts getting watched now.",
+        "today": "Fresh Divine posts getting watched today.",
+        "week": "Fresh Divine posts getting watched this week.",
+        "month": "Fresh Divine posts getting watched this month.",
+        "all": "Fresh Divine posts people keep coming back to."
+      },
+      "classic": {
+        "now": "Classic Vines getting watched now.",
+        "today": "Classic Vines getting watched today.",
+        "week": "Classic Vines getting watched this week.",
+        "month": "Classic Vines getting watched this month.",
+        "all": "Classic Vines people keep watching on Divine."
+      },
+      "all": {
+        "now": "Everything Divine is watching now.",
+        "today": "Everything Divine watched today.",
+        "week": "Everything Divine watched this week.",
+        "month": "Everything Divine watched this month.",
+        "all": "Everything people keep watching on Divine."
+      }
+    }
   },
   "trendingPage": {
     "heading": "Di tendenza",

--- a/src/lib/i18n/locales/ja/common.json
+++ b/src/lib/i18n/locales/ja/common.json
@@ -7,6 +7,7 @@
   "nav": {
     "home": "ホーム",
     "discover": "発見",
+    "popular": "Popular",
     "search": "検索",
     "messages": "メッセージ",
     "notifications": "通知",
@@ -1091,6 +1092,47 @@
     "previewEmpty": "上にnpubを入力するとプレビューが表示されます",
     "iframeTitle": "Divine動画ウィジェット",
     "previewIframeTitle": "Divine動画ウィジェットのプレビュー"
+  },
+  "popularPage": {
+    "heading": "Popular",
+    "controlsLabel": "Popular feed filters",
+    "sourceLabel": "Source",
+    "periodLabel": "Period",
+    "sources": {
+      "new": "New",
+      "classic": "Classic",
+      "all": "All"
+    },
+    "periods": {
+      "now": "Now",
+      "today": "Today",
+      "week": "Week",
+      "month": "Month",
+      "all": "All time"
+    },
+    "subheadings": {
+      "new": {
+        "now": "Fresh Divine posts getting watched now.",
+        "today": "Fresh Divine posts getting watched today.",
+        "week": "Fresh Divine posts getting watched this week.",
+        "month": "Fresh Divine posts getting watched this month.",
+        "all": "Fresh Divine posts people keep coming back to."
+      },
+      "classic": {
+        "now": "Classic Vines getting watched now.",
+        "today": "Classic Vines getting watched today.",
+        "week": "Classic Vines getting watched this week.",
+        "month": "Classic Vines getting watched this month.",
+        "all": "Classic Vines people keep watching on Divine."
+      },
+      "all": {
+        "now": "Everything Divine is watching now.",
+        "today": "Everything Divine watched today.",
+        "week": "Everything Divine watched this week.",
+        "month": "Everything Divine watched this month.",
+        "all": "Everything people keep watching on Divine."
+      }
+    }
   },
   "trendingPage": {
     "heading": "トレンド",

--- a/src/lib/i18n/locales/ko/common.json
+++ b/src/lib/i18n/locales/ko/common.json
@@ -7,6 +7,7 @@
   "nav": {
     "home": "홈",
     "discover": "탐색",
+    "popular": "Popular",
     "search": "검색",
     "messages": "메시지",
     "notifications": "알림",
@@ -1091,6 +1092,47 @@
     "previewEmpty": "위에 npub을 입력하면 미리보기가 표시돼요",
     "iframeTitle": "Divine 비디오 위젯",
     "previewIframeTitle": "Divine 비디오 위젯 미리보기"
+  },
+  "popularPage": {
+    "heading": "Popular",
+    "controlsLabel": "Popular feed filters",
+    "sourceLabel": "Source",
+    "periodLabel": "Period",
+    "sources": {
+      "new": "New",
+      "classic": "Classic",
+      "all": "All"
+    },
+    "periods": {
+      "now": "Now",
+      "today": "Today",
+      "week": "Week",
+      "month": "Month",
+      "all": "All time"
+    },
+    "subheadings": {
+      "new": {
+        "now": "Fresh Divine posts getting watched now.",
+        "today": "Fresh Divine posts getting watched today.",
+        "week": "Fresh Divine posts getting watched this week.",
+        "month": "Fresh Divine posts getting watched this month.",
+        "all": "Fresh Divine posts people keep coming back to."
+      },
+      "classic": {
+        "now": "Classic Vines getting watched now.",
+        "today": "Classic Vines getting watched today.",
+        "week": "Classic Vines getting watched this week.",
+        "month": "Classic Vines getting watched this month.",
+        "all": "Classic Vines people keep watching on Divine."
+      },
+      "all": {
+        "now": "Everything Divine is watching now.",
+        "today": "Everything Divine watched today.",
+        "week": "Everything Divine watched this week.",
+        "month": "Everything Divine watched this month.",
+        "all": "Everything people keep watching on Divine."
+      }
+    }
   },
   "trendingPage": {
     "heading": "인기",

--- a/src/lib/i18n/locales/nl/common.json
+++ b/src/lib/i18n/locales/nl/common.json
@@ -7,6 +7,7 @@
   "nav": {
     "home": "Home",
     "discover": "Ontdekken",
+    "popular": "Popular",
     "search": "Zoeken",
     "messages": "Berichten",
     "notifications": "Meldingen",
@@ -1091,6 +1092,47 @@
     "previewEmpty": "Vul hierboven je npub in om een voorbeeld te zien",
     "iframeTitle": "Divine-videowidget",
     "previewIframeTitle": "Voorbeeld Divine-videowidget"
+  },
+  "popularPage": {
+    "heading": "Popular",
+    "controlsLabel": "Popular feed filters",
+    "sourceLabel": "Source",
+    "periodLabel": "Period",
+    "sources": {
+      "new": "New",
+      "classic": "Classic",
+      "all": "All"
+    },
+    "periods": {
+      "now": "Now",
+      "today": "Today",
+      "week": "Week",
+      "month": "Month",
+      "all": "All time"
+    },
+    "subheadings": {
+      "new": {
+        "now": "Fresh Divine posts getting watched now.",
+        "today": "Fresh Divine posts getting watched today.",
+        "week": "Fresh Divine posts getting watched this week.",
+        "month": "Fresh Divine posts getting watched this month.",
+        "all": "Fresh Divine posts people keep coming back to."
+      },
+      "classic": {
+        "now": "Classic Vines getting watched now.",
+        "today": "Classic Vines getting watched today.",
+        "week": "Classic Vines getting watched this week.",
+        "month": "Classic Vines getting watched this month.",
+        "all": "Classic Vines people keep watching on Divine."
+      },
+      "all": {
+        "now": "Everything Divine is watching now.",
+        "today": "Everything Divine watched today.",
+        "week": "Everything Divine watched this week.",
+        "month": "Everything Divine watched this month.",
+        "all": "Everything people keep watching on Divine."
+      }
+    }
   },
   "trendingPage": {
     "heading": "Trending",

--- a/src/lib/i18n/locales/pl/common.json
+++ b/src/lib/i18n/locales/pl/common.json
@@ -7,6 +7,7 @@
   "nav": {
     "home": "Strona glowna",
     "discover": "Odkrywaj",
+    "popular": "Popular",
     "search": "Szukaj",
     "messages": "Wiadomosci",
     "notifications": "Powiadomienia",
@@ -1093,6 +1094,47 @@
     "previewEmpty": "Wpisz swój npub powyżej, żeby zobaczyć podgląd",
     "iframeTitle": "Widget wideo Divine",
     "previewIframeTitle": "Podgląd widgetu wideo Divine"
+  },
+  "popularPage": {
+    "heading": "Popular",
+    "controlsLabel": "Popular feed filters",
+    "sourceLabel": "Source",
+    "periodLabel": "Period",
+    "sources": {
+      "new": "New",
+      "classic": "Classic",
+      "all": "All"
+    },
+    "periods": {
+      "now": "Now",
+      "today": "Today",
+      "week": "Week",
+      "month": "Month",
+      "all": "All time"
+    },
+    "subheadings": {
+      "new": {
+        "now": "Fresh Divine posts getting watched now.",
+        "today": "Fresh Divine posts getting watched today.",
+        "week": "Fresh Divine posts getting watched this week.",
+        "month": "Fresh Divine posts getting watched this month.",
+        "all": "Fresh Divine posts people keep coming back to."
+      },
+      "classic": {
+        "now": "Classic Vines getting watched now.",
+        "today": "Classic Vines getting watched today.",
+        "week": "Classic Vines getting watched this week.",
+        "month": "Classic Vines getting watched this month.",
+        "all": "Classic Vines people keep watching on Divine."
+      },
+      "all": {
+        "now": "Everything Divine is watching now.",
+        "today": "Everything Divine watched today.",
+        "week": "Everything Divine watched this week.",
+        "month": "Everything Divine watched this month.",
+        "all": "Everything people keep watching on Divine."
+      }
+    }
   },
   "trendingPage": {
     "heading": "Na czasie",

--- a/src/lib/i18n/locales/pt/common.json
+++ b/src/lib/i18n/locales/pt/common.json
@@ -7,6 +7,7 @@
   "nav": {
     "home": "Inicio",
     "discover": "Descobrir",
+    "popular": "Popular",
     "search": "Pesquisar",
     "messages": "Mensagens",
     "notifications": "Notificacoes",
@@ -1091,6 +1092,47 @@
     "previewEmpty": "Insira seu npub acima pra ver uma pré-visualização",
     "iframeTitle": "Widget de vídeo Divine",
     "previewIframeTitle": "Pré-visualização do widget de vídeo Divine"
+  },
+  "popularPage": {
+    "heading": "Popular",
+    "controlsLabel": "Popular feed filters",
+    "sourceLabel": "Source",
+    "periodLabel": "Period",
+    "sources": {
+      "new": "New",
+      "classic": "Classic",
+      "all": "All"
+    },
+    "periods": {
+      "now": "Now",
+      "today": "Today",
+      "week": "Week",
+      "month": "Month",
+      "all": "All time"
+    },
+    "subheadings": {
+      "new": {
+        "now": "Fresh Divine posts getting watched now.",
+        "today": "Fresh Divine posts getting watched today.",
+        "week": "Fresh Divine posts getting watched this week.",
+        "month": "Fresh Divine posts getting watched this month.",
+        "all": "Fresh Divine posts people keep coming back to."
+      },
+      "classic": {
+        "now": "Classic Vines getting watched now.",
+        "today": "Classic Vines getting watched today.",
+        "week": "Classic Vines getting watched this week.",
+        "month": "Classic Vines getting watched this month.",
+        "all": "Classic Vines people keep watching on Divine."
+      },
+      "all": {
+        "now": "Everything Divine is watching now.",
+        "today": "Everything Divine watched today.",
+        "week": "Everything Divine watched this week.",
+        "month": "Everything Divine watched this month.",
+        "all": "Everything people keep watching on Divine."
+      }
+    }
   },
   "trendingPage": {
     "heading": "Em alta",

--- a/src/lib/i18n/locales/ro/common.json
+++ b/src/lib/i18n/locales/ro/common.json
@@ -7,6 +7,7 @@
   "nav": {
     "home": "Acasa",
     "discover": "Descopera",
+    "popular": "Popular",
     "search": "Cauta",
     "messages": "Mesaje",
     "notifications": "Notificari",
@@ -1092,6 +1093,47 @@
     "previewEmpty": "Introdu npub-ul tău mai sus ca să vezi previzualizarea",
     "iframeTitle": "Widget video Divine",
     "previewIframeTitle": "Previzualizare widget video Divine"
+  },
+  "popularPage": {
+    "heading": "Popular",
+    "controlsLabel": "Popular feed filters",
+    "sourceLabel": "Source",
+    "periodLabel": "Period",
+    "sources": {
+      "new": "New",
+      "classic": "Classic",
+      "all": "All"
+    },
+    "periods": {
+      "now": "Now",
+      "today": "Today",
+      "week": "Week",
+      "month": "Month",
+      "all": "All time"
+    },
+    "subheadings": {
+      "new": {
+        "now": "Fresh Divine posts getting watched now.",
+        "today": "Fresh Divine posts getting watched today.",
+        "week": "Fresh Divine posts getting watched this week.",
+        "month": "Fresh Divine posts getting watched this month.",
+        "all": "Fresh Divine posts people keep coming back to."
+      },
+      "classic": {
+        "now": "Classic Vines getting watched now.",
+        "today": "Classic Vines getting watched today.",
+        "week": "Classic Vines getting watched this week.",
+        "month": "Classic Vines getting watched this month.",
+        "all": "Classic Vines people keep watching on Divine."
+      },
+      "all": {
+        "now": "Everything Divine is watching now.",
+        "today": "Everything Divine watched today.",
+        "week": "Everything Divine watched this week.",
+        "month": "Everything Divine watched this month.",
+        "all": "Everything people keep watching on Divine."
+      }
+    }
   },
   "trendingPage": {
     "heading": "În tendințe",

--- a/src/lib/i18n/locales/sv/common.json
+++ b/src/lib/i18n/locales/sv/common.json
@@ -7,6 +7,7 @@
   "nav": {
     "home": "Hem",
     "discover": "Utforska",
+    "popular": "Popular",
     "search": "Sok",
     "messages": "Meddelanden",
     "notifications": "Aviseringar",
@@ -1091,6 +1092,47 @@
     "previewEmpty": "Ange din npub ovan för att se en förhandsgranskning",
     "iframeTitle": "Divine videowidget",
     "previewIframeTitle": "Förhandsgranskning av Divine videowidget"
+  },
+  "popularPage": {
+    "heading": "Popular",
+    "controlsLabel": "Popular feed filters",
+    "sourceLabel": "Source",
+    "periodLabel": "Period",
+    "sources": {
+      "new": "New",
+      "classic": "Classic",
+      "all": "All"
+    },
+    "periods": {
+      "now": "Now",
+      "today": "Today",
+      "week": "Week",
+      "month": "Month",
+      "all": "All time"
+    },
+    "subheadings": {
+      "new": {
+        "now": "Fresh Divine posts getting watched now.",
+        "today": "Fresh Divine posts getting watched today.",
+        "week": "Fresh Divine posts getting watched this week.",
+        "month": "Fresh Divine posts getting watched this month.",
+        "all": "Fresh Divine posts people keep coming back to."
+      },
+      "classic": {
+        "now": "Classic Vines getting watched now.",
+        "today": "Classic Vines getting watched today.",
+        "week": "Classic Vines getting watched this week.",
+        "month": "Classic Vines getting watched this month.",
+        "all": "Classic Vines people keep watching on Divine."
+      },
+      "all": {
+        "now": "Everything Divine is watching now.",
+        "today": "Everything Divine watched today.",
+        "week": "Everything Divine watched this week.",
+        "month": "Everything Divine watched this month.",
+        "all": "Everything people keep watching on Divine."
+      }
+    }
   },
   "trendingPage": {
     "heading": "Populärt",

--- a/src/lib/i18n/locales/tr/common.json
+++ b/src/lib/i18n/locales/tr/common.json
@@ -7,6 +7,7 @@
   "nav": {
     "home": "Ana sayfa",
     "discover": "Kesfet",
+    "popular": "Popular",
     "search": "Ara",
     "messages": "Mesajlar",
     "notifications": "Bildirimler",
@@ -1091,6 +1092,47 @@
     "previewEmpty": "Önizleme görmek için yukarıya npub'ını gir",
     "iframeTitle": "Divine Video Widget",
     "previewIframeTitle": "Divine Video Widget Önizleme"
+  },
+  "popularPage": {
+    "heading": "Popular",
+    "controlsLabel": "Popular feed filters",
+    "sourceLabel": "Source",
+    "periodLabel": "Period",
+    "sources": {
+      "new": "New",
+      "classic": "Classic",
+      "all": "All"
+    },
+    "periods": {
+      "now": "Now",
+      "today": "Today",
+      "week": "Week",
+      "month": "Month",
+      "all": "All time"
+    },
+    "subheadings": {
+      "new": {
+        "now": "Fresh Divine posts getting watched now.",
+        "today": "Fresh Divine posts getting watched today.",
+        "week": "Fresh Divine posts getting watched this week.",
+        "month": "Fresh Divine posts getting watched this month.",
+        "all": "Fresh Divine posts people keep coming back to."
+      },
+      "classic": {
+        "now": "Classic Vines getting watched now.",
+        "today": "Classic Vines getting watched today.",
+        "week": "Classic Vines getting watched this week.",
+        "month": "Classic Vines getting watched this month.",
+        "all": "Classic Vines people keep watching on Divine."
+      },
+      "all": {
+        "now": "Everything Divine is watching now.",
+        "today": "Everything Divine watched today.",
+        "week": "Everything Divine watched this week.",
+        "month": "Everything Divine watched this month.",
+        "all": "Everything people keep watching on Divine."
+      }
+    }
   },
   "trendingPage": {
     "heading": "Trend",

--- a/src/pages/PopularPage.test.tsx
+++ b/src/pages/PopularPage.test.tsx
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+import { initializeI18n } from '@/lib/i18n';
+import PopularPage from './PopularPage';
+
+const mockVideoFeed = vi.fn();
+
+vi.mock('@/components/VideoFeed', () => ({
+  VideoFeed: (props: unknown) => {
+    mockVideoFeed(props);
+    return <div data-testid="popular-feed" />;
+  },
+}));
+
+function LocationDisplay() {
+  const location = useLocation();
+  return <div data-testid="location-display">{location.pathname}{location.search}</div>;
+}
+
+async function renderPage(initialEntry = '/popular') {
+  await initializeI18n({ force: true, languages: ['en-US'] });
+  mockVideoFeed.mockClear();
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <PopularPage />
+      <LocationDisplay />
+    </MemoryRouter>
+  );
+}
+
+describe('PopularPage', () => {
+  beforeEach(() => {
+    const storage = new Map<string, string>();
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: (key: string) => storage.get(key) ?? null,
+        setItem: (key: string, value: string) => storage.set(key, value),
+        removeItem: (key: string) => storage.delete(key),
+        clear: () => storage.clear(),
+      } satisfies Pick<Storage, 'getItem' | 'setItem' | 'removeItem' | 'clear'>,
+    });
+  });
+
+  it('defaults to New and Now with canonical empty query params', async () => {
+    await renderPage('/popular');
+
+    expect(screen.getByRole('heading', { name: 'Popular' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'New' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'Now' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('location-display')).toHaveTextContent('/popular');
+    expect(mockVideoFeed).toHaveBeenCalledWith(expect.objectContaining({
+      feedType: 'popular',
+      popularSource: 'new',
+      popularPeriod: 'now',
+    }));
+  });
+
+  it('updates URL params when selecting Classic and Week', async () => {
+    const user = userEvent.setup();
+    await renderPage('/popular');
+
+    await user.click(screen.getByRole('button', { name: 'Classic' }));
+    await user.click(screen.getByRole('button', { name: 'Week' }));
+
+    expect(screen.getByRole('button', { name: 'Classic' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'Week' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('location-display')).toHaveTextContent('/popular?source=classic&period=week');
+    expect(mockVideoFeed).toHaveBeenLastCalledWith(expect.objectContaining({
+      feedType: 'popular',
+      popularSource: 'classic',
+      popularPeriod: 'week',
+    }));
+  });
+
+  it('normalizes invalid params to defaults', async () => {
+    await renderPage('/popular?source=bad&period=ancient');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location-display')).toHaveTextContent('/popular');
+    });
+    expect(screen.getByRole('button', { name: 'New' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'Now' })).toHaveAttribute('aria-pressed', 'true');
+  });
+});

--- a/src/pages/PopularPage.tsx
+++ b/src/pages/PopularPage.tsx
@@ -1,0 +1,153 @@
+// ABOUTME: Dedicated popular feed page with source and period controls
+// ABOUTME: Uses Funnelcake v2 popular period feeds through the shared VideoFeed stack
+
+import { useEffect, useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { Clock, FilmSlate, Flame, Sparkle, TrendUp, type Icon } from '@phosphor-icons/react';
+import { VideoFeed } from '@/components/VideoFeed';
+import { cn } from '@/lib/utils';
+import type { PopularPeriod, PopularSource } from '@/hooks/useInfiniteVideosFunnelcake';
+
+interface PopularOption<TValue extends string> {
+  value: TValue;
+  labelKey: string;
+  icon: Icon;
+}
+
+const SOURCE_OPTIONS: Array<PopularOption<PopularSource>> = [
+  { value: 'new', labelKey: 'popularPage.sources.new', icon: Sparkle },
+  { value: 'classic', labelKey: 'popularPage.sources.classic', icon: FilmSlate },
+  { value: 'all', labelKey: 'popularPage.sources.all', icon: TrendUp },
+];
+
+const PERIOD_OPTIONS: Array<PopularOption<PopularPeriod>> = [
+  { value: 'now', labelKey: 'popularPage.periods.now', icon: Flame },
+  { value: 'today', labelKey: 'popularPage.periods.today', icon: Clock },
+  { value: 'week', labelKey: 'popularPage.periods.week', icon: Clock },
+  { value: 'month', labelKey: 'popularPage.periods.month', icon: Clock },
+  { value: 'all', labelKey: 'popularPage.periods.all', icon: TrendUp },
+];
+
+const SOURCE_VALUES = new Set<PopularSource>(SOURCE_OPTIONS.map(option => option.value));
+const PERIOD_VALUES = new Set<PopularPeriod>(PERIOD_OPTIONS.map(option => option.value));
+
+function parseSource(value: string | null): PopularSource {
+  return value && SOURCE_VALUES.has(value as PopularSource) ? (value as PopularSource) : 'new';
+}
+
+function parsePeriod(value: string | null): PopularPeriod {
+  return value && PERIOD_VALUES.has(value as PopularPeriod) ? (value as PopularPeriod) : 'now';
+}
+
+function buildCanonicalParams(source: PopularSource, period: PopularPeriod): URLSearchParams {
+  const params = new URLSearchParams();
+  if (source !== 'new') params.set('source', source);
+  if (period !== 'now') params.set('period', period);
+  return params;
+}
+
+export function PopularPage() {
+  const { t } = useTranslation();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const source = parseSource(searchParams.get('source'));
+  const period = parsePeriod(searchParams.get('period'));
+
+  const canonicalParams = useMemo(
+    () => buildCanonicalParams(source, period),
+    [source, period]
+  );
+  const canonicalSearch = canonicalParams.toString();
+
+  useEffect(() => {
+    const currentSearch = searchParams.toString();
+    if (currentSearch !== canonicalSearch) {
+      setSearchParams(canonicalParams, { replace: true });
+    }
+  }, [canonicalParams, canonicalSearch, searchParams, setSearchParams]);
+
+  const updateSource = (nextSource: PopularSource) => {
+    setSearchParams(buildCanonicalParams(nextSource, period));
+  };
+
+  const updatePeriod = (nextPeriod: PopularPeriod) => {
+    setSearchParams(buildCanonicalParams(source, nextPeriod));
+  };
+
+  const subheadingKey = `popularPage.subheadings.${source}.${period}`;
+
+  return (
+    <div className="container mx-auto px-4 py-6">
+      <div className="mx-auto max-w-2xl">
+        <header className="mb-6 space-y-4">
+          <div>
+            <h1 className="text-2xl font-bold">{t('popularPage.heading')}</h1>
+            <p className="text-muted-foreground">{t(subheadingKey)}</p>
+          </div>
+
+          <div className="space-y-3" aria-label={t('popularPage.controlsLabel')}>
+            <div className="flex flex-wrap gap-2" role="group" aria-label={t('popularPage.sourceLabel')}>
+              {SOURCE_OPTIONS.map(option => {
+                const OptionIcon = option.icon;
+                const selected = source === option.value;
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    aria-pressed={selected}
+                    onClick={() => updateSource(option.value)}
+                    className={cn(
+                      'flex items-center gap-2 rounded-lg px-4 py-2 font-medium transition-all',
+                      selected
+                        ? 'bg-primary text-primary-foreground shadow-md'
+                        : 'bg-brand-light-green text-muted-foreground hover:bg-muted hover:text-foreground dark:bg-brand-dark-green'
+                    )}
+                  >
+                    <OptionIcon className="h-4 w-4" />
+                    <span>{t(option.labelKey)}</span>
+                  </button>
+                );
+              })}
+            </div>
+
+            <div className="flex flex-wrap gap-2" role="group" aria-label={t('popularPage.periodLabel')}>
+              {PERIOD_OPTIONS.map(option => {
+                const OptionIcon = option.icon;
+                const selected = period === option.value;
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    aria-pressed={selected}
+                    onClick={() => updatePeriod(option.value)}
+                    className={cn(
+                      'flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm font-medium transition-all sm:px-4 sm:py-2',
+                      selected
+                        ? 'bg-primary text-primary-foreground shadow-md'
+                        : 'bg-background text-muted-foreground ring-1 ring-border hover:bg-muted hover:text-foreground'
+                    )}
+                  >
+                    <OptionIcon className="h-3.5 w-3.5" />
+                    <span>{t(option.labelKey)}</span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        </header>
+
+        <VideoFeed
+          feedType="popular"
+          popularSource={source}
+          popularPeriod={period}
+          accent="pink"
+          data-testid="video-feed-popular"
+          className="space-y-6"
+        />
+      </div>
+    </div>
+  );
+}
+
+export default PopularPage;

--- a/src/types/funnelcake.ts
+++ b/src/types/funnelcake.ts
@@ -121,13 +121,17 @@ export interface FunnelcakeError {
 /**
  * Options for fetching videos from Funnelcake
  */
+export type FunnelcakePopularPeriod = 'now' | 'today' | 'week' | 'month' | 'all';
+
 export interface FunnelcakeFetchOptions {
   sort?: 'trending' | 'recent' | 'popular' | 'loops' | 'engagement' | 'watching' | 'likes' | 'comments' | 'published';
+  period?: FunnelcakePopularPeriod;
   limit?: number;
   before?: string;        // Cursor for pagination (timestamp)
   offset?: number;        // Offset for page-based pagination (0-indexed)
   classic?: boolean;      // Filter for classic/archived vines
   platform?: string;      // Filter by origin platform ('vine', 'tiktok', etc.)
+  exclude_platform?: string; // Exclude an origin platform ('vine' for native-only feeds)
   category?: string;      // Filter by content category
   signal?: AbortSignal;
 }


### PR DESCRIPTION
## Summary
- Add a dedicated `/popular` page with New, Classic, and All source filters plus Now, Today, Week, Month, and All time periods.
- Wire popular feeds through Funnelcake v2 using `sort=popular`, `period`, `platform=vine`, and `exclude_platform=vine`.
- Add Popular to desktop and mobile navigation with tests for URL-backed filter state and mobile nav routing.

## Motivation
Give Divine a first-class way to browse posts that are popular now, this week, this month, and all time across new posts, classic Vines, or both.

## Test Plan
- [x] `npm run test`
- [x] Browser verified `/popular` defaults to New + Now.
- [x] Browser verified Classic + Week updates the URL to `/popular?source=classic&period=week`.
- [x] Browser verified Funnelcake requests include `exclude_platform=vine` for New and `platform=vine` for Classic.

## Screenshots / Video
- Browser verified locally at `http://localhost:8080/popular`; no screenshot attached from this environment.