### PR TITLE
feat: add web fallback for /invite/:code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7751,13 +7751,16 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.17",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.17.tgz",
-      "integrity": "sha512-j5zJcx6golJYTG6c05LUZ3Z8Gi+M62zRT/ycz4Xq4iCOdpcxwg7ngEYD4KA0eWZC7U17qh/Smq8bYbACJ0ipBA==",
+      "version": "2.10.33",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.33.tgz",
+      "integrity": "sha512-bA6+tcSLpz2tIEdDXZPpPTIuxBcC4+w6SieaYyfigIa4h8GlFxbA17v22Vx3JUtuZQj9SgOsnbK+aTBzyDyEuw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/binary-extensions": {
@@ -7938,9 +7941,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001751",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001751.tgz",
-      "integrity": "sha512-A0QJhug0Ly64Ii3eIqHu5X51ebln3k4yTUkY1j8drqpWHVreg/VLijN48cZ1bYPiqOQuqpkIKnzr/Ul8V+p6Cw==",
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
       "dev": true,
       "funding": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7751,16 +7751,13 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.33",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.33.tgz",
-      "integrity": "sha512-bA6+tcSLpz2tIEdDXZPpPTIuxBcC4+w6SieaYyfigIa4h8GlFxbA17v22Vx3JUtuZQj9SgOsnbK+aTBzyDyEuw==",
+      "version": "2.8.17",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.17.tgz",
+      "integrity": "sha512-j5zJcx6golJYTG6c05LUZ3Z8Gi+M62zRT/ycz4Xq4iCOdpcxwg7ngEYD4KA0eWZC7U17qh/Smq8bYbACJ0ipBA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.cjs"
-      },
-      "engines": {
-        "node": ">=6.0.0"
+        "baseline-browser-mapping": "dist/cli.js"
       }
     },
     "node_modules/binary-extensions": {
@@ -7941,9 +7938,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001793",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
-      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+      "version": "1.0.30001751",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001751.tgz",
+      "integrity": "sha512-A0QJhug0Ly64Ii3eIqHu5X51ebln3k4yTUkY1j8drqpWHVreg/VLijN48cZ1bYPiqOQuqpkIKnzr/Ul8V+p6Cw==",
       "dev": true,
       "funding": [
         {

--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -47,6 +47,7 @@ import { TermsPage } from "./pages/TermsPage";
 import GetEmbedPage from "./pages/GetEmbedPage";
 import AppCallbackPage from "./pages/AppCallbackPage";
 import AuthCallbackPage from "./pages/AuthCallbackPage";
+import InvitesLandingPage from "./pages/InvitesLandingPage";
 import { AppLayout } from "@/components/AppLayout";
 import { DebugVideoPage } from "./pages/DebugVideoPage";
 import LeaderboardPage from "./pages/LeaderboardPage";
@@ -93,6 +94,7 @@ export function AppRouter() {
         <Route path="/get-embed" element={<GetEmbedPage />} />
         <Route path="/app/callback" element={<AppCallbackPage />} />
         <Route path="/auth/callback" element={<AuthCallbackPage />} />
+        <Route path="/invite/:code" element={<InvitesLandingPage />} />
 
         {/* Dev-only brand primitives preview — tree-shaken in production */}
         {import.meta.env.DEV && BrandPreview && (

--- a/src/components/auth/InviteCodeForm.tsx
+++ b/src/components/auth/InviteCodeForm.tsx
@@ -12,6 +12,7 @@ interface InviteCodeFormProps {
   onSubmit: (event: FormEvent<HTMLFormElement>) => void;
   value: string;
   waitlistEnabled: boolean;
+  inputClassName?: string;
 }
 
 export function InviteCodeForm(props: InviteCodeFormProps) {
@@ -24,6 +25,7 @@ export function InviteCodeForm(props: InviteCodeFormProps) {
     onSubmit,
     value,
     waitlistEnabled,
+    inputClassName,
   } = props;
 
   return (
@@ -34,6 +36,7 @@ export function InviteCodeForm(props: InviteCodeFormProps) {
         </label>
         <Input
           autoComplete="off"
+          className={inputClassName}
           id="invite-code"
           onChange={(event) => onInviteCodeChange(event.target.value)}
           placeholder={t('inviteCodeForm.placeholder')}

--- a/src/lib/i18n/locales/ar/common.json
+++ b/src/lib/i18n/locales/ar/common.json
@@ -439,7 +439,7 @@
     "errorFileNoValidKey": "الملف لا يحتوي على مفتاح سري صالح.",
     "errorFileReadFailed": "تعذّرت قراءة الملف.",
     "errorInviteValidationFailed": "تعذّر التحقق من رمز الدعوة",
-            "errorInviteCodeUsed": "This invite code has already been used",
+    "errorInviteCodeUsed": "تم استخدام رمز الدعوة هذا من قبل",
     "errorSignInStartFailed": "تعذّر بدء تسجيل الدخول",
     "errorWaitlistJoinFailed": "تعذّر الانضمام إلى قائمة الانتظار"
   },
@@ -1403,14 +1403,14 @@
     "joinWaitlist": "ليس لديك دعوة؟ انضم إلى قائمة الانتظار."
   },
   "invitesLandingPage": {
-    "seoTitle": "Join diVine with invite code {{code}}",
-    "seoTitleDefault": "Join diVine",
-    "seoDescription": "You've been invited! Use invite code {{code}} to join diVine.",
-    "seoDescriptionDefault": "Use your invite code to join diVine and start sharing video.",
-    "heading": "You're Invited!",
-    "subheading": "Enter your invite code to join diVine",
-    "alreadyHaveAccount": "Already have an account?",
-    "signIn": "Sign in"
+    "seoTitle": "انضم إلى diVine برمز الدعوة {{code}}",
+    "seoTitleDefault": "انضم إلى diVine",
+    "seoDescription": "لقد تلقيت دعوة! استخدم الرمز {{code}} للانضمام إلى diVine.",
+    "seoDescriptionDefault": "استخدم رمز الدعوة للانضمام إلى diVine وبدء مشاركة الفيديو.",
+    "heading": "أنت مدعو!",
+    "subheading": "أدخل رمز الدعوة للانضمام إلى diVine",
+    "alreadyHaveAccount": "هل لديك حساب بالفعل؟",
+    "signIn": "تسجيل الدخول"
   },
   "applePodcastEmbed": {
     "defaultTitle": "Vine Revisited and The Fight Against AI Slop",

--- a/src/lib/i18n/locales/ar/common.json
+++ b/src/lib/i18n/locales/ar/common.json
@@ -439,7 +439,7 @@
     "errorFileNoValidKey": "الملف لا يحتوي على مفتاح سري صالح.",
     "errorFileReadFailed": "تعذّرت قراءة الملف.",
     "errorInviteValidationFailed": "تعذّر التحقق من رمز الدعوة",
-            "errorInviteCodeUsed": "This invite code has already been used",
+            "errorInviteCodeUsed": "Invite code already claimed - sorry!",
     "errorSignInStartFailed": "تعذّر بدء تسجيل الدخول",
     "errorWaitlistJoinFailed": "تعذّر الانضمام إلى قائمة الانتظار"
   },

--- a/src/lib/i18n/locales/ar/common.json
+++ b/src/lib/i18n/locales/ar/common.json
@@ -439,6 +439,7 @@
     "errorFileNoValidKey": "الملف لا يحتوي على مفتاح سري صالح.",
     "errorFileReadFailed": "تعذّرت قراءة الملف.",
     "errorInviteValidationFailed": "تعذّر التحقق من رمز الدعوة",
+            "errorInviteCodeUsed": "This invite code has already been used",
     "errorSignInStartFailed": "تعذّر بدء تسجيل الدخول",
     "errorWaitlistJoinFailed": "تعذّر الانضمام إلى قائمة الانتظار"
   },

--- a/src/lib/i18n/locales/ar/common.json
+++ b/src/lib/i18n/locales/ar/common.json
@@ -1401,6 +1401,16 @@
     "continue": "متابعة",
     "joinWaitlist": "ليس لديك دعوة؟ انضم إلى قائمة الانتظار."
   },
+  "invitesLandingPage": {
+    "seoTitle": "Join diVine with invite code {{code}}",
+    "seoTitleDefault": "Join diVine",
+    "seoDescription": "You've been invited! Use invite code {{code}} to join diVine.",
+    "seoDescriptionDefault": "Use your invite code to join diVine and start sharing video.",
+    "heading": "You're Invited!",
+    "subheading": "Enter your invite code to join diVine",
+    "alreadyHaveAccount": "Already have an account?",
+    "signIn": "Sign in"
+  },
   "applePodcastEmbed": {
     "defaultTitle": "Vine Revisited and The Fight Against AI Slop",
     "defaultDescription": "خلف كواليس إطلاق Divine",

--- a/src/lib/i18n/locales/ar/common.json
+++ b/src/lib/i18n/locales/ar/common.json
@@ -439,7 +439,7 @@
     "errorFileNoValidKey": "الملف لا يحتوي على مفتاح سري صالح.",
     "errorFileReadFailed": "تعذّرت قراءة الملف.",
     "errorInviteValidationFailed": "تعذّر التحقق من رمز الدعوة",
-            "errorInviteCodeUsed": "Invite code already claimed - sorry!",
+            "errorInviteCodeUsed": "This invite code has already been used",
     "errorSignInStartFailed": "تعذّر بدء تسجيل الدخول",
     "errorWaitlistJoinFailed": "تعذّر الانضمام إلى قائمة الانتظار"
   },

--- a/src/lib/i18n/locales/de/common.json
+++ b/src/lib/i18n/locales/de/common.json
@@ -1397,6 +1397,16 @@
     "continue": "Weiter",
     "joinWaitlist": "Keine Einladung? Auf die Warteliste."
   },
+  "invitesLandingPage": {
+    "seoTitle": "Join diVine with invite code {{code}}",
+    "seoTitleDefault": "Join diVine",
+    "seoDescription": "You've been invited! Use invite code {{code}} to join diVine.",
+    "seoDescriptionDefault": "Use your invite code to join diVine and start sharing video.",
+    "heading": "You're Invited!",
+    "subheading": "Enter your invite code to join diVine",
+    "alreadyHaveAccount": "Already have an account?",
+    "signIn": "Sign in"
+  },
   "applePodcastEmbed": {
     "defaultTitle": "Vine Revisited and The Fight Against AI Slop",
     "defaultDescription": "Hinter den Kulissen des Divine-Launchs",

--- a/src/lib/i18n/locales/de/common.json
+++ b/src/lib/i18n/locales/de/common.json
@@ -435,7 +435,7 @@
     "errorFileNoValidKey": "Datei enthält keinen gültigen geheimen Schlüssel.",
     "errorFileReadFailed": "Datei konnte nicht gelesen werden.",
     "errorInviteValidationFailed": "Einladungscode konnte nicht validiert werden",
-            "errorInviteCodeUsed": "This invite code has already been used",
+            "errorInviteCodeUsed": "Invite code already claimed - sorry!",
     "errorSignInStartFailed": "Anmeldung konnte nicht gestartet werden",
     "errorWaitlistJoinFailed": "Warteliste konnte nicht beigetreten werden"
   },

--- a/src/lib/i18n/locales/de/common.json
+++ b/src/lib/i18n/locales/de/common.json
@@ -435,7 +435,7 @@
     "errorFileNoValidKey": "Datei enthält keinen gültigen geheimen Schlüssel.",
     "errorFileReadFailed": "Datei konnte nicht gelesen werden.",
     "errorInviteValidationFailed": "Einladungscode konnte nicht validiert werden",
-            "errorInviteCodeUsed": "This invite code has already been used",
+    "errorInviteCodeUsed": "Dieser Einladungscode wurde bereits verwendet",
     "errorSignInStartFailed": "Anmeldung konnte nicht gestartet werden",
     "errorWaitlistJoinFailed": "Warteliste konnte nicht beigetreten werden"
   },
@@ -1399,14 +1399,14 @@
     "joinWaitlist": "Keine Einladung? Auf die Warteliste."
   },
   "invitesLandingPage": {
-    "seoTitle": "Join diVine with invite code {{code}}",
-    "seoTitleDefault": "Join diVine",
-    "seoDescription": "You've been invited! Use invite code {{code}} to join diVine.",
-    "seoDescriptionDefault": "Use your invite code to join diVine and start sharing video.",
-    "heading": "You're Invited!",
-    "subheading": "Enter your invite code to join diVine",
-    "alreadyHaveAccount": "Already have an account?",
-    "signIn": "Sign in"
+    "seoTitle": "Tritt diVine mit Einladungscode {{code}} bei",
+    "seoTitleDefault": "Tritt diVine bei",
+    "seoDescription": "Du wurdest eingeladen! Nutze den Code {{code}}, um diVine beizutreten.",
+    "seoDescriptionDefault": "Nutze deinen Einladungscode, um diVine beizutreten und Videos zu teilen.",
+    "heading": "Du bist eingeladen!",
+    "subheading": "Gib deinen Einladungscode ein, um diVine beizutreten",
+    "alreadyHaveAccount": "Hast du schon ein Konto?",
+    "signIn": "Anmelden"
   },
   "applePodcastEmbed": {
     "defaultTitle": "Vine Revisited and The Fight Against AI Slop",

--- a/src/lib/i18n/locales/de/common.json
+++ b/src/lib/i18n/locales/de/common.json
@@ -435,7 +435,7 @@
     "errorFileNoValidKey": "Datei enthält keinen gültigen geheimen Schlüssel.",
     "errorFileReadFailed": "Datei konnte nicht gelesen werden.",
     "errorInviteValidationFailed": "Einladungscode konnte nicht validiert werden",
-            "errorInviteCodeUsed": "Invite code already claimed - sorry!",
+            "errorInviteCodeUsed": "This invite code has already been used",
     "errorSignInStartFailed": "Anmeldung konnte nicht gestartet werden",
     "errorWaitlistJoinFailed": "Warteliste konnte nicht beigetreten werden"
   },

--- a/src/lib/i18n/locales/de/common.json
+++ b/src/lib/i18n/locales/de/common.json
@@ -435,6 +435,7 @@
     "errorFileNoValidKey": "Datei enthält keinen gültigen geheimen Schlüssel.",
     "errorFileReadFailed": "Datei konnte nicht gelesen werden.",
     "errorInviteValidationFailed": "Einladungscode konnte nicht validiert werden",
+            "errorInviteCodeUsed": "This invite code has already been used",
     "errorSignInStartFailed": "Anmeldung konnte nicht gestartet werden",
     "errorWaitlistJoinFailed": "Warteliste konnte nicht beigetreten werden"
   },

--- a/src/lib/i18n/locales/en/common.json
+++ b/src/lib/i18n/locales/en/common.json
@@ -435,7 +435,7 @@
     "errorFileNoValidKey": "File does not contain a valid secret key.",
     "errorFileReadFailed": "Failed to read file.",
     "errorInviteValidationFailed": "Unable to validate invite code",
-    "errorInviteCodeUsed": "Invite code already claimed - sorry!",
+    "errorInviteCodeUsed": "This invite code has already been used",
     "errorSignInStartFailed": "Unable to start sign-in",
     "errorWaitlistJoinFailed": "Unable to join the waitlist"
   },

