### PR TITLE
fix: prevent HubSpot tracking script from capturing native forms

### DIFF
--- a/src/components/EditProfileForm.tsx
+++ b/src/components/EditProfileForm.tsx
@@ -152,7 +152,7 @@ export const EditProfileForm: React.FC<EditProfileFormProps> = ({ onSuccess }) =
 
   return (
     <Form {...form}>
-      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4" data-hs-do-not-collect="true">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           <FormField
             control={form.control}

--- a/src/components/auth/InviteCodeForm.tsx
+++ b/src/components/auth/InviteCodeForm.tsx
@@ -27,7 +27,7 @@ export function InviteCodeForm(props: InviteCodeFormProps) {
   } = props;
 
   return (
-    <form className="space-y-4" onSubmit={onSubmit}>
+    <form className="space-y-4" data-hs-do-not-collect="true" onSubmit={onSubmit}>
       <div className="space-y-2">
         <label className="text-sm font-medium" htmlFor="invite-code">
           {t('inviteCodeForm.label')}

--- a/src/components/auth/WaitlistForm.tsx
+++ b/src/components/auth/WaitlistForm.tsx
@@ -48,7 +48,7 @@ export function WaitlistForm(props: WaitlistFormProps) {
   }
 
   return (
-    <form className="space-y-4" onSubmit={onSubmit}>
+    <form className="space-y-4" data-hs-do-not-collect="true" onSubmit={onSubmit}>
       <label className="flex cursor-pointer items-center justify-center gap-2 text-sm text-muted-foreground" htmlFor="waitlist-newsletter">
         <Checkbox
           checked={newsletterOptIn}

--- a/src/components/comments/CommentForm.tsx
+++ b/src/components/comments/CommentForm.tsx
@@ -57,7 +57,7 @@ export function CommentForm({
   );
 
   const formContent = (
-    <form onSubmit={handleSubmit} className="space-y-4">
+    <form onSubmit={handleSubmit} className="space-y-4" data-hs-do-not-collect="true">
       <Textarea
         value={content}
         onChange={(e) => setContent(e.target.value)}


### PR DESCRIPTION
## Summary

The global HubSpot tracking script (`hs-scripts.com`, loaded via `hubSpotLoader.ts`) has a "Non-HubSpot Forms" feature that auto-captures submissions from any native `<form>` element on the page. This was creating ghost contacts in the CRM -- HubSpot named them `.space-y-4` (the Tailwind class on the form element) and attributed them to whatever page the user was on.

divine-web has exactly four native `<form>` elements. None are intended for HubSpot:

| Form | Submits to | Has email field? |
|---|---|---|
| `WaitlistForm` | invite.divine.video | Yes |
| `InviteCodeForm` | invite.divine.video | No |
| `CommentForm` | Nostr relay | No |
| `EditProfileForm` | Nostr relay | No |

The only actual HubSpot form (`HubSpotSignup.tsx`, in the footer and landing page) uses HubSpot's own forms SDK and renders inside a `<div>`, not a native `<form>`. It is completely unaffected by this change.

This PR adds `data-hs-do-not-collect="true"` to all four native forms, which tells HubSpot's tracking script to skip them.

### Why not remove the tracking script entirely?

The tracking script also provides page-view analytics that may feed into marketing workflows (lead scoring, email triggers, contact activity timelines). Removing it has unknown blast radius. This approach is surgical -- it stops the ghost contacts without affecting anything else.

### Alternative: HubSpot settings toggle

There is also a "Non-HubSpot Forms" toggle in HubSpot settings (Settings > Marketing > Forms) that could disable this globally. That would be safe for divine.video but needs confirmation from the marketing side that about.divine.video (WordPress) doesn't rely on it. This PR is defense-in-depth regardless.

## Test plan

- [ ] Verify waitlist signup still works (submit via the auth dialog, confirm entry appears in invite.divine.video)
- [ ] Monitor that no new `.space-y-4` form submissions appear in HubSpot after deploy