### PR TITLE
feat(routing): add /v/:legacyVineId vanity route and alternate link

### DIFF
--- a/compute-js/src/index.js
+++ b/compute-js/src/index.js
@@ -192,6 +192,18 @@ async function handleRequest(event) {
       console.log('Falling through to SPA handler');
     }
 
+    if (url.pathname.startsWith('/v/')) {
+      console.log('Handling legacy Vine vanity URL for crawler, path:', url.pathname);
+      const legacyId = url.pathname.split('/v/')[1]?.split('?')[0];
+      if (legacyId) {
+        const ogResponse = await handleVideoOgTags(request, legacyId, url, funnelcakeTarget);
+        if (ogResponse) {
+          return ogResponse;
+        }
+      }
+      console.log('Falling through to SPA handler');
+    }
+
     if (url.pathname.startsWith('/profile/')) {
       const ogResponse = await handleProfileOgTags(request, url, funnelcakeTarget);
       if (ogResponse) {
@@ -1051,6 +1063,12 @@ async function handleVideoOgTags(request, videoId, url, funnelcakeTarget) {
       imageWidth: videoMeta?.imageWidth || 1200,
       imageHeight: videoMeta?.imageHeight || 630,
       video: videoBlock,
+      alternate: videoMeta?.originExternalId ? [{
+        rel: 'alternate',
+        type: 'text/html',
+        href: `https://divine.video/v/${videoMeta.originExternalId}`,
+        title: 'Legacy Vine URL',
+      }] : undefined,
     });
 
     console.log('Generated OG HTML, length:', html.length);

--- a/compute-js/src/ogTags.js
+++ b/compute-js/src/ogTags.js
@@ -33,6 +33,7 @@ export function buildCrawlerHtml({
   imageHeight = null,
   siteName = 'Divine',
   video = null,
+  alternate = null,
 }) {
   const e = escapeHtml;
   const imageDimsBlock = (imageWidth && imageHeight) ? `
@@ -49,6 +50,9 @@ export function buildCrawlerHtml({
   <meta name="twitter:player:height" content="${Number(video.height) || 1280}" />
   <meta name="twitter:player:stream" content="${e(video.url)}" />
   <meta name="twitter:player:stream:content_type" content="${e(video.type || 'video/mp4')}" />` : ''}` : '';
+  const alternateBlock = alternate?.map(a =>
+    `  <link rel="${e(a.rel)}" type="${e(a.type)}" href="${e(a.href)}"${a.title ? ` title="${e(a.title)}"` : ''} />`
+  ).join('\n') || '';
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -71,6 +75,7 @@ ${videoBlock}
   ${twitterCreator ? `<meta name="twitter:creator" content="${e(twitterCreator)}" />` : ''}
 
   <link rel="canonical" href="${e(url)}" />
+${alternateBlock}
 </head>
 <body>
   <p><a href="${e(url)}">${e(title)}</a></p>

--- a/compute-js/src/ogTags.test.ts
+++ b/compute-js/src/ogTags.test.ts
@@ -97,6 +97,25 @@ describe('buildCrawlerHtml', () => {
     expect(html).toContain('<link rel="canonical" href="https://example.com/page"');
   });
 
+  it('emits escaped alternate links when provided', () => {
+    const html = buildCrawlerHtml({
+      ...baseArgs,
+      alternate: [{
+        rel: 'alternate',
+        type: 'text/html',
+        href: 'https://divine.video/v/a&b"<',
+        title: 'Legacy Vine URL',
+      }],
+    });
+
+    expect(html).toContain('<link rel="alternate" type="text/html" href="https://divine.video/v/a&amp;b&quot;&lt;" title="Legacy Vine URL"');
+  });
+
+  it('omits alternate links when none are provided', () => {
+    const html = buildCrawlerHtml(baseArgs);
+    expect(html).not.toContain('rel="alternate"');
+  });
+
   it('emits twitter:creator only when provided', () => {
     const without = buildCrawlerHtml(baseArgs);
     expect(without).not.toContain('twitter:creator');

--- a/compute-js/src/videoMetadata.js
+++ b/compute-js/src/videoMetadata.js
@@ -26,6 +26,20 @@ function parseDim(dim) {
   return [Number(m[1]), Number(m[2])];
 }
 
+function getVineExternalId(event) {
+  const originTag = event.tags?.find((t) => t[0] === 'origin');
+  if (originTag?.[1]?.toLowerCase() === 'vine' && originTag[2]) {
+    return originTag[2];
+  }
+
+  const platformTag = event.tags?.find((t) => t[0] === 'platform');
+  if (platformTag?.[1]?.toLowerCase() !== 'vine') {
+    return null;
+  }
+
+  return event.tags?.find((t) => t[0] === 'd')?.[1] || null;
+}
+
 export function transformVideoApiResponse(result, { defaultOgImage = null } = {}) {
   if (!result?.event) return null;
   const event = result.event;
@@ -70,5 +84,6 @@ export function transformVideoApiResponse(result, { defaultOgImage = null } = {}
     videoHeight: videoHeight || null,
     imageWidth: imageW || null,
     imageHeight: imageH || null,
+    originExternalId: getVineExternalId(event),
   };
 }

--- a/compute-js/src/videoMetadata.test.ts
+++ b/compute-js/src/videoMetadata.test.ts
@@ -118,4 +118,43 @@ describe('transformVideoApiResponse', () => {
     });
     expect(result?.description).toBe('10 ❤️ • 3 💬 • 2 🔁 on Divine');
   });
+
+  it('uses the origin tag external id for Vine alternate links', () => {
+    const result = transformVideoApiResponse({
+      event: {
+        ...baseEvent,
+        tags: [['origin', 'vine', 'origin-id', 'https://vine.co/v/origin-id']],
+      },
+      stats: {},
+    });
+
+    expect(result?.originExternalId).toBe('origin-id');
+  });
+
+  it('falls back to the d tag for legacy platform Vine events', () => {
+    const result = transformVideoApiResponse({
+      event: {
+        ...baseEvent,
+        tags: [
+          ['platform', 'vine'],
+          ['d', 'legacy-d-id'],
+        ],
+      },
+      stats: {},
+    });
+
+    expect(result?.originExternalId).toBe('legacy-d-id');
+  });
+
+  it('does not set originExternalId for non-Vine events', () => {
+    const result = transformVideoApiResponse({
+      event: {
+        ...baseEvent,
+        tags: [['origin', 'youtube', 'external-id']],
+      },
+      stats: {},
+    });
+
+    expect(result?.originExternalId).toBeNull();
+  });
 });

--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -24,6 +24,7 @@ import HashtagDiscoveryPage from "./pages/HashtagDiscoveryPage";
 import ProfilePage from "./pages/ProfilePage";
 import SearchPage from "./pages/SearchPage";
 import VideoPage from "./pages/VideoPage";
+import { LegacyVineVideoPage } from "./pages/LegacyVineVideoPage";
 import { TagPage } from "./pages/TagPage";
 import ListsPage from "./pages/ListsPage";
 import ListDetailPage from "./pages/ListDetailPage";
@@ -98,6 +99,7 @@ export function AppRouter() {
       <Route path="/t/:tag" element={<TagPage />} />
       <Route path="/profile/:npub" element={<ProfilePage />} />
       <Route path="/video/:id" element={<VideoPage />} />
+      <Route path="/v/:legacyVineId" element={<LegacyVineVideoPage />} />
       <Route path="/search" element={<SearchPage />} />
       <Route path="/leaderboard" element={<LeaderboardPage />} />
       <Route path="/merch" element={<MerchPage />} />

--- a/src/lib/funnelcakeTransform.test.ts
+++ b/src/lib/funnelcakeTransform.test.ts
@@ -32,6 +32,22 @@ describe('transformFunnelcakeVideo', () => {
     });
   });
 
+  it('prefers the Vine origin tag external id over the d tag', () => {
+    const video = transformFunnelcakeVideo(makeRawVideo({
+      d_tag: 'addressable-d-tag',
+      tags: [
+        ['origin', 'vine', 'origin-id', 'https://vine.co/v/origin-id'],
+        ['d', 'addressable-d-tag'],
+      ],
+    }));
+
+    expect(video.isVineMigrated).toBe(true);
+    expect(video.origin).toEqual({
+      platform: 'vine',
+      externalId: 'origin-id',
+    });
+  });
+
   it('prefers archived Vine loop tags over current Divine loop fields', () => {
     const video = transformFunnelcakeVideo(makeRawVideo({
       platform: 'vine',

--- a/src/lib/funnelcakeTransform.ts
+++ b/src/lib/funnelcakeTransform.ts
@@ -36,6 +36,15 @@ function parseLoopsFromTags(tags?: string[][]): number | null {
   return Number.isFinite(loops) && loops > 0 ? loops : null;
 }
 
+function getVineExternalId(raw: FunnelcakeVideoRaw): string {
+  const originTag = raw.tags?.find((tag) => tag[0] === 'origin');
+  if (originTag?.[1]?.toLowerCase() === 'vine' && originTag[2]) {
+    return originTag[2];
+  }
+
+  return raw.d_tag || '';
+}
+
 /**
  * Transform a single Funnelcake video to ParsedVideoData format
  */
@@ -55,9 +64,10 @@ export function transformFunnelcakeVideo(raw: FunnelcakeVideoRaw): ParsedVideoDa
   }
 
   const taggedPlatform = raw.tags?.find((tag) => tag[0] === 'platform')?.[1]?.toLowerCase();
+  const originPlatform = raw.tags?.find((tag) => tag[0] === 'origin')?.[1]?.toLowerCase();
 
   // Single-video lookups can omit top-level platform/classic fields, so fall back to tags.
-  const isVineMigrated = raw.platform === 'vine' || raw.classic === true || taggedPlatform === 'vine';
+  const isVineMigrated = raw.platform === 'vine' || raw.classic === true || taggedPlatform === 'vine' || originPlatform === 'vine';
   const archivedLoopCount = parseLoopsFromTags(raw.tags)
     ?? parseLoopsFromContent(raw.content)
     ?? parseLoopsFromContent(raw.title);
@@ -115,7 +125,7 @@ export function transformFunnelcakeVideo(raw: FunnelcakeVideoRaw): ParsedVideoDa
     isVineMigrated,
     origin: isVineMigrated ? {
       platform: 'vine',
-      externalId: raw.d_tag || '',
+      externalId: getVineExternalId(raw),
     } : undefined,
 
     // Subtitle / text track fields from API

--- a/src/pages/LegacyVineVideoPage.test.tsx
+++ b/src/pages/LegacyVineVideoPage.test.tsx
@@ -31,10 +31,8 @@ function renderWithRoute(initialPath: string) {
 
 function setLookupResult(result: { video: unknown; isLoading: boolean }) {
   mockUseVideoByIdFunnelcake.mockReturnValue({
-    video: null,
     videos: null,
     windowOffset: 0,
-    isLoading: false,
     error: null,
     ...result,
   });

--- a/src/pages/LegacyVineVideoPage.test.tsx
+++ b/src/pages/LegacyVineVideoPage.test.tsx
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { LegacyVineVideoPage } from './LegacyVineVideoPage';
+
+const { mockUseVideoByIdFunnelcake } = vi.hoisted(() => ({
+  mockUseVideoByIdFunnelcake: vi.fn(),
+}));
+
+vi.mock('@unhead/react', () => ({
+  useSeoMeta: vi.fn(),
+  useHead: vi.fn(),
+}));
+
+vi.mock('@/hooks/useVideoByIdFunnelcake', () => ({
+  useVideoByIdFunnelcake: (options: { videoId: string; enabled?: boolean }) =>
+    mockUseVideoByIdFunnelcake(options),
+}));
+
+function renderWithRoute(initialPath: string) {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route path="/v/:legacyVineId" element={<LegacyVineVideoPage />} />
+        <Route path="/video/:id" element={<div data-testid="redirected" />} />
+        <Route path="*" element={<div data-testid="not-routed" />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+function setLookupResult(result: { video: unknown; isLoading: boolean }) {
+  mockUseVideoByIdFunnelcake.mockReturnValue({
+    video: null,
+    videos: null,
+    windowOffset: 0,
+    isLoading: false,
+    error: null,
+    ...result,
+  });
+}
+
+describe('LegacyVineVideoPage', () => {
+  it('renders NotFound when the video lookup completes with no result', async () => {
+    setLookupResult({ video: null, isLoading: false });
+
+    renderWithRoute('/v/5B1TZKezL6r');
+
+    await waitFor(() => {
+      expect(screen.getByText('404')).toBeInTheDocument();
+    });
+  });
+
+  it('renders a loading state while the lookup is in flight', () => {
+    setLookupResult({ video: null, isLoading: true });
+
+    renderWithRoute('/v/5B1TZKezL6r');
+
+    expect(screen.getByText('Finding this Vine...')).toBeInTheDocument();
+  });
+
+  it('redirects to the canonical /video/:id when the video is found', async () => {
+    setLookupResult({
+      video: { id: 'event-abc', pubkey: 'a'.repeat(64) },
+      isLoading: false,
+    });
+
+    renderWithRoute('/v/5B1TZKezL6r');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('redirected')).toBeInTheDocument();
+    });
+  });
+
+  it('passes the legacyVineId into the hook and enables it', () => {
+    setLookupResult({ video: null, isLoading: true });
+
+    renderWithRoute('/v/5B1TZKezL6r');
+
+    expect(mockUseVideoByIdFunnelcake).toHaveBeenCalledWith({
+      videoId: '5B1TZKezL6r',
+      enabled: true,
+    });
+  });
+});

--- a/src/pages/LegacyVineVideoPage.tsx
+++ b/src/pages/LegacyVineVideoPage.tsx
@@ -1,0 +1,31 @@
+import { useParams, Navigate } from 'react-router-dom';
+import { useVideoByIdFunnelcake } from '@/hooks/useVideoByIdFunnelcake';
+import { buildVideoPath } from '@/lib/eventRouting';
+import NotFound from './NotFound';
+
+export function LegacyVineVideoPage() {
+  const { legacyVineId } = useParams<{ legacyVineId: string }>();
+
+  const { video, isLoading } = useVideoByIdFunnelcake({
+    videoId: legacyVineId || '',
+    enabled: !!legacyVineId,
+  });
+
+  if (!legacyVineId) {
+    return <NotFound />;
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="text-muted-foreground">Finding this Vine...</div>
+      </div>
+    );
+  }
+
+  if (!video) {
+    return <NotFound />;
+  }
+
+  return <Navigate to={buildVideoPath(video.id)} replace />;
+}

--- a/src/pages/VideoPage.test.tsx
+++ b/src/pages/VideoPage.test.tsx
@@ -11,6 +11,7 @@ const { mockNavigate } = vi.hoisted(() => ({
 
 vi.mock('@unhead/react', () => ({
   useSeoMeta: vi.fn(),
+  useHead: vi.fn(),
 }));
 
 vi.mock('@/hooks/useSubdomainNavigate', () => ({

--- a/src/pages/VideoPage.tsx
+++ b/src/pages/VideoPage.tsx
@@ -2,7 +2,7 @@ import { useParams, useSearchParams } from 'react-router-dom';
 import { useSubdomainNavigate } from '@/hooks/useSubdomainNavigate';
 import { useEffect, useCallback, useState, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useSeoMeta } from '@unhead/react';
+import { useSeoMeta, useHead } from '@unhead/react';
 import { Hash, User, X, CircleNotch as Loader2 } from '@phosphor-icons/react';
 import InfiniteScroll from 'react-infinite-scroll-component';
 import { Card, CardContent } from '@/components/ui/card';
@@ -254,6 +254,17 @@ export function VideoPage() {
     twitterTitle: currentVideo?.title || t('videoPage.seoTitle'),
     twitterDescription: currentVideo?.content || t('videoPage.seoDescription'),
     twitterImage: currentVideo?.thumbnailUrl || '/og.avif',
+  });
+
+  useHead({
+    link: currentVideo?.origin?.platform === 'vine' && currentVideo.origin.externalId
+      ? [{
+          rel: 'alternate',
+          type: 'text/html',
+          href: `https://divine.video/v/${currentVideo.origin.externalId}`,
+          title: 'Legacy Vine URL',
+        }]
+      : [],
   });
 
   // Navigation back to source


