### PR TITLE
feat(proof): render compact verification summaries

### DIFF
--- a/src/components/ProofModeBadge.test.tsx
+++ b/src/components/ProofModeBadge.test.tsx
@@ -1,0 +1,28 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+import { ProofModeBadge } from './ProofModeBadge';
+
+describe('ProofModeBadge', () => {
+  it('does not render compact-summary sentinel values in the details popover', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <ProofModeBadge
+          level="basic_proof"
+          showDetails
+          proofData={{
+            level: 'basic_proof',
+            manifest: 'summary:present',
+            pgpFingerprint: 'summary:present',
+          }}
+        />
+      </MemoryRouter>
+    );
+
+    const trigger = container.querySelector('[title]');
+    expect(trigger).not.toBeNull();
+    fireEvent.click(trigger!);
+
+    expect(screen.queryByText('summary:present')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/ProofModeBadge.tsx
+++ b/src/components/ProofModeBadge.tsx
@@ -32,6 +32,9 @@ export function ProofModeBadge({ level, proofData, className, showDetails = fals
   const label = t(`proofModeBadge.levels.${config.tKey}.label`);
   const tooltip = t(`proofModeBadge.levels.${config.tKey}.tooltip`);
   const description = t(`proofModeBadge.levels.${config.tKey}.description`);
+  const pgpFingerprint = proofData?.pgpFingerprint === 'summary:present'
+    ? undefined
+    : proofData?.pgpFingerprint;
 
   const badge = (
     <Badge
@@ -86,9 +89,11 @@ export function ProofModeBadge({ level, proofData, className, showDetails = fals
                 <Shield className="h-4 w-4 mt-0.5 text-brand-blue-dark dark:text-brand-blue flex-shrink-0" />
                 <div>
                   <p className="font-medium">{t('proofModeBadge.cryptographicSignature')}</p>
-                  <p className="text-xs text-muted-foreground font-mono break-all">
-                    {proofData.pgpFingerprint}
-                  </p>
+                  {pgpFingerprint && (
+                    <p className="text-xs text-muted-foreground font-mono break-all">
+                      {pgpFingerprint}
+                    </p>
+                  )}
                 </div>
               </div>
             )}

--- a/src/lib/funnelcakeTransform.test.ts
+++ b/src/lib/funnelcakeTransform.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { transformFunnelcakeVideo, transformToVideoPage } from './funnelcakeTransform';
+import { parseFullEvent, transformFunnelcakeVideo, transformToVideoPage } from './funnelcakeTransform';
 import type { FunnelcakeVideoRaw, FunnelcakeResponse } from '@/types/funnelcake';
 
 function makeRawVideo(overrides: Partial<FunnelcakeVideoRaw> = {}): FunnelcakeVideoRaw {
@@ -187,6 +187,75 @@ describe('transformFunnelcakeVideo', () => {
     expect(video.proofMode?.c2paManifestId).toBe('summary:present');
   });
 
+  it('caps verified_* summary levels to basic_proof when status is not verified', () => {
+    const present = transformFunnelcakeVideo(makeRawVideo({
+      proof: {
+        status: 'present',
+        level: 'verified_mobile',
+        version: 1,
+        checks: {
+          proofmode_present: true,
+          proofmode_parse_ok: true,
+        },
+      },
+    }));
+
+    expect(present.proofMode?.level).toBe('basic_proof');
+
+    const partial = transformFunnelcakeVideo(makeRawVideo({
+      proof: {
+        status: 'partial',
+        level: 'verified_web',
+        version: 1,
+        checks: {
+          pgp_signature_present: true,
+          pgp_signature_valid: null,
+        },
+      },
+    }));
+
+    expect(partial.proofMode?.level).toBe('basic_proof');
+  });
+
+  it('honors verified_* summary levels when status is verified', () => {
+    const video = transformFunnelcakeVideo(makeRawVideo({
+      proof: {
+        status: 'verified',
+        level: 'verified_mobile',
+        version: 1,
+        checks: {
+          proofmode_present: true,
+          proofmode_parse_ok: true,
+          device_attestation_present: true,
+          device_attestation_valid: true,
+        },
+      },
+    }));
+
+    expect(video.proofMode?.level).toBe('verified_mobile');
+  });
+
+  it('ignores verified summaries with no usable components', () => {
+    const video = transformFunnelcakeVideo(makeRawVideo({
+      proof: {
+        status: 'verified',
+        version: 1,
+        checks: {
+          proofmode_present: false,
+          proofmode_parse_ok: null,
+          pgp_signature_present: true,
+          pgp_signature_valid: false,
+          device_attestation_present: false,
+          device_attestation_valid: null,
+          c2pa_manifest_present: false,
+          c2pa_manifest_valid: null,
+        },
+      },
+    }));
+
+    expect(video.proofMode).toBeUndefined();
+  });
+
   it('does not mark explicitly invalid proof components as present', () => {
     const video = transformFunnelcakeVideo(makeRawVideo({
       proof: {
@@ -261,6 +330,91 @@ describe('transformFunnelcakeVideo', () => {
 
     expect(video.title).toBe('A title with no description');
     expect(video.content).toBe('');
+  });
+});
+
+describe('parseFullEvent', () => {
+  const verificationTags = [
+    ['d', 'vine-id'],
+    ['verification', 'verified_mobile'],
+  ];
+
+  const fullEventPayload = {
+    id: 'json-id',
+    pubkey: 'json-pubkey',
+    created_at: 1800000000,
+    kind: 34236,
+    tags: verificationTags,
+    content: 'from event_json',
+    sig: 'json-sig',
+  };
+
+  it('parses a string event_json payload', () => {
+    const event = parseFullEvent(
+      makeRawVideo({ event_json: JSON.stringify(fullEventPayload) }),
+      'video-1',
+      'pubkey-1',
+    );
+
+    expect(event).toEqual(fullEventPayload);
+  });
+
+  it('passes through an object event_json payload', () => {
+    const event = parseFullEvent(
+      makeRawVideo({ event_json: fullEventPayload }),
+      'video-1',
+      'pubkey-1',
+    );
+
+    expect(event).toEqual(fullEventPayload);
+  });
+
+  it('falls back to top-level tags when event_json is malformed', () => {
+    const event = parseFullEvent(
+      makeRawVideo({ event_json: '{not valid json', tags: verificationTags }),
+      'video-1',
+      'pubkey-1',
+    );
+
+    expect(event?.id).toBe('video-1');
+    expect(event?.pubkey).toBe('pubkey-1');
+    expect(event?.tags).toEqual(verificationTags);
+  });
+
+  it('returns undefined when event_json is malformed and no tags exist', () => {
+    const event = parseFullEvent(
+      makeRawVideo({ event_json: '{not valid json' }),
+      'video-1',
+      'pubkey-1',
+    );
+
+    expect(event).toBeUndefined();
+  });
+
+  it('defaults missing event fields from the raw payload', () => {
+    const event = parseFullEvent(
+      makeRawVideo({ event_json: { tags: verificationTags } }),
+      'video-1',
+      'pubkey-1',
+    );
+
+    expect(event).toEqual({
+      id: 'video-1',
+      pubkey: 'pubkey-1',
+      created_at: 1700000000,
+      kind: 34236,
+      tags: verificationTags,
+      content: 'Test content',
+      sig: '',
+    });
+  });
+
+  it('feeds event_json tags into proofMode extraction', () => {
+    const video = transformFunnelcakeVideo(makeRawVideo({
+      event_json: JSON.stringify(fullEventPayload),
+    }));
+
+    expect(video.proofMode?.level).toBe('verified_mobile');
   });
 });
 

--- a/src/lib/funnelcakeTransform.test.ts
+++ b/src/lib/funnelcakeTransform.test.ts
@@ -113,6 +113,120 @@ describe('transformFunnelcakeVideo', () => {
     expect(video.proofMode).toBeUndefined();
   });
 
+  it('maps compact proof summary when list endpoint omits tags', () => {
+    const video = transformFunnelcakeVideo(makeRawVideo({
+      proof: {
+        status: 'present',
+        level: 'basic_proof',
+        checked_at: 1779494400,
+        version: 1,
+        checks: {
+          proofmode_present: true,
+          proofmode_parse_ok: true,
+          pgp_signature_present: true,
+          pgp_signature_valid: null,
+          device_attestation_present: false,
+          device_attestation_valid: null,
+          c2pa_manifest_present: false,
+          c2pa_manifest_valid: null,
+        },
+      },
+    }));
+
+    expect(video.proofMode?.level).toBe('basic_proof');
+    expect(video.proofMode?.manifest).toBe('summary:present');
+    expect(video.proofMode?.pgpFingerprint).toBe('summary:present');
+    expect(video.proofMode?.deviceAttestation).toBeUndefined();
+    expect(video.proofMode?.c2paManifestId).toBeUndefined();
+  });
+
+  it('ignores invalid compact proof summaries', () => {
+    const video = transformFunnelcakeVideo(makeRawVideo({
+      proof: {
+        status: 'invalid',
+        version: 1,
+        checks: {
+          proofmode_present: true,
+          proofmode_parse_ok: false,
+          pgp_signature_present: true,
+          pgp_signature_valid: false,
+          device_attestation_present: true,
+          device_attestation_valid: false,
+          c2pa_manifest_present: true,
+          c2pa_manifest_valid: false,
+        },
+      },
+    }));
+
+    expect(video.proofMode).toBeUndefined();
+  });
+
+  it('defaults verified compact proof summaries to verified_web when level is missing', () => {
+    const video = transformFunnelcakeVideo(makeRawVideo({
+      proof: {
+        status: 'verified',
+        checked_at: 1779494400,
+        version: 1,
+        checks: {
+          proofmode_present: true,
+          proofmode_parse_ok: true,
+          pgp_signature_present: true,
+          pgp_signature_valid: true,
+          device_attestation_present: true,
+          device_attestation_valid: true,
+          c2pa_manifest_present: true,
+          c2pa_manifest_valid: true,
+        },
+      },
+    }));
+
+    expect(video.proofMode?.level).toBe('verified_web');
+    expect(video.proofMode?.manifest).toBe('summary:present');
+    expect(video.proofMode?.pgpFingerprint).toBe('summary:present');
+    expect(video.proofMode?.deviceAttestation).toBe('summary:present');
+    expect(video.proofMode?.c2paManifestId).toBe('summary:present');
+  });
+
+  it('does not mark explicitly invalid proof components as present', () => {
+    const video = transformFunnelcakeVideo(makeRawVideo({
+      proof: {
+        status: 'present',
+        version: 1,
+        checks: {
+          proofmode_present: true,
+          proofmode_parse_ok: false,
+          pgp_signature_present: true,
+          pgp_signature_valid: false,
+          device_attestation_present: true,
+          device_attestation_valid: false,
+          c2pa_manifest_present: true,
+          c2pa_manifest_valid: false,
+        },
+      },
+    }));
+
+    expect(video.proofMode).toBeUndefined();
+  });
+
+  it('maps partial compact proof summaries only when a usable component is present', () => {
+    const video = transformFunnelcakeVideo(makeRawVideo({
+      proof: {
+        status: 'partial',
+        version: 1,
+        checks: {
+          proofmode_present: true,
+          proofmode_parse_ok: false,
+          c2pa_manifest_present: true,
+          c2pa_manifest_valid: null,
+        },
+      },
+    }));
+
+    expect(video.proofMode?.level).toBe('basic_proof');
+    expect(video.proofMode?.manifest).toBeUndefined();
+    expect(video.proofMode?.c2paManifestId).toBe('summary:present');
+  });
+
   it('extracts proofMode when verification tags are present (single-video shape)', () => {
     const video = transformFunnelcakeVideo(makeRawVideo({
       tags: [

--- a/src/lib/funnelcakeTransform.test.ts
+++ b/src/lib/funnelcakeTransform.test.ts
@@ -140,6 +140,31 @@ describe('transformFunnelcakeVideo', () => {
     expect(video.proofMode?.c2paManifestId).toBeUndefined();
   });
 
+  it('uses compact proof summary when full event tags contain no proof data', () => {
+    const video = transformFunnelcakeVideo(makeRawVideo({
+      tags: [
+        ['d', 'vine-id-1'],
+        ['title', 'Plain tagged video'],
+      ],
+      proof: {
+        status: 'present',
+        level: 'basic_proof',
+        checked_at: 1779494400,
+        version: 1,
+        checks: {
+          proofmode_present: true,
+          proofmode_parse_ok: true,
+          pgp_signature_present: true,
+          pgp_signature_valid: null,
+        },
+      },
+    }));
+
+    expect(video.proofMode?.level).toBe('basic_proof');
+    expect(video.proofMode?.manifest).toBe('summary:present');
+    expect(video.proofMode?.pgpFingerprint).toBe('summary:present');
+  });
+
   it('ignores invalid compact proof summaries', () => {
     const video = transformFunnelcakeVideo(makeRawVideo({
       proof: {

--- a/src/lib/funnelcakeTransform.ts
+++ b/src/lib/funnelcakeTransform.ts
@@ -170,6 +170,7 @@ export function transformFunnelcakeVideo(raw: FunnelcakeVideoRaw): ParsedVideoDa
     ?? parseLoopsFromContent(raw.title);
 
   const fullEvent = parseFullEvent(raw, id, pubkey);
+  const fullEventProofMode = fullEvent ? getProofModeData(fullEvent) : undefined;
 
   const video: ParsedVideoData = {
     id,
@@ -222,7 +223,7 @@ export function transformFunnelcakeVideo(raw: FunnelcakeVideoRaw): ParsedVideoDa
     textTrackContent: raw.text_track_content,
 
     // ProofMode data - extract from tags when available (single video endpoint)
-    proofMode: fullEvent ? getProofModeData(fullEvent) : proofSummaryToProofMode(raw),
+    proofMode: fullEventProofMode ?? proofSummaryToProofMode(raw),
 
     // Empty reposts array (Funnelcake doesn't return individual reposts)
     reposts: [],

--- a/src/lib/funnelcakeTransform.ts
+++ b/src/lib/funnelcakeTransform.ts
@@ -51,7 +51,18 @@ export function parseFullEvent(raw: FunnelcakeVideoRaw, id: string, pubkey: stri
     try {
       const event = typeof eventJson === 'string' ? JSON.parse(eventJson) : eventJson;
       if (event && typeof event === 'object' && Array.isArray(event.tags)) {
-        return event as NostrEvent;
+        // Detail APIs may send partial payloads; default any missing fields
+        // from the raw row the same way the tags branch below does.
+        const partial = event as Partial<NostrEvent> & { tags: string[][] };
+        return {
+          id: typeof partial.id === 'string' ? partial.id : id,
+          pubkey: typeof partial.pubkey === 'string' ? partial.pubkey : pubkey,
+          created_at: typeof partial.created_at === 'number' ? partial.created_at : raw.created_at,
+          kind: typeof partial.kind === 'number' ? partial.kind : raw.kind,
+          tags: partial.tags,
+          content: typeof partial.content === 'string' ? partial.content : (raw.content || ''),
+          sig: typeof partial.sig === 'string' ? partial.sig : '',
+        } as NostrEvent;
       }
     } catch {
       // Fall through to top-level tags below.
@@ -78,32 +89,49 @@ function isProofModeLevel(level: string): level is ProofModeLevel {
     level === 'unverified';
 }
 
+/**
+ * Sentinel stored in ProofModeData component fields when the data comes from a
+ * compact proof summary. A summary only says "this component exists and did
+ * not fail verification" — it carries no real manifest JSON, fingerprint, or
+ * attestation token. These values are presence markers only and MUST NOT be
+ * rendered verbatim in UI (e.g. ProofModeBadge's showDetails popover).
+ */
+const SUMMARY_PRESENT = 'summary:present';
+
 function proofSummaryToProofMode(raw: FunnelcakeVideoRaw): ProofModeData | undefined {
   if (!raw.proof || raw.proof.status === 'unknown' || raw.proof.status === 'invalid') return undefined;
 
   const checks = raw.proof.checks ?? {};
   const manifest = checks.proofmode_present && checks.proofmode_parse_ok === true
-    ? 'summary:present'
+    ? SUMMARY_PRESENT
     : undefined;
   const deviceAttestation = checks.device_attestation_present && checks.device_attestation_valid !== false
-    ? 'summary:present'
+    ? SUMMARY_PRESENT
     : undefined;
   const pgpFingerprint = checks.pgp_signature_present && checks.pgp_signature_valid !== false
-    ? 'summary:present'
+    ? SUMMARY_PRESENT
     : undefined;
   const c2paManifestId = checks.c2pa_manifest_present && checks.c2pa_manifest_valid !== false
-    ? 'summary:present'
+    ? SUMMARY_PRESENT
     : undefined;
 
-  const level = raw.proof.level && isProofModeLevel(raw.proof.level)
-    ? raw.proof.level
-    : raw.proof.status === 'verified'
-      ? 'verified_web'
-      : 'basic_proof';
-
-  if (raw.proof.status !== 'verified' && !manifest && !deviceAttestation && !pgpFingerprint && !c2paManifestId) {
+  // A summary with no usable components carries nothing worth badging — even
+  // a (contradictory) 'verified' status over an all-failed checklist.
+  if (!manifest && !deviceAttestation && !pgpFingerprint && !c2paManifestId) {
     return undefined;
   }
+
+  const isVerified = raw.proof.status === 'verified';
+  const summaryLevel = raw.proof.level && isProofModeLevel(raw.proof.level)
+    ? raw.proof.level
+    : undefined;
+  // Only a 'verified' status can earn a verified_* badge. Cap anything else to
+  // basic_proof — the same fallback used when present/partial summaries omit
+  // the level entirely.
+  const cappedLevel = !isVerified && (summaryLevel === 'verified_mobile' || summaryLevel === 'verified_web')
+    ? 'basic_proof'
+    : summaryLevel;
+  const level: ProofModeLevel = cappedLevel ?? (isVerified ? 'verified_web' : 'basic_proof');
 
   return {
     level,

--- a/src/lib/funnelcakeTransform.ts
+++ b/src/lib/funnelcakeTransform.ts
@@ -2,7 +2,7 @@
 // ABOUTME: Bridges the gap between REST API data and existing video display components
 
 import { parseByteArrayId } from './funnelcakeClient';
-import { SHORT_VIDEO_KIND, type ParsedVideoData } from '@/types/video';
+import { SHORT_VIDEO_KIND, type ParsedVideoData, type ProofModeData, type ProofModeLevel } from '@/types/video';
 import type { FunnelcakeVideoRaw, FunnelcakeResponse } from '@/types/funnelcake';
 import { debugLog } from './debug';
 import { getProofModeData } from './videoParser';
@@ -45,6 +45,75 @@ function getVineExternalId(raw: FunnelcakeVideoRaw): string {
   return raw.d_tag || '';
 }
 
+export function parseFullEvent(raw: FunnelcakeVideoRaw, id: string, pubkey: string): NostrEvent | undefined {
+  const eventJson = raw.event_json;
+  if (eventJson) {
+    try {
+      const event = typeof eventJson === 'string' ? JSON.parse(eventJson) : eventJson;
+      if (event && typeof event === 'object' && Array.isArray(event.tags)) {
+        return event as NostrEvent;
+      }
+    } catch {
+      // Fall through to top-level tags below.
+    }
+  }
+
+  if (!raw.tags) return undefined;
+
+  return {
+    id,
+    pubkey,
+    created_at: raw.created_at,
+    kind: raw.kind,
+    tags: raw.tags,
+    content: raw.content || '',
+    sig: '',
+  } as NostrEvent;
+}
+
+function isProofModeLevel(level: string): level is ProofModeLevel {
+  return level === 'verified_mobile' ||
+    level === 'verified_web' ||
+    level === 'basic_proof' ||
+    level === 'unverified';
+}
+
+function proofSummaryToProofMode(raw: FunnelcakeVideoRaw): ProofModeData | undefined {
+  if (!raw.proof || raw.proof.status === 'unknown' || raw.proof.status === 'invalid') return undefined;
+
+  const checks = raw.proof.checks ?? {};
+  const manifest = checks.proofmode_present && checks.proofmode_parse_ok === true
+    ? 'summary:present'
+    : undefined;
+  const deviceAttestation = checks.device_attestation_present && checks.device_attestation_valid !== false
+    ? 'summary:present'
+    : undefined;
+  const pgpFingerprint = checks.pgp_signature_present && checks.pgp_signature_valid !== false
+    ? 'summary:present'
+    : undefined;
+  const c2paManifestId = checks.c2pa_manifest_present && checks.c2pa_manifest_valid !== false
+    ? 'summary:present'
+    : undefined;
+
+  const level = raw.proof.level && isProofModeLevel(raw.proof.level)
+    ? raw.proof.level
+    : raw.proof.status === 'verified'
+      ? 'verified_web'
+      : 'basic_proof';
+
+  if (raw.proof.status !== 'verified' && !manifest && !deviceAttestation && !pgpFingerprint && !c2paManifestId) {
+    return undefined;
+  }
+
+  return {
+    level,
+    manifest,
+    deviceAttestation,
+    pgpFingerprint,
+    c2paManifestId,
+  };
+}
+
 /**
  * Transform a single Funnelcake video to ParsedVideoData format
  */
@@ -72,15 +141,7 @@ export function transformFunnelcakeVideo(raw: FunnelcakeVideoRaw): ParsedVideoDa
     ?? parseLoopsFromContent(raw.content)
     ?? parseLoopsFromContent(raw.title);
 
-  const fullEvent = raw.tags ? ({
-    id: id,
-    pubkey: pubkey,
-    created_at: raw.created_at,
-    kind: raw.kind,
-    tags: raw.tags,
-    content: raw.content || '',
-    sig: '',
-  } as NostrEvent) : undefined;
+  const fullEvent = parseFullEvent(raw, id, pubkey);
 
   const video: ParsedVideoData = {
     id,
@@ -133,7 +194,7 @@ export function transformFunnelcakeVideo(raw: FunnelcakeVideoRaw): ParsedVideoDa
     textTrackContent: raw.text_track_content,
 
     // ProofMode data - extract from tags when available (single video endpoint)
-    proofMode: fullEvent ? getProofModeData(fullEvent) : undefined,
+    proofMode: fullEvent ? getProofModeData(fullEvent) : proofSummaryToProofMode(raw),
 
     // Empty reposts array (Funnelcake doesn't return individual reposts)
     reposts: [],

--- a/src/types/funnelcake.ts
+++ b/src/types/funnelcake.ts
@@ -1,6 +1,25 @@
 // ABOUTME: TypeScript types for Funnelcake REST API responses
 // ABOUTME: Defines interfaces for video data, search results, and API responses
 
+export interface FunnelcakeProofChecks {
+  proofmode_present?: boolean | null;
+  proofmode_parse_ok?: boolean | null;
+  pgp_signature_present?: boolean | null;
+  pgp_signature_valid?: boolean | null;
+  device_attestation_present?: boolean | null;
+  device_attestation_valid?: boolean | null;
+  c2pa_manifest_present?: boolean | null;
+  c2pa_manifest_valid?: boolean | null;
+}
+
+export interface FunnelcakeProofSummary {
+  status: 'unknown' | 'present' | 'invalid' | 'partial' | 'verified';
+  level?: string;
+  checked_at?: number;
+  version: number;
+  checks: FunnelcakeProofChecks;
+}
+
 /**
  * Raw video data from Funnelcake API
  * Note: id and pubkey are hex strings from the API
@@ -50,6 +69,8 @@ export interface FunnelcakeVideoRaw {
 
   // Full event tags (only present from /api/videos/{id} endpoint)
   tags?: string[][];      // Nostr event tags for ProofMode extraction
+  event_json?: string | Record<string, unknown>; // Full Nostr event payload when provided by detail APIs
+  proof?: FunnelcakeProofSummary; // Compact ProofMode summary for list/feed endpoints
 }
 
 /**

--- a/src/types/video.ts
+++ b/src/types/video.ts
@@ -45,11 +45,15 @@ export type ProofModeLevel = 'verified_mobile' | 'verified_web' | 'basic_proof' 
 
 export interface ProofModeData {
   level: ProofModeLevel;
-  manifest?: string; // Raw JSON string
+  // CAUTION: when this data is built from a compact Funnelcake proof summary
+  // (proofSummaryToProofMode in funnelcakeTransform.ts), the string fields
+  // below hold the sentinel 'summary:present' instead of real values. Treat
+  // them as presence flags — never render them verbatim in UI.
+  manifest?: string; // Raw JSON string (or 'summary:present' sentinel)
   manifestData?: Record<string, unknown>; // Parsed manifest object
-  deviceAttestation?: string; // Hardware attestation token (iOS App Attest / Android Play Integrity)
-  pgpFingerprint?: string; // PGP public key fingerprint for signature verification
-  c2paManifestId?: string; // Content Credentials manifest ID
+  deviceAttestation?: string; // Hardware attestation token (iOS App Attest / Android Play Integrity), or sentinel
+  pgpFingerprint?: string; // PGP public key fingerprint for signature verification, or sentinel
+  c2paManifestId?: string; // Content Credentials manifest ID, or sentinel
 }
 
 export interface OriginData {


### PR DESCRIPTION
## Summary
- Add typed Funnelcake compact proof summary fields to web API types.
- Map compact `proof` summaries into the existing `proofMode` UI shape when full Nostr event tags are absent.
- Preserve full-event tag parsing precedence and prevent invalid/failed summaries from rendering as proof.

## Motivation
Backend compact feed rows may omit raw `tags`, `proofmode`, and `device_attestation`. Web needs to keep proof badges working from the compact summary without treating invalid proof as verified/proven.

## Related backend
- divine-funnelcake PR: https://github.com/divinevideo/divine-funnelcake/pull/455

## Test plan
- `npm run test`

## Manual notes
- No visual layout change expected. Proof UI should continue to appear for compact rows with valid/present summaries and stay hidden for invalid summaries.