### PR TITLE
fix(auth): bunker login dropped on cross-subdomain hydration (intermittent logout)

### DIFF
--- a/docs/superpowers/plans/2026-06-03-pr1-bunker-cookie-data-shape.md
+++ b/docs/superpowers/plans/2026-06-03-pr1-bunker-cookie-data-shape.md
@@ -1,0 +1,406 @@
+# PR 1 — Bunker cookie data-shape fix (Issue #390) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop moderators/team bunker logins from being silently dropped on cross-subdomain hydration by storing the bunker login `data` object (not the raw `bunker://` URI string) in the cross-subdomain cookie, validating it on rehydration, and self-healing poisoned entries.
+
+**Architecture:** The cross-subdomain cookie (`nostr_login`) currently stores the bunker payload under a single `bunkerUri` field written in two incompatible shapes (a `bunker://` string from fresh login, an object from the localStorage-sync path). Rehydration assigns that field straight into `login.data`, which `NUser.fromBunkerLogin` requires to be `{ bunkerPubkey, clientNsec, relays }` — a string makes it throw and the login is filtered out (apparent logout). The fix makes the cookie carry the structured object consistently, adds an `isValidBunkerData` guard so invalid/legacy payloads are ignored rather than persisted, and drops already-poisoned localStorage entries so the re-poison loop stops.
+
+**Tech Stack:** TypeScript, React, `@nostrify/react/login`, Vitest (jsdom-style mocks already present in the test file).
+
+**Issue:** Closes #390. Design: `docs/superpowers/specs/2026-06-03-bunker-team-intermittent-logout-design.md`.
+
+**Branch:** `fix/bunker-cookie-data-shape` (already created; spec already committed here).
+
+---
+
+## File Structure
+
+- **Modify:** `src/lib/crossSubdomainAuth.ts` — change `LoginCookieData.bunkerUri: string` → `bunkerData?: BunkerLoginData`; add exported type `BunkerLoginData` and guard `isValidBunkerData`; update the localStorage-sync writer and the rehydration reader; self-heal poisoned localStorage entries.
+- **Modify:** `src/hooks/useLoginActions.ts:26` — write `bunkerData: login.data` instead of `bunkerUri: uri` (TypeScript forces this once the type changes).
+- **Modify/Test:** `src/lib/crossSubdomainAuth.test.ts` — rewrite the existing buggy `bunkerUri` test (lines 182-195) and add round-trip / rejection / self-heal tests.
+
+No other files read `LoginCookieData.bunkerUri` (verified in Task 1, Step 1). The JWT cookie's separate `bunkerUrl` field is untouched.
+
+---
+
+### Task 1: Confirm no other consumers of `bunkerUri`
+
+**Files:** none (read-only verification)
+
+- [ ] **Step 1: Grep for any other reader/writer of the cookie field**
+
+Run:
+```bash
+cd /Users/mjb/code/divine-web
+grep -rn "bunkerUri" src --include="*.ts" --include="*.tsx"
+```
+Expected: matches ONLY in `src/lib/crossSubdomainAuth.ts` (interface field + read in `hydrateLoginFromCookie`) and `src/hooks/useLoginActions.ts:26`, plus `src/lib/crossSubdomainAuth.test.ts`. If `bunkerUri` appears anywhere else, stop and reconcile before continuing — the plan assumes only these consumers.
+
+Note: `bunkerUrl` (JWT cookie / `useDivineSession`) is a DIFFERENT field — ignore those matches.
+
+---
+
+### Task 2: Add `BunkerLoginData` type and `isValidBunkerData` guard
+
+**Files:**
+- Modify: `src/lib/crossSubdomainAuth.ts:13-17` (interface) and add a guard function
+- Test: `src/lib/crossSubdomainAuth.test.ts`
+
+- [ ] **Step 1: Write the failing test for the guard**
+
+Add to `src/lib/crossSubdomainAuth.test.ts` (import `isValidBunkerData` in the top import from `./crossSubdomainAuth`):
+
+```typescript
+describe('isValidBunkerData', () => {
+  it('accepts a well-formed bunker data object', () => {
+    expect(isValidBunkerData({
+      bunkerPubkey: 'abc',
+      clientNsec: 'nsec1examplekey',
+      relays: ['wss://relay.example'],
+    })).toBe(true);
+  });
+
+  it('rejects a raw bunker:// URI string', () => {
+    expect(isValidBunkerData('bunker://pub?relay=wss://r&secret=s')).toBe(false);
+  });
+
+  it('rejects an object missing clientNsec', () => {
+    expect(isValidBunkerData({ bunkerPubkey: 'abc', relays: ['wss://r'] })).toBe(false);
+  });
+
+  it('rejects an object with empty relays', () => {
+    expect(isValidBunkerData({ bunkerPubkey: 'abc', clientNsec: 'nsec1x', relays: [] })).toBe(false);
+  });
+
+  it('rejects null/undefined', () => {
+    expect(isValidBunkerData(null)).toBe(false);
+    expect(isValidBunkerData(undefined)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/lib/crossSubdomainAuth.test.ts -t isValidBunkerData`
+Expected: FAIL — `isValidBunkerData` is not exported / not defined.
+
+- [ ] **Step 3: Implement the type and guard**
+
+In `src/lib/crossSubdomainAuth.ts`, replace the `LoginCookieData` interface (lines 13-17):
+
+```typescript
+export interface BunkerLoginData {
+  bunkerPubkey: string;
+  clientNsec: string;
+  relays: string[];
+}
+
+interface LoginCookieData {
+  type: 'extension' | 'bunker' | 'nsec';
+  pubkey: string;
+  bunkerData?: BunkerLoginData; // only for bunker logins; the exact shape NUser.fromBunkerLogin consumes
+}
+
+/**
+ * Structural guard for a bunker login `data` payload. A raw `bunker://` URI
+ * string (the legacy/poisoned shape) and any partial object fail this, so they
+ * are never persisted into localStorage where NUser.fromBunkerLogin would throw.
+ */
+export function isValidBunkerData(data: unknown): data is BunkerLoginData {
+  if (!data || typeof data !== 'object') return false;
+  const d = data as Record<string, unknown>;
+  return (
+    typeof d.bunkerPubkey === 'string' &&
+    typeof d.clientNsec === 'string' &&
+    d.clientNsec.startsWith('nsec1') &&
+    Array.isArray(d.relays) &&
+    d.relays.length > 0
+  );
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run src/lib/crossSubdomainAuth.test.ts -t isValidBunkerData`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/crossSubdomainAuth.ts src/lib/crossSubdomainAuth.test.ts
+git commit -m "fix(auth): add BunkerLoginData type and isValidBunkerData guard"
+```
+
+---
+
+### Task 3: Rehydrate bunker logins from structured `bunkerData` (reject legacy strings)
+
+**Files:**
+- Modify: `src/lib/crossSubdomainAuth.ts:204-214` (the bunker rehydration branch)
+- Test: `src/lib/crossSubdomainAuth.test.ts:182-195` (rewrite) + new tests
+
+- [ ] **Step 1: Rewrite the existing buggy test and add rejection test**
+
+In `src/lib/crossSubdomainAuth.test.ts`, REPLACE the existing test at lines 182-195 (`when localStorage is empty and cookie has bunker login with URI, hydrates localStorage`) with:
+
+```typescript
+  it('when localStorage is empty and cookie has valid bunkerData, hydrates localStorage with the object', () => {
+    const bunkerData = {
+      bunkerPubkey: 'bunkerpub',
+      clientNsec: 'nsec1clientkey',
+      relays: ['wss://relay.example'],
+    };
+    const data = { type: 'bunker' as const, pubkey: 'pub789', bunkerData };
+    cookieJar = `nostr_login=${btoa(JSON.stringify(data))}`;
+
+    hydrateLoginFromCookie();
+
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+    expect(stored).toEqual([{
+      id: mockUUID,
+      type: 'bunker',
+      pubkey: 'pub789',
+      data: bunkerData,
+    }]);
+  });
+
+  it('when cookie has a legacy bunkerUri string (no bunkerData), does NOT hydrate', () => {
+    const data = { type: 'bunker' as const, pubkey: 'pub789', bunkerUri: 'bunker://xyz' };
+    cookieJar = `nostr_login=${btoa(JSON.stringify(data))}`;
+
+    hydrateLoginFromCookie();
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run src/lib/crossSubdomainAuth.test.ts -t "bunkerData"`
+Expected: the first new test FAILS (current code reads `cookie.bunkerUri`, writes `data: undefined`); the legacy-string test may pass incidentally but will be locked in by the implementation.
+
+- [ ] **Step 3: Implement the rehydration branch**
+
+In `src/lib/crossSubdomainAuth.ts`, REPLACE the bunker rehydration block (currently lines 204-214):
+
+```typescript
+  // For bunker logins, restore from the structured data object so the signer
+  // can be rebuilt. A legacy/poisoned cookie (raw bunker:// string under the old
+  // `bunkerUri` field, or any malformed payload) fails the guard and is ignored
+  // rather than persisted — NUser.fromBunkerLogin would throw on a bad shape and
+  // the user would appear logged out. They re-login instead.
+  if (cookie.type === 'bunker') {
+    if (isValidBunkerData(cookie.bunkerData)) {
+      const loginState = [{
+        id: crypto.randomUUID(),
+        type: 'bunker' as const,
+        pubkey: cookie.pubkey,
+        data: cookie.bunkerData,
+      }];
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(loginState));
+    }
+    return;
+  }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npx vitest run src/lib/crossSubdomainAuth.test.ts -t "bunkerData"`
+Expected: PASS. Also run the existing nsec/extension/empty hydration tests:
+Run: `npx vitest run src/lib/crossSubdomainAuth.test.ts -t hydrateLoginFromCookie`
+Expected: PASS (extension hydrate, nsec no-hydrate, empty, both new bunker tests, JWT tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/crossSubdomainAuth.ts src/lib/crossSubdomainAuth.test.ts
+git commit -m "fix(auth): rehydrate bunker login from structured bunkerData, reject legacy string"
+```
+
+---
+
+### Task 4: Sync `bunkerData` to the cookie and self-heal poisoned localStorage
+
+**Files:**
+- Modify: `src/lib/crossSubdomainAuth.ts:170-187` (the localStorage-sync branch)
+- Test: `src/lib/crossSubdomainAuth.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add inside the `describe('hydrateLoginFromCookie', ...)` block in `src/lib/crossSubdomainAuth.test.ts`:
+
+```typescript
+  it('when localStorage has a valid bunker login, syncs bunkerData object TO cookie', () => {
+    const bunkerData = {
+      bunkerPubkey: 'bunkerpub',
+      clientNsec: 'nsec1clientkey',
+      relays: ['wss://relay.example'],
+    };
+    const loginState = [{ id: '1', type: 'bunker', pubkey: 'pubB', data: bunkerData }];
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(loginState));
+
+    hydrateLoginFromCookie();
+
+    expect(getLoginCookie()).toEqual({ type: 'bunker', pubkey: 'pubB', bunkerData });
+    // localStorage unchanged
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY)!)).toEqual(loginState);
+  });
+
+  it('self-heals: drops a poisoned bunker login (string data) and does not poison the cookie', () => {
+    const loginState = [{ id: '1', type: 'bunker', pubkey: 'pubB', data: 'bunker://poisoned' }];
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(loginState));
+
+    hydrateLoginFromCookie();
+
+    // poisoned entry removed; cookie not written with a string payload
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+    expect(getLoginCookie()).toBeNull();
+  });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run src/lib/crossSubdomainAuth.test.ts -t "syncs bunkerData|self-heals"`
+Expected: FAIL — current sync writes `bunkerUri: first.data`, and there is no self-heal of poisoned entries.
+
+- [ ] **Step 3: Implement the localStorage-sync branch**
+
+In `src/lib/crossSubdomainAuth.ts`, REPLACE the localStorage-sync block (currently lines 169-187, starting at the `// Already logged in on this origin` comment) with:
+
+```typescript
+  // Already logged in on this origin - sync cookie FROM localStorage instead
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored) {
+    try {
+      const logins = JSON.parse(stored);
+      if (Array.isArray(logins) && logins.length > 0) {
+        // Self-heal: a bunker login whose `data` is not a valid object is the
+        // legacy/poisoned shape. Persisting it would make NUser.fromBunkerLogin
+        // throw (apparent logout) and re-syncing it would re-poison the shared
+        // cookie. Drop those entries instead.
+        const cleaned = logins.filter(
+          (l: { type?: string; data?: unknown }) =>
+            l.type !== 'bunker' || isValidBunkerData(l.data),
+        );
+        if (cleaned.length === 0) {
+          localStorage.removeItem(STORAGE_KEY);
+          clearLoginCookie();
+          return;
+        }
+        if (cleaned.length !== logins.length) {
+          localStorage.setItem(STORAGE_KEY, JSON.stringify(cleaned));
+        }
+
+        const first = cleaned[0];
+        // Keep cookie in sync with current login
+        setLoginCookie({
+          type: first.type,
+          pubkey: first.pubkey,
+          ...(first.type === 'bunker' && isValidBunkerData(first.data)
+            ? { bunkerData: first.data }
+            : {}),
+        });
+        return;
+      }
+    } catch {
+      // corrupted localStorage, continue to cookie check
+    }
+  }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npx vitest run src/lib/crossSubdomainAuth.test.ts`
+Expected: PASS (entire file, including the pre-existing extension-sync test and JWT tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/crossSubdomainAuth.ts src/lib/crossSubdomainAuth.test.ts
+git commit -m "fix(auth): sync bunkerData object to cookie and self-heal poisoned logins"
+```
+
+---
+
+### Task 5: Make fresh bunker login write `bunkerData` (type-forced)
+
+**Files:**
+- Modify: `src/hooks/useLoginActions.ts:26`
+
+- [ ] **Step 1: Verify the type error exists**
+
+Run: `npx tsc --noEmit`
+Expected: an error at `src/hooks/useLoginActions.ts:26` — object literal may only specify known properties, `bunkerUri` does not exist in type `LoginCookieData`. (This is the type system forcing the consistency fix.)
+
+- [ ] **Step 2: Update the cookie write**
+
+In `src/hooks/useLoginActions.ts`, change the bunker login (line 24-26) so the cookie carries the structured data object:
+
+```typescript
+    async bunker(uri: string): Promise<void> {
+      const login = await NLogin.fromBunker(uri, nostr);
+      addLogin(login);
+      setLoginCookie({ type: 'bunker', pubkey: login.pubkey, bunkerData: login.data });
+    },
+```
+
+(`login.data` from `NLogin.fromBunker` is exactly `{ bunkerPubkey, clientNsec, relays }`. The `uri` param is still used by `NLogin.fromBunker`, so no unused variable.)
+
+- [ ] **Step 3: Verify the type error is gone**
+
+Run: `npx tsc --noEmit`
+Expected: no errors (clean).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/hooks/useLoginActions.ts
+git commit -m "fix(auth): persist structured bunkerData on fresh bunker login"
+```
+
+---
+
+### Task 6: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 2: Run the full test suite**
+
+Run: `npx vitest run`
+Expected: PASS. If any unrelated pre-existing failures appear, confirm they exist on `main` before this branch (run `git stash` is not needed — just compare); do not fix unrelated failures in this PR.
+
+- [ ] **Step 3: Lint (if configured)**
+
+Run: `npm run lint`
+Expected: no new lint errors in the touched files. (If `lint` script is absent, skip.)
+
+- [ ] **Step 4: Confirm the branch diff is scoped**
+
+Run: `git diff main --stat`
+Expected: only `src/lib/crossSubdomainAuth.ts`, `src/lib/crossSubdomainAuth.test.ts`, `src/hooks/useLoginActions.ts`, and the spec/plan docs.
+
+---
+
+## Manual / staging validation (post-merge, document only)
+
+Automated tests cover the cookie round-trip. The cross-origin behavior is hard to
+reproduce in unit tests (per-origin localStorage). After deploy, validate per the
+spec's reproduction steps: log in on `divine.video` with a team bunker URL, open a
+sibling origin (e.g. a `*.divine.video` subdomain) with no localStorage, and confirm
+the session hydrates instead of showing logged-out. Legacy-poisoned users will need
+to re-login once (note in the issue).
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Structured `bunkerData` field (Task 2); `useLoginActions` writes the object (Task 5); sync path writes the object (Task 4); rehydration validates and assigns the object (Task 3); `isValidBunkerData` guard (Task 2); self-heal of poisoned localStorage (Task 4); back-compat drop of legacy `bunkerUri` string (Task 3). All spec items for PR 1 mapped.
+- **Placeholder scan:** none — every code step shows complete code.
+- **Type consistency:** `BunkerLoginData` / `isValidBunkerData` / `bunkerData` used consistently across Tasks 2-5; `login.data` shape matches `BunkerLoginData`.
+- **Not in scope (correctly):** `useCurrentUser` precedence (PR 2 / #391), refresh-token wiring (PR 3 / #391), the unused `bunkerToWindowNostr.ts`.

--- a/docs/superpowers/plans/2026-06-03-pr1-bunker-cookie-data-shape.md
+++ b/docs/superpowers/plans/2026-06-03-pr1-bunker-cookie-data-shape.md
@@ -257,12 +257,36 @@ Add inside the `describe('hydrateLoginFromCookie', ...)` block in `src/lib/cross
     expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
     expect(getLoginCookie()).toBeNull();
   });
+
+  it('self-recovers: poisoned local entry dropped, healthy cookie re-hydrates the session', () => {
+    const bunkerData = {
+      bunkerPubkey: 'bp',
+      clientNsec: 'nsec1goodkey',
+      relays: ['wss://relay.example'],
+    };
+    // poisoned localStorage on this origin
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([
+      { id: '1', type: 'bunker', pubkey: 'pubB', data: 'bunker://poisoned' },
+    ]));
+    // but a healthy shared cookie exists (written by another origin)
+    cookieJar = `nostr_login=${btoa(JSON.stringify({ type: 'bunker', pubkey: 'pubB', bunkerData }))}`;
+
+    hydrateLoginFromCookie();
+
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+    expect(stored).toEqual([{
+      id: mockUUID,
+      type: 'bunker',
+      pubkey: 'pubB',
+      data: bunkerData,
+    }]);
+  });
 ```
 
 - [ ] **Step 2: Run the tests to verify they fail**
 
-Run: `npx vitest run src/lib/crossSubdomainAuth.test.ts -t "syncs bunkerData|self-heals"`
-Expected: FAIL — current sync writes `bunkerUri: first.data`, and there is no self-heal of poisoned entries.
+Run: `npx vitest run src/lib/crossSubdomainAuth.test.ts -t "syncs bunkerData|self-heals|self-recovers"`
+Expected: FAIL — current sync writes `bunkerUri: first.data`, there is no self-heal of poisoned entries, and no fall-through recovery from a healthy cookie.
 
 - [ ] **Step 3: Implement the localStorage-sync branch**
 
@@ -278,30 +302,35 @@ In `src/lib/crossSubdomainAuth.ts`, REPLACE the localStorage-sync block (current
         // Self-heal: a bunker login whose `data` is not a valid object is the
         // legacy/poisoned shape. Persisting it would make NUser.fromBunkerLogin
         // throw (apparent logout) and re-syncing it would re-poison the shared
-        // cookie. Drop those entries instead.
+        // cookie. Drop those entries.
         const cleaned = logins.filter(
           (l: { type?: string; data?: unknown }) =>
             l.type !== 'bunker' || isValidBunkerData(l.data),
         );
-        if (cleaned.length === 0) {
-          localStorage.removeItem(STORAGE_KEY);
-          clearLoginCookie();
-          return;
-        }
         if (cleaned.length !== logins.length) {
-          localStorage.setItem(STORAGE_KEY, JSON.stringify(cleaned));
+          if (cleaned.length === 0) {
+            // Everything was poisoned. Remove the bad local state but DON'T clear
+            // the shared cookie or return — fall through to cookie hydration so a
+            // healthy cookie (written by another origin) can recover the session.
+            localStorage.removeItem(STORAGE_KEY);
+          } else {
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(cleaned));
+          }
         }
 
-        const first = cleaned[0];
-        // Keep cookie in sync with current login
-        setLoginCookie({
-          type: first.type,
-          pubkey: first.pubkey,
-          ...(first.type === 'bunker' && isValidBunkerData(first.data)
-            ? { bunkerData: first.data }
-            : {}),
-        });
-        return;
+        if (cleaned.length > 0) {
+          const first = cleaned[0];
+          // Keep cookie in sync with current login
+          setLoginCookie({
+            type: first.type,
+            pubkey: first.pubkey,
+            ...(first.type === 'bunker' && isValidBunkerData(first.data)
+              ? { bunkerData: first.data }
+              : {}),
+          });
+          return;
+        }
+        // cleaned.length === 0: fall through to cookie-based recovery below.
       }
     } catch {
       // corrupted localStorage, continue to cookie check

--- a/docs/superpowers/plans/2026-06-03-pr1-bunker-cookie-data-shape.md
+++ b/docs/superpowers/plans/2026-06-03-pr1-bunker-cookie-data-shape.md
@@ -359,7 +359,7 @@ git commit -m "fix(auth): sync bunkerData object to cookie and self-heal poisone
 
 - [ ] **Step 1: Verify the type error exists**
 
-Run: `npx tsc --noEmit`
+Run: `npx tsc -b`
 Expected: an error at `src/hooks/useLoginActions.ts:26` — object literal may only specify known properties, `bunkerUri` does not exist in type `LoginCookieData`. (This is the type system forcing the consistency fix.)
 
 - [ ] **Step 2: Update the cookie write**
@@ -378,7 +378,7 @@ In `src/hooks/useLoginActions.ts`, change the bunker login (line 24-26) so the c
 
 - [ ] **Step 3: Verify the type error is gone**
 
-Run: `npx tsc --noEmit`
+Run: `npx tsc -b`
 Expected: no errors (clean).
 
 - [ ] **Step 4: Commit**
@@ -396,7 +396,7 @@ git commit -m "fix(auth): persist structured bunkerData on fresh bunker login"
 
 - [ ] **Step 1: Type-check**
 
-Run: `npx tsc --noEmit`
+Run: `npx tsc -b`
 Expected: no errors.
 
 - [ ] **Step 2: Run the full test suite**

--- a/docs/superpowers/specs/2026-06-03-bunker-team-intermittent-logout-design.md
+++ b/docs/superpowers/specs/2026-06-03-bunker-team-intermittent-logout-design.md
@@ -1,0 +1,113 @@
+# Intermittent logout for bunker / Keycast-team users — design
+
+**Date:** 2026-06-03
+**Status:** Approved (design); implementation pending
+**Credit:** Aleysha articulated and demonstrated this symptom thoroughly on 2026-06-02. This design follows from that report and the code investigation it prompted.
+
+## Symptom
+
+End users whose account signs through a Keycast-hosted NIP-46 bunker (because the account is part of a Keycast team) intermittently appear logged out. Logout is repeated / non-deterministic from the user's perspective: no logout action is taken, yet the UI flips to a signed-out state.
+
+## Investigation summary
+
+Two independent root causes were found, both in `divine-web`. Keycast is not at fault: team-authorization secrets do not expire, pod restarts reload handlers from the DB on demand, and reconnection from the same client pubkey is accepted (the connect secret is single-use per NIP-46 but reusable by the original client). See `~/code/nips/46.md:48`.
+
+A third path that looked suspicious — `src/lib/bunkerToWindowNostr.ts` / `useWindowNostr` (30s timeout, single attempt, swallowed errors) — is **not wired into the live login flow** and is a red herring for this symptom. The live bunker login path is `LoginDialog → useLoginActions.bunker → NLogin.fromBunker`.
+
+### Root cause A — bunker `login.data` type-confusion in the cross-subdomain cookie
+
+`NUser.fromBunkerLogin` (in `@nostrify/react/login`) requires `login.data` to be the object `{ bunkerPubkey, clientNsec, relays }`. It is synchronous and never touches the relay, so it only throws when `data` is structurally invalid — a transient signer/relay outage does **not** cause it to throw.
+
+The cross-subdomain cookie (`nostr_login`, domain `.divine.video` / `.dvines.org`) stores the bunker payload under a single field, `bunkerUri`, in **two incompatible shapes**:
+
+- `src/hooks/useLoginActions.ts:26` (fresh login) writes `bunkerUri: uri` — the raw `bunker://…` **string**.
+- `src/lib/crossSubdomainAuth.ts:180` (sync from localStorage) writes `bunkerUri: first.data` — the **object** `{ bunkerPubkey, clientNsec, relays }`.
+
+Rehydration on an origin with no localStorage assigns that field straight into `data`:
+
+```ts
+// src/lib/crossSubdomainAuth.ts:205-213
+if (cookie.type === 'bunker' && cookie.bunkerUri) {
+  const loginState = [{ id: crypto.randomUUID(), type: 'bunker',
+    pubkey: cookie.pubkey, data: cookie.bunkerUri }];   // string OR object
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(loginState));
+}
+```
+
+When `data` ends up the **string**, `NUser.fromBunkerLogin` does `nip19.decode(login.data.clientNsec)` where `login.data.clientNsec` is `undefined` → throws. The throw is swallowed by the filters in `src/hooks/useCurrentUser.ts:62-67` and `src/hooks/useLoggedInAccounts.ts:24-30` (`catch { return false }`), so `users[0]` becomes `undefined` and `isLoggedIn = Boolean(user)` (`src/AppRouter.tsx:69`) goes false. No logout event fires.
+
+**Why it is intermittent and self-perpetuating:**
+- Same-origin reload is fine: `crossSubdomainAuth.ts:170-182` sees existing localStorage and returns early without overwriting it.
+- Cross-origin hydration (e.g. `divine.video` ↔ `<username>.divine.video`) depends on which writer last touched the cookie — string (broken) vs object (works).
+- Once a broken string-shaped login is written into an origin's localStorage (`:212`), that origin's next reload writes `bunkerUri: first.data` (the string) back into the shared cookie (`:180`), re-poisoning it for other origins.
+
+Only bunker logins are affected: nsec is intentionally not restored from the cookie; extension needs no `data`.
+
+### Root cause B — hosted-JWT session lifecycle
+
+The hosted Divine login (`DivineJWTSigner`, backed by `login.divine.video` / Keycast via `@divinevideo/login`) is the primary intended auth path. It has two defects:
+
+**B-a — session hard-expires with no refresh.** `src/pages/AuthCallbackPage.tsx:33` calls `saveSession(result.token, null, /*rememberMe*/ false)` and **discards `result.refreshToken`**. With `rememberMe=false`, the moment `now > expiration`, `getValidToken()` calls `clearSession()` and returns null (`src/hooks/useDivineSession.ts:229-236`). Access-token lifetime is the JWT `exp` claim or a 24h fallback (`:112-117`). The entire refresh / re-auth apparatus (`refreshSession`, `needsReauth`, `isExpiringSoon`, `isExpired`) has **zero consumers** — it is dead code. The library already supports silent renewal (`getSessionWithRefresh()`, `refreshSession(refreshToken)`, near-expiry check), and `divineLogin.ts:30` already surfaces `refreshToken`, but divine-web throws it away. Result: hosted sessions die on a clock (≤24h) for everyone.
+
+**B-b — JWT presence suppresses the bunker fallback, transiently.** `src/hooks/useCurrentUser.ts:84-86`:
+
+```ts
+const users = token ? (jwtUser ? [jwtUser] : []) : manualUsers;
+```
+
+`jwtUser` requires `jwtPubkey`, set by an async network call `jwtSigner.getPublicKey()` (POST to the hosted RPC, 10s timeout — `src/hooks/useCurrentUser.ts:30-56`, `src/lib/DivineJWTSigner.ts:72-110`). While that resolves, or if it fails/times out (`:46-51` sets `jwtPubkey=undefined`), `users = []` (logged out) even when a valid bunker login sits unused in `manualUsers`. A present-but-unresolved or stale JWT cookie blanks out an otherwise-working login.
+
+B bites the reported bunker users when a `divine_jwt` cookie is also in play (the hosted flow issues both a JWT and a `bunkerUrl`). Whether that was true in the original repro is unconfirmed; both A and B are real regardless and are tracked separately.
+
+## Plan: 2 issues, 3 PRs (all independent, all target `main`)
+
+- **Issue A** → **PR 1**: structured bunker data in the cross-subdomain cookie.
+- **Issue B** → **PR 2** (B-b precedence) + **PR 3** (B-a refresh-token wiring).
+
+PRs do not stack; each is independently reviewable and revertable.
+
+## PR 1 — Issue A: structured bunker data in the cookie
+
+**Files:** `src/lib/crossSubdomainAuth.ts`, `src/hooks/useLoginActions.ts`
+
+- `LoginCookieData`: replace `bunkerUri?: string` with `bunkerData?: { bunkerPubkey: string; clientNsec: string; relays: string[] }` — the exact shape `NUser.fromBunkerLogin` consumes.
+- `useLoginActions.bunker`: write `bunkerData: login.data` (the object from `NLogin.fromBunker`), not the raw `uri`.
+- Sync-from-localStorage path (`crossSubdomainAuth.ts:177-181`): write `bunkerData: first.data`.
+- Rehydration (`:205-213`): add `isValidBunkerData(d)` — object with an nsec-decodable `clientNsec` and a non-empty `relays` array. Only write `data: cookie.bunkerData` when valid; otherwise skip.
+- **Self-heal:** in the localStorage branch, if an existing `nostr:login` bunker entry has a non-object `data` (legacy poison), drop it rather than re-syncing it into the cookie — breaks the flap / re-poison loop.
+- **Back-compat:** a cookie carrying the old `bunkerUri` string fails `isValidBunkerData` → ignored, not persisted. Affected users land in a clean logged-out state and re-login.
+
+**Why round-trip the object instead of re-deriving from the URI:** the connect `secret` is single-use per NIP-46 (`~/code/nips/46.md:48`) and the `clientNsec` is the ephemeral key Keycast bound the connection to. Re-running `NLogin.fromBunker(uri)` mints a new client key and reuses a spent secret — Keycast ignores it. The original `clientNsec` must be preserved.
+
+**Already-affected users:** a currently-poisoned origin has lost its `clientNsec` (the cookie string only held the spent connect secret). Those users must re-login, and because the old secret is spent they may need a freshly-issued bunker URL from the Keycast team admin. The fix prevents recurrence; it cannot retroactively restore a spent connection. Call this out in the issue.
+
+**Tests:** object round-trips localStorage→cookie→localStorage; string-shaped `data` is rejected; a poisoned localStorage entry is dropped on hydrate.
+
+## PR 2 — Issue B-b: JWT no longer blanks out a valid login
+
+**File:** `src/hooks/useCurrentUser.ts`
+
+Replace the bare-`token`-truthiness switch with three explicit JWT states:
+
+- **resolving** (`token && !jwtPubkey && !jwtError`): do not render logged-out; expose a loading state so the UI does not flash signed-out while `getPublicKey()` is in flight. `AppRouter`'s `isLoggedIn` must not treat "resolving" as "logged out."
+- **resolved**: `jwtUser` is current (first slot).
+- **failed** (`jwtError`): fall back to `manualUsers` (a valid bunker login keeps working), else logged-out.
+
+This fixes both the logged-out flash on every JWT load and the stuck logout when the signer RPC fails, without flipping to the wrong identity mid-resolve. Requires the hook to track/expose a JWT error state (currently the catch only sets `jwtPubkey=undefined`, indistinguishable from "resolving").
+
+**Tests:** JWT resolving → not logged out; JWT failed + bunker present → bunker serves; JWT resolved → JWT serves; no JWT → manual logins serve (unchanged).
+
+## PR 3 — Issue B: refresh-token wiring (outline; detailed design when picked up)
+
+**Files:** `src/pages/AuthCallbackPage.tsx`, `src/hooks/useDivineSession.ts`, `src/lib/crossSubdomainAuth.ts`, the JWT token-resolution layer.
+
+- Capture `result.refreshToken` in `AuthCallbackPage`; persist it alongside the access token (new `keycast_refresh_token` key + JWT cookie field, same storage class as the access token already uses).
+- On expiry / near-expiry, call `refreshSession(refreshToken)` / `getSessionWithRefresh()` to mint a fresh access token instead of `clearSession()`. Hard logout only when refresh genuinely fails.
+- **Deferred decision (this PR's own plan):** adopt the library `SessionManager` (`getSessionWithRefresh`) as source of truth vs. keep `useDivineSession` storage and call `refreshSession()` manually.
+- This is the security-sensitive PR (a longer-lived bearer credential in browser storage) and gets a focused security review when started.
+
+## Out of scope
+
+- Any Keycast change (no server defect found).
+- The unused `bunkerToWindowNostr.ts` / `useWindowNostr` utility (not in the live login path).
+- Unrelated auth refactors.

--- a/src/hooks/useLoginActions.ts
+++ b/src/hooks/useLoginActions.ts
@@ -23,7 +23,7 @@ export function useLoginActions() {
     async bunker(uri: string): Promise<void> {
       const login = await NLogin.fromBunker(uri, nostr);
       addLogin(login);
-      setLoginCookie({ type: 'bunker', pubkey: login.pubkey, bunkerUri: uri });
+      setLoginCookie({ type: 'bunker', pubkey: login.pubkey, bunkerData: login.data });
     },
     // Login with a NIP-07 browser extension
     async extension(): Promise<void> {

--- a/src/lib/crossSubdomainAuth.test.ts
+++ b/src/lib/crossSubdomainAuth.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { getCookieDomain, getLoginCookie, setLoginCookie, clearLoginCookie, hydrateLoginFromCookie, setJwtCookie, getJwtCookie, clearJwtCookie } from './crossSubdomainAuth';
+import { getCookieDomain, getLoginCookie, setLoginCookie, clearLoginCookie, hydrateLoginFromCookie, setJwtCookie, getJwtCookie, clearJwtCookie, isValidBunkerData } from './crossSubdomainAuth';
 
 // Mock localStorage for Node.js environment
 const localStorageMock = (() => {
@@ -64,6 +64,33 @@ afterEach(() => {
     configurable: true,
   });
   Object.defineProperty(document, 'cookie', originalCookieDescriptor);
+});
+
+describe('isValidBunkerData', () => {
+  it('accepts a well-formed bunker data object', () => {
+    expect(isValidBunkerData({
+      bunkerPubkey: 'abc',
+      clientNsec: 'nsec1examplekey',
+      relays: ['wss://relay.example'],
+    })).toBe(true);
+  });
+
+  it('rejects a raw bunker:// URI string', () => {
+    expect(isValidBunkerData('bunker://pub?relay=wss://r&secret=s')).toBe(false);
+  });
+
+  it('rejects an object missing clientNsec', () => {
+    expect(isValidBunkerData({ bunkerPubkey: 'abc', relays: ['wss://r'] })).toBe(false);
+  });
+
+  it('rejects an object with empty relays', () => {
+    expect(isValidBunkerData({ bunkerPubkey: 'abc', clientNsec: 'nsec1x', relays: [] })).toBe(false);
+  });
+
+  it('rejects null/undefined', () => {
+    expect(isValidBunkerData(null)).toBe(false);
+    expect(isValidBunkerData(undefined)).toBe(false);
+  });
 });
 
 describe('getCookieDomain', () => {

--- a/src/lib/crossSubdomainAuth.test.ts
+++ b/src/lib/crossSubdomainAuth.test.ts
@@ -87,6 +87,10 @@ describe('isValidBunkerData', () => {
     expect(isValidBunkerData({ bunkerPubkey: 'abc', clientNsec: 'nsec1x', relays: [] })).toBe(false);
   });
 
+  it('rejects an object whose relays contains a non-string', () => {
+    expect(isValidBunkerData({ bunkerPubkey: 'abc', clientNsec: 'nsec1x', relays: [123] })).toBe(false);
+  });
+
   it('rejects null/undefined', () => {
     expect(isValidBunkerData(null)).toBe(false);
     expect(isValidBunkerData(undefined)).toBe(false);

--- a/src/lib/crossSubdomainAuth.test.ts
+++ b/src/lib/crossSubdomainAuth.test.ts
@@ -251,6 +251,57 @@ describe('hydrateLoginFromCookie', () => {
     expect(cookieJar).toBe('');
   });
 
+  it('when localStorage has a valid bunker login, syncs bunkerData object TO cookie', () => {
+    const bunkerData = {
+      bunkerPubkey: 'bunkerpub',
+      clientNsec: 'nsec1clientkey',
+      relays: ['wss://relay.example'],
+    };
+    const loginState = [{ id: '1', type: 'bunker', pubkey: 'pubB', data: bunkerData }];
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(loginState));
+
+    hydrateLoginFromCookie();
+
+    expect(getLoginCookie()).toEqual({ type: 'bunker', pubkey: 'pubB', bunkerData });
+    // localStorage unchanged
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY)!)).toEqual(loginState);
+  });
+
+  it('self-heals: drops a poisoned bunker login (string data) and does not poison the cookie', () => {
+    const loginState = [{ id: '1', type: 'bunker', pubkey: 'pubB', data: 'bunker://poisoned' }];
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(loginState));
+
+    hydrateLoginFromCookie();
+
+    // poisoned entry removed; cookie not written with a string payload
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+    expect(getLoginCookie()).toBeNull();
+  });
+
+  it('self-recovers: poisoned local entry dropped, healthy cookie re-hydrates the session', () => {
+    const bunkerData = {
+      bunkerPubkey: 'bp',
+      clientNsec: 'nsec1goodkey',
+      relays: ['wss://relay.example'],
+    };
+    // poisoned localStorage on this origin
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([
+      { id: '1', type: 'bunker', pubkey: 'pubB', data: 'bunker://poisoned' },
+    ]));
+    // but a healthy shared cookie exists (written by another origin)
+    cookieJar = `nostr_login=${btoa(JSON.stringify({ type: 'bunker', pubkey: 'pubB', bunkerData }))}`;
+
+    hydrateLoginFromCookie();
+
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+    expect(stored).toEqual([{
+      id: mockUUID,
+      type: 'bunker',
+      pubkey: 'pubB',
+      data: bunkerData,
+    }]);
+  });
+
   // --- JWT cross-subdomain hydration ---
 
   it('when localStorage has JWT, syncs TO jwt cookie', () => {

--- a/src/lib/crossSubdomainAuth.test.ts
+++ b/src/lib/crossSubdomainAuth.test.ts
@@ -300,6 +300,9 @@ describe('hydrateLoginFromCookie', () => {
       pubkey: 'pubB',
       data: bunkerData,
     }]);
+    // the healthy shared cookie must be left intact (not cleared/overwritten),
+    // so other origins still recover from it
+    expect(getLoginCookie()).toEqual({ type: 'bunker', pubkey: 'pubB', bunkerData });
   });
 
   // --- JWT cross-subdomain hydration ---

--- a/src/lib/crossSubdomainAuth.test.ts
+++ b/src/lib/crossSubdomainAuth.test.ts
@@ -206,8 +206,13 @@ describe('hydrateLoginFromCookie', () => {
     }]);
   });
 
