### PR TITLE
fix: retry comments when metric count mismatches

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,22 @@
+self.addEventListener('install', (event) => {
+  self.skipWaiting();
+  event.waitUntil(
+    caches.keys().then((cacheNames) => Promise.all(
+      cacheNames.map((cacheName) => caches.delete(cacheName))
+    ))
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    Promise.all([
+      self.registration.unregister(),
+      caches.keys().then((cacheNames) => Promise.all(
+        cacheNames.map((cacheName) => caches.delete(cacheName))
+      )),
+      self.clients.matchAll({ type: 'window' }).then((clients) => Promise.all(
+        clients.map((client) => client.navigate(client.url))
+      )),
+    ])
+  );
+});

--- a/src/components/VideoCommentsModal.tsx
+++ b/src/components/VideoCommentsModal.tsx
@@ -76,6 +76,7 @@ export function VideoCommentsModal({
               emptyStateMessage={t('videoCommentsModal.emptyMessage')}
               emptyStateSubtitle={t('videoCommentsModal.emptySubtitle')}
               compact={true}
+              expectedCommentCount={video.commentCount ?? 0}
               data-testid="comments-section"
               data-root-kind={video.kind.toString()}
               data-root-id={video.id}

--- a/src/components/comments/CommentsSection.tsx
+++ b/src/components/comments/CommentsSection.tsx
@@ -16,6 +16,7 @@ interface CommentsSectionProps {
   className?: string;
   limit?: number;
   compact?: boolean; // Remove Card wrapper for use in modals
+  expectedCommentCount?: number;
 }
 
 export function CommentsSection({
@@ -26,10 +27,12 @@ export function CommentsSection({
   className,
   limit = 500,
   compact = false,
+  expectedCommentCount = 0,
 }: CommentsSectionProps) {
   const { t } = useTranslation();
-  const { data: commentsData, isLoading, error } = useComments(root, limit);
+  const { data: commentsData, isLoading, error } = useComments(root, limit, { expectedCommentCount });
   const comments = commentsData?.topLevelComments || [];
+  const hasCommentCountMismatch = expectedCommentCount > 0 && comments.length === 0;
   const resolvedTitle = title ?? t('comments.title');
   const resolvedEmptyStateMessage = emptyStateMessage ?? t('comments.noCommentsYet');
   const resolvedEmptyStateSubtitle = emptyStateSubtitle ?? t('comments.beFirstToShare');
@@ -77,7 +80,7 @@ export function CommentsSection({
         <CommentForm root={root} compact={compact} />
 
         {/* Comments List */}
-        {isLoading ? (
+        {isLoading || hasCommentCountMismatch ? (
           <div className="space-y-4">
             {[...Array(3)].map((_, i) => (
               <Card key={i} className="bg-card/50">

--- a/src/hooks/useComments.test.ts
+++ b/src/hooks/useComments.test.ts
@@ -1,0 +1,94 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { NostrEvent } from '@nostrify/nostrify';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useComments } from '@/hooks/useComments';
+import { SHORT_VIDEO_KIND } from '@/types/video';
+
+const nostrQuery = vi.hoisted(() => vi.fn());
+
+vi.mock('@nostrify/react', () => ({
+  useNostr: () => ({
+    nostr: {
+      query: nostrQuery,
+    },
+  }),
+}));
+
+const ROOT_ID = '61e1c1413aa0e6b239eef566eadad4ce5ab70923facfddfec3aac2f6b04fa741';
+const ROOT_PUBKEY = '91ac02c1490ca2f1f78ed7c2b55d6513bf0b9bdaaf40037eb63820f616c7ba9f';
+const ROOT_D = 'e58ce5181cc90b8aa6dc995a92a9af14ce8756d06246811d5dfa62bd7e8163c7';
+const ROOT_COORDINATE = `${SHORT_VIDEO_KIND}:${ROOT_PUBKEY}:${ROOT_D}`;
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+}
+
+function rootEvent(): NostrEvent {
+  return {
+    id: ROOT_ID,
+    pubkey: ROOT_PUBKEY,
+    kind: SHORT_VIDEO_KIND,
+    tags: [['d', ROOT_D]],
+    content: '',
+    created_at: 1780229091,
+    sig: 'aa'.repeat(64),
+  };
+}
+
+function topLevelComment(): NostrEvent {
+  return {
+    id: '42fb4012ecabcce659f35b502bc32723fcf33d3f35fa438e37c84c58794ec985',
+    pubkey: 'aedd8f688e95f9533139ea7078b5c0fae73916f36ce29ad66e6c93d8296cf1be',
+    kind: 1111,
+    tags: [
+      ['E', ROOT_ID],
+      ['A', ROOT_COORDINATE],
+      ['K', String(SHORT_VIDEO_KIND)],
+      ['P', ROOT_PUBKEY],
+      ['e', ROOT_ID],
+      ['a', ROOT_COORDINATE],
+      ['k', String(SHORT_VIDEO_KIND)],
+      ['p', ROOT_PUBKEY],
+    ],
+    content: 'beta testing curiosity',
+    created_at: 1780517073,
+    sig: 'bb'.repeat(64),
+  };
+}
+
+describe('useComments', () => {
+  beforeEach(() => {
+    nostrQuery.mockReset();
+  });
+
+  it('immediately retries when a known comment count loads as empty', async () => {
+    const comment = topLevelComment();
+    nostrQuery
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([comment])
+      .mockResolvedValueOnce([]);
+
+    const { result } = renderHook(
+      () => useComments(rootEvent(), 500, { expectedCommentCount: 22 }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.data?.topLevelComments).toHaveLength(1);
+    });
+
+    expect(nostrQuery).toHaveBeenCalledTimes(4);
+  });
+});

--- a/src/hooks/useComments.ts
+++ b/src/hooks/useComments.ts
@@ -2,88 +2,122 @@ import { NKinds, NostrEvent, NostrFilter } from '@nostrify/nostrify';
 import { useNostr } from '@nostrify/react';
 import { useQuery } from '@tanstack/react-query';
 
-export function useComments(root: NostrEvent | URL, limit?: number) {
+type UseCommentsOptions = {
+  expectedCommentCount?: number;
+};
+
+type CommentsData = {
+  allComments: NostrEvent[];
+  topLevelComments: NostrEvent[];
+};
+
+const COMMENT_MISMATCH_RETRY_ATTEMPTS = 2;
+const COMMENT_MISMATCH_REFETCH_MS = 500;
+
+function getTagValue(event: NostrEvent, tagName: string): string | undefined {
+  const tag = event.tags.find(([name]) => name === tagName);
+  return tag?.[1];
+}
+
+function getAddressableId(root: NostrEvent): string {
+  const d = getTagValue(root, 'd') ?? '';
+  return `${root.kind}:${root.pubkey}:${d}`;
+}
+
+function buildCommentsData(root: NostrEvent | URL, events: NostrEvent[]): CommentsData {
+  const topLevelComments = events.filter(comment => {
+    if (root instanceof URL) {
+      return getTagValue(comment, 'i') === root.toString();
+    } else if (NKinds.addressable(root.kind)) {
+      const addressableId = getAddressableId(root);
+      const aMatch = getTagValue(comment, 'a') === addressableId;
+      const eMatch = getTagValue(comment, 'e') === root.id;
+      return aMatch || eMatch;
+    } else if (NKinds.replaceable(root.kind)) {
+      return getTagValue(comment, 'a') === `${root.kind}:${root.pubkey}:`;
+    } else {
+      return getTagValue(comment, 'e') === root.id;
+    }
+  });
+
+  return {
+    allComments: events,
+    topLevelComments: topLevelComments.sort((a, b) => b.created_at - a.created_at),
+  };
+}
+
+export function useComments(root: NostrEvent | URL, limit?: number, options: UseCommentsOptions = {}) {
   const { nostr } = useNostr();
+  const expectedCommentCount = options.expectedCommentCount ?? 0;
 
   return useQuery({
-    queryKey: ['nostr', 'comments', root instanceof URL ? root.toString() : root.id, limit],
+    queryKey: ['nostr', 'comments', root instanceof URL ? root.toString() : root.id, limit, expectedCommentCount],
     queryFn: async (c) => {
       const signal = AbortSignal.any([c.signal, AbortSignal.timeout(5000)]);
-      let events: NostrEvent[];
 
-      if (root instanceof URL) {
-        const filter: NostrFilter = { kinds: [1111], '#I': [root.toString()] };
-        if (typeof limit === 'number') filter.limit = limit;
-        events = await nostr.query([filter], { signal });
-      } else if (NKinds.addressable(root.kind)) {
-        // For addressable events, query by BOTH #E (event ID) and #A (addressable identifier)
-        // Funnelcake indexes by E tag, but NIP-22 standard uses A tag for addressable events
-        const d = root.tags.find(([name]) => name === 'd')?.[1] ?? '';
-        const addressableId = `${root.kind}:${root.pubkey}:${d}`;
+      const queryOnce = async (): Promise<CommentsData> => {
+        let events: NostrEvent[];
 
-        const filterByE: NostrFilter = { kinds: [1111], '#E': [root.id] };
-        const filterByA: NostrFilter = { kinds: [1111], '#A': [addressableId] };
-        if (typeof limit === 'number') {
-          filterByE.limit = limit;
-          filterByA.limit = limit;
+        if (root instanceof URL) {
+          const filter: NostrFilter = { kinds: [1111], '#I': [root.toString()] };
+          if (typeof limit === 'number') filter.limit = limit;
+          events = await nostr.query([filter], { signal });
+        } else if (NKinds.addressable(root.kind)) {
+          const addressableId = getAddressableId(root);
+
+          const filterByE: NostrFilter = { kinds: [1111], '#E': [root.id] };
+          const filterByA: NostrFilter = { kinds: [1111], '#A': [addressableId] };
+          if (typeof limit === 'number') {
+            filterByE.limit = limit;
+            filterByA.limit = limit;
+          }
+
+          const [eventsE, eventsA] = await Promise.all([
+            nostr.query([filterByE], { signal }),
+            nostr.query([filterByA], { signal }),
+          ]);
+
+          const seenIds = new Set<string>();
+          events = [...eventsE, ...eventsA].filter(e => {
+            if (seenIds.has(e.id)) return false;
+            seenIds.add(e.id);
+            return true;
+          });
+        } else if (NKinds.replaceable(root.kind)) {
+          const filter: NostrFilter = { kinds: [1111], '#A': [`${root.kind}:${root.pubkey}:`] };
+          if (typeof limit === 'number') filter.limit = limit;
+          events = await nostr.query([filter], { signal });
+        } else {
+          const filter: NostrFilter = { kinds: [1111], '#E': [root.id] };
+          if (typeof limit === 'number') filter.limit = limit;
+          events = await nostr.query([filter], { signal });
         }
 
-        // Run both queries in parallel and merge results
-        const [eventsE, eventsA] = await Promise.all([
-          nostr.query([filterByE], { signal }),
-          nostr.query([filterByA], { signal }),
-        ]);
+        return buildCommentsData(root, events);
+      };
 
-        // Deduplicate by event ID
-        const seenIds = new Set<string>();
-        events = [...eventsE, ...eventsA].filter(e => {
-          if (seenIds.has(e.id)) return false;
-          seenIds.add(e.id);
-          return true;
-        });
-      } else if (NKinds.replaceable(root.kind)) {
-        const filter: NostrFilter = { kinds: [1111], '#A': [`${root.kind}:${root.pubkey}:`] };
-        if (typeof limit === 'number') filter.limit = limit;
-        events = await nostr.query([filter], { signal });
-      } else {
-        const filter: NostrFilter = { kinds: [1111], '#E': [root.id] };
-        if (typeof limit === 'number') filter.limit = limit;
-        events = await nostr.query([filter], { signal });
+      let commentsData = await queryOnce();
+
+      for (
+        let attempt = 1;
+        expectedCommentCount > 0
+          && commentsData.topLevelComments.length === 0
+          && attempt < COMMENT_MISMATCH_RETRY_ATTEMPTS;
+        attempt += 1
+      ) {
+        commentsData = await queryOnce();
       }
 
-      // Helper function to get tag value
-      const getTagValue = (event: NostrEvent, tagName: string): string | undefined => {
-        const tag = event.tags.find(([name]) => name === tagName);
-        return tag?.[1];
-      };
-
-      // Filter top-level comments (those with lowercase tag matching the root)
-      const topLevelComments = events.filter(comment => {
-        if (root instanceof URL) {
-          return getTagValue(comment, 'i') === root.toString();
-        } else if (NKinds.addressable(root.kind)) {
-          const d = getTagValue(root, 'd') ?? '';
-          const addressableId = `${root.kind}:${root.pubkey}:${d}`;
-          // Top-level if parent matches root via either 'a' tag (addressable) or 'e' tag (event ID)
-          const aMatch = getTagValue(comment, 'a') === addressableId;
-          const eMatch = getTagValue(comment, 'e') === root.id;
-          return aMatch || eMatch;
-        } else if (NKinds.replaceable(root.kind)) {
-          return getTagValue(comment, 'a') === `${root.kind}:${root.pubkey}:`;
-        } else {
-          return getTagValue(comment, 'e') === root.id;
-        }
-      });
-
-      // Sort top-level comments by creation time (newest first)
-      const sortedTopLevel = topLevelComments.sort((a, b) => b.created_at - a.created_at);
-
-      return {
-        allComments: events,
-        topLevelComments: sortedTopLevel,
-      };
+      return commentsData;
     },
     enabled: !!root,
+    refetchInterval: (query) => {
+      const data = query.state.data as CommentsData | undefined;
+      return expectedCommentCount > 0 && data?.topLevelComments.length === 0
+        ? COMMENT_MISMATCH_REFETCH_MS
+        : false;
+    },
+    refetchIntervalInBackground: true,
   });
 }
 
@@ -91,11 +125,6 @@ export function useComments(root: NostrEvent | URL, limit?: number) {
  * Get direct replies to a comment
  */
 export function getDirectReplies(allComments: NostrEvent[], commentId: string): NostrEvent[] {
-  const getTagValue = (event: NostrEvent, tagName: string): string | undefined => {
-    const tag = event.tags.find(([name]) => name === tagName);
-    return tag?.[1];
-  };
-  
   const directReplies = allComments.filter(comment => {
     const eTag = getTagValue(comment, 'e');
     return eTag === commentId;

--- a/src/lib/serviceWorkerCleanup.test.ts
+++ b/src/lib/serviceWorkerCleanup.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { cleanupServiceWorkersAndCaches } from '@/lib/serviceWorkerCleanup';
+
+describe('cleanupServiceWorkersAndCaches', () => {
+  it('unregisters existing service workers and clears browser caches', async () => {
+    const unregisterFirst = vi.fn().mockResolvedValue(true);
+    const unregisterSecond = vi.fn().mockResolvedValue(true);
+    const deleteCache = vi.fn().mockResolvedValue(true);
+
+    const result = await cleanupServiceWorkersAndCaches({
+      serviceWorker: {
+        getRegistrations: vi.fn().mockResolvedValue([
+          { scope: 'https://divine.video/', unregister: unregisterFirst },
+          { scope: 'https://divine.video/old/', unregister: unregisterSecond },
+        ]),
+      },
+      caches: {
+        keys: vi.fn().mockResolvedValue(['workbox-precache-v1', 'runtime-videos']),
+        delete: deleteCache,
+      },
+      logger: { log: vi.fn(), warn: vi.fn() },
+    });
+
+    expect(unregisterFirst).toHaveBeenCalledTimes(1);
+    expect(unregisterSecond).toHaveBeenCalledTimes(1);
+    expect(deleteCache).toHaveBeenCalledWith('workbox-precache-v1');
+    expect(deleteCache).toHaveBeenCalledWith('runtime-videos');
+    expect(result).toEqual({
+      registrationsRemoved: 2,
+      cachesDeleted: 2,
+    });
+  });
+
+  it('does nothing when the browser has no service worker or cache APIs', async () => {
+    const result = await cleanupServiceWorkersAndCaches({
+      logger: { log: vi.fn(), warn: vi.fn() },
+    });
+
+    expect(result).toEqual({
+      registrationsRemoved: 0,
+      cachesDeleted: 0,
+    });
+  });
+});

--- a/src/lib/serviceWorkerCleanup.ts
+++ b/src/lib/serviceWorkerCleanup.ts
@@ -1,0 +1,86 @@
+type ServiceWorkerRegistrationLike = {
+  scope?: string;
+  unregister: () => boolean | Promise<boolean>;
+};
+
+type ServiceWorkerContainerLike = {
+  getRegistrations: () => Promise<readonly ServiceWorkerRegistrationLike[]>;
+};
+
+type CacheStorageLike = {
+  keys: () => Promise<string[]>;
+  delete: (cacheName: string) => boolean | Promise<boolean>;
+};
+
+type CleanupLogger = {
+  log?: (...args: unknown[]) => void;
+  warn?: (...args: unknown[]) => void;
+};
+
+type CleanupDependencies = {
+  serviceWorker?: ServiceWorkerContainerLike;
+  caches?: CacheStorageLike;
+  logger?: CleanupLogger;
+};
+
+type CleanupResult = {
+  registrationsRemoved: number;
+  cachesDeleted: number;
+};
+
+function getBrowserCleanupDependencies(): CleanupDependencies {
+  if (typeof window === 'undefined' || typeof navigator === 'undefined') {
+    return {};
+  }
+
+  return {
+    serviceWorker: 'serviceWorker' in navigator ? navigator.serviceWorker : undefined,
+    caches: 'caches' in window ? window.caches : undefined,
+    logger: console,
+  };
+}
+
+export async function cleanupServiceWorkersAndCaches(
+  dependencies: CleanupDependencies = getBrowserCleanupDependencies()
+): Promise<CleanupResult> {
+  let registrationsRemoved = 0;
+  let cachesDeleted = 0;
+
+  try {
+    const registrations = await dependencies.serviceWorker?.getRegistrations() ?? [];
+
+    for (const registration of registrations) {
+      const removed = await registration.unregister();
+      if (removed !== false) {
+        registrationsRemoved += 1;
+      }
+    }
+  } catch (error) {
+    dependencies.logger?.warn?.('[PWA] Service worker cleanup failed:', error);
+  }
+
+  try {
+    const cacheNames = await dependencies.caches?.keys() ?? [];
+
+    for (const cacheName of cacheNames) {
+      const deleted = await dependencies.caches?.delete(cacheName);
+      if (deleted !== false) {
+        cachesDeleted += 1;
+      }
+    }
+  } catch (error) {
+    dependencies.logger?.warn?.('[PWA] Cache cleanup failed:', error);
+  }
+
+  if (registrationsRemoved > 0 || cachesDeleted > 0) {
+    dependencies.logger?.log?.('[PWA] Removed stale offline cache state:', {
+      registrationsRemoved,
+      cachesDeleted,
+    });
+  }
+
+  return {
+    registrationsRemoved,
+    cachesDeleted,
+  };
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -21,6 +21,7 @@ hydrateLoginFromCookie();
 import { createRoot } from 'react-dom/client';
 import { IconContext } from '@phosphor-icons/react';
 import { initializeI18n } from '@/lib/i18n';
+import { cleanupServiceWorkersAndCaches } from '@/lib/serviceWorkerCleanup';
 
 // Import polyfills first
 import './lib/polyfills.ts';
@@ -43,41 +44,9 @@ import './index.css';
 // Import custom fonts
 import '@fontsource-variable/inter';
 
-// PWA Service Worker Registration
-// The app works fully without a service worker — SW is only for offline caching.
-// Skip registration on subdomains (e.g., alice.divine.video) — they don't need SW
-// and it causes errors when sw.js routing differs from the apex domain.
-const isSubdomain = /^[^.]+\.(dvine\.video|divine\.video)$/.test(location.hostname)
-  && !location.hostname.startsWith('www.');
-if ('serviceWorker' in navigator && !isSubdomain) {
+if ('serviceWorker' in navigator || 'caches' in window) {
   window.addEventListener('load', () => {
-    try {
-      navigator.serviceWorker.register('/sw.js', { scope: '/' })
-        .then((registration) => {
-          console.log('[PWA] Service Worker registered:', registration.scope);
-
-          // Check for updates every hour
-          setInterval(() => {
-            registration.update();
-          }, 60 * 60 * 1000);
-        })
-        .catch((error) => {
-          // User/browser denied SW permission, or SW script unavailable.
-          // App continues to work normally without offline caching.
-          console.warn('[PWA] Service Worker registration failed (app works without it):', error.message);
-        });
-    } catch (error) {
-      // Synchronous throw on some browsers when SW is completely blocked
-      console.warn('[PWA] Service Worker not available:', error);
-    }
-  });
-} else if (isSubdomain && 'serviceWorker' in navigator) {
-  // Unregister any existing SW on subdomains to clean up stale registrations
-  navigator.serviceWorker.getRegistrations().then(registrations => {
-    for (const registration of registrations) {
-      registration.unregister();
-      console.log('[PWA] Unregistered stale SW on subdomain');
-    }
+    void cleanupServiceWorkersAndCaches();
   });
 }
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="vite/client" />
-/// <reference types="vite-plugin-pwa/client" />
 
 // Build-time constants injected by Vite
 declare const __BUILD_TIME__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,6 @@ import path from "node:path";
 
 import react from "@vitejs/plugin-react-swc";
 import { configDefaults, defineConfig } from "vitest/config";
-import { VitePWA } from 'vite-plugin-pwa';
 
 // https://vitejs.dev/config/
 export default defineConfig(() => ({
@@ -56,80 +55,6 @@ export default defineConfig(() => ({
   },
   plugins: [
     react(),
-VitePWA({
-      registerType: 'autoUpdate',
-      injectRegister: null,
-      devOptions: {
-        enabled: false
-      },
-      workbox: {
-        // Disable all caching - network only
-        skipWaiting: true,
-        clientsClaim: true,
-        navigateFallback: null,
-        runtimeCaching: [],
-        // Allow larger JS bundles (default 2MB is too small for this app).
-        // 16 locales × ~1500 keys of i18n catalog inlined via import.meta.glob
-        // pushes the main bundle past 3.5MB; 5MB gives headroom for further growth.
-        // Long-term fix: lazy-load locale JSON instead of eager glob import.
-        maximumFileSizeToCacheInBytes: 5 * 1024 * 1024, // 5MB
-      },
-      includeAssets: [
-        'app_icon.png',
-        'favicon.png',
-        'divine-logo.svg',
-        'og.png',
-        'no-ai-icon.svg',
-        'divine_icon_transparent.avif',
-        'browserconfig.xml'
-      ],
-      manifest: {
-        name: 'Divine Web - Short-form Looping Videos',
-        short_name: 'Divine',
-        description: 'Watch and share 6-second looping videos on the decentralized Nostr network.',
-        theme_color: '#27C58B',
-        background_color: '#09090b',
-        display: 'standalone',
-        orientation: 'portrait-primary',
-        scope: '/',
-        start_url: '/',
-        categories: ['entertainment', 'video', 'social'],
-        screenshots: [
-          {
-            src: '/screenshots/iPad 13 inch-0.avif',
-            sizes: '2048x2732',
-            type: 'image/avif',
-            form_factor: 'wide'
-          },
-          {
-            src: '/screenshots/iPad 13 inch-1.avif',
-            sizes: '2048x2732',
-            type: 'image/avif',
-            form_factor: 'wide'
-          },
-          {
-            src: '/screenshots/iPad 13 inch-2.avif',
-            sizes: '2048x2732',
-            type: 'image/avif',
-            form_factor: 'wide'
-          }
-        ],
-        icons: [
-          {
-            src: 'app_icon.png',
-            sizes: '1024x1024',
-            type: 'image/png',
-            purpose: 'any'
-          },
-          {
-            src: 'app_icon.png',
-            sizes: '1024x1024',
-            type: 'image/png',
-            purpose: 'maskable'
-          }
-        ]
-      }
-    })
   ],
   test: {
     globals: true,


### PR DESCRIPTION
## Summary

- Retry comment queries immediately when a video advertises comments but the first relay response returns no top-level comments.
- Keep the comments modal in its existing loading state during that mismatch instead of showing a false empty thread.
- Remove the generated PWA service worker path and add automatic cleanup for stale service workers/caches.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- Comment metrics can come from a different path than the modal comment query, so a transient or stale empty response should not require users to know about manual cache cleanup or hidden unregister URLs.
- Stale service-worker cache state can preserve old frontend behavior after deploys, so the app should clean that up automatically.

## Related Issue

- N/A

## Testing

- [x] `npm run test`
- [x] Manual verification completed

Manual verification: opened the local discovery feed in the browser, opened a video comment modal whose metric showed comments, and confirmed comments loaded instead of the empty state.

## Visuals

- [ ] UI change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved