### PR TITLE
docs(skills): add cloudflare-agent-setup skill

### DIFF
--- a/.agents/SKILLS.md
+++ b/.agents/SKILLS.md
@@ -10,3 +10,4 @@ in that area.
 | `pr-conventions` | Creating commits, writing PR descriptions, preparing branches |
 | `project-structure` | Creating new files, moving code, navigating the codebase |
 | `spa-subdomain-root-render` | Subdomain routing that renders at / without URL redirect |
+| `cloudflare-agent-setup` | Installing Cloudflare skills and MCP servers for this agent |

--- a/.agents/skills/cloudflare-agent-setup/SKILL.md
+++ b/.agents/skills/cloudflare-agent-setup/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: cloudflare-agent-setup
+description: |
+  Install Cloudflare skills and MCP servers for this agent. Load when you need
+  to set up or verify Cloudflare agent tooling. The URL below is the canonical,
+  always-current source of truth.
+---
+
+# Cloudflare Agent Setup
+
+For the latest verified installation instructions, see:
+
+https://developers.cloudflare.com/agent-setup/prompt.md


### PR DESCRIPTION
## Summary
- Adds `.agents/skills/cloudflare-agent-setup/SKILL.md`, a thin skill pointing agents to the canonical Cloudflare agent setup URL.
- Adds the skill to `.agents/SKILLS.md` so it shows up in the skill index.

## Motivation
Future agents working on this repo can quickly discover the right way to install Cloudflare skills and MCP servers without re-deriving the URL or instructions.

## Related Issue
N/A

## Testing
- [x] `npm run test` (no code changes — skill markdown only, no test surface)
- [x] Manual verification: frontmatter validates, link resolves to the canonical Cloudflare page
- [x] Branch rebased on `origin/main`

## Visuals
- [x] No visual change