### PR TITLE
ci: use 16-core GitHub runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
-
+    runs-on: ubuntu-24.04-16core
     strategy:
       matrix:
         node-version: [20.x]

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-16core
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -37,7 +37,7 @@ jobs:
 
   deploy-fastly:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-16core
     permissions:
       contents: read
       deployments: write
@@ -130,7 +130,7 @@ jobs:
 
   deploy-cloudflare:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-16core
     permissions:
       contents: read
       deployments: write

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   deploy-preview:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-16core
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Summary
- move Ubuntu GitHub Actions jobs from `ubuntu-latest` to the org hosted `ubuntu-24.04-16core` runner
- keep workflow logic unchanged; this only changes runner capacity

## Motivation
Reduce CI/build lead time across Divine repos. The org runner `ubuntu-24.04-16core` is configured as Ubuntu 24.04, 16 cores, 64 GB RAM, max 50 concurrent runners.

## Manual validation
- Parsed changed workflow YAML with Ruby
- Ran `git diff --check -- .github/workflows`