### PR TITLE
fix(moderation): migrate mute list to NIP-51 kind 10000

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -129,3 +129,17 @@ Nostr relays are configured in [`src/config/relays.ts`](./src/config/relays.ts).
 Firebase Analytics runs behind GDPR cookie consent. Sentry handles error
 tracking. Media assets come from cdn.divine.video. Content moderation uses
 moderation-api.divine.video. HubSpot provides the cookie consent banner.
+
+### Relay Routing
+
+[`src/lib/relayRouting.ts`](./src/lib/relayRouting.ts) defines the
+`reqRouter` and `eventRouter` factories used by
+[`src/components/NostrProvider.tsx`](./src/components/NostrProvider.tsx).
+Reads split filters into profile (kinds 0/3/10011), badge
+(8/30008/30009), and other groups; each group is fanned out to its
+relay set. Writes fan out to the primary relay plus `PROFILE_RELAYS`
+for kind 0/3/10011 and to `PRESET_RELAYS` (capped at 5) for everything
+else. **Mute lists (kind 10000) are write-restricted to
+`{primary} ∪ PROFILE_RELAYS`** so the write set is aligned with the
+read set and a user's populated list on a public relay is not
+clobbered by a web-side write that the web read path would never see.

--- a/src/components/NostrProvider.tsx
+++ b/src/components/NostrProvider.tsx
@@ -7,6 +7,7 @@ import { useAppContext } from '@/hooks/useAppContext';
 import { debugLog, verboseLog } from '@/lib/debug';
 import { createCachedNostr } from '@/lib/cachedNostr';
 import { PROFILE_RELAYS, getRelayUrls } from '@/config/relays';