--- a/src/lib/i18n/locales/en/common.json
+++ b/src/lib/i18n/locales/en/common.json
@@ -435,6 +435,7 @@
     "errorFileNoValidKey": "File does not contain a valid secret key.",
     "errorFileReadFailed": "Failed to read file.",
     "errorInviteValidationFailed": "Unable to validate invite code",
+    "errorInviteCodeUsed": "This invite code has already been used",
     "errorSignInStartFailed": "Unable to start sign-in",
     "errorWaitlistJoinFailed": "Unable to join the waitlist"
   },

--- a/src/lib/i18n/locales/en/common.json
+++ b/src/lib/i18n/locales/en/common.json
@@ -435,7 +435,7 @@
     "errorFileNoValidKey": "File does not contain a valid secret key.",
     "errorFileReadFailed": "Failed to read file.",
     "errorInviteValidationFailed": "Unable to validate invite code",
-    "errorInviteCodeUsed": "This invite code has already been used",
+    "errorInviteCodeUsed": "Invite code already claimed - sorry!",
     "errorSignInStartFailed": "Unable to start sign-in",
     "errorWaitlistJoinFailed": "Unable to join the waitlist"
   },

--- a/src/lib/i18n/locales/en/common.json
+++ b/src/lib/i18n/locales/en/common.json
@@ -1397,6 +1397,16 @@
     "continue": "Continue",
     "joinWaitlist": "No invite? Get on the waitlist."
   },
+  "invitesLandingPage": {
+    "seoTitle": "Join diVine with invite code {{code}}",
+    "seoTitleDefault": "Join diVine",
+    "seoDescription": "You've been invited! Use invite code {{code}} to join diVine.",
+    "seoDescriptionDefault": "Use your invite code to join diVine and start sharing video.",
+    "heading": "You're Invited!",
+    "subheading": "Enter your invite code to join diVine",
+    "alreadyHaveAccount": "Already have an account?",
+    "signIn": "Sign in"
+  },
   "applePodcastEmbed": {
     "defaultTitle": "Vine Revisited and The Fight Against AI Slop",
     "defaultDescription": "Behind the scenes of the Divine launch",

--- a/src/lib/i18n/locales/es/common.json
+++ b/src/lib/i18n/locales/es/common.json
@@ -435,7 +435,7 @@
     "errorFileNoValidKey": "El archivo no contiene una clave secreta válida.",
     "errorFileReadFailed": "Falló la lectura del archivo.",
     "errorInviteValidationFailed": "No se pudo validar el código de invitación",
-            "errorInviteCodeUsed": "This invite code has already been used",
+    "errorInviteCodeUsed": "Este código de invitación ya se usó",
     "errorSignInStartFailed": "No se pudo iniciar el inicio de sesión",
     "errorWaitlistJoinFailed": "No se pudo unir a la lista de espera"
   },
@@ -1399,14 +1399,14 @@
     "joinWaitlist": "¿Sin invitación? Apúntate a la lista de espera."
   },
   "invitesLandingPage": {
-    "seoTitle": "Join diVine with invite code {{code}}",
-    "seoTitleDefault": "Join diVine",
-    "seoDescription": "You've been invited! Use invite code {{code}} to join diVine.",
-    "seoDescriptionDefault": "Use your invite code to join diVine and start sharing video.",
-    "heading": "You're Invited!",
-    "subheading": "Enter your invite code to join diVine",
-    "alreadyHaveAccount": "Already have an account?",
-    "signIn": "Sign in"
+    "seoTitle": "Únete a diVine con el código de invitación {{code}}",
+    "seoTitleDefault": "Únete a diVine",
+    "seoDescription": "¡Te han invitado! Usa el código {{code}} para unirte a diVine.",
+    "seoDescriptionDefault": "Usa tu código de invitación para unirte a diVine y empezar a compartir video.",
+    "heading": "¡Estás invitado!",
+    "subheading": "Introduce tu código de invitación para unirte a diVine",
+    "alreadyHaveAccount": "¿Ya tienes cuenta?",
+    "signIn": "Iniciar sesión"
   },
   "applePodcastEmbed": {
     "defaultTitle": "Vine Revisited and The Fight Against AI Slop",

--- a/src/lib/i18n/locales/es/common.json
+++ b/src/lib/i18n/locales/es/common.json
@@ -435,7 +435,7 @@
     "errorFileNoValidKey": "El archivo no contiene una clave secreta válida.",
     "errorFileReadFailed": "Falló la lectura del archivo.",
     "errorInviteValidationFailed": "No se pudo validar el código de invitación",
-            "errorInviteCodeUsed": "This invite code has already been used",
+            "errorInviteCodeUsed": "Invite code already claimed - sorry!",
     "errorSignInStartFailed": "No se pudo iniciar el inicio de sesión",
     "errorWaitlistJoinFailed": "No se pudo unir a la lista de espera"
   },

--- a/src/lib/i18n/locales/es/common.json
+++ b/src/lib/i18n/locales/es/common.json
@@ -1397,6 +1397,16 @@
     "continue": "Continuar",
     "joinWaitlist": "¿Sin invitación? Apúntate a la lista de espera."
   },
+  "invitesLandingPage": {
+    "seoTitle": "Join diVine with invite code {{code}}",
+    "seoTitleDefault": "Join diVine",
+    "seoDescription": "You've been invited! Use invite code {{code}} to join diVine.",
+    "seoDescriptionDefault": "Use your invite code to join diVine and start sharing video.",
+    "heading": "You're Invited!",
+    "subheading": "Enter your invite code to join diVine",
+    "alreadyHaveAccount": "Already have an account?",
+    "signIn": "Sign in"
+  },
   "applePodcastEmbed": {
     "defaultTitle": "Vine Revisited and The Fight Against AI Slop",
     "defaultDescription": "Detrás de cámaras del lanzamiento de Divine",

--- a/src/lib/i18n/locales/es/common.json
+++ b/src/lib/i18n/locales/es/common.json
@@ -435,7 +435,7 @@
     "errorFileNoValidKey": "El archivo no contiene una clave secreta válida.",
     "errorFileReadFailed": "Falló la lectura del archivo.",
     "errorInviteValidationFailed": "No se pudo validar el código de invitación",
-            "errorInviteCodeUsed": "Invite code already claimed - sorry!",
+            "errorInviteCodeUsed": "This invite code has already been used",
     "errorSignInStartFailed": "No se pudo iniciar el inicio de sesión",
     "errorWaitlistJoinFailed": "No se pudo unir a la lista de espera"
   },

--- a/src/lib/i18n/locales/es/common.json
+++ b/src/lib/i18n/locales/es/common.json
@@ -435,6 +435,7 @@
     "errorFileNoValidKey": "El archivo no contiene una clave secreta válida.",
     "errorFileReadFailed": "Falló la lectura del archivo.",
     "errorInviteValidationFailed": "No se pudo validar el código de invitación",
+            "errorInviteCodeUsed": "This invite code has already been used",
     "errorSignInStartFailed": "No se pudo iniciar el inicio de sesión",
     "errorWaitlistJoinFailed": "No se pudo unir a la lista de espera"
   },

--- a/src/lib/i18n/locales/fil/common.json
+++ b/src/lib/i18n/locales/fil/common.json
@@ -435,7 +435,7 @@
     "errorFileNoValidKey": "Walang valid na secret key sa file.",
     "errorFileReadFailed": "Hindi mabasa ang file.",
     "errorInviteValidationFailed": "Hindi ma-validate ang invite code",
-            "errorInviteCodeUsed": "This invite code has already been used",
+            "errorInviteCodeUsed": "Invite code already claimed - sorry!",
     "errorSignInStartFailed": "Hindi masimulan ang sign-in",
     "errorWaitlistJoinFailed": "Hindi maka-join sa waitlist"
   },

--- a/src/lib/i18n/locales/fil/common.json
+++ b/src/lib/i18n/locales/fil/common.json
@@ -435,7 +435,7 @@
     "errorFileNoValidKey": "Walang valid na secret key sa file.",
     "errorFileReadFailed": "Hindi mabasa ang file.",
     "errorInviteValidationFailed": "Hindi ma-validate ang invite code",
-            "errorInviteCodeUsed": "This invite code has already been used",
+    "errorInviteCodeUsed": "Nagamit na ang invite code na ito",
     "errorSignInStartFailed": "Hindi masimulan ang sign-in",
     "errorWaitlistJoinFailed": "Hindi maka-join sa waitlist"
   },
@@ -1399,14 +1399,14 @@
     "joinWaitlist": "Walang invite? Sumali sa waitlist."
   },
   "invitesLandingPage": {
-    "seoTitle": "Join diVine with invite code {{code}}",
-    "seoTitleDefault": "Join diVine",
-    "seoDescription": "You've been invited! Use invite code {{code}} to join diVine.",
-    "seoDescriptionDefault": "Use your invite code to join diVine and start sharing video.",
-    "heading": "You're Invited!",
-    "subheading": "Enter your invite code to join diVine",
-    "alreadyHaveAccount": "Already have an account?",
-    "signIn": "Sign in"
+    "seoTitle": "Sumali sa diVine gamit ang invite code {{code}}",
+    "seoTitleDefault": "Sumali sa diVine",
+    "seoDescription": "Inimbitahan ka! Gamitin ang code {{code}} para sumali sa diVine.",
+    "seoDescriptionDefault": "Gamitin ang invite code mo para sumali sa diVine at magsimulang mag-share ng video.",
+    "heading": "Imbitado Ka!",
+    "subheading": "Ilagay ang invite code mo para sumali sa diVine",
+    "alreadyHaveAccount": "May account ka na?",
+    "signIn": "Mag-sign in"
   },
   "applePodcastEmbed": {
     "defaultTitle": "Vine Revisited at ang Laban Kontra AI Slop",

--- a/src/lib/i18n/locales/fil/common.json
+++ b/src/lib/i18n/locales/fil/common.json
@@ -1397,6 +1397,16 @@
     "continue": "Magpatuloy",
     "joinWaitlist": "Walang invite? Sumali sa waitlist."
   },
+  "invitesLandingPage": {
+    "seoTitle": "Join diVine with invite code {{code}}",
+    "seoTitleDefault": "Join diVine",
+    "seoDescription": "You've been invited! Use invite code {{code}} to join diVine.",
+    "seoDescriptionDefault": "Use your invite code to join diVine and start sharing video.",
+    "heading": "You're Invited!",
+    "subheading": "Enter your invite code to join diVine",
+    "alreadyHaveAccount": "Already have an account?",
+    "signIn": "Sign in"
+  },
   "applePodcastEmbed": {
     "defaultTitle": "Vine Revisited at ang Laban Kontra AI Slop",
     "defaultDescription": "Sa likod ng eksena ng Divine launch",

--- a/src/lib/i18n/locales/fil/common.json
+++ b/src/lib/i18n/locales/fil/common.json
@@ -435,6 +435,7 @@
     "errorFileNoValidKey": "Walang valid na secret key sa file.",
     "errorFileReadFailed": "Hindi mabasa ang file.",
     "errorInviteValidationFailed": "Hindi ma-validate ang invite code",
+            "errorInviteCodeUsed": "This invite code has already been used",
     "errorSignInStartFailed": "Hindi masimulan ang sign-in",
     "errorWaitlistJoinFailed": "Hindi maka-join sa waitlist"
   },

