### PR TITLE
fix(video): start route API lookup immediately

### DIFF
--- a/src/hooks/useVideoByIdFunnelcake.test.ts
+++ b/src/hooks/useVideoByIdFunnelcake.test.ts
@@ -113,7 +113,43 @@ describe('useVideoByIdFunnelcake', () => {
     expect(result.current.error).toBeNull();
   });
 
-  it('skips the direct lookup when the context window already contains the target video', async () => {
+  it('starts the direct lookup immediately while profile context is still loading', async () => {
+    let resolveUserVideos: (response: { videos: Array<{ id: string; pubkey: string; d_tag?: string }> }) => void;
+    mockFetchUserVideos.mockImplementationOnce(() => new Promise(resolve => {
+      resolveUserVideos = resolve;
+    }));
+    mockFetchVideoById.mockResolvedValueOnce({
+      id: 'target-video',
+      pubkey: 'p'.repeat(64),
+      d_tag: 'target-video',
+    });
+
+    const { result } = renderHook(
+      () => useVideoByIdFunnelcake({
+        videoId: 'target-video',
+        pubkey: 'p'.repeat(64),
+        currentIndex: 0,
+      }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(mockFetchVideoById).toHaveBeenCalledWith(
+        'https://api.divine.video',
+        'target-video',
+        'p'.repeat(64),
+        expect.any(AbortSignal)
+      );
+    });
+
+    await waitFor(() => {
+      expect(result.current.video?.id).toBe('target-video');
+    });
+
+    resolveUserVideos!({ videos: [] });
+  });
+
+  it('uses context video for navigation when the context window already contains the target video', async () => {
     mockFetchUserVideos.mockResolvedValueOnce({
       videos: [
         { id: 'target-video', pubkey: 'p'.repeat(64), d_tag: 'target-video' },
@@ -135,7 +171,7 @@ describe('useVideoByIdFunnelcake', () => {
     });
 
     expect(mockFetchUserVideos).toHaveBeenCalledTimes(1);
-    expect(mockFetchVideoById).not.toHaveBeenCalled();
+    expect(result.current.videos?.map(video => video.id)).toEqual(['target-video']);
     expect(result.current.windowOffset).toBe(0);
   });
 
@@ -172,7 +208,12 @@ describe('useVideoByIdFunnelcake', () => {
         signal: expect.any(AbortSignal),
       })
     );
-    expect(mockFetchVideoById).not.toHaveBeenCalled();
+    expect(mockFetchVideoById).toHaveBeenCalledWith(
+      'https://api.divine.video',
+      'target-video',
+      undefined,
+      expect.any(AbortSignal)
+    );
     expect(result.current.videos?.map(video => video.id)).toEqual(['neighbor-1', 'target-video']);
   });
 });

--- a/src/hooks/useVideoByIdFunnelcake.ts
+++ b/src/hooks/useVideoByIdFunnelcake.ts
@@ -154,9 +154,8 @@ export function useVideoByIdFunnelcake(options: UseVideoByIdOptions): UseVideoBy
       : searchValue
         ? (searchVideosQuery.error as Error | null)
         : null;
-  const shouldLookupSingleVideo = enabled && (
-    (!pubkey && !hashtag && !searchValue)
-      || (((!!pubkey || !!hashtag || !!searchValue) && !contextLoading && !contextVideo))
+  const shouldLookupSingleVideo = enabled && !!videoId && (
+    !contextVideo
   );
 
   // Single video lookup (used when no context or as fallback)

--- a/src/lib/funnelcakeClient.test.ts
+++ b/src/lib/funnelcakeClient.test.ts
@@ -33,6 +33,7 @@ describe('funnelcakeClient', () => {
   let fetchRecommendations: typeof import('./funnelcakeClient').fetchRecommendations;
   let markNotificationsRead: typeof import('./funnelcakeClient').markNotificationsRead;
   let fetchNotifications: typeof import('./funnelcakeClient').fetchNotifications;
+  let fetchVideoById: typeof import('./funnelcakeClient').fetchVideoById;
 
   beforeEach(async () => {
     vi.resetModules();
@@ -49,6 +50,7 @@ describe('funnelcakeClient', () => {
     fetchRecommendations = client.fetchRecommendations;
     markNotificationsRead = client.markNotificationsRead;
     fetchNotifications = client.fetchNotifications;
+    fetchVideoById = client.fetchVideoById;
   });
 
   afterEach(() => {
@@ -336,6 +338,51 @@ describe('funnelcakeClient', () => {
 
       expect(result.stats).toEqual([]);
       expect(result.missing).toContain(eventIds[0]);
+    });
+  });
+
+  describe('fetchVideoById', () => {
+    it('allows the route lookup to use the mobile-parity timeout', async () => {
+      const timeoutSpy = vi.spyOn(AbortSignal, 'timeout');
+      const videoId = 'ab0b34b53e29564eda8943385844de3dd164cd883d469675c14689a8e8772188';
+      const pubkey = TEST_PUBKEY;
+      const mockResponse = {
+        event: {
+          id: videoId,
+          pubkey,
+          created_at: 1477352093,
+          kind: 34236,
+          tags: [
+            ['d', '5dhdEiniwUO'],
+            ['imeta', 'url https://media.divine.video/video.mp4', 'm video/mp4'],
+          ],
+          content: '',
+          sig: 'sig',
+        },
+        stats: {
+          reactions: 0,
+          comments: 0,
+          reposts: 0,
+          engagement_score: 0,
+          trending_score: 0,
+        },
+      };
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      });
+
+      const result = await fetchVideoById(API_URL, videoId, pubkey);
+
+      expect(result?.id).toBe(videoId);
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining(`/api/videos/${videoId}`),
+        expect.objectContaining({
+          signal: expect.any(AbortSignal),
+        })
+      );
+      expect(timeoutSpy).toHaveBeenCalledWith(15000);
     });
   });
 

--- a/src/lib/funnelcakeClient.ts
+++ b/src/lib/funnelcakeClient.ts
@@ -54,14 +54,14 @@ async function funnelcakeRequest<T>(
   apiUrl: string,
   endpoint: string,
   params: Record<string, string | number | boolean | undefined> = {},
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  timeoutMs: number = API_CONFIG.funnelcake.timeout
 ): Promise<T> {
   const url = buildUrl(apiUrl, endpoint, params);
-  const timeout = API_CONFIG.funnelcake.timeout;
 
   debugLog(`[FunnelcakeClient] Request: ${url}`);
 
-  const timeoutSignal = AbortSignal.timeout(timeout);
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
   const combinedSignal = signal
     ? AbortSignal.any([signal, timeoutSignal])
     : timeoutSignal;
@@ -748,7 +748,8 @@ export async function fetchVideoById(
         apiUrl,
         `${API_CONFIG.funnelcake.endpoints.videos}/${identifier}`,
         {},
-        signal
+        signal,
+        15000
       );
 
       if (response && response.event) {


### PR DESCRIPTION
## Summary
- start the direct Funnelcake video route lookup immediately instead of waiting for profile/search context requests to finish
- allow the single-video Funnelcake route lookup to use a 15s timeout, matching the mobile route API behavior
- add regression coverage for the immediate direct lookup and route lookup timeout

## Motivation
Video deep links with profile context can be slow when the profile window endpoint stalls or times out. The direct `/api/videos/{id}` route lookup can still resolve the video, so the web route should not block that lookup behind contextual navigation data.

## Test Plan
- [x] npm run test

## Notes
No visual change.