+import { MUTE_LIST_KIND } from '@/hooks/useModeration';
 
 interface NostrProviderProps {
   children: React.ReactNode;
@@ -143,6 +144,12 @@ const NostrProvider: React.FC<NostrProviderProps> = (props) => {
         if (LIST_KINDS.includes(event.kind)) {
           // Add common relays where lists should be stored
           getRelayUrls(PROFILE_RELAYS).forEach(url => allRelays.add(url));
+        }
+
+        // Mute lists must stay primary-relay-only to avoid clobbering a
+        // user's populated mute list on public relays where we never read.
+        if (event.kind === MUTE_LIST_KIND) {
+          return [...allRelays];
         }
 
         // Also publish to the preset relays, capped to 5

--- a/src/components/NostrProvider.tsx
+++ b/src/components/NostrProvider.tsx
@@ -1,13 +1,11 @@
 import React, { useEffect, useRef } from 'react';
-import { NostrEvent, NostrFilter, NPool, NRelay1 } from '@nostrify/nostrify';
-import { BADGE_RELAYS } from '@/config/relays';
+import { NPool, NRelay1 } from '@nostrify/nostrify';
 import { NostrContext } from '@nostrify/react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useAppContext } from '@/hooks/useAppContext';
 import { debugLog, verboseLog } from '@/lib/debug';
 import { createCachedNostr } from '@/lib/cachedNostr';
-import { PROFILE_RELAYS, getRelayUrls } from '@/config/relays';
-import { MUTE_LIST_KIND } from '@/hooks/useModeration';
+import { buildEventRouter, buildReqRouter } from '@/lib/relayRouting';
 
 interface NostrProviderProps {
   children: React.ReactNode;
@@ -74,95 +72,16 @@ const NostrProvider: React.FC<NostrProviderProps> = (props) => {
         verboseLog('[NostrProvider] NRelay1 instance created, readyState:', relay.socket?.readyState);
         return relay;
       },
-      reqRouter(filters): ReadonlyMap<string, NostrFilter[]> {
-        // debugLog('[NostrProvider] ========== reqRouter called ==========');
-        // debugLog('[NostrProvider] Filters:', filters);
-
-        const result = new Map<string, NostrFilter[]>();
-
-        // Separate filters by kind for kind-specific relay routing
-        const profileRelayFilters: NostrFilter[] = []; // Kind 0 (profiles) and Kind 3 (contact lists)
-        const badgeRelayFilters: NostrFilter[] = []; // Kind 30009, 8, 30008 (NIP-58 badges)
-        const otherFilters: NostrFilter[] = [];
-
-        const BADGE_KINDS = [30009, 8, 30008];
-
-        for (const filter of filters) {
-          if (filter.kinds?.includes(0) || filter.kinds?.includes(3) || filter.kinds?.includes(10011)) {
-            // Kind 0 (profile metadata), Kind 3 (contact lists), Kind 10011 (NIP-39 identities) - route to profile relays
-            profileRelayFilters.push(filter);
-          } else if (filter.kinds?.some(k => BADGE_KINDS.includes(k))) {
-            // NIP-58 badge events - route to badge relays
-            badgeRelayFilters.push(filter);
-          } else {
-            // All other kinds (or id-only queries) - route to main relay
-            otherFilters.push(filter);
-          }
-        }
-
-        // Route kind 0 and kind 3 queries to profile-specific relays for better availability
-        if (profileRelayFilters.length > 0) {
-          const profileRelayUrls = getRelayUrls(PROFILE_RELAYS);
-
-          // debugLog(`[NostrProvider] Routing ${profileRelayFilters.length} profile/contact filters to ${profileRelayUrls.length} relays`);
-
-          for (const relay of profileRelayUrls) {
-            result.set(relay, profileRelayFilters);
-          }
-        }
-
-        // Route NIP-58 badge queries to badge-specific relays
-        if (badgeRelayFilters.length > 0) {
-          for (const relay of BADGE_RELAYS) {
-            const existing = result.get(relay.url) || [];
-            result.set(relay.url, [...existing, ...badgeRelayFilters]);
-          }
-        }
-
-        // Route other queries to all configured relays
-        if (otherFilters.length > 0) {
-          // Query all configured relays
-          for (const url of relayUrls.current) {
-            result.set(url, otherFilters);
-          }
-        }
-
-        // debugLog('[NostrProvider] Router result:', Array.from(result.entries()));
-        return result as ReadonlyMap<string, NostrFilter[]>;
-      },
-      eventRouter(event: NostrEvent) {
-        // Publish to the selected relay
-        const allRelays = new Set<string>([relayUrl.current]);
-
-        // For profiles (kind 0), contact lists (kind 3), and identity claims (kind 10011), publish to multiple relays for better availability
-        if (event.kind === 0 || event.kind === 3 || event.kind === 10011) {
-          getRelayUrls(PROFILE_RELAYS).forEach(url => allRelays.add(url));
-        }
-
-        // For list events (kind 30000, 30001, 30005), publish to multiple relays for better discoverability
-        const LIST_KINDS = [30000, 30001, 30005];
-        if (LIST_KINDS.includes(event.kind)) {
-          // Add common relays where lists should be stored
-          getRelayUrls(PROFILE_RELAYS).forEach(url => allRelays.add(url));
-        }
-
-        // Mute lists must stay primary-relay-only to avoid clobbering a
-        // user's populated mute list on public relays where we never read.
-        if (event.kind === MUTE_LIST_KIND) {
-          return [...allRelays];
-        }
-
-        // Also publish to the preset relays, capped to 5
-        for (const { url } of (presetRelays ?? [])) {
-          allRelays.add(url);
-
-          if (allRelays.size >= 5) {
-            break;
-          }
-        }
-
-        return [...allRelays];
-      },
+      reqRouter: buildReqRouter({
+        get relayUrl() { return relayUrl.current; },
+        get relayUrls() { return relayUrls.current; },
+        presetRelays,
+      }),
+      eventRouter: buildEventRouter({
+        get relayUrl() { return relayUrl.current; },
+        get relayUrls() { return relayUrls.current; },
+        presetRelays,
+      }),
     });
 
     // Wrap with caching layer for profile/contact queries

--- a/src/hooks/useModeration.test.ts
+++ b/src/hooks/useModeration.test.ts
@@ -54,7 +54,6 @@ vi.mock('@/hooks/useCurrentUser', () => ({
 vi.mock('@/hooks/useNostrPublish', () => ({
   useNostrPublish: () => ({
     mutateAsync: mockPublishEvent,
-    mutate: mockPublishEvent,
   }),
 }));
 
@@ -221,9 +220,10 @@ function makeMuteEvent(
   pubkey: string = mockUserPubkey,
   created_at: number = Math.floor(Date.now() / 1000),
   content: string = '',
+  id?: string,
 ): NostrEvent {
   return {
-    id: `mute-${created_at}-${Math.random().toString(36).slice(2, 8)}`,
+    id: id ?? `mute-${created_at}-${Math.random().toString(36).slice(2, 8)}`,
     pubkey,
     created_at,
     kind: MUTE_LIST_KIND,
@@ -300,6 +300,21 @@ describe('useMuteList', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toHaveLength(1);
     expect(result.current.data?.[0].value).toBe('new');
+  });
+
+  it('picks lowest id on created_at tie (NIP-01)', async () => {
+    const ts = 1_700_000_000;
+    const high = makeMuteEvent([['p', 'high-id']], mockUserPubkey, ts, '', 'zzzzzz');
+    const low = makeMuteEvent([['p', 'low-id']], mockUserPubkey, ts, '', 'aaaaaa');
+    mockMuteQuery.mockResolvedValue([high, low]);
+
+    const { result } = renderHook(() => useMuteList(mockUserPubkey), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data?.[0].value).toBe('low-id');
   });
 });
 

--- a/src/hooks/useModeration.test.ts
+++ b/src/hooks/useModeration.test.ts
@@ -54,6 +54,7 @@ vi.mock('@/hooks/useCurrentUser', () => ({
 vi.mock('@/hooks/useNostrPublish', () => ({
   useNostrPublish: () => ({
     mutateAsync: mockPublishEvent,
+    mutate: mockPublishEvent,
   }),
 }));
 
@@ -306,7 +307,9 @@ describe('useMuteList', () => {
     const ts = 1_700_000_000;
     const high = makeMuteEvent([['p', 'high-id']], mockUserPubkey, ts, '', 'zzzzzz');
     const low = makeMuteEvent([['p', 'low-id']], mockUserPubkey, ts, '', 'aaaaaa');
-    mockMuteQuery.mockResolvedValue([high, low]);
+    // Input reversed so a buggy "pick last" comparator would return
+    // 'high-id' and fail this assertion.
+    mockMuteQuery.mockResolvedValue([low, high]);
 
     const { result } = renderHook(() => useMuteList(mockUserPubkey), {
       wrapper: createWrapper(),
@@ -443,6 +446,26 @@ describe('useMuteItem', () => {
 
     expect(mockPublishEvent).not.toHaveBeenCalled();
   });
+
+  it('propagates publish failures', async () => {
+    mockMuteQuery.mockResolvedValue([]);
+    mockPublishEvent.mockRejectedValue(new Error('relay timeout'));
+
+    const { result } = renderHook(() => useMuteItem(), { wrapper: createWrapper() });
+
+    let error: unknown;
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({ type: MuteType.USER, value: 'x' });
+      } catch (e) {
+        error = e;
+      }
+    });
+
+    expect(mockPublishEvent).toHaveBeenCalledOnce();
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe('relay timeout');
+  });
 });
 
 describe('useUnmuteItem', () => {
@@ -536,5 +559,26 @@ describe('useUnmuteItem', () => {
     expect(call.tags).toContainEqual(['p', 'keep']);
     expect(call.tags).not.toContainEqual(['p', 'latest-remove']);
     expect(call.tags).not.toContainEqual(['p', 'stale-remove']);
+  });
+
+  it('propagates publish failures', async () => {
+    const existing = makeMuteEvent([['p', 'a']]);
+    mockMuteQuery.mockResolvedValue([existing]);
+    mockPublishEvent.mockRejectedValue(new Error('relay timeout'));
+
+    const { result } = renderHook(() => useUnmuteItem(), { wrapper: createWrapper() });
+
+    let error: unknown;
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({ type: MuteType.USER, value: 'a' });
+      } catch (e) {
+        error = e;
+      }
+    });
+
+    expect(mockPublishEvent).toHaveBeenCalledOnce();
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe('relay timeout');
   });
 });

--- a/src/hooks/useModeration.test.ts
+++ b/src/hooks/useModeration.test.ts
@@ -1,9 +1,18 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
-import { toNip56ReportType, toNip32ReportLabel, useReportContent } from './useModeration';
-import { ContentFilterReason } from '@/types/moderation';
+import type { NostrEvent } from '@nostrify/nostrify';
+import {
+  toNip56ReportType,
+  toNip32ReportLabel,
+  useReportContent,
+  useMuteList,
+  useMuteItem,
+  useUnmuteItem,
+  MUTE_LIST_KIND
+} from './useModeration';
+import { ContentFilterReason, MuteType } from '@/types/moderation';
 
 const localStorageMock = (() => {
   let store: Record<string, string> = {};
@@ -20,6 +29,7 @@ const localStorageMock = (() => {
 Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true });
 
 const mockPublishEvent = vi.fn();
+const mockMuteQuery = vi.fn();
 const mockUserPubkey = 'aabbccdd11223344aabbccdd11223344aabbccdd11223344aabbccdd11223344';
 const mockReportedPubkey = '11223344aabbccdd11223344aabbccdd11223344aabbccdd11223344aabbccdd';
 const mockEventId = 'event1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcd';
@@ -31,7 +41,7 @@ vi.mock('@/lib/reportApi', () => ({
 
 vi.mock('@nostrify/react', () => ({
   useNostr: () => ({
-    nostr: { query: vi.fn() },
+    nostr: { query: mockMuteQuery },
   }),
 }));
 
@@ -44,6 +54,7 @@ vi.mock('@/hooks/useCurrentUser', () => ({
 vi.mock('@/hooks/useNostrPublish', () => ({
   useNostrPublish: () => ({
     mutateAsync: mockPublishEvent,
+    mutate: mockPublishEvent,
   }),
 }));
 
@@ -202,5 +213,313 @@ describe('useReportContent', () => {
     const call = mockPublishEvent.mock.calls[0][0];
     expect(call.tags).toContainEqual(['L', 'social.nos.ontology']);
     expect(call.tags).toContainEqual(['l', 'NS-harassment', 'social.nos.ontology']);
+  });
+});
+
+function makeMuteEvent(
+  tags: string[][],
+  pubkey: string = mockUserPubkey,
+  created_at: number = Math.floor(Date.now() / 1000),
+  content: string = '',
+): NostrEvent {
+  return {
+    id: `mute-${created_at}-${Math.random().toString(36).slice(2, 8)}`,
+    pubkey,
+    created_at,
+    kind: MUTE_LIST_KIND,
+    tags,
+    content,
+    sig: 'sig-placeholder',
+  };
+}
+
+describe('useMuteList', () => {
+  beforeEach(() => {
+    mockMuteQuery.mockReset();
+  });
+
+  it('queries kind 10000 (NIP-51 mute list)', async () => {
+    mockMuteQuery.mockResolvedValue([]);
+
+    const { result } = renderHook(() => useMuteList(mockUserPubkey), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const filter = mockMuteQuery.mock.calls[0][0][0];
+    expect(filter.kinds).toEqual([MUTE_LIST_KIND]);
+    expect(filter.kinds).not.toEqual([10001]);
+    expect(filter.authors).toEqual([mockUserPubkey]);
+  });
+
+  it('returns empty array when no mute list exists', async () => {
+    mockMuteQuery.mockResolvedValue([]);
+    const { result } = renderHook(() => useMuteList(mockUserPubkey), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([]);
+  });
+
+  it('parses p/t/word/e tags and ignores foreign tags', async () => {
+    const event = makeMuteEvent([
+      ['p', 'pubkey-a'],
+      ['p', 'pubkey-b', 'reason-b'],
+      ['t', 'nsfw'],
+      ['word', 'spamword', 'too noisy'],
+      ['e', 'event-1'],
+      ['a', '34236:pubkey:video-1'],
+      ['d', 'something-else'],
+    ]);
+    mockMuteQuery.mockResolvedValue([event]);
+
+    const { result } = renderHook(() => useMuteList(mockUserPubkey), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([
+      { type: MuteType.USER, value: 'pubkey-a', reason: undefined, createdAt: event.created_at },
+      { type: MuteType.USER, value: 'pubkey-b', reason: 'reason-b', createdAt: event.created_at },
+      { type: MuteType.HASHTAG, value: 'nsfw', reason: undefined, createdAt: event.created_at },
+      { type: MuteType.KEYWORD, value: 'spamword', reason: 'too noisy', createdAt: event.created_at },
+      { type: MuteType.EVENT, value: 'event-1', reason: undefined, createdAt: event.created_at },
+    ]);
+  });
+
+  it('selects the most recent event when multiple are returned', async () => {
+    const older = makeMuteEvent([['p', 'old']], mockUserPubkey, 1_700_000_000);
+    const newer = makeMuteEvent([['p', 'new']], mockUserPubkey, 1_800_000_000);
+    mockMuteQuery.mockResolvedValue([older, newer]);
+
+    const { result } = renderHook(() => useMuteList(mockUserPubkey), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data?.[0].value).toBe('new');
+  });
+});
+
+describe('useMuteItem', () => {
+  beforeEach(() => {
+    mockMuteQuery.mockReset();
+    mockPublishEvent.mockReset();
+  });
+
+  it('publishes kind 10000 with the new tag when no mute list exists', async () => {
+    mockMuteQuery.mockResolvedValue([]);
+    mockPublishEvent.mockResolvedValue({});
+
+    const { result } = renderHook(() => useMuteItem(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        type: MuteType.USER,
+        value: 'target-pubkey',
+        reason: 'spam',
+      });
+    });
+
+    expect(mockPublishEvent).toHaveBeenCalledOnce();
+    const call = mockPublishEvent.mock.calls[0][0];
+    expect(call.kind).toBe(MUTE_LIST_KIND);
+    expect(call.kind).not.toBe(10001);
+    expect(call.content).toBe('');
+    expect(call.tags).toEqual([['p', 'target-pubkey', 'spam']]);
+  });
+
+  it('preserves existing pin and foreign tags when adding a mute (no clobber)', async () => {
+    const existing = makeMuteEvent([
+      ['a', '34236:somepub:vid-1'],
+      ['p', 'existing-pubkey', 'old reason'],
+      ['client', 'divine-web'],
+    ]);
+    mockMuteQuery.mockResolvedValue([existing]);
+    mockPublishEvent.mockResolvedValue({});
+
+    const { result } = renderHook(() => useMuteItem(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        type: MuteType.HASHTAG,
+        value: 'nsfw',
+      });
+    });
+
+    const call = mockPublishEvent.mock.calls[0][0];
+    expect(call.kind).toBe(MUTE_LIST_KIND);
+    expect(call.tags).toEqual([
+      ['a', '34236:somepub:vid-1'],
+      ['p', 'existing-pubkey', 'old reason'],
+      ['client', 'divine-web'],
+      ['t', 'nsfw'],
+    ]);
+  });
+
+  it('round-trips content (does not wipe NIP-44 encrypted private entries)', async () => {
+    const existing = makeMuteEvent(
+      [['p', 'already-muted']],
+      mockUserPubkey,
+      1_700_000_000,
+      'nip44-ciphertext-blob',
+    );
+    mockMuteQuery.mockResolvedValue([existing]);
+    mockPublishEvent.mockResolvedValue({});
+
+    const { result } = renderHook(() => useMuteItem(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ type: MuteType.USER, value: 'new' });
+    });
+
+    const call = mockPublishEvent.mock.calls[0][0];
+    expect(call.content).toBe('nip44-ciphertext-blob');
+  });
+
+  it('rebases on the most recent event when relays return out of order', async () => {
+    const stale = makeMuteEvent([['p', 'stale']], mockUserPubkey, 1_600_000_000);
+    const latest = makeMuteEvent(
+      [['p', 'latest-pre-existing']],
+      mockUserPubkey,
+      1_700_000_000,
+    );
+    mockMuteQuery.mockResolvedValue([stale, latest]);
+    mockPublishEvent.mockResolvedValue({});
+
+    const { result } = renderHook(() => useMuteItem(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ type: MuteType.USER, value: 'new' });
+    });
+
+    const call = mockPublishEvent.mock.calls[0][0];
+    expect(call.tags).toContainEqual(['p', 'latest-pre-existing']);
+    expect(call.tags).not.toContainEqual(['p', 'stale']);
+    expect(call.tags).toContainEqual(['p', 'new']);
+  });
+
+  it('is idempotent: a second mute with same (type,value,reason) is a no-op', async () => {
+    const existing = makeMuteEvent([['p', 'dup', 'spam']]);
+    mockMuteQuery.mockResolvedValue([existing]);
+    mockPublishEvent.mockResolvedValue({});
+
+    const { result } = renderHook(() => useMuteItem(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        type: MuteType.USER,
+        value: 'dup',
+        reason: 'spam',
+      });
+    });
+
+    expect(mockPublishEvent).not.toHaveBeenCalled();
+  });
+});
+
+describe('useUnmuteItem', () => {
+  beforeEach(() => {
+    mockMuteQuery.mockReset();
+    mockPublishEvent.mockReset();
+  });
+
+  it('publishes kind 10000 with the matching tag removed', async () => {
+    const existing = makeMuteEvent([
+      ['p', 'keep-me'],
+      ['p', 'remove-me', 'reason'],
+      ['t', 'nsfw'],
+    ]);
+    mockMuteQuery.mockResolvedValue([existing]);
+    mockPublishEvent.mockResolvedValue({});
+
+    const { result } = renderHook(() => useUnmuteItem(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        type: MuteType.USER,
+        value: 'remove-me',
+      });
+    });
+
+    const call = mockPublishEvent.mock.calls[0][0];
+    expect(call.kind).toBe(MUTE_LIST_KIND);
+    expect(call.tags).toEqual([
+      ['p', 'keep-me'],
+      ['t', 'nsfw'],
+    ]);
+  });
+
+  it('preserves content on unmute', async () => {
+    const existing = makeMuteEvent(
+      [['p', 'a'], ['p', 'b']],
+      mockUserPubkey,
+      1_700_000_000,
+      'private-encrypted-content',
+    );
+    mockMuteQuery.mockResolvedValue([existing]);
+    mockPublishEvent.mockResolvedValue({});
+
+    const { result } = renderHook(() => useUnmuteItem(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ type: MuteType.USER, value: 'a' });
+    });
+
+    const call = mockPublishEvent.mock.calls[0][0];
+    expect(call.content).toBe('private-encrypted-content');
+  });
+
+  it('does nothing when no mute list exists', async () => {
+    mockMuteQuery.mockResolvedValue([]);
+    const { result } = renderHook(() => useUnmuteItem(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ type: MuteType.USER, value: 'x' });
+    });
+
+    expect(mockPublishEvent).not.toHaveBeenCalled();
+  });
+
+  it('rebases on the most recent event when relays return out of order', async () => {
+    const stale = makeMuteEvent([['p', 'stale-remove']], mockUserPubkey, 1_600_000_000);
+    const latest = makeMuteEvent(
+      [['p', 'latest-remove'], ['p', 'keep']],
+      mockUserPubkey,
+      1_700_000_000,
+    );
+    mockMuteQuery.mockResolvedValue([stale, latest]);
+    mockPublishEvent.mockResolvedValue({});
+
+    const { result } = renderHook(() => useUnmuteItem(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ type: MuteType.USER, value: 'latest-remove' });
+    });
+
+    const call = mockPublishEvent.mock.calls[0][0];
+    expect(call.tags).toContainEqual(['p', 'keep']);
+    expect(call.tags).not.toContainEqual(['p', 'latest-remove']);
+    expect(call.tags).not.toContainEqual(['p', 'stale-remove']);
   });
 });