-  it('when localStorage is empty and cookie has bunker login with URI, hydrates localStorage', () => {
-    const data = { type: 'bunker' as const, pubkey: 'pub789', bunkerUri: 'bunker://xyz' };
+  it('when localStorage is empty and cookie has valid bunkerData, hydrates localStorage with the object', () => {
+    const bunkerData = {
+      bunkerPubkey: 'bunkerpub',
+      clientNsec: 'nsec1clientkey',
+      relays: ['wss://relay.example'],
+    };
+    const data = { type: 'bunker' as const, pubkey: 'pub789', bunkerData };
     cookieJar = `nostr_login=${btoa(JSON.stringify(data))}`;
 
     hydrateLoginFromCookie();
@@ -217,8 +222,17 @@ describe('hydrateLoginFromCookie', () => {
       id: mockUUID,
       type: 'bunker',
       pubkey: 'pub789',
-      data: 'bunker://xyz',
+      data: bunkerData,
     }]);
+  });
+
+  it('when cookie has a legacy bunkerUri string (no bunkerData), does NOT hydrate', () => {
+    const data = { type: 'bunker' as const, pubkey: 'pub789', bunkerUri: 'bunker://xyz' };
+    cookieJar = `nostr_login=${btoa(JSON.stringify(data))}`;
+
+    hydrateLoginFromCookie();
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
   });
 
   it('when localStorage is empty and cookie has nsec login, does NOT hydrate', () => {

--- a/src/lib/crossSubdomainAuth.ts
+++ b/src/lib/crossSubdomainAuth.ts
@@ -195,14 +195,38 @@ export function hydrateLoginFromCookie(): void {
     try {
       const logins = JSON.parse(stored);
       if (Array.isArray(logins) && logins.length > 0) {
-        const first = logins[0];
-        // Keep cookie in sync with current login
-        setLoginCookie({
-          type: first.type,
-          pubkey: first.pubkey,
-          ...(first.type === 'bunker' && first.data ? { bunkerUri: first.data } : {}),
-        });
-        return;
+        // Self-heal: a bunker login whose `data` is not a valid object is the
+        // legacy/poisoned shape. Persisting it would make NUser.fromBunkerLogin
+        // throw (apparent logout) and re-syncing it would re-poison the shared
+        // cookie. Drop those entries.
+        const cleaned = logins.filter(
+          (l: { type?: string; data?: unknown }) =>
+            l.type !== 'bunker' || isValidBunkerData(l.data),
+        );
+        if (cleaned.length !== logins.length) {
+          if (cleaned.length === 0) {
+            // Everything was poisoned. Remove the bad local state but DON'T clear
+            // the shared cookie or return — fall through to cookie hydration so a
+            // healthy cookie (written by another origin) can recover the session.
+            localStorage.removeItem(STORAGE_KEY);
+          } else {
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(cleaned));
+          }
+        }
+
+        if (cleaned.length > 0) {
+          const first = cleaned[0];
+          // Keep cookie in sync with current login
+          setLoginCookie({
+            type: first.type,
+            pubkey: first.pubkey,
+            ...(first.type === 'bunker' && isValidBunkerData(first.data)
+              ? { bunkerData: first.data }
+              : {}),
+          });
+          return;
+        }
+        // cleaned.length === 0: fall through to cookie-based recovery below.
       }
     } catch {
       // corrupted localStorage, continue to cookie check

--- a/src/lib/crossSubdomainAuth.ts
+++ b/src/lib/crossSubdomainAuth.ts
@@ -224,15 +224,21 @@ export function hydrateLoginFromCookie(): void {
     return;
   }
 
-  // For bunker logins, restore with the bunker URI so it can reconnect
-  if (cookie.type === 'bunker' && cookie.bunkerUri) {
-    const loginState = [{
-      id: crypto.randomUUID(),
-      type: 'bunker' as const,
-      pubkey: cookie.pubkey,
-      data: cookie.bunkerUri,
-    }];
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(loginState));
+  // For bunker logins, restore from the structured data object so the signer
+  // can be rebuilt. A legacy/poisoned cookie (raw bunker:// string under the old
+  // `bunkerUri` field, or any malformed payload) fails the guard and is ignored
+  // rather than persisted — NUser.fromBunkerLogin would throw on a bad shape and
+  // the user would appear logged out. They re-login instead.
+  if (cookie.type === 'bunker') {
+    if (isValidBunkerData(cookie.bunkerData)) {
+      const loginState = [{
+        id: crypto.randomUUID(),
+        type: 'bunker' as const,
+        pubkey: cookie.pubkey,
+        data: cookie.bunkerData,
+      }];
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(loginState));
+    }
     return;
   }
 

--- a/src/lib/crossSubdomainAuth.ts
+++ b/src/lib/crossSubdomainAuth.ts
@@ -10,10 +10,33 @@
 const COOKIE_NAME = 'nostr_login';
 const JWT_COOKIE_NAME = 'divine_jwt';
 
+export interface BunkerLoginData {
+  bunkerPubkey: string;
+  clientNsec: string;
+  relays: string[];
+}
+
 interface LoginCookieData {
   type: 'extension' | 'bunker' | 'nsec';
   pubkey: string;
-  bunkerUri?: string; // only for bunker logins
+  bunkerData?: BunkerLoginData; // only for bunker logins; the exact shape NUser.fromBunkerLogin consumes
+}
+
+/**
+ * Structural guard for a bunker login `data` payload. A raw `bunker://` URI
+ * string (the legacy/poisoned shape) and any partial object fail this, so they
+ * are never persisted into localStorage where NUser.fromBunkerLogin would throw.
+ */
+export function isValidBunkerData(data: unknown): data is BunkerLoginData {
+  if (!data || typeof data !== 'object') return false;
+  const d = data as Record<string, unknown>;
+  return (
+    typeof d.bunkerPubkey === 'string' &&
+    typeof d.clientNsec === 'string' &&
+    d.clientNsec.startsWith('nsec1') &&
+    Array.isArray(d.relays) &&
+    d.relays.length > 0
+  );
 }
 
 interface JwtCookieData {

--- a/src/lib/crossSubdomainAuth.ts
+++ b/src/lib/crossSubdomainAuth.ts
@@ -199,6 +199,12 @@ export function hydrateLoginFromCookie(): void {
         // legacy/poisoned shape. Persisting it would make NUser.fromBunkerLogin
         // throw (apparent logout) and re-syncing it would re-poison the shared
         // cookie. Drop those entries.
+        //
+        // Scope: only `bunker` data is validated here, because the cookie
+        // data-shape ambiguity was bunker-specific. Malformed nsec/extension
+        // logins (rare) are already handled gracefully downstream — the login
+        // filters in useCurrentUser / useLoggedInAccounts swallow the throw — so
+        // this self-heal stays bunker-scoped.
         const cleaned = logins.filter(
           (l: { type?: string; data?: unknown }) =>
             l.type !== 'bunker' || isValidBunkerData(l.data),
@@ -215,6 +221,10 @@ export function hydrateLoginFromCookie(): void {
         }
 
         if (cleaned.length > 0) {
+          // If the original first login was a dropped poison entry, the next
+          // valid login becomes the cookie's advertised identity. That's
+          // intended: the poisoned login was unusable, so promoting the next
+          // working one is better than advertising a login that can't sign.
           const first = cleaned[0];
           // Keep cookie in sync with current login
           setLoginCookie({

--- a/src/lib/crossSubdomainAuth.ts
+++ b/src/lib/crossSubdomainAuth.ts
@@ -10,6 +10,11 @@
 const COOKIE_NAME = 'nostr_login';
 const JWT_COOKIE_NAME = 'divine_jwt';
 
+// NOTE: `clientNsec` is an ephemeral, per-login client key (generated fresh by
+// NLogin.fromBunker), NOT the user's identity key — the remote bunker holds the
+// identity key. Persisting this object in the cross-subdomain cookie is required
+// so subdomains can rebuild the NIP-46 signer; it predates this change (the
+// localStorage-sync path already wrote it) and the cookie is Secure + SameSite=Lax.
 export interface BunkerLoginData {
   bunkerPubkey: string;
   clientNsec: string;
@@ -35,7 +40,8 @@ export function isValidBunkerData(data: unknown): data is BunkerLoginData {
     typeof d.clientNsec === 'string' &&
     d.clientNsec.startsWith('nsec1') &&
     Array.isArray(d.relays) &&
-    d.relays.length > 0
+    d.relays.length > 0 &&
+    d.relays.every((relay) => typeof relay === 'string')
   );
 }
 


### PR DESCRIPTION
Closes #390.

## Context

T&S moderators sign in to the web client as the shared **moderation identity**, held by a Keycast team that each moderator connects to with their own NIP-46 bunker URL. They intermittently appeared logged out of the moderation identity with no logout action taken, which blocked moderating via the web. Aleysha articulated and demonstrated this thoroughly on 2026-06-02; this PR fixes the first of two root causes that investigation surfaced.

Full design: `docs/superpowers/specs/2026-06-03-bunker-team-intermittent-logout-design.md`.

## Root cause

The cross-subdomain cookie (`nostr_login`) stored the bunker payload under one field, `bunkerUri`, in two incompatible shapes: a raw `bunker://` string (fresh login) and the `{ bunkerPubkey, clientNsec, relays }` object (localStorage-sync path). Rehydration assigned that field straight into `login.data`, which `NUser.fromBunkerLogin` requires to be the object. When it landed as the string, `nip19.decode(login.data.clientNsec)` threw on `undefined`; the throw was swallowed by the login filters, so the user silently appeared logged out. Once a string-shaped login was written to an origin's localStorage, its next reload re-poisoned the shared cookie for other origins.

## What changed

- `LoginCookieData.bunkerUri: string` → `bunkerData?: BunkerLoginData` (the exact object shape the signer consumes).
- Fresh bunker login and the localStorage-sync path both write the structured object.
- Rehydration validates with a new `isValidBunkerData` guard and only persists a valid object; legacy/malformed payloads (incl. the old `bunker://` string) are ignored rather than persisted.
- Self-recovery: a poisoned localStorage entry is dropped and, if a healthy shared cookie exists, the session is recovered from it instead of forcing a logout.

Re-deriving via `NLogin.fromBunker(uri)` is intentionally not used: the connect secret is single-use per NIP-46 and the original ephemeral `clientNsec` must be preserved, so the object is round-tripped.

## Test plan

- [x] `npx tsc -b` clean
- [x] `npx eslint` clean on touched files
- [x] Full suite: 736/736 tests pass (incl. new round-trip, legacy-string rejection, self-heal, and self-recover cases in `crossSubdomainAuth.test.ts`)
- [ ] Staging: log in on `divine.video` with a team bunker URL, open a `*.divine.video` sibling origin with no localStorage, confirm the session hydrates instead of showing logged-out.

## Note on already-affected users

An already-poisoned origin has lost its `clientNsec` (the cookie string held only the spent connect secret). Those moderators must re-login once, and because the old secret is spent they may need a freshly-issued bunker URL for the Keycast team. This PR prevents recurrence; it can't restore a spent connection.

## Scope

Issue #391 (hosted-JWT precedence + refresh-token wiring) is tracked separately and not in this PR.

## Security note (review)

This fix persists the bunker login object `{ bunkerPubkey, clientNsec, relays }` in the cross-subdomain `nostr_login` cookie (base64, `Secure; SameSite=Lax`). This is **not a net-new exposure**: the pre-existing localStorage-sync path already wrote that same object into the cookie's field, and the legacy `bunker://` string it replaced carried the connect `secret`. `clientNsec` is an ephemeral *per-login client key* generated by `NLogin.fromBunker` — not the user's identity key (the remote bunker holds that). The guard `isValidBunkerData` validates the shape (incl. relay element types) on read. The secure end-state for credential handling across subdomains is tracked separately at keycast#250.