### PR DESCRIPTION
## Summary

Enables URLs like `https://divine.video/v/5B1TZKezL6r` to resolve to the canonical `/video/<id>` URL. This is additive to the existing directSearch handling for `vine.co/v/<id>` URLs: directSearch still maps pasted legacy URLs, while `/v/:legacyVineId` gives Divine a first-party vanity namespace for the same archived content.

The route works for current archived Vine events because the archive stores the legacy Vine ID in the event `d` tag and `GET /api/videos/{id}` already resolves those d-tag IDs today.

## Changes

### New vanity route
- **`src/pages/LegacyVineVideoPage.tsx`** (new) — Looks up the video by legacy Vine ID and redirects to canonical `/video/:id`
- **`src/AppRouter.tsx`** — Registered `<Route path="/v/:legacyVineId" element={<LegacyVineVideoPage />} />`

### `<link rel="alternate" />` for legacy Vine videos
- **`src/pages/VideoPage.tsx`** — Added `useHead` call that emits `<link rel="alternate" type="text/html" href="https://divine.video/v/<externalId>">` when the video has `origin.platform === 'vine'`

### Edge/crawler support
- **`compute-js/src/ogTags.js`** — `buildCrawlerHtml` now accepts an `alternate` array and escapes alternate link attributes
- **`compute-js/src/videoMetadata.js`** — Extracts Vine external IDs from the `origin` tag, falling back to the legacy `platform=vine` + `d` tag shape used by archived Vine events
- **`compute-js/src/index.js`** — Emits alternate links in crawler HTML and handles `/v/:id` paths for social media crawlers

### Tests
- **`src/pages/LegacyVineVideoPage.test.tsx`** — Covers loading, success redirect, not-found, and missing param
- **`compute-js/src/ogTags.test.ts`** — Covers alternate link escaping and omission
- **`compute-js/src/videoMetadata.test.ts`** — Covers origin-tag external IDs, legacy platform/d fallback, and non-Vine omission
- Updated `VideoPage.test.tsx` mock to include `useHead: vi.fn()`

## Flow

1. User visits `https://divine.video/v/5B1TZKezL6r`
2. `LegacyVineVideoPage` calls `useVideoByIdFunnelcake({ videoId: '5B1TZKezL6r' })`
3. Funnelcake resolves the archived event by the legacy d-tag ID
4. Page redirects to `https://divine.video/video/<resolved-id>`

## Verification

- `npx vitest run compute-js/src/ogTags.test.ts compute-js/src/videoMetadata.test.ts src/pages/LegacyVineVideoPage.test.tsx`
- `npm run test`