--- a/src/lib/i18n/locales/fil/common.json
+++ b/src/lib/i18n/locales/fil/common.json
@@ -435,7 +435,7 @@
     "errorFileNoValidKey": "Walang valid na secret key sa file.",
     "errorFileReadFailed": "Hindi mabasa ang file.",
     "errorInviteValidationFailed": "Hindi ma-validate ang invite code",
-            "errorInviteCodeUsed": "Invite code already claimed - sorry!",
+            "errorInviteCodeUsed": "This invite code has already been used",
     "errorSignInStartFailed": "Hindi masimulan ang sign-in",
     "errorWaitlistJoinFailed": "Hindi maka-join sa waitlist"
   },

--- a/src/lib/i18n/locales/fr/common.json
+++ b/src/lib/i18n/locales/fr/common.json
@@ -435,7 +435,7 @@
     "errorFileNoValidKey": "Le fichier ne contient pas de clé secrète valide.",
     "errorFileReadFailed": "Échec de la lecture du fichier.",
     "errorInviteValidationFailed": "Impossible de valider le code d'invitation",
-            "errorInviteCodeUsed": "This invite code has already been used",
+            "errorInviteCodeUsed": "Invite code already claimed - sorry!",
     "errorSignInStartFailed": "Impossible de démarrer la connexion",
     "errorWaitlistJoinFailed": "Impossible de rejoindre la liste d'attente"
   },

--- a/src/lib/i18n/locales/fr/common.json
+++ b/src/lib/i18n/locales/fr/common.json
@@ -435,6 +435,7 @@
     "errorFileNoValidKey": "Le fichier ne contient pas de clé secrète valide.",
     "errorFileReadFailed": "Échec de la lecture du fichier.",
     "errorInviteValidationFailed": "Impossible de valider le code d'invitation",
+            "errorInviteCodeUsed": "This invite code has already been used",
     "errorSignInStartFailed": "Impossible de démarrer la connexion",
     "errorWaitlistJoinFailed": "Impossible de rejoindre la liste d'attente"
   },

--- a/src/lib/i18n/locales/fr/common.json
+++ b/src/lib/i18n/locales/fr/common.json
@@ -1397,6 +1397,16 @@
     "continue": "Continuer",
     "joinWaitlist": "Pas d'invitation ? Inscris-toi sur la liste d'attente."
   },
+  "invitesLandingPage": {
+    "seoTitle": "Join diVine with invite code {{code}}",
+    "seoTitleDefault": "Join diVine",
+    "seoDescription": "You've been invited! Use invite code {{code}} to join diVine.",
+    "seoDescriptionDefault": "Use your invite code to join diVine and start sharing video.",
+    "heading": "You're Invited!",
+    "subheading": "Enter your invite code to join diVine",
+    "alreadyHaveAccount": "Already have an account?",
+    "signIn": "Sign in"
+  },
   "applePodcastEmbed": {
     "defaultTitle": "Vine Revisited and The Fight Against AI Slop",
     "defaultDescription": "Dans les coulisses du lancement de Divine",

--- a/src/lib/i18n/locales/fr/common.json
+++ b/src/lib/i18n/locales/fr/common.json
@@ -435,7 +435,7 @@
     "errorFileNoValidKey": "Le fichier ne contient pas de clé secrète valide.",
     "errorFileReadFailed": "Échec de la lecture du fichier.",
     "errorInviteValidationFailed": "Impossible de valider le code d'invitation",
-            "errorInviteCodeUsed": "Invite code already claimed - sorry!",
+            "errorInviteCodeUsed": "This invite code has already been used",
     "errorSignInStartFailed": "Impossible de démarrer la connexion",
     "errorWaitlistJoinFailed": "Impossible de rejoindre la liste d'attente"
   },

--- a/src/lib/i18n/locales/fr/common.json
+++ b/src/lib/i18n/locales/fr/common.json
@@ -435,7 +435,7 @@
     "errorFileNoValidKey": "Le fichier ne contient pas de clé secrète valide.",
     "errorFileReadFailed": "Échec de la lecture du fichier.",
     "errorInviteValidationFailed": "Impossible de valider le code d'invitation",
-            "errorInviteCodeUsed": "This invite code has already been used",
+    "errorInviteCodeUsed": "Ce code d'invitation a déjà été utilisé",
     "errorSignInStartFailed": "Impossible de démarrer la connexion",
     "errorWaitlistJoinFailed": "Impossible de rejoindre la liste d'attente"
   },
@@ -1399,14 +1399,14 @@
     "joinWaitlist": "Pas d'invitation ? Inscris-toi sur la liste d'attente."
   },
   "invitesLandingPage": {
-    "seoTitle": "Join diVine with invite code {{code}}",
-    "seoTitleDefault": "Join diVine",
-    "seoDescription": "You've been invited! Use invite code {{code}} to join diVine.",
-    "seoDescriptionDefault": "Use your invite code to join diVine and start sharing video.",
-    "heading": "You're Invited!",
-    "subheading": "Enter your invite code to join diVine",
-    "alreadyHaveAccount": "Already have an account?",
-    "signIn": "Sign in"
+    "seoTitle": "Rejoins diVine avec le code d'invitation {{code}}",
+    "seoTitleDefault": "Rejoins diVine",
+    "seoDescription": "Tu as été invité ! Utilise le code {{code}} pour rejoindre diVine.",
+    "seoDescriptionDefault": "Utilise ton code d'invitation pour rejoindre diVine et commencer à partager des vidéos.",
+    "heading": "Tu es invité !",
+    "subheading": "Entre ton code d'invitation pour rejoindre diVine",
+    "alreadyHaveAccount": "Tu as déjà un compte ?",
+    "signIn": "Se connecter"
   },
   "applePodcastEmbed": {
     "defaultTitle": "Vine Revisited and The Fight Against AI Slop",

--- a/src/lib/i18n/locales/id/common.json
+++ b/src/lib/i18n/locales/id/common.json
@@ -435,7 +435,7 @@
     "errorFileNoValidKey": "File tidak berisi kunci rahasia yang valid.",
     "errorFileReadFailed": "Gagal membaca file.",
     "errorInviteValidationFailed": "Tidak bisa memvalidasi kode invite",
-            "errorInviteCodeUsed": "Invite code already claimed - sorry!",
+            "errorInviteCodeUsed": "This invite code has already been used",
     "errorSignInStartFailed": "Tidak bisa memulai sign-in",
     "errorWaitlistJoinFailed": "Tidak bisa bergabung ke waitlist"
   },

--- a/src/lib/i18n/locales/id/common.json
+++ b/src/lib/i18n/locales/id/common.json
@@ -1397,6 +1397,16 @@
     "continue": "Lanjut",
     "joinWaitlist": "Belum punya undangan? Masuk waitlist."
   },
+  "invitesLandingPage": {
+    "seoTitle": "Join diVine with invite code {{code}}",
+    "seoTitleDefault": "Join diVine",
+    "seoDescription": "You've been invited! Use invite code {{code}} to join diVine.",
+    "seoDescriptionDefault": "Use your invite code to join diVine and start sharing video.",
+    "heading": "You're Invited!",
+    "subheading": "Enter your invite code to join diVine",
+    "alreadyHaveAccount": "Already have an account?",
+    "signIn": "Sign in"
+  },
   "applePodcastEmbed": {
     "defaultTitle": "Vine Revisited and The Fight Against AI Slop",
     "defaultDescription": "Di balik layar peluncuran Divine",

--- a/src/lib/i18n/locales/id/common.json
+++ b/src/lib/i18n/locales/id/common.json
@@ -435,7 +435,7 @@
     "errorFileNoValidKey": "File tidak berisi kunci rahasia yang valid.",
     "errorFileReadFailed": "Gagal membaca file.",
     "errorInviteValidationFailed": "Tidak bisa memvalidasi kode invite",
-            "errorInviteCodeUsed": "This invite code has already been used",
+    "errorInviteCodeUsed": "Kode invite ini sudah digunakan",
     "errorSignInStartFailed": "Tidak bisa memulai sign-in",
     "errorWaitlistJoinFailed": "Tidak bisa bergabung ke waitlist"
   },
@@ -1399,14 +1399,14 @@
     "joinWaitlist": "Belum punya undangan? Masuk waitlist."
   },
   "invitesLandingPage": {
-    "seoTitle": "Join diVine with invite code {{code}}",
-    "seoTitleDefault": "Join diVine",
-    "seoDescription": "You've been invited! Use invite code {{code}} to join diVine.",
-    "seoDescriptionDefault": "Use your invite code to join diVine and start sharing video.",
-    "heading": "You're Invited!",
-    "subheading": "Enter your invite code to join diVine",
-    "alreadyHaveAccount": "Already have an account?",
-    "signIn": "Sign in"
+    "seoTitle": "Gabung diVine dengan kode invite {{code}}",
+    "seoTitleDefault": "Gabung diVine",
+    "seoDescription": "Kamu diundang! Gunakan kode {{code}} untuk bergabung ke diVine.",
+    "seoDescriptionDefault": "Gunakan kode invite kamu untuk bergabung ke diVine dan mulai berbagi video.",
+    "heading": "Kamu Diundang!",
+    "subheading": "Masukkan kode invite kamu untuk bergabung ke diVine",
+    "alreadyHaveAccount": "Sudah punya akun?",
+    "signIn": "Masuk"
   },
   "applePodcastEmbed": {
     "defaultTitle": "Vine Revisited and The Fight Against AI Slop",

--- a/src/lib/i18n/locales/id/common.json
+++ b/src/lib/i18n/locales/id/common.json
@@ -435,7 +435,7 @@
     "errorFileNoValidKey": "File tidak berisi kunci rahasia yang valid.",
     "errorFileReadFailed": "Gagal membaca file.",
     "errorInviteValidationFailed": "Tidak bisa memvalidasi kode invite",
-            "errorInviteCodeUsed": "This invite code has already been used",
+            "errorInviteCodeUsed": "Invite code already claimed - sorry!",
     "errorSignInStartFailed": "Tidak bisa memulai sign-in",
     "errorWaitlistJoinFailed": "Tidak bisa bergabung ke waitlist"
   },

--- a/src/lib/i18n/locales/id/common.json
+++ b/src/lib/i18n/locales/id/common.json
@@ -435,6 +435,7 @@
     "errorFileNoValidKey": "File tidak berisi kunci rahasia yang valid.",
     "errorFileReadFailed": "Gagal membaca file.",
     "errorInviteValidationFailed": "Tidak bisa memvalidasi kode invite",
+            "errorInviteCodeUsed": "This invite code has already been used",
     "errorSignInStartFailed": "Tidak bisa memulai sign-in",
     "errorWaitlistJoinFailed": "Tidak bisa bergabung ke waitlist"
   },

--- a/src/lib/i18n/locales/it/common.json
+++ b/src/lib/i18n/locales/it/common.json
@@ -435,7 +435,7 @@
     "errorFileNoValidKey": "Il file non contiene una chiave segreta valida.",
     "errorFileReadFailed": "Lettura del file non riuscita.",
     "errorInviteValidationFailed": "Impossibile validare il codice invito",
-            "errorInviteCodeUsed": "This invite code has already been used",
+            "errorInviteCodeUsed": "Invite code already claimed - sorry!",
     "errorSignInStartFailed": "Impossibile avviare l'accesso",
     "errorWaitlistJoinFailed": "Impossibile unirsi alla lista d'attesa"
   },

--- a/src/lib/i18n/locales/it/common.json
+++ b/src/lib/i18n/locales/it/common.json
@@ -1397,6 +1397,16 @@
     "continue": "Continua",
     "joinWaitlist": "Niente invito? Mettiti in lista d'attesa."
   },
+  "invitesLandingPage": {
+    "seoTitle": "Join diVine with invite code {{code}}",
+    "seoTitleDefault": "Join diVine",
+    "seoDescription": "You've been invited! Use invite code {{code}} to join diVine.",
+    "seoDescriptionDefault": "Use your invite code to join diVine and start sharing video.",
+    "heading": "You're Invited!",
+    "subheading": "Enter your invite code to join diVine",
+    "alreadyHaveAccount": "Already have an account?",
+    "signIn": "Sign in"
+  },
   "applePodcastEmbed": {
     "defaultTitle": "Vine Revisited and The Fight Against AI Slop",
     "defaultDescription": "Dietro le quinte del lancio di Divine",

--- a/src/lib/i18n/locales/it/common.json
+++ b/src/lib/i18n/locales/it/common.json
@@ -435,7 +435,7 @@
     "errorFileNoValidKey": "Il file non contiene una chiave segreta valida.",
     "errorFileReadFailed": "Lettura del file non riuscita.",
     "errorInviteValidationFailed": "Impossibile validare il codice invito",
-            "errorInviteCodeUsed": "This invite code has already been used",
+    "errorInviteCodeUsed": "Questo codice invito è già stato usato",
     "errorSignInStartFailed": "Impossibile avviare l'accesso",
     "errorWaitlistJoinFailed": "Impossibile unirsi alla lista d'attesa"
   },