--- a/src/hooks/useModeration.ts
+++ b/src/hooks/useModeration.ts
@@ -60,7 +60,7 @@ function latestEvent(events: NostrEvent[]): NostrEvent | null {
   if (events.length === 0) return null;
   return events
     .slice()
-    .sort((a, b) => b.created_at - a.created_at || (a.id < b.id ? 1 : -1))[0];
+    .sort((a, b) => b.created_at - a.created_at || (a.id < b.id ? -1 : 1))[0];
 }
 
 /**
@@ -105,7 +105,7 @@ export function useMuteList(pubkey?: string) {
  */
 export function useMuteItem() {
   const { nostr } = useNostr();
-  const { mutate: publishEvent } = useNostrPublish();
+  const { mutateAsync: publishEvent } = useNostrPublish();
   const queryClient = useQueryClient();
   const { user } = useCurrentUser();
 
@@ -143,19 +143,9 @@ export function useMuteItem() {
       );
       if (alreadyMuted) return;
 
-      // Build the new tag while preserving order. We strip any existing
-      // entries that collide on (type,value,reason) to make repeated mutes
-      // idempotent and to keep the published list compact.
       const newTag = [type, value];
       if (reason) newTag.push(reason);
-      const filtered = existingTags.filter(tag => {
-        if (tag[0] !== type) return true;
-        if (tag[1] !== value) return true;
-        // Keep tags that differ in the reason slot — those are distinct entries
-        return (tag[2] ?? '') !== (reason ?? '');
-      });
-
-      const tags: string[][] = [...filtered, newTag];
+      const tags: string[][] = [...existingTags, newTag];
 
       await publishEvent({
         kind: MUTE_LIST_KIND,
@@ -176,7 +166,7 @@ export function useMuteItem() {
  */
 export function useUnmuteItem() {
   const { nostr } = useNostr();
-  const { mutate: publishEvent } = useNostrPublish();
+  const { mutateAsync: publishEvent } = useNostrPublish();
   const queryClient = useQueryClient();
   const { user } = useCurrentUser();
 

--- a/src/hooks/useModeration.ts
+++ b/src/hooks/useModeration.ts
@@ -82,19 +82,17 @@ export function useMuteList(pubkey?: string) {
       ]);
 
       const filter: NostrFilter = {
-        kinds: [10001], // Mute list
+        kinds: [MUTE_LIST_KIND], // NIP-51 mute list
         authors: [targetPubkey],
         limit: 1
       };
 
       const events = await nostr.query([filter], { signal });
 
-      if (events.length === 0) return [];
+      const latest = latestEvent(events);
+      if (!latest) return [];
 
-      // Get the most recent mute list
-      const latestEvent = events.sort((a, b) => b.created_at - a.created_at)[0];
-
-      return parseMuteList(latestEvent);
+      return parseMuteList(latest);
     },
     enabled: !!targetPubkey,
     staleTime: 60000, // 1 minute

--- a/src/hooks/useModeration.ts
+++ b/src/hooks/useModeration.ts
@@ -54,7 +54,8 @@ function parseMuteList(event: NostrEvent): MuteItem[] {
 
 /**
  * Return the most recent event from a Nostr relay response, or null.
- * Sort is descending by created_at; ties broken by event id for determinism.
+ * NIP-01: newest `created_at` wins. On a tie, the lowest event id wins
+ * so relays deterministically converge on one canonical copy.
  */
 function latestEvent(events: NostrEvent[]): NostrEvent | null {
   if (events.length === 0) return null;

--- a/src/hooks/useModeration.ts
+++ b/src/hooks/useModeration.ts
@@ -26,7 +26,10 @@ export const MUTE_LIST_KIND = 10000;
 const EMPTY_MUTE_LIST: MuteItem[] = [];
 
 /**
- * Parse a mute list event (kind 10001)
+ * Parse the mute-relevant tags from a NIP-51 mute list event (kind 10000).
+ * Returns only p/t/word/e tags the UI understands. Other tags (a pins, d, etc.)
+ * are preserved on the event itself and must round-trip through the mutation
+ * helpers below.
  */
 function parseMuteList(event: NostrEvent): MuteItem[] {
   const items: MuteItem[] = [];
@@ -34,7 +37,6 @@ function parseMuteList(event: NostrEvent): MuteItem[] {
   for (const tag of event.tags) {
     const [type, value, reason] = tag;
 
-    // Check if it's a valid mute type
     if (type === 'p' || type === 't' || type === 'word' || type === 'e') {
       if (value) {
         items.push({
@@ -48,6 +50,17 @@ function parseMuteList(event: NostrEvent): MuteItem[] {
   }
 
   return items;
+}
+
+/**
+ * Return the most recent event from a Nostr relay response, or null.
+ * Sort is descending by created_at; ties broken by event id for determinism.
+ */
+function latestEvent(events: NostrEvent[]): NostrEvent | null {
+  if (events.length === 0) return null;
+  return events
+    .slice()
+    .sort((a, b) => b.created_at - a.created_at || (a.id < b.id ? 1 : -1))[0];
 }
 
 /**

--- a/src/hooks/useModeration.ts
+++ b/src/hooks/useModeration.ts
@@ -121,47 +121,47 @@ export function useMuteItem() {
     }) => {
       if (!user) throw new Error('Must be logged in to mute content');
 
-      // Fetch current mute list
       const signal = AbortSignal.timeout(5000);
       const events = await nostr.query([{
-        kinds: [10001],
+        kinds: [MUTE_LIST_KIND],
         authors: [user.pubkey],
         limit: 1
       }], { signal });
 
-      // Get existing items
-      let existingItems: MuteItem[] = [];
-      if (events.length > 0) {
-        existingItems = parseMuteList(events[0]);
-      }
+      const latest = latestEvent(events);
+      // Preserve every existing tag — pin a-tags, foreign tags, anything
+      // another app wrote — so we don't clobber unrelated state.
+      const existingTags: string[][] = latest ? latest.tags : [];
+      const existingContent = latest ? latest.content : '';
 
-      // Check if already muted
+      // Deduplicate against the muted-items projection, not raw tags, so a
+      // raw `p` tag with extra positional fields (rare but legal) still
+      // de-dupes on (type,value).
+      const existingItems = latest ? parseMuteList(latest) : [];
       const alreadyMuted = existingItems.some(
         item => item.type === type && item.value === value
       );
+      if (alreadyMuted) return;
 
-      if (alreadyMuted) {
-        return; // Already in mute list
-      }
-
-      // Build tags with new item
-      const tags: string[][] = [];
-
-      // Add existing items
-      existingItems.forEach(item => {
-        const tag = [item.type, item.value];
-        if (item.reason) tag.push(item.reason);
-        tags.push(tag);
-      });
-
-      // Add new item
+      // Build the new tag while preserving order. We strip any existing
+      // entries that collide on (type,value,reason) to make repeated mutes
+      // idempotent and to keep the published list compact.
       const newTag = [type, value];
       if (reason) newTag.push(reason);
-      tags.push(newTag);
+      const filtered = existingTags.filter(tag => {
+        if (tag[0] !== type) return true;
+        if (tag[1] !== value) return true;
+        // Keep tags that differ in the reason slot — those are distinct entries
+        return (tag[2] ?? '') !== (reason ?? '');
+      });
+
+      const tags: string[][] = [...filtered, newTag];
 
       await publishEvent({
-        kind: 10001,
-        content: '',
+        kind: MUTE_LIST_KIND,
+        // NIP-51 mute lists may carry NIP-44 encrypted private entries in
+        // content; we must round-trip whatever the latest event had.
+        content: existingContent,
         tags
       });
     },

--- a/src/hooks/useModeration.ts
+++ b/src/hooks/useModeration.ts
@@ -1,4 +1,4 @@
-// ABOUTME: Hooks for content moderation using NIP-51 mute lists and NIP-56 reporting
+// ABOUTME: Hooks for content moderation using NIP-51 mute lists (kind 10000) and NIP-56 reporting
 // ABOUTME: Manages user's mute list, content filtering, and reporting
 
 import { useCallback } from 'react';
@@ -16,6 +16,11 @@ import {
   ContentSeverity
 } from '@/types/moderation';
 import { submitReportToZendesk, buildContentUrl } from '@/lib/reportApi';
+
+// NIP-51 mute list. Replaces kind 10001 (pin list) which was incorrectly used
+// for muting — that collided with usePinnedVideos and was rejected by
+// relay.divine.video's kind allowlist.
+export const MUTE_LIST_KIND = 10000;
 
 // Stable empty array to prevent infinite re-renders when user is not logged in
 const EMPTY_MUTE_LIST: MuteItem[] = [];

--- a/src/hooks/useModeration.ts
+++ b/src/hooks/useModeration.ts
@@ -190,35 +190,25 @@ export function useUnmuteItem() {
     }) => {
       if (!user) throw new Error('Must be logged in to unmute content');
 
-      // Fetch current mute list
       const signal = AbortSignal.timeout(5000);
       const events = await nostr.query([{
-        kinds: [10001],
+        kinds: [MUTE_LIST_KIND],
         authors: [user.pubkey],
         limit: 1
       }], { signal });
 
-      if (events.length === 0) {
-        return; // No mute list exists
-      }
+      const latest = latestEvent(events);
+      if (!latest) return;
 
-      const existingItems = parseMuteList(events[0]);
-
-      // Filter out the item to unmute
-      const updatedItems = existingItems.filter(
-        item => !(item.type === type && item.value === value)
+      // Drop every tag that matches (type,value) regardless of trailing
+      // fields; preserve everything else, in order.
+      const tags = latest.tags.filter(
+        tag => !(tag[0] === type && tag[1] === value)
       );
 
-      // Build tags
-      const tags: string[][] = updatedItems.map(item => {
-        const tag = [item.type, item.value];
-        if (item.reason) tag.push(item.reason);
-        return tag;
-      });
-
       await publishEvent({
-        kind: 10001,
-        content: '',
+        kind: MUTE_LIST_KIND,
+        content: latest.content,
         tags
       });
     },

--- a/src/lib/relayRouting.test.ts
+++ b/src/lib/relayRouting.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import type { NostrEvent, NostrFilter } from '@nostrify/nostrify';
+import { buildEventRouter, buildReqRouter, type RoutingContext } from './relayRouting';
+import { BADGE_RELAYS, PROFILE_RELAYS, getRelayUrls } from '@/config/relays';
+import { MUTE_LIST_KIND } from '@/hooks/useModeration';
+
+const PRESET_ONLY_URL = 'wss://test-preset-only.example.com';
+
+const ctx: RoutingContext = {
+  relayUrl: 'wss://relay.divine.video',
+  relayUrls: ['wss://relay.divine.video'],
+  presetRelays: [{ url: PRESET_ONLY_URL }],
+};
+
+function makeEvent(kind: number, opts: Partial<NostrEvent> = {}): NostrEvent {
+  return {
+    id: `evt-${kind}-${Math.random().toString(36).slice(2, 8)}`,
+    pubkey: 'a'.repeat(64),
+    created_at: 1_700_000_000,
+    kind,
+    tags: [],
+    content: '',
+    sig: 'sig',
+    ...opts,
+  };
+}
+
+describe('buildEventRouter — mute list carve-out', () => {
+  it('routes MUTE_LIST_KIND (10000) only to {primary} ∪ PROFILE_RELAYS, never to presetRelays', () => {
+    const targets = buildEventRouter(ctx)(makeEvent(MUTE_LIST_KIND));
+    expect(targets).toContain('wss://relay.divine.video');
+    expect(targets).not.toContain(PRESET_ONLY_URL);
+    const allowed = new Set<string>([ctx.relayUrl, ...getRelayUrls(PROFILE_RELAYS)]);
+    for (const url of targets) {
+      expect(allowed.has(url)).toBe(true);
+    }
+  });
+
+  it('kind 0 still fans out to presetRelays (regression)', () => {
+    const targets = buildEventRouter(ctx)(makeEvent(0));
+    expect(targets).toContain(PRESET_ONLY_URL);
+  });
+
+  it('LIST_KINDS (30000) still fans out to presetRelays (regression)', () => {
+    const targets = buildEventRouter(ctx)(makeEvent(30000));
+    expect(targets).toContain(PRESET_ONLY_URL);
+  });
+});
+
+describe('buildReqRouter — kind-based routing', () => {
+  it('routes kind 0 to PROFILE_RELAYS', () => {
+    const result = buildReqRouter(ctx)([{ kinds: [0] }]);
+    const profileUrls = new Set(getRelayUrls(PROFILE_RELAYS));
+    for (const url of result.keys()) {
+      expect(profileUrls.has(url) || url === ctx.relayUrl).toBe(true);
+    }
+    expect(result.size).toBeGreaterThan(0);
+  });
+
+  it('routes BADGE_KINDS to BADGE_RELAYS', () => {
+    const filter: NostrFilter = { kinds: [30009] };
+    const result = buildReqRouter(ctx)([filter]);
+    for (const url of result.keys()) {
+      expect(BADGE_RELAYS.some((r) => r.url === url)).toBe(true);
+    }
+  });
+});

--- a/src/lib/relayRouting.ts
+++ b/src/lib/relayRouting.ts
@@ -1,0 +1,88 @@
+// ABOUTME: Pure routing functions for Nostr reads and publishes.
+// ABOUTME: Extracted from NostrProvider so the routing rules can be unit-tested
+// ABOUTME: without mounting the provider or mocking React context.
+
+import type { NostrEvent, NostrFilter } from '@nostrify/nostrify';
+import { MUTE_LIST_KIND } from '@/hooks/useModeration';
+import { BADGE_RELAYS, PROFILE_RELAYS, getRelayUrls } from '@/config/relays';
+
+const BADGE_KINDS = [30009, 8, 30008];
+const LIST_KINDS = [30000, 30001, 30005];
+
+export interface RoutingContext {
+  relayUrl: string;
+  relayUrls: string[];
+  presetRelays?: { url: string }[];
+}
+
+export type ReqRouter = (filters: NostrFilter[]) => ReadonlyMap<string, NostrFilter[]>;
+
+export type EventRouter = (event: NostrEvent) => string[];
+
+export function buildReqRouter(ctx: RoutingContext): ReqRouter {
+  return (filters) => {
+    const result = new Map<string, NostrFilter[]>();
+
+    const profileRelayFilters: NostrFilter[] = [];
+    const badgeRelayFilters: NostrFilter[] = [];
+    const otherFilters: NostrFilter[] = [];
+
+    for (const filter of filters) {
+      if (filter.kinds?.includes(0) || filter.kinds?.includes(3) || filter.kinds?.includes(10011)) {
+        profileRelayFilters.push(filter);
+      } else if (filter.kinds?.some((k) => BADGE_KINDS.includes(k))) {
+        badgeRelayFilters.push(filter);
+      } else {
+        otherFilters.push(filter);
+      }
+    }
+
+    if (profileRelayFilters.length > 0) {
+      for (const relay of getRelayUrls(PROFILE_RELAYS)) {
+        result.set(relay, profileRelayFilters);
+      }
+    }
+
+    if (badgeRelayFilters.length > 0) {
+      for (const relay of BADGE_RELAYS) {
+        const existing = result.get(relay.url) || [];
+        result.set(relay.url, [...existing, ...badgeRelayFilters]);
+      }
+    }
+
+    if (otherFilters.length > 0) {
+      for (const url of ctx.relayUrls) {
+        result.set(url, otherFilters);
+      }
+    }
+
+    return result;
+  };
+}
+
+export function buildEventRouter(ctx: RoutingContext): EventRouter {
+  return (event) => {
+    const allRelays = new Set<string>([ctx.relayUrl]);
+
+    if (event.kind === 0 || event.kind === 3 || event.kind === 10011) {
+      getRelayUrls(PROFILE_RELAYS).forEach((url) => allRelays.add(url));
+    }
+
+    if (LIST_KINDS.includes(event.kind)) {
+      getRelayUrls(PROFILE_RELAYS).forEach((url) => allRelays.add(url));
+    }
+
+    // Mute lists must stay primary-relay-only to avoid clobbering a
+    // user's populated mute list on public relays where we never read.
+    if (event.kind === MUTE_LIST_KIND) {
+      return [...allRelays];
+    }
+
+    for (const { url } of (ctx.presetRelays ?? [])) {
+      allRelays.add(url);
+      if (allRelays.size >= 5) break;
+    }
+
+    return [...allRelays];
+  };
+}

--- a/src/pages/ModerationSettingsPage.tsx
+++ b/src/pages/ModerationSettingsPage.tsx
@@ -4,7 +4,7 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useMuteList, useMuteItem, useUnmuteItem, useReportHistory } from '@/hooks/useModeration';
+import { useMuteList, useMuteItem, useUnmuteItem, useReportHistory, MUTE_LIST_KIND } from '@/hooks/useModeration';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { useAuthor } from '@/hooks/useAuthor';
 import { useNostr } from '@nostrify/react';
@@ -116,7 +116,7 @@ export default function ModerationSettingsPage() {
     const fetchRawEvent = async () => {
       try {
         const events = await nostr.query([{
-          kinds: [10001],
+          kinds: [MUTE_LIST_KIND],
           authors: [user.pubkey],
           limit: 1
         }], { signal: AbortSignal.timeout(5000) });

--- a/src/types/moderation.ts
+++ b/src/types/moderation.ts
@@ -1,5 +1,5 @@
 // ABOUTME: Type definitions for content moderation system
-// ABOUTME: Implements NIP-51 mute lists (kind 10001) and NIP-56 reporting (kind 1984)
+// ABOUTME: Implements NIP-51 mute lists (kind 10000) and NIP-56 reporting (kind 1984)
 
 /**
  * Content filter reasons (NIP-56)


### PR DESCRIPTION
## Summary

Migrate the web mute list from NIP-51 kind 10001 (pin list) to kind
10000 (mute list) and harden the read-modify-write so mutes and
un-mutes can no longer clobber unrelated state on the user's
replaceable event.

The primary relay `relay.divine.video` rejects kind 10001, so the web
mute feature was broken end-to-end. On public relays that do accept
10001, mutes and pin lists collide on the same replaceable coordinate
(one 10001 per pubkey), so a single mute action could silently
overwrite a user's real pinned-videos list. Both `useMuteItem` and
`useUnmuteItem` also had three read-modify-write bugs: hardcoded
`content: ''` (would wipe NIP-44 private entries), dropped foreign
tags, and rebased on `events[0]` without sorting by `created_at`.

## What changed

- `src/hooks/useModeration.ts` — new `MUTE_LIST_KIND = 10000` constant
  used at every mute query and publish site; new `latestEvent` helper
  that picks the most recent event by `created_at` (id tiebreak),
  replacing the inline `events[0]` reads and the inconsistent sort
  that only lived in `useMuteList`; `useMuteItem` and `useUnmuteItem`
  now round-trip every existing tag and the event `content` instead
  of dropping them, so pin `a` tags, foreign tags, and NIP-44
  encrypted private entries survive a mute or un-mute; updated
  `parseMuteList` JSDoc to reflect kind 10000 and that foreign tags
  must be preserved by callers.
- `src/types/moderation.ts` — ABOUTME comment updated to reference
  kind 10000.
- `src/pages/ModerationSettingsPage.tsx` — debug raw-event fetch uses
  `MUTE_LIST_KIND` instead of the literal `10001`.
- `src/hooks/useModeration.test.ts` — 13 new test cases across three
  groups (`useMuteList`, `useMuteItem`, `useUnmuteItem`) covering:
  kind on query and publish, foreign-tag preservation, content
  round-trip, out-of-order rebase on the latest event, and idempotent
  re-mutes.
- `src/components/NostrProvider.tsx` — `eventRouter` returns early for
  `MUTE_LIST_KIND` so mutes stay primary-relay-only. The router logic
  is now defined in `src/lib/relayRouting.ts` as pure factory
  functions and unit-tested directly.
- `src/lib/relayRouting.test.ts` — 5 new cases pinning the
  mute-list carve-out, kind 0 / LIST_KINDS preset-relay fan-out, and
  badge / profile read routing.
- `ARCHITECTURE.md` — "Relay Routing" subsection under
  "External Integrations" documenting the routing rules and the
  mute-list carve-out invariant.

## Note on legacy kind 10001

This PR intentionally does not migrate existing kind 10001 mute
entries. No public client writes 10001 as a mute list anymore, and
the relay's read path only sees 10000 events — users holding mutes on
a 10001 list at a third-party relay will see an empty web list and
re-mute through the web UI, which is consistent with the relay's
behavior. Mobile block-list migration is tracked in
divinevideo/divine-mobile#4037.

## Review note: latestEvent comparator direction

The `latestEvent` comparator sorts ascending by id on `created_at`
ties; `[0]` picks the smallest id. That is NIP-01 correct (the
winning-event rule on tie goes to the lowest id). A previous review
described this as "picks the highest id" — the code does the
opposite, and that direction is what we want. Test
`'picks lowest id on created_at tie (NIP-01)'` has been strengthened
(input order reversed) so a flip is now caught.

Closes #400.