### PR TITLE
ci: reduce GitHub Actions runner size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-24.04-16core
+    runs-on: ubuntu-24.04-4core
     strategy:
       matrix:
         node-version: [20.x]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-24.04-4core
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         node-version: [20.x]
@@ -26,4 +26,3 @@ jobs:
 
       - name: Run tests (includes lint, type-check, and build)
         run: npm test
-

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04-16core
+    runs-on: ubuntu-24.04-4core
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -37,7 +37,7 @@ jobs:
 
   deploy-fastly:
     needs: build
-    runs-on: ubuntu-24.04-16core
+    runs-on: ubuntu-24.04-4core
     permissions:
       contents: read
       deployments: write
@@ -130,7 +130,7 @@ jobs:
 
   deploy-cloudflare:
     needs: build
-    runs-on: ubuntu-24.04-16core
+    runs-on: ubuntu-24.04-4core
     permissions:
       contents: read
       deployments: write

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04-4core
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -37,7 +37,7 @@ jobs:
 
   deploy-fastly:
     needs: build
-    runs-on: ubuntu-24.04-4core
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       deployments: write
@@ -130,7 +130,7 @@ jobs:
 
   deploy-cloudflare:
     needs: build
-    runs-on: ubuntu-24.04-4core
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       deployments: write

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   deploy-preview:
-    runs-on: ubuntu-24.04-16core
+    runs-on: ubuntu-24.04-4core
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   deploy-preview:
-    runs-on: ubuntu-24.04-4core
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Summary
- replace `ubuntu-24.04-16core` GitHub larger runner labels with the standard `ubuntu-24.04` runner
- reduce Actions spend by moving CI/deploy/preview jobs off paid larger runners entirely

## Motivation
The Divine org has used 90% of its May 2026 Actions budget. The standard GitHub-hosted `ubuntu-24.04` runner is free for public repos / billed at the lowest rate, and the test job runs in ~2m38s on it (vs ~1m19s on 16-core) — an acceptable trade for the cost reduction.

Note: an earlier revision of this PR used `ubuntu-24.04-4core`; the final diff uses the plain `ubuntu-24.04` standard runner (see commit 4dce5ef).

## Linked issue
None.

## Manual validation
- Verified changed workflow files no longer contain `ubuntu-24.04-16core`.
- Verified changed workflow files now use the standard `ubuntu-24.04` label.
- `test (20.x)` ran green on the standard runner in ~2m38s on this PR.