@@ -1399,14 +1399,14 @@
     "joinWaitlist": "Niente invito? Mettiti in lista d'attesa."
   },
   "invitesLandingPage": {
-    "seoTitle": "Join diVine with invite code {{code}}",
-    "seoTitleDefault": "Join diVine",
-    "seoDescription": "You've been invited! Use invite code {{code}} to join diVine.",
-    "seoDescriptionDefault": "Use your invite code to join diVine and start sharing video.",
-    "heading": "You're Invited!",
-    "subheading": "Enter your invite code to join diVine",
-    "alreadyHaveAccount": "Already have an account?",
-    "signIn": "Sign in"
+    "seoTitle": "Unisciti a diVine con il codice invito {{code}}",
+    "seoTitleDefault": "Unisciti a diVine",
+    "seoDescription": "Hai ricevuto un invito! Usa il codice {{code}} per unirti a diVine.",
+    "seoDescriptionDefault": "Usa il tuo codice invito per unirti a diVine e iniziare a condividere video.",
+    "heading": "Sei invitato!",
+    "subheading": "Inserisci il tuo codice invito per unirti a diVine",
+    "alreadyHaveAccount": "Hai già un account?",
+    "signIn": "Accedi"
   },
   "applePodcastEmbed": {
     "defaultTitle": "Vine Revisited and The Fight Against AI Slop",

--- a/src/lib/i18n/locales/it/common.json
+++ b/src/lib/i18n/locales/it/common.json
@@ -435,7 +435,7 @@
     "errorFileNoValidKey": "Il file non contiene una chiave segreta valida.",
     "errorFileReadFailed": "Lettura del file non riuscita.",
     "errorInviteValidationFailed": "Impossibile validare il codice invito",
-            "errorInviteCodeUsed": "Invite code already claimed - sorry!",
+            "errorInviteCodeUsed": "This invite code has already been used",
     "errorSignInStartFailed": "Impossibile avviare l'accesso",
     "errorWaitlistJoinFailed": "Impossibile unirsi alla lista d'attesa"
   },

--- a/src/lib/i18n/locales/it/common.json
+++ b/src/lib/i18n/locales/it/common.json
@@ -435,6 +435,7 @@
     "errorFileNoValidKey": "Il file non contiene una chiave segreta valida.",
     "errorFileReadFailed": "Lettura del file non riuscita.",
     "errorInviteValidationFailed": "Impossibile validare il codice invito",
+            "errorInviteCodeUsed": "This invite code has already been used",
     "errorSignInStartFailed": "Impossibile avviare l'accesso",
     "errorWaitlistJoinFailed": "Impossibile unirsi alla lista d'attesa"
   },

--- a/src/lib/i18n/locales/ja/common.json
+++ b/src/lib/i18n/locales/ja/common.json
@@ -435,7 +435,7 @@
     "errorFileNoValidKey": "ファイルに有効な秘密鍵が含まれていません。",
     "errorFileReadFailed": "ファイルの読み込みに失敗しました。",
     "errorInviteValidationFailed": "招待コードを検証できません",
-            "errorInviteCodeUsed": "This invite code has already been used",
+            "errorInviteCodeUsed": "Invite code already claimed - sorry!",
     "errorSignInStartFailed": "サインインを開始できません",
     "errorWaitlistJoinFailed": "順番待ちリストに参加できません"
   },

--- a/src/lib/i18n/locales/ja/common.json
+++ b/src/lib/i18n/locales/ja/common.json
@@ -435,7 +435,7 @@
     "errorFileNoValidKey": "ファイルに有効な秘密鍵が含まれていません。",
     "errorFileReadFailed": "ファイルの読み込みに失敗しました。",
     "errorInviteValidationFailed": "招待コードを検証できません",
-            "errorInviteCodeUsed": "Invite code already claimed - sorry!",
+            "errorInviteCodeUsed": "This invite code has already been used",
     "errorSignInStartFailed": "サインインを開始できません",
     "errorWaitlistJoinFailed": "順番待ちリストに参加できません"
   },

--- a/src/lib/i18n/locales/ja/common.json
+++ b/src/lib/i18n/locales/ja/common.json
@@ -1397,6 +1397,16 @@
     "continue": "続ける",
     "joinWaitlist": "招待がない?ウェイトリストに登録してください。"
   },
+  "invitesLandingPage": {
+    "seoTitle": "Join diVine with invite code {{code}}",
+    "seoTitleDefault": "Join diVine",
+    "seoDescription": "You've been invited! Use invite code {{code}} to join diVine.",
+    "seoDescriptionDefault": "Use your invite code to join diVine and start sharing video.",
+    "heading": "You're Invited!",
+    "subheading": "Enter your invite code to join diVine",
+    "alreadyHaveAccount": "Already have an account?",
+    "signIn": "Sign in"
+  },
   "applePodcastEmbed": {
     "defaultTitle": "Vine Revisited and The Fight Against AI Slop",
     "defaultDescription": "Divineローンチの舞台裏",

--- a/src/lib/i18n/locales/ja/common.json
+++ b/src/lib/i18n/locales/ja/common.json
@@ -435,6 +435,7 @@
     "errorFileNoValidKey": "ファイルに有効な秘密鍵が含まれていません。",
     "errorFileReadFailed": "ファイルの読み込みに失敗しました。",
     "errorInviteValidationFailed": "招待コードを検証できません",
+            "errorInviteCodeUsed": "This invite code has already been used",
     "errorSignInStartFailed": "サインインを開始できません",
     "errorWaitlistJoinFailed": "順番待ちリストに参加できません"
   },

--- a/src/lib/i18n/locales/ja/common.json
+++ b/src/lib/i18n/locales/ja/common.json
@@ -435,7 +435,7 @@
     "errorFileNoValidKey": "ファイルに有効な秘密鍵が含まれていません。",
     "errorFileReadFailed": "ファイルの読み込みに失敗しました。",
     "errorInviteValidationFailed": "招待コードを検証できません",
-            "errorInviteCodeUsed": "This invite code has already been used",
+    "errorInviteCodeUsed": "この招待コードはすでに使用されています",
     "errorSignInStartFailed": "サインインを開始できません",
     "errorWaitlistJoinFailed": "順番待ちリストに参加できません"
   },
@@ -1399,14 +1399,14 @@
     "joinWaitlist": "招待がない?ウェイトリストに登録してください。"
   },
   "invitesLandingPage": {
-    "seoTitle": "Join diVine with invite code {{code}}",
-    "seoTitleDefault": "Join diVine",
-    "seoDescription": "You've been invited! Use invite code {{code}} to join diVine.",
-    "seoDescriptionDefault": "Use your invite code to join diVine and start sharing video.",
-    "heading": "You're Invited!",
-    "subheading": "Enter your invite code to join diVine",
-    "alreadyHaveAccount": "Already have an account?",
-    "signIn": "Sign in"
+    "seoTitle": "招待コード {{code}} でdiVineに参加",
+    "seoTitleDefault": "diVineに参加",
+    "seoDescription": "招待されています！コード {{code}} を使ってdiVineに参加しましょう。",
+    "seoDescriptionDefault": "招待コードを使ってdiVineに参加し、動画の共有を始めましょう。",
+    "heading": "招待されています！",
+    "subheading": "diVineに参加するには招待コードを入力してください",
+    "alreadyHaveAccount": "すでにアカウントをお持ちですか？",
+    "signIn": "サインイン"
   },
   "applePodcastEmbed": {
     "defaultTitle": "Vine Revisited and The Fight Against AI Slop",

--- a/src/lib/i18n/locales/ko/common.json
+++ b/src/lib/i18n/locales/ko/common.json
@@ -435,7 +435,7 @@
     "errorFileNoValidKey": "파일에 유효한 비밀키가 없어요.",
     "errorFileReadFailed": "파일을 읽을 수 없어요.",
     "errorInviteValidationFailed": "초대 코드를 확인할 수 없음",
-            "errorInviteCodeUsed": "This invite code has already been used",
+            "errorInviteCodeUsed": "Invite code already claimed - sorry!",
     "errorSignInStartFailed": "로그인을 시작할 수 없음",
     "errorWaitlistJoinFailed": "대기자 명단에 등록할 수 없음"
   },

--- a/src/lib/i18n/locales/ko/common.json
+++ b/src/lib/i18n/locales/ko/common.json
@@ -435,7 +435,7 @@
     "errorFileNoValidKey": "파일에 유효한 비밀키가 없어요.",
     "errorFileReadFailed": "파일을 읽을 수 없어요.",
     "errorInviteValidationFailed": "초대 코드를 확인할 수 없음",
-            "errorInviteCodeUsed": "Invite code already claimed - sorry!",
+            "errorInviteCodeUsed": "This invite code has already been used",
     "errorSignInStartFailed": "로그인을 시작할 수 없음",
     "errorWaitlistJoinFailed": "대기자 명단에 등록할 수 없음"
   },

--- a/src/lib/i18n/locales/ko/common.json
+++ b/src/lib/i18n/locales/ko/common.json
@@ -1397,6 +1397,16 @@
     "continue": "계속",
     "joinWaitlist": "초대 코드가 없나요? 대기자 명단에 등록하세요."
   },
+  "invitesLandingPage": {
+    "seoTitle": "Join diVine with invite code {{code}}",
+    "seoTitleDefault": "Join diVine",
+    "seoDescription": "You've been invited! Use invite code {{code}} to join diVine.",
+    "seoDescriptionDefault": "Use your invite code to join diVine and start sharing video.",
+    "heading": "You're Invited!",
+    "subheading": "Enter your invite code to join diVine",
+    "alreadyHaveAccount": "Already have an account?",
+    "signIn": "Sign in"
+  },
   "applePodcastEmbed": {
     "defaultTitle": "Vine Revisited and The Fight Against AI Slop",
     "defaultDescription": "Divine 출시의 비하인드 스토리",

--- a/src/lib/i18n/locales/ko/common.json
+++ b/src/lib/i18n/locales/ko/common.json
@@ -435,6 +435,7 @@
     "errorFileNoValidKey": "파일에 유효한 비밀키가 없어요.",
     "errorFileReadFailed": "파일을 읽을 수 없어요.",
     "errorInviteValidationFailed": "초대 코드를 확인할 수 없음",
+            "errorInviteCodeUsed": "This invite code has already been used",
     "errorSignInStartFailed": "로그인을 시작할 수 없음",
     "errorWaitlistJoinFailed": "대기자 명단에 등록할 수 없음"
   },

--- a/src/lib/i18n/locales/ko/common.json
+++ b/src/lib/i18n/locales/ko/common.json
@@ -435,7 +435,7 @@
     "errorFileNoValidKey": "파일에 유효한 비밀키가 없어요.",
     "errorFileReadFailed": "파일을 읽을 수 없어요.",
     "errorInviteValidationFailed": "초대 코드를 확인할 수 없음",
-            "errorInviteCodeUsed": "This invite code has already been used",
+    "errorInviteCodeUsed": "이 초대 코드는 이미 사용되었습니다",
     "errorSignInStartFailed": "로그인을 시작할 수 없음",
     "errorWaitlistJoinFailed": "대기자 명단에 등록할 수 없음"
   },
@@ -1399,14 +1399,14 @@
     "joinWaitlist": "초대 코드가 없나요? 대기자 명단에 등록하세요."
   },
   "invitesLandingPage": {
-    "seoTitle": "Join diVine with invite code {{code}}",
-    "seoTitleDefault": "Join diVine",
-    "seoDescription": "You've been invited! Use invite code {{code}} to join diVine.",
-    "seoDescriptionDefault": "Use your invite code to join diVine and start sharing video.",
-    "heading": "You're Invited!",
-    "subheading": "Enter your invite code to join diVine",
-    "alreadyHaveAccount": "Already have an account?",
-    "signIn": "Sign in"
+    "seoTitle": "초대 코드 {{code}}로 diVine에 가입",
+    "seoTitleDefault": "diVine에 가입",
+    "seoDescription": "초대받았어요! 코드 {{code}}를 사용해 diVine에 가입하세요.",
+    "seoDescriptionDefault": "초대 코드를 사용해 diVine에 가입하고 동영상 공유를 시작하세요.",
+    "heading": "초대받았어요!",
+    "subheading": "diVine에 가입하려면 초대 코드를 입력하세요",
+    "alreadyHaveAccount": "이미 계정이 있나요?",
+    "signIn": "로그인"
   },
   "applePodcastEmbed": {
     "defaultTitle": "Vine Revisited and The Fight Against AI Slop",

--- a/src/lib/i18n/locales/nl/common.json
+++ b/src/lib/i18n/locales/nl/common.json
@@ -435,7 +435,7 @@
     "errorFileNoValidKey": "Bestand bevat geen geldige geheime sleutel.",
     "errorFileReadFailed": "Bestand lezen mislukt.",
     "errorInviteValidationFailed": "Kan uitnodigingscode niet valideren",
-            "errorInviteCodeUsed": "This invite code has already been used",
+    "errorInviteCodeUsed": "Deze uitnodigingscode is al gebruikt",
     "errorSignInStartFailed": "Kan inloggen niet starten",
     "errorWaitlistJoinFailed": "Kan niet aansluiten bij de wachtlijst"
   },
@@ -1399,14 +1399,14 @@
     "joinWaitlist": "Geen uitnodiging? Zet je op de wachtlijst."
   },
   "invitesLandingPage": {
-    "seoTitle": "Join diVine with invite code {{code}}",
-    "seoTitleDefault": "Join diVine",
-    "seoDescription": "You've been invited! Use invite code {{code}} to join diVine.",
-    "seoDescriptionDefault": "Use your invite code to join diVine and start sharing video.",
-    "heading": "You're Invited!",
-    "subheading": "Enter your invite code to join diVine",
-    "alreadyHaveAccount": "Already have an account?",
-    "signIn": "Sign in"
+    "seoTitle": "Word lid van diVine met uitnodigingscode {{code}}",
+    "seoTitleDefault": "Word lid van diVine",
+    "seoDescription": "Je bent uitgenodigd! Gebruik code {{code}} om lid te worden van diVine.",
+    "seoDescriptionDefault": "Gebruik je uitnodigingscode om lid te worden van diVine en video te delen.",
+    "heading": "Je bent uitgenodigd!",
+    "subheading": "Voer je uitnodigingscode in om lid te worden van diVine",
+    "alreadyHaveAccount": "Heb je al een account?",
+    "signIn": "Inloggen"
   },
   "applePodcastEmbed": {
     "defaultTitle": "Vine Revisited and The Fight Against AI Slop",

--- a/src/lib/i18n/locales/nl/common.json
+++ b/src/lib/i18n/locales/nl/common.json
@@ -1397,6 +1397,16 @@
     "continue": "Doorgaan",
     "joinWaitlist": "Geen uitnodiging? Zet je op de wachtlijst."
   },
+  "invitesLandingPage": {
+    "seoTitle": "Join diVine with invite code {{code}}",
+    "seoTitleDefault": "Join diVine",
+    "seoDescription": "You've been invited! Use invite code {{code}} to join diVine.",
+    "seoDescriptionDefault": "Use your invite code to join diVine and start sharing video.",
+    "heading": "You're Invited!",
+    "subheading": "Enter your invite code to join diVine",
+    "alreadyHaveAccount": "Already have an account?",
+    "signIn": "Sign in"
+  },
   "applePodcastEmbed": {
     "defaultTitle": "Vine Revisited and The Fight Against AI Slop",
     "defaultDescription": "Achter de schermen bij de lancering van Divine",

--- a/src/lib/i18n/locales/nl/common.json
+++ b/src/lib/i18n/locales/nl/common.json
@@ -435,7 +435,7 @@
     "errorFileNoValidKey": "Bestand bevat geen geldige geheime sleutel.",
     "errorFileReadFailed": "Bestand lezen mislukt.",
     "errorInviteValidationFailed": "Kan uitnodigingscode niet valideren",
-            "errorInviteCodeUsed": "Invite code already claimed - sorry!",
+            "errorInviteCodeUsed": "This invite code has already been used",
     "errorSignInStartFailed": "Kan inloggen niet starten",
     "errorWaitlistJoinFailed": "Kan niet aansluiten bij de wachtlijst"
   },

--- a/src/lib/i18n/locales/nl/common.json
+++ b/src/lib/i18n/locales/nl/common.json
@@ -435,7 +435,7 @@
     "errorFileNoValidKey": "Bestand bevat geen geldige geheime sleutel.",
     "errorFileReadFailed": "Bestand lezen mislukt.",
     "errorInviteValidationFailed": "Kan uitnodigingscode niet valideren",
-            "errorInviteCodeUsed": "This invite code has already been used",
+            "errorInviteCodeUsed": "Invite code already claimed - sorry!",
     "errorSignInStartFailed": "Kan inloggen niet starten",
     "errorWaitlistJoinFailed": "Kan niet aansluiten bij de wachtlijst"
   },

--- a/src/lib/i18n/locales/nl/common.json
+++ b/src/lib/i18n/locales/nl/common.json
@@ -435,6 +435,7 @@
     "errorFileNoValidKey": "Bestand bevat geen geldige geheime sleutel.",
     "errorFileReadFailed": "Bestand lezen mislukt.",
     "errorInviteValidationFailed": "Kan uitnodigingscode niet valideren",
+            "errorInviteCodeUsed": "This invite code has already been used",
     "errorSignInStartFailed": "Kan inloggen niet starten",
     "errorWaitlistJoinFailed": "Kan niet aansluiten bij de wachtlijst"
   },

--- a/src/lib/i18n/locales/pl/common.json
+++ b/src/lib/i18n/locales/pl/common.json
@@ -1399,6 +1399,16 @@
     "continue": "Dalej",
     "joinWaitlist": "Nie masz zaproszenia? Zapisz się na listę oczekujących."
   },
+  "invitesLandingPage": {
+    "seoTitle": "Join diVine with invite code {{code}}",
+    "seoTitleDefault": "Join diVine",
+    "seoDescription": "You've been invited! Use invite code {{code}} to join diVine.",
+    "seoDescriptionDefault": "Use your invite code to join diVine and start sharing video.",
+    "heading": "You're Invited!",
+    "subheading": "Enter your invite code to join diVine",
+    "alreadyHaveAccount": "Already have an account?",
+    "signIn": "Sign in"
+  },
   "applePodcastEmbed": {
     "defaultTitle": "Vine Revisited and The Fight Against AI Slop",
     "defaultDescription": "Kulisy startu Divine",

--- a/src/lib/i18n/locales/pl/common.json
+++ b/src/lib/i18n/locales/pl/common.json
@@ -437,7 +437,7 @@
     "errorFileNoValidKey": "Plik nie zawiera prawidłowego klucza prywatnego.",
     "errorFileReadFailed": "Nie udało się odczytać pliku.",
     "errorInviteValidationFailed": "Nie można zweryfikować kodu zaproszenia",
-            "errorInviteCodeUsed": "This invite code has already been used",
+            "errorInviteCodeUsed": "Invite code already claimed - sorry!",
     "errorSignInStartFailed": "Nie można rozpocząć logowania",
     "errorWaitlistJoinFailed": "Nie można dołączyć do listy oczekujących"
   },

--- a/src/lib/i18n/locales/pl/common.json
+++ b/src/lib/i18n/locales/pl/common.json
@@ -437,6 +437,7 @@
     "errorFileNoValidKey": "Plik nie zawiera prawidłowego klucza prywatnego.",
     "errorFileReadFailed": "Nie udało się odczytać pliku.",
     "errorInviteValidationFailed": "Nie można zweryfikować kodu zaproszenia",
+            "errorInviteCodeUsed": "This invite code has already been used",
     "errorSignInStartFailed": "Nie można rozpocząć logowania",
     "errorWaitlistJoinFailed": "Nie można dołączyć do listy oczekujących"
   },

--- a/src/lib/i18n/locales/pl/common.json
+++ b/src/lib/i18n/locales/pl/common.json
@@ -437,7 +437,7 @@
     "errorFileNoValidKey": "Plik nie zawiera prawidłowego klucza prywatnego.",
     "errorFileReadFailed": "Nie udało się odczytać pliku.",
     "errorInviteValidationFailed": "Nie można zweryfikować kodu zaproszenia",
-            "errorInviteCodeUsed": "Invite code already claimed - sorry!",
+            "errorInviteCodeUsed": "This invite code has already been used",
     "errorSignInStartFailed": "Nie można rozpocząć logowania",
     "errorWaitlistJoinFailed": "Nie można dołączyć do listy oczekujących"
   },

--- a/src/lib/i18n/locales/pl/common.json
+++ b/src/lib/i18n/locales/pl/common.json
@@ -437,7 +437,7 @@
     "errorFileNoValidKey": "Plik nie zawiera prawidłowego klucza prywatnego.",
     "errorFileReadFailed": "Nie udało się odczytać pliku.",
     "errorInviteValidationFailed": "Nie można zweryfikować kodu zaproszenia",
-            "errorInviteCodeUsed": "This invite code has already been used",
+    "errorInviteCodeUsed": "Ten kod zaproszenia został już użyty",
     "errorSignInStartFailed": "Nie można rozpocząć logowania",
     "errorWaitlistJoinFailed": "Nie można dołączyć do listy oczekujących"
   },
@@ -1401,14 +1401,14 @@
     "joinWaitlist": "Nie masz zaproszenia? Zapisz się na listę oczekujących."
   },
   "invitesLandingPage": {
-    "seoTitle": "Join diVine with invite code {{code}}",
-    "seoTitleDefault": "Join diVine",
-    "seoDescription": "You've been invited! Use invite code {{code}} to join diVine.",
-    "seoDescriptionDefault": "Use your invite code to join diVine and start sharing video.",
-    "heading": "You're Invited!",
-    "subheading": "Enter your invite code to join diVine",
-    "alreadyHaveAccount": "Already have an account?",
-    "signIn": "Sign in"
+    "seoTitle": "Dołącz do diVine z kodem zaproszenia {{code}}",
+    "seoTitleDefault": "Dołącz do diVine",
+    "seoDescription": "Masz zaproszenie! Użyj kodu {{code}}, aby dołączyć do diVine.",
+    "seoDescriptionDefault": "Użyj kodu zaproszenia, aby dołączyć do diVine i zacząć udostępniać wideo.",
+    "heading": "Masz zaproszenie!",
+    "subheading": "Wpisz kod zaproszenia, aby dołączyć do diVine",
+    "alreadyHaveAccount": "Masz już konto?",
+    "signIn": "Zaloguj się"
   },
   "applePodcastEmbed": {
     "defaultTitle": "Vine Revisited and The Fight Against AI Slop",

--- a/src/lib/i18n/locales/pt/common.json
+++ b/src/lib/i18n/locales/pt/common.json
@@ -435,7 +435,7 @@
     "errorFileNoValidKey": "O arquivo não contém uma chave secreta válida.",
     "errorFileReadFailed": "Falha ao ler o arquivo.",
     "errorInviteValidationFailed": "Não foi possível validar o código de convite",
-            "errorInviteCodeUsed": "Invite code already claimed - sorry!",
+            "errorInviteCodeUsed": "This invite code has already been used",
     "errorSignInStartFailed": "Não foi possível iniciar o login",
     "errorWaitlistJoinFailed": "Não foi possível entrar na lista de espera"
   },

--- a/src/lib/i18n/locales/pt/common.json
+++ b/src/lib/i18n/locales/pt/common.json
@@ -435,7 +435,7 @@
     "errorFileNoValidKey": "O arquivo não contém uma chave secreta válida.",
     "errorFileReadFailed": "Falha ao ler o arquivo.",
     "errorInviteValidationFailed": "Não foi possível validar o código de convite",
-            "errorInviteCodeUsed": "This invite code has already been used",
+            "errorInviteCodeUsed": "Invite code already claimed - sorry!",
     "errorSignInStartFailed": "Não foi possível iniciar o login",
     "errorWaitlistJoinFailed": "Não foi possível entrar na lista de espera"
   },

--- a/src/lib/i18n/locales/pt/common.json
+++ b/src/lib/i18n/locales/pt/common.json
@@ -435,7 +435,7 @@
     "errorFileNoValidKey": "O arquivo não contém uma chave secreta válida.",
     "errorFileReadFailed": "Falha ao ler o arquivo.",
     "errorInviteValidationFailed": "Não foi possível validar o código de convite",
-            "errorInviteCodeUsed": "This invite code has already been used",
+    "errorInviteCodeUsed": "Este código de convite já foi usado",
     "errorSignInStartFailed": "Não foi possível iniciar o login",
     "errorWaitlistJoinFailed": "Não foi possível entrar na lista de espera"
   },
@@ -1399,14 +1399,14 @@
     "joinWaitlist": "Sem convite? Entre na lista de espera."
   },
   "invitesLandingPage": {
-    "seoTitle": "Join diVine with invite code {{code}}",
-    "seoTitleDefault": "Join diVine",
-    "seoDescription": "You've been invited! Use invite code {{code}} to join diVine.",
-    "seoDescriptionDefault": "Use your invite code to join diVine and start sharing video.",
-    "heading": "You're Invited!",
-    "subheading": "Enter your invite code to join diVine",
-    "alreadyHaveAccount": "Already have an account?",
-    "signIn": "Sign in"
+    "seoTitle": "Entre no diVine com o código de convite {{code}}",
+    "seoTitleDefault": "Entre no diVine",
+    "seoDescription": "Você recebeu um convite! Use o código {{code}} para entrar no diVine.",
+    "seoDescriptionDefault": "Use seu código de convite para entrar no diVine e começar a compartilhar vídeo.",
+    "heading": "Você recebeu um convite!",
+    "subheading": "Digite seu código de convite para entrar no diVine",
+    "alreadyHaveAccount": "Já tem uma conta?",
+    "signIn": "Entrar"
   },
   "applePodcastEmbed": {
     "defaultTitle": "Vine Revisited and The Fight Against AI Slop",

--- a/src/lib/i18n/locales/pt/common.json
+++ b/src/lib/i18n/locales/pt/common.json
@@ -435,6 +435,7 @@
     "errorFileNoValidKey": "O arquivo não contém uma chave secreta válida.",
     "errorFileReadFailed": "Falha ao ler o arquivo.",
     "errorInviteValidationFailed": "Não foi possível validar o código de convite",
+            "errorInviteCodeUsed": "This invite code has already been used",
     "errorSignInStartFailed": "Não foi possível iniciar o login",
     "errorWaitlistJoinFailed": "Não foi possível entrar na lista de espera"
   },

--- a/src/lib/i18n/locales/pt/common.json
+++ b/src/lib/i18n/locales/pt/common.json
@@ -1397,6 +1397,16 @@
     "continue": "Continuar",
     "joinWaitlist": "Sem convite? Entre na lista de espera."
   },
+  "invitesLandingPage": {
+    "seoTitle": "Join diVine with invite code {{code}}",
+    "seoTitleDefault": "Join diVine",
+    "seoDescription": "You've been invited! Use invite code {{code}} to join diVine.",
+    "seoDescriptionDefault": "Use your invite code to join diVine and start sharing video.",
+    "heading": "You're Invited!",
+    "subheading": "Enter your invite code to join diVine",
+    "alreadyHaveAccount": "Already have an account?",
+    "signIn": "Sign in"
+  },
   "applePodcastEmbed": {
     "defaultTitle": "Vine Revisited and The Fight Against AI Slop",
     "defaultDescription": "Os bastidores do lançamento do Divine",

--- a/src/lib/i18n/locales/ro/common.json
+++ b/src/lib/i18n/locales/ro/common.json
@@ -436,6 +436,7 @@
     "errorFileNoValidKey": "Fișierul nu conține o cheie secretă validă.",
     "errorFileReadFailed": "Citirea fișierului a eșuat.",
     "errorInviteValidationFailed": "Codul de invitație nu poate fi validat",
+            "errorInviteCodeUsed": "This invite code has already been used",
     "errorSignInStartFailed": "Conectarea nu poate fi pornită",
     "errorWaitlistJoinFailed": "Înscrierea pe lista de așteptare a eșuat"
   },

--- a/src/lib/i18n/locales/ro/common.json
+++ b/src/lib/i18n/locales/ro/common.json
@@ -436,7 +436,7 @@
     "errorFileNoValidKey": "Fișierul nu conține o cheie secretă validă.",
     "errorFileReadFailed": "Citirea fișierului a eșuat.",
     "errorInviteValidationFailed": "Codul de invitație nu poate fi validat",
-            "errorInviteCodeUsed": "This invite code has already been used",
+            "errorInviteCodeUsed": "Invite code already claimed - sorry!",
     "errorSignInStartFailed": "Conectarea nu poate fi pornită",
     "errorWaitlistJoinFailed": "Înscrierea pe lista de așteptare a eșuat"
   },

--- a/src/lib/i18n/locales/ro/common.json
+++ b/src/lib/i18n/locales/ro/common.json
@@ -436,7 +436,7 @@
     "errorFileNoValidKey": "Fișierul nu conține o cheie secretă validă.",
     "errorFileReadFailed": "Citirea fișierului a eșuat.",
     "errorInviteValidationFailed": "Codul de invitație nu poate fi validat",
-            "errorInviteCodeUsed": "This invite code has already been used",
+    "errorInviteCodeUsed": "Acest cod de invitație a fost deja folosit",
     "errorSignInStartFailed": "Conectarea nu poate fi pornită",
     "errorWaitlistJoinFailed": "Înscrierea pe lista de așteptare a eșuat"
   },
@@ -1400,14 +1400,14 @@
     "joinWaitlist": "N-ai invitație? Înscrie-te pe lista de așteptare."
   },
   "invitesLandingPage": {
-    "seoTitle": "Join diVine with invite code {{code}}",
-    "seoTitleDefault": "Join diVine",
-    "seoDescription": "You've been invited! Use invite code {{code}} to join diVine.",
-    "seoDescriptionDefault": "Use your invite code to join diVine and start sharing video.",
-    "heading": "You're Invited!",
-    "subheading": "Enter your invite code to join diVine",
-    "alreadyHaveAccount": "Already have an account?",
-    "signIn": "Sign in"
+    "seoTitle": "Alătură-te diVine cu codul de invitație {{code}}",
+    "seoTitleDefault": "Alătură-te diVine",
+    "seoDescription": "Ai fost invitat! Folosește codul {{code}} ca să te alături diVine.",
+    "seoDescriptionDefault": "Folosește codul tău de invitație ca să te alături diVine și să începi să distribui video.",
+    "heading": "Ești invitat!",
+    "subheading": "Introdu codul de invitație ca să te alături diVine",
+    "alreadyHaveAccount": "Ai deja un cont?",
+    "signIn": "Conectează-te"
   },
   "applePodcastEmbed": {
     "defaultTitle": "Vine Revisited and The Fight Against AI Slop",

--- a/src/lib/i18n/locales/ro/common.json
+++ b/src/lib/i18n/locales/ro/common.json
@@ -436,7 +436,7 @@
     "errorFileNoValidKey": "Fișierul nu conține o cheie secretă validă.",
     "errorFileReadFailed": "Citirea fișierului a eșuat.",
     "errorInviteValidationFailed": "Codul de invitație nu poate fi validat",
-            "errorInviteCodeUsed": "Invite code already claimed - sorry!",
+            "errorInviteCodeUsed": "This invite code has already been used",
     "errorSignInStartFailed": "Conectarea nu poate fi pornită",
     "errorWaitlistJoinFailed": "Înscrierea pe lista de așteptare a eșuat"
   },

--- a/src/lib/i18n/locales/ro/common.json
+++ b/src/lib/i18n/locales/ro/common.json
@@ -1398,6 +1398,16 @@
     "continue": "Continuă",
     "joinWaitlist": "N-ai invitație? Înscrie-te pe lista de așteptare."
   },
+  "invitesLandingPage": {
+    "seoTitle": "Join diVine with invite code {{code}}",
+    "seoTitleDefault": "Join diVine",
+    "seoDescription": "You've been invited! Use invite code {{code}} to join diVine.",
+    "seoDescriptionDefault": "Use your invite code to join diVine and start sharing video.",
+    "heading": "You're Invited!",
+    "subheading": "Enter your invite code to join diVine",
+    "alreadyHaveAccount": "Already have an account?",
+    "signIn": "Sign in"
+  },
   "applePodcastEmbed": {
     "defaultTitle": "Vine Revisited and The Fight Against AI Slop",
     "defaultDescription": "În culisele lansării Divine",

--- a/src/lib/i18n/locales/sv/common.json
+++ b/src/lib/i18n/locales/sv/common.json
@@ -1397,6 +1397,16 @@
     "continue": "Fortsätt",
     "joinWaitlist": "Ingen inbjudan? Ställ dig på väntelistan."
   },
+  "invitesLandingPage": {
+    "seoTitle": "Join diVine with invite code {{code}}",
+    "seoTitleDefault": "Join diVine",
+    "seoDescription": "You've been invited! Use invite code {{code}} to join diVine.",
+    "seoDescriptionDefault": "Use your invite code to join diVine and start sharing video.",
+    "heading": "You're Invited!",
+    "subheading": "Enter your invite code to join diVine",
+    "alreadyHaveAccount": "Already have an account?",
+    "signIn": "Sign in"
+  },
   "applePodcastEmbed": {
     "defaultTitle": "Vine Revisited and The Fight Against AI Slop",
     "defaultDescription": "Bakom kulisserna på Divine-lanseringen",

--- a/src/lib/i18n/locales/sv/common.json
+++ b/src/lib/i18n/locales/sv/common.json
@@ -435,7 +435,7 @@
     "errorFileNoValidKey": "Filen innehåller ingen giltig hemlig nyckel.",
     "errorFileReadFailed": "Kunde inte läsa filen.",
     "errorInviteValidationFailed": "Kunde inte validera inbjudningskoden",
-            "errorInviteCodeUsed": "This invite code has already been used",
+            "errorInviteCodeUsed": "Invite code already claimed - sorry!",
     "errorSignInStartFailed": "Kunde inte starta inloggning",
     "errorWaitlistJoinFailed": "Kunde inte gå med i väntelistan"
   },

--- a/src/lib/i18n/locales/sv/common.json
+++ b/src/lib/i18n/locales/sv/common.json
@@ -435,7 +435,7 @@
     "errorFileNoValidKey": "Filen innehåller ingen giltig hemlig nyckel.",
     "errorFileReadFailed": "Kunde inte läsa filen.",
     "errorInviteValidationFailed": "Kunde inte validera inbjudningskoden",
-            "errorInviteCodeUsed": "This invite code has already been used",
+    "errorInviteCodeUsed": "Den här inbjudningskoden har redan använts",
     "errorSignInStartFailed": "Kunde inte starta inloggning",
     "errorWaitlistJoinFailed": "Kunde inte gå med i väntelistan"
   },
@@ -1399,14 +1399,14 @@
     "joinWaitlist": "Ingen inbjudan? Ställ dig på väntelistan."
   },
   "invitesLandingPage": {
-    "seoTitle": "Join diVine with invite code {{code}}",
-    "seoTitleDefault": "Join diVine",
-    "seoDescription": "You've been invited! Use invite code {{code}} to join diVine.",
-    "seoDescriptionDefault": "Use your invite code to join diVine and start sharing video.",
-    "heading": "You're Invited!",
-    "subheading": "Enter your invite code to join diVine",
-    "alreadyHaveAccount": "Already have an account?",
-    "signIn": "Sign in"
+    "seoTitle": "Gå med i diVine med inbjudningskoden {{code}}",
+    "seoTitleDefault": "Gå med i diVine",
+    "seoDescription": "Du har blivit inbjuden! Använd koden {{code}} för att gå med i diVine.",
+    "seoDescriptionDefault": "Använd din inbjudningskod för att gå med i diVine och börja dela video.",
+    "heading": "Du är inbjuden!",
+    "subheading": "Ange din inbjudningskod för att gå med i diVine",
+    "alreadyHaveAccount": "Har du redan ett konto?",
+    "signIn": "Logga in"
   },
   "applePodcastEmbed": {
     "defaultTitle": "Vine Revisited and The Fight Against AI Slop",

--- a/src/lib/i18n/locales/sv/common.json
+++ b/src/lib/i18n/locales/sv/common.json
@@ -435,6 +435,7 @@
     "errorFileNoValidKey": "Filen innehåller ingen giltig hemlig nyckel.",
     "errorFileReadFailed": "Kunde inte läsa filen.",
     "errorInviteValidationFailed": "Kunde inte validera inbjudningskoden",
+            "errorInviteCodeUsed": "This invite code has already been used",
     "errorSignInStartFailed": "Kunde inte starta inloggning",
     "errorWaitlistJoinFailed": "Kunde inte gå med i väntelistan"
   },

--- a/src/lib/i18n/locales/sv/common.json
+++ b/src/lib/i18n/locales/sv/common.json
@@ -435,7 +435,7 @@
     "errorFileNoValidKey": "Filen innehåller ingen giltig hemlig nyckel.",
     "errorFileReadFailed": "Kunde inte läsa filen.",
     "errorInviteValidationFailed": "Kunde inte validera inbjudningskoden",
-            "errorInviteCodeUsed": "Invite code already claimed - sorry!",
+            "errorInviteCodeUsed": "This invite code has already been used",
     "errorSignInStartFailed": "Kunde inte starta inloggning",
     "errorWaitlistJoinFailed": "Kunde inte gå med i väntelistan"
   },

--- a/src/lib/i18n/locales/tr/common.json
+++ b/src/lib/i18n/locales/tr/common.json
@@ -435,7 +435,7 @@
     "errorFileNoValidKey": "Dosya geçerli bir gizli anahtar içermiyor.",
     "errorFileReadFailed": "Dosya okunamadı.",
     "errorInviteValidationFailed": "Davet kodu doğrulanamadı",
-            "errorInviteCodeUsed": "This invite code has already been used",
+            "errorInviteCodeUsed": "Invite code already claimed - sorry!",
     "errorSignInStartFailed": "Giriş başlatılamadı",
     "errorWaitlistJoinFailed": "Bekleme listesine katılınamadı"
   },

--- a/src/lib/i18n/locales/tr/common.json
+++ b/src/lib/i18n/locales/tr/common.json
@@ -1397,6 +1397,16 @@
     "continue": "Devam et",
     "joinWaitlist": "Davetin yok mu? Bekleme listesine katıl."
   },
+  "invitesLandingPage": {
+    "seoTitle": "Join diVine with invite code {{code}}",
+    "seoTitleDefault": "Join diVine",
+    "seoDescription": "You've been invited! Use invite code {{code}} to join diVine.",
+    "seoDescriptionDefault": "Use your invite code to join diVine and start sharing video.",
+    "heading": "You're Invited!",
+    "subheading": "Enter your invite code to join diVine",
+    "alreadyHaveAccount": "Already have an account?",
+    "signIn": "Sign in"
+  },
   "applePodcastEmbed": {
     "defaultTitle": "Vine Revisited and The Fight Against AI Slop",
     "defaultDescription": "Divine lansmanının perde arkası",

--- a/src/lib/i18n/locales/tr/common.json
+++ b/src/lib/i18n/locales/tr/common.json
@@ -435,7 +435,7 @@
     "errorFileNoValidKey": "Dosya geçerli bir gizli anahtar içermiyor.",
     "errorFileReadFailed": "Dosya okunamadı.",
     "errorInviteValidationFailed": "Davet kodu doğrulanamadı",
-            "errorInviteCodeUsed": "Invite code already claimed - sorry!",
+            "errorInviteCodeUsed": "This invite code has already been used",
     "errorSignInStartFailed": "Giriş başlatılamadı",
     "errorWaitlistJoinFailed": "Bekleme listesine katılınamadı"
   },

--- a/src/lib/i18n/locales/tr/common.json
+++ b/src/lib/i18n/locales/tr/common.json
@@ -435,7 +435,7 @@
     "errorFileNoValidKey": "Dosya geçerli bir gizli anahtar içermiyor.",
     "errorFileReadFailed": "Dosya okunamadı.",
     "errorInviteValidationFailed": "Davet kodu doğrulanamadı",
-            "errorInviteCodeUsed": "This invite code has already been used",
+    "errorInviteCodeUsed": "Bu davet kodu zaten kullanılmış",
     "errorSignInStartFailed": "Giriş başlatılamadı",
     "errorWaitlistJoinFailed": "Bekleme listesine katılınamadı"
   },
@@ -1399,14 +1399,14 @@
     "joinWaitlist": "Davetin yok mu? Bekleme listesine katıl."
   },
   "invitesLandingPage": {
-    "seoTitle": "Join diVine with invite code {{code}}",
-    "seoTitleDefault": "Join diVine",
-    "seoDescription": "You've been invited! Use invite code {{code}} to join diVine.",
-    "seoDescriptionDefault": "Use your invite code to join diVine and start sharing video.",
-    "heading": "You're Invited!",
-    "subheading": "Enter your invite code to join diVine",
-    "alreadyHaveAccount": "Already have an account?",
-    "signIn": "Sign in"
+    "seoTitle": "{{code}} davet koduyla diVine'a katıl",
+    "seoTitleDefault": "diVine'a katıl",
+    "seoDescription": "Davet edildin! diVine'a katılmak için {{code}} kodunu kullan.",
+    "seoDescriptionDefault": "diVine'a katılıp video paylaşmaya başlamak için davet kodunu kullan.",
+    "heading": "Davetlisin!",
+    "subheading": "diVine'a katılmak için davet kodunu gir",
+    "alreadyHaveAccount": "Zaten hesabın var mı?",
+    "signIn": "Giriş yap"
   },
   "applePodcastEmbed": {
     "defaultTitle": "Vine Revisited and The Fight Against AI Slop",

--- a/src/lib/i18n/locales/tr/common.json
+++ b/src/lib/i18n/locales/tr/common.json
@@ -435,6 +435,7 @@
     "errorFileNoValidKey": "Dosya geçerli bir gizli anahtar içermiyor.",
     "errorFileReadFailed": "Dosya okunamadı.",
     "errorInviteValidationFailed": "Davet kodu doğrulanamadı",
+            "errorInviteCodeUsed": "This invite code has already been used",
     "errorSignInStartFailed": "Giriş başlatılamadı",
     "errorWaitlistJoinFailed": "Bekleme listesine katılınamadı"
   },

--- a/src/lib/inviteApi.ts
+++ b/src/lib/inviteApi.ts
@@ -21,12 +21,14 @@ export interface WaitlistJoinResult {
 export class InviteApiError extends Error {
   code: InviteApiErrorCode;
   status: number;
+  inviteStatus?: string;
 
-  constructor(message: string, code: InviteApiErrorCode, status: number) {
+  constructor(message: string, code: InviteApiErrorCode, status: number, inviteStatus?: string) {
     super(message);
     this.name = 'InviteApiError';
     this.code = code;
     this.status = status;
+    this.inviteStatus = inviteStatus;
   }
 }
 
@@ -45,16 +47,17 @@ async function readJson(response: Response): Promise<Record<string, unknown>> {
 function toInviteApiError(response: Response, body: Record<string, unknown>): InviteApiError {
   const code = typeof body.code === 'string' ? body.code : undefined;
   const message = typeof body.error === 'string' ? body.error : 'Invite service request failed';
+  const inviteStatus = typeof body.status === 'string' ? body.status : undefined;
 
   if (response.status === 400 || response.status === 404 || code === 'invalid_invite') {
-    return new InviteApiError(message, 'invalid_invite', response.status);
+    return new InviteApiError(message, 'invalid_invite', response.status, inviteStatus);
   }
 
   if (response.status >= 500 || response.status === 0) {
-    return new InviteApiError(message, 'unavailable', response.status);
+    return new InviteApiError(message, 'unavailable', response.status, inviteStatus);
   }
 
-  return new InviteApiError(message, 'unknown', response.status);
+  return new InviteApiError(message, 'unknown', response.status, inviteStatus);
 }
 
 function toNetworkInviteApiError(error: unknown): InviteApiError {

--- a/src/pages/InvitesLandingPage.test.tsx
+++ b/src/pages/InvitesLandingPage.test.tsx
@@ -1,0 +1,139 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { LOCALE_STORAGE_KEY } from '@/lib/i18n/config';
+import { initializeI18n } from '@/lib/i18n';
+import InvitesLandingPage from './InvitesLandingPage';
+
+const { mockValidateInviteCode, mockNavigate, mockCurrentUser } = vi.hoisted(() => ({
+  mockValidateInviteCode: vi.fn(),
+  mockNavigate: vi.fn(),
+  mockCurrentUser: { user: null as { pubkey: string } | null },
+}));
+
+vi.mock('@/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => mockCurrentUser,
+}));
+
+vi.mock('@/lib/inviteApi', () => ({
+  validateInviteCode: mockValidateInviteCode,
+  InviteApiError: class InviteApiError extends Error {
+    code: 'invalid_invite' | 'unavailable' | 'unknown';
+    status: number;
+    inviteStatus?: string;
+    constructor(message: string, code: 'invalid_invite' | 'unavailable' | 'unknown', status: number, inviteStatus?: string) {
+      super(message);
+      this.name = 'InviteApiError';
+      this.code = code;
+      this.status = status;
+      this.inviteStatus = inviteStatus;
+    }
+  },
+}));
+
+vi.mock('@unhead/react', () => ({
+  useHead: () => undefined,
+  useSeoMeta: () => undefined,
+}));
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+function renderAt(url: string) {
+  return render(
+    <MemoryRouter initialEntries={[url]}>
+      <Routes>
+        <Route path="/invite/:code" element={<InvitesLandingPage />} />
+        <Route path="/home" element={<div data-testid="home-page">Home</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('InvitesLandingPage', () => {
+  beforeEach(async () => {
+    mockValidateInviteCode.mockReset();
+    mockNavigate.mockReset();
+    mockCurrentUser.user = null;
+
+    const storage = new Map<string, string>();
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: (key: string) => storage.get(key) ?? null,
+        setItem: (key: string, value: string) => storage.set(key, value),
+        removeItem: (key: string) => storage.delete(key),
+        clear: () => storage.clear(),
+      },
+    });
+
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, 'en');
+    await initializeI18n({ force: true, languages: ['en-US'] });
+  });
+
+  it('shows the heading and pre-fills the code from the URL when the API confirms it is valid', async () => {
+    mockValidateInviteCode.mockResolvedValue({ valid: true, normalizedCode: 'ABCD-1234' });
+
+    renderAt('/invite/ABCD-1234');
+
+    expect(screen.getByRole('heading', { name: "You're Invited!" })).toBeInTheDocument();
+    expect(screen.getByLabelText('Invite code')).toHaveValue('ABCD-1234');
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('shows a specific used-code message when the API returns status: "used"', async () => {
+    mockValidateInviteCode.mockRejectedValue(
+      new (class extends Error {
+        code = 'invalid_invite' as const;
+        status = 400;
+        inviteStatus = 'used';
+        constructor() {
+          super('This invite code has already been used');
+          this.name = 'InviteApiError';
+        }
+      })(),
+    );
+
+    renderAt('/invite/ZHV5-HECU');
+
+    await waitFor(() => {
+      expect(screen.getByText('This invite code has already been used')).toBeInTheDocument();
+    });
+  });
+
+  it('falls back to the generic error message for codes the API marks as invalid', async () => {
+    mockValidateInviteCode.mockRejectedValue(
+      new (class extends Error {
+        code = 'invalid_invite' as const;
+        status = 400;
+        inviteStatus = 'invalid';
+        constructor() {
+          super('Unable to validate invite code');
+          this.name = 'InviteApiError';
+        }
+      })(),
+    );
+
+    renderAt('/invite/NOTREAL-9999');
+
+    await waitFor(() => {
+      expect(screen.getByText('Unable to validate invite code')).toBeInTheDocument();
+    });
+  });
+
+  it('navigates to /home when the visitor is already logged in', async () => {
+    mockCurrentUser.user = { pubkey: 'a'.repeat(64) };
+    mockValidateInviteCode.mockResolvedValue({ valid: true, normalizedCode: 'ABCD-1234' });
+
+    renderAt('/invite/ABCD-1234');
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/home', { replace: true });
+    });
+  });
+});

--- a/src/pages/InvitesLandingPage.test.tsx
+++ b/src/pages/InvitesLandingPage.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { LOCALE_STORAGE_KEY } from '@/lib/i18n/config';
 import { initializeI18n } from '@/lib/i18n';
+import { InviteApiError } from '@/lib/inviteApi';
 import InvitesLandingPage from './InvitesLandingPage';
 
 const { mockValidateInviteCode, mockNavigate, mockCurrentUser } = vi.hoisted(() => ({
@@ -82,21 +83,15 @@ describe('InvitesLandingPage', () => {
     renderAt('/invite/ABCD-1234');
 
     expect(screen.getByRole('heading', { name: "You're Invited!" })).toBeInTheDocument();
-    expect(screen.getByLabelText('Invite code')).toHaveValue('ABCD-1234');
+    await waitFor(() => {
+      expect(screen.getByLabelText('Invite code')).toHaveValue('ABCD-1234');
+    });
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 
   it('shows a specific used-code message when the API returns status: "used"', async () => {
     mockValidateInviteCode.mockRejectedValue(
-      new (class extends Error {
-        code = 'invalid_invite' as const;
-        status = 400;
-        inviteStatus = 'used';
-        constructor() {
-          super('This invite code has already been used');
-          this.name = 'InviteApiError';
-        }
-      })(),
+      new InviteApiError('Invite already claimed', 'invalid_invite', 400, 'used'),
     );
 
     renderAt('/invite/ZHV5-HECU');
@@ -108,15 +103,7 @@ describe('InvitesLandingPage', () => {
 
   it('falls back to the generic error message for codes the API marks as invalid', async () => {
     mockValidateInviteCode.mockRejectedValue(
-      new (class extends Error {
-        code = 'invalid_invite' as const;
-        status = 400;
-        inviteStatus = 'invalid';
-        constructor() {
-          super('Unable to validate invite code');
-          this.name = 'InviteApiError';
-        }
-      })(),
+      new InviteApiError('Invite not found', 'invalid_invite', 400, 'invalid'),
     );
 
     renderAt('/invite/NOTREAL-9999');
@@ -135,5 +122,6 @@ describe('InvitesLandingPage', () => {
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith('/home', { replace: true });
     });
+    expect(mockValidateInviteCode).not.toHaveBeenCalled();
   });
 });

--- a/src/pages/InvitesLandingPage.tsx
+++ b/src/pages/InvitesLandingPage.tsx
@@ -1,10 +1,11 @@
 import { FormEvent, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { useHead, useSeoMeta } from '@unhead/react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { BrandLogo } from '@/components/brand/BrandLogo';
 import { InviteCodeForm } from '@/components/auth/InviteCodeForm';
+import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { DIVINE_IOS_APP_ID } from '@/lib/mobileStoreLinks';
 import { setInviteHandoff } from '@/lib/authHandoff';
 import { buildSignupRedirect } from '@/lib/divineLogin';
@@ -13,11 +14,19 @@ import { validateInviteCode, InviteApiError } from '@/lib/inviteApi';
 const InvitesLandingPage = () => {
   const { t } = useTranslation();
   const { code } = useParams<{ code: string }>();
+  const { user } = useCurrentUser();
+  const navigate = useNavigate();
 
   const [inviteCode, setInviteCode] = useState(code ?? '');
   const [isValidating, setIsValidating] = useState(true);
   const [validationError, setValidationError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (user?.pubkey) {
+      navigate('/home', { replace: true });
+    }
+  }, [user, navigate]);
 
   useSeoMeta({
     title: code ? t('invitesLandingPage.seoTitle', { code }) : t('invitesLandingPage.seoTitleDefault'),

--- a/src/pages/InvitesLandingPage.tsx
+++ b/src/pages/InvitesLandingPage.tsx
@@ -3,7 +3,9 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useHead, useSeoMeta } from '@unhead/react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { BrandLogo } from '@/components/brand/BrandLogo';
+import { SectionHeader } from '@/components/brand/SectionHeader';
 import { InviteCodeForm } from '@/components/auth/InviteCodeForm';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { DIVINE_IOS_APP_ID } from '@/lib/mobileStoreLinks';
@@ -117,25 +119,26 @@ const InvitesLandingPage = () => {
 
           {/* Header */}
           <div className="space-y-2">
-            <h1 className="text-3xl font-bold tracking-tight text-foreground">
+            <SectionHeader as="h2" className="text-3xl">
               {t('invitesLandingPage.heading')}
-            </h1>
+            </SectionHeader>
             <p className="text-muted-foreground">{t('invitesLandingPage.subheading')}</p>
           </div>
 
           {/* Content Card */}
-          <div className="rounded-2xl bg-card p-6 shadow-lg">
-            {isValidating ? (
-              <div className="rounded-2xl bg-muted px-4 py-6 text-center text-sm text-muted-foreground">
-                {t('loginDialog.checkingInvite')}
-              </div>
-            ) : validationError ? (
-              <Alert variant="destructive">
-                <AlertDescription>{validationError}</AlertDescription>
-              </Alert>
-            ) : null}
-
-            <div className="mt-4">
+          <Card>
+            <CardHeader>
+              {isValidating ? (
+                <div className="rounded-2xl bg-muted px-4 py-6 text-center text-sm text-muted-foreground">
+                  {t('loginDialog.checkingInvite')}
+                </div>
+              ) : validationError ? (
+                <Alert variant="destructive">
+                  <AlertDescription>{validationError}</AlertDescription>
+                </Alert>
+              ) : null}
+            </CardHeader>
+            <CardContent>
               <InviteCodeForm
                 inputClassName="text-center text-lg font-mono tracking-widest"
                 isLoading={isSubmitting || isValidating}
@@ -144,8 +147,8 @@ const InvitesLandingPage = () => {
                 value={inviteCode}
                 waitlistEnabled={false}
               />
-            </div>
-          </div>
+            </CardContent>
+          </Card>
 
           {/* Footer */}
           <p className="text-sm text-muted-foreground">

--- a/src/pages/InvitesLandingPage.tsx
+++ b/src/pages/InvitesLandingPage.tsx
@@ -1,0 +1,151 @@
+import { FormEvent, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router-dom';
+import { useHead, useSeoMeta } from '@unhead/react';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { BrandLogo } from '@/components/brand/BrandLogo';
+import { InviteCodeForm } from '@/components/auth/InviteCodeForm';
+import { setInviteHandoff } from '@/lib/authHandoff';
+import { buildSignupRedirect } from '@/lib/divineLogin';
+import { validateInviteCode, InviteApiError } from '@/lib/inviteApi';
+
+const InvitesLandingPage = () => {
+  const { t } = useTranslation();
+  const { code } = useParams<{ code: string }>();
+
+  const [inviteCode, setInviteCode] = useState(code ?? '');
+  const [isValidating, setIsValidating] = useState(true);
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useSeoMeta({
+    title: code ? t('invitesLandingPage.seoTitle', { code }) : t('invitesLandingPage.seoTitleDefault'),
+    description: code
+      ? t('invitesLandingPage.seoDescription', { code })
+      : t('invitesLandingPage.seoDescriptionDefault'),
+  });
+
+  useHead({
+    meta: [
+      { name: 'apple-itunes-app', content: 'app-id=6747959501' },
+    ],
+  });
+
+  useEffect(() => {
+    if (!code) {
+      setIsValidating(false);
+      setValidationError(t('loginDialog.errorInviteValidationFailed'));
+      return;
+    }
+
+    let isCancelled = false;
+
+    validateInviteCode(code)
+      .then(() => {
+        if (!isCancelled) {
+          setInviteCode(code);
+          setValidationError(null);
+        }
+      })
+      .catch((caughtError) => {
+        if (!isCancelled) {
+          const message =
+            caughtError instanceof InviteApiError && caughtError.code === 'invalid_invite'
+              ? t('loginDialog.errorInviteValidationFailed')
+              : caughtError instanceof Error
+                ? caughtError.message
+                : t('loginDialog.inviteUnavailable');
+          setValidationError(message);
+        }
+      })
+      .finally(() => {
+        if (!isCancelled) {
+          setIsValidating(false);
+        }
+      });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [code, t]);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setValidationError(null);
+    setIsSubmitting(true);
+
+    try {
+      const result = await validateInviteCode(inviteCode);
+      const returnPath = `${window.location.pathname}${window.location.search}`;
+      setInviteHandoff({
+        code: result.normalizedCode,
+        mode: 'signup',
+        createdAt: Date.now(),
+        returnPath,
+      });
+      const redirect = await buildSignupRedirect({ returnPath });
+      window.location.assign(redirect.url);
+    } catch (caughtError) {
+      setValidationError(
+        caughtError instanceof Error ? caughtError.message : t('loginDialog.errorInviteValidationFailed'),
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-brand-off-white dark:bg-brand-dark-green">
+      <div className="flex min-h-screen flex-col items-center justify-center px-4">
+        <div className="w-full max-w-md space-y-8 text-center">
+          {/* Logo */}
+          <div className="mb-8 flex justify-center">
+            <BrandLogo className="h-12 w-auto" />
+          </div>
+
+          {/* Header */}
+          <div className="space-y-2">
+            <h1 className="text-3xl font-bold tracking-tight text-foreground">
+              {t('invitesLandingPage.heading')}
+            </h1>
+            <p className="text-muted-foreground">{t('invitesLandingPage.subheading')}</p>
+          </div>
+
+          {/* Content Card */}
+          <div className="rounded-2xl bg-card p-6 shadow-lg">
+            {isValidating ? (
+              <div className="rounded-2xl bg-muted px-4 py-6 text-center text-sm text-muted-foreground">
+                {t('loginDialog.checkingInvite')}
+              </div>
+            ) : validationError ? (
+              <Alert variant="destructive">
+                <AlertDescription>{validationError}</AlertDescription>
+              </Alert>
+            ) : null}
+
+            <div className="mt-4">
+              <InviteCodeForm
+                error={validationError}
+                isLoading={isSubmitting || isValidating}
+                onInviteCodeChange={setInviteCode}
+                onSubmit={handleSubmit}
+                value={inviteCode}
+                waitlistEnabled={false}
+              />
+            </div>
+          </div>
+
+          {/* Footer */}
+          <p className="text-sm text-muted-foreground">
+            {t('invitesLandingPage.alreadyHaveAccount')}{' '}
+            <a className="font-medium text-primary hover:underline" href="https://login.divine.video">
+              {t('invitesLandingPage.signIn')}
+            </a>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default InvitesLandingPage;

--- a/src/pages/InvitesLandingPage.tsx
+++ b/src/pages/InvitesLandingPage.tsx
@@ -11,6 +11,7 @@ import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { DIVINE_IOS_APP_ID } from '@/lib/mobileStoreLinks';
 import { setInviteHandoff } from '@/lib/authHandoff';
 import { buildSignupRedirect } from '@/lib/divineLogin';
+import { DIVINE_LOGIN_ORIGIN } from '@/lib/divineLoginOrigin';
 import { validateInviteCode, InviteApiError } from '@/lib/inviteApi';
 
 const InvitesLandingPage = () => {
@@ -44,6 +45,11 @@ const InvitesLandingPage = () => {
   });
 
   useEffect(() => {
+    if (user?.pubkey) {
+      setIsValidating(false);
+      return;
+    }
+
     if (!code) {
       setIsValidating(false);
       setValidationError(t('loginDialog.errorInviteValidationFailed'));
@@ -81,7 +87,7 @@ const InvitesLandingPage = () => {
     return () => {
       isCancelled = true;
     };
-  }, [code, t]);
+  }, [code, t, user?.pubkey]);
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -153,7 +159,7 @@ const InvitesLandingPage = () => {
           {/* Footer */}
           <p className="text-sm text-muted-foreground">
             {t('invitesLandingPage.alreadyHaveAccount')}{' '}
-            <a className="font-medium text-primary hover:underline" href="https://login.divine.video">
+            <a className="font-medium text-primary hover:underline" href={DIVINE_LOGIN_ORIGIN}>
               {t('invitesLandingPage.signIn')}
             </a>
           </p>

--- a/src/pages/InvitesLandingPage.tsx
+++ b/src/pages/InvitesLandingPage.tsx
@@ -50,11 +50,13 @@ const InvitesLandingPage = () => {
       .catch((caughtError) => {
         if (!isCancelled) {
           const message =
-            caughtError instanceof InviteApiError && caughtError.code === 'invalid_invite'
-              ? t('loginDialog.errorInviteValidationFailed')
-              : caughtError instanceof Error
-                ? caughtError.message
-                : t('loginDialog.inviteUnavailable');
+            caughtError instanceof InviteApiError && caughtError.inviteStatus === 'used'
+              ? t('loginDialog.errorInviteCodeUsed')
+              : caughtError instanceof InviteApiError && caughtError.code === 'invalid_invite'
+                ? t('loginDialog.errorInviteValidationFailed')
+                : caughtError instanceof Error
+                  ? caughtError.message
+                  : t('loginDialog.inviteUnavailable');
           setValidationError(message);
         }
       })
@@ -125,7 +127,7 @@ const InvitesLandingPage = () => {
 
             <div className="mt-4">
               <InviteCodeForm
-                error={validationError}
+                inputClassName="text-center text-lg font-mono tracking-widest"
                 isLoading={isSubmitting || isValidating}
                 onInviteCodeChange={setInviteCode}
                 onSubmit={handleSubmit}

--- a/src/pages/InvitesLandingPage.tsx
+++ b/src/pages/InvitesLandingPage.tsx
@@ -5,6 +5,7 @@ import { useHead, useSeoMeta } from '@unhead/react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { BrandLogo } from '@/components/brand/BrandLogo';
 import { InviteCodeForm } from '@/components/auth/InviteCodeForm';
+import { DIVINE_IOS_APP_ID } from '@/lib/mobileStoreLinks';
 import { setInviteHandoff } from '@/lib/authHandoff';
 import { buildSignupRedirect } from '@/lib/divineLogin';
 import { validateInviteCode, InviteApiError } from '@/lib/inviteApi';
@@ -27,7 +28,7 @@ const InvitesLandingPage = () => {
 
   useHead({
     meta: [
-      { name: 'apple-itunes-app', content: 'app-id=6747959501' },
+      { name: 'apple-itunes-app', content: `app-id=${DIVINE_IOS_APP_ID}` },
     ],
   });
 


### PR DESCRIPTION
## Context

When someone shares an invite code from our mobile app — like `ABCD-1234` — the URL that gets constructed is `https://divine.video/invite/ABCD-1234`. This is something we ship as a universal link, meant to open our app if someone's got it installed.

- **Android**: The intent filter in our manifest already handles `/invite/*` with `autoVerify="true"` — the app opens there.  
- **iOS**: We're not updating the AASA — users without the app will fall through to the web page.

The problem: visiting `/invite/:code` on web hit our 404 page. Nothing happened. The code was lost.

## What This Does

### 1. New page at `/invite/:code`
`InvitesLandingPage` reads the code from the URL, validates it against `/v1/validate`, and shows the appropriate state:

| State | Behavior |
|-------|----------|
| Valid code | Form pre-filled and ready to submit |
| Invalid code | Error shown, user can still enter their own code |
| Submit | Invite handoff stored in a cross-subdomain cookie, redirect to `login.divine.video` |
| Already-logged-in visitor | Redirects to `/home` (their feed), so the post-auth callback never loops them back |

The route is placed in `AppRouter` **outside** the auth-gated block, alongside other public routes like `/app/callback` and `/auth/callback`.

### 2. Smart App Banner for iOS
Added `apple-itunes-app` meta tag (using `DIVINE_IOS_APP_ID` from `mobileStoreLinks.ts` for consistency) — when someone visits from Safari on iOS without the app installed, they get the "Download in the App Store" banner.

### 3. i18n across all 16 locales
`src/lib/i18n/locales.test.ts` enforces key parity across all locales. Added 9 new keys (`invitesLandingPage.*` + `loginDialog.errorInviteCodeUsed`) to all 16 locale files with English placeholder values. The used-code path uses a contextual error message ("This invite code has already been used") for the `status: 'used'` API response. Proper translations can follow in a subsequent effort.

### 4. Brand consistency
Uses the standard `Card` + `CardHeader` + `CardContent` and the `SectionHeader` brand primitive so the public-facing surface matches the rest of the marketing pages.

### 5. Tests
`InvitesLandingPage.test.tsx` covers the four key paths: valid code, used code (`status: 'used'`), invalid code (`status: 'invalid'`), and the logged-in redirect.

## What I'd Like to See Next

- Proper translations for Spanish, French, Portuguese
- Possibly a follow-up to track adoption of the `/invite/:code` path (e.g., analytics event on page load)