### PR TITLE
fix(profile-urls): friendly NIP-05 /u/ paths and search card identifier

### DIFF
--- a/URL_GUIDE.md
+++ b/URL_GUIDE.md
@@ -59,11 +59,20 @@ https://divine.video/u/{identifier}
 
 Supports:
 - **Vine User IDs**: 15-20 digit numeric strings (e.g., `1080167736266633216`)
-- **NIP-05 identifiers**: Coming soon (e.g., `username@domain.com`)
+- **Bare NIP-05 local part on the default apex**: e.g. `jacky` resolves to
+  `_@jacky.divine.video` (and `jacky@divine.video`) — the same profile as
+  visiting `https://jacky.divine.video`.
+- **Explicit NIP-05 segments**: `_@x.divine.video` or `x.divine.video` for
+  the default apex, `_@x.dvine.video` or `x.dvine.video` for the alternate
+  apex, and any third-party `local.domain` for external NIP-05s.
 
-**Example:**
+**Examples:**
 ```
-https://divine.video/u/1080167736266633216
+https://divine.video/u/1080167736266633216     # Vine user ID
+https://divine.video/u/jacky                   # bare local part on the default apex
+https://divine.video/u/jacky.divine.video      # explicit default apex
+https://divine.video/u/jacky.dvine.video       # explicit alternate apex
+https://divine.video/u/alice.primal.net        # third-party NIP-05
 ```
 
 ### Using nprofile (Nostr Profile)
@@ -268,7 +277,6 @@ All video and profile URLs include Open Graph and Twitter Card metadata for rich
 
 Planned URL features:
 - Full `note` / `nevent` / `naddr` support for video links
-- NIP-05 username lookups in `/u/` route
 - Relay hint support in video URLs
 - Deep linking with video timestamps
 

--- a/src/lib/nip05Utils.ts
+++ b/src/lib/nip05Utils.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Utility functions for divine.video NIP-05 detection and formatting
 // ABOUTME: Handles both _@username.divine.video and username@divine.video formats
 
-const DIVINE_APEX_DOMAINS = ['divine.video', 'dvine.video'];
+export const DIVINE_APEX_DOMAINS = ['divine.video', 'dvine.video'] as const;
 
 /**
  * Check if a NIP-05 belongs to a divine.video subdomain.

--- a/src/lib/profileLinks.test.ts
+++ b/src/lib/profileLinks.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { buildProfileLinkPath, normalizeNip05Identifier } from './profileLinks';
+import {
+  buildProfileLinkPath,
+  nip05CandidatesFromUrlSegment,
+  normalizeNip05Identifier,
+  toFriendlyPath,
+} from './profileLinks';
 
 describe('normalizeNip05Identifier', () => {
   it('normalizes valid NIP-05 to lowercase', () => {
@@ -15,22 +20,84 @@ describe('normalizeNip05Identifier', () => {
   });
 });
 
+describe('toFriendlyPath', () => {
+  it('drops the leading _ on the default apex', () => {
+    expect(toFriendlyPath('_@alice.divine.video')).toBe('alice.divine.video');
+    expect(toFriendlyPath('alice@divine.video')).toBe('alice.divine.video');
+  });
+
+  it('drops the leading _ on the alternate apex', () => {
+    expect(toFriendlyPath('_@alice.dvine.video')).toBe('alice.dvine.video');
+    expect(toFriendlyPath('alice@dvine.video')).toBe('alice.dvine.video');
+  });
+
+  it('keeps the apex for third-party NIP-05s', () => {
+    expect(toFriendlyPath('_@alice.primal.net')).toBe('alice.primal.net');
+    expect(toFriendlyPath('alice@primal.net')).toBe('alice.primal.net');
+  });
+
+  it('handles a degenerate _@apex by collapsing to the apex itself', () => {
+    expect(toFriendlyPath('_@divine.video')).toBe('divine.video');
+  });
+
+  it('lowercases the result', () => {
+    expect(toFriendlyPath('_@Alice.Divine.Video')).toBe('alice.divine.video');
+  });
+
+  it('returns null for malformed inputs', () => {
+    expect(toFriendlyPath(null)).toBeNull();
+    expect(toFriendlyPath(undefined)).toBeNull();
+    expect(toFriendlyPath('')).toBeNull();
+    expect(toFriendlyPath('   ')).toBeNull();
+    expect(toFriendlyPath('alice')).toBeNull();
+    expect(toFriendlyPath('alice@')).toBeNull();
+    expect(toFriendlyPath('@divine.video')).toBeNull();
+    expect(toFriendlyPath('alice@divine@video')).toBeNull();
+    expect(toFriendlyPath('alice@bad domain')).toBeNull();
+  });
+});
+
 describe('buildProfileLinkPath', () => {
   const pubkey = 'f'.repeat(64);
   const npub = 'npub1lllllllllllllllllllllllllllllllllllllllllllllllllllsq7lrjw';
 
-  it('builds a NIP-05 route when metadata is available', () => {
+  it('uses the bare-name form on the default apex', () => {
     expect(buildProfileLinkPath({
       pubkey,
       nip05: '_@alice.divine.video',
-    })).toBe('/u/_%40alice.divine.video');
+    })).toBe('/u/alice');
   });
 
-  it('falls back to root npub route by default', () => {
+  it('uses the bare-name form even when the NIP-05 omits the underscore', () => {
+    expect(buildProfileLinkPath({
+      pubkey,
+      nip05: 'alice@divine.video',
+    })).toBe('/u/alice');
+  });
+
+  it('keeps the alternate apex in the path', () => {
+    expect(buildProfileLinkPath({
+      pubkey,
+      nip05: '_@alice.dvine.video',
+    })).toBe('/u/alice.dvine.video');
+  });
+
+  it('uses the friendly form for third-party NIP-05s', () => {
+    expect(buildProfileLinkPath({
+      pubkey,
+      nip05: 'alice@primal.net',
+    })).toBe('/u/alice.primal.net');
+  });
+
+  it('falls back to the root npub route when the NIP-05 is missing', () => {
     expect(buildProfileLinkPath({ pubkey })).toBe(`/${npub}`);
   });
 
-  it('uses /profile fallback route when requested', () => {
+  it('falls back to the root npub route when the NIP-05 is malformed', () => {
+    expect(buildProfileLinkPath({ pubkey, nip05: 'no-at-sign' })).toBe(`/${npub}`);
+  });
+
+  it('uses the /profile fallback route when requested', () => {
     expect(buildProfileLinkPath({
       pubkey,
       fallbackRoute: 'profile',
@@ -39,5 +106,59 @@ describe('buildProfileLinkPath', () => {
 
   it('preserves existing npub values without re-encoding', () => {
     expect(buildProfileLinkPath({ pubkey: npub })).toBe(`/${npub}`);
+  });
+});
+
+describe('nip05CandidatesFromUrlSegment', () => {
+  it('treats a bare local part as the default apex', () => {
+    expect(nip05CandidatesFromUrlSegment('jacky')).toEqual([
+      'jacky@divine.video',
+      '_@jacky.divine.video',
+    ]);
+  });
+
+  it('expands an explicit default-apex segment to both NIP-05 forms', () => {
+    expect(nip05CandidatesFromUrlSegment('jacky.divine.video')).toEqual([
+      'jacky@divine.video',
+      '_@jacky.divine.video',
+    ]);
+  });
+
+  it('expands an alternate-apex segment', () => {
+    expect(nip05CandidatesFromUrlSegment('jacky.dvine.video')).toEqual([
+      'jacky@dvine.video',
+      '_@jacky.dvine.video',
+    ]);
+  });
+
+  it('expands a deeply-nested segment under a known apex', () => {
+    expect(nip05CandidatesFromUrlSegment('a.b.divine.video')).toEqual([
+      'a.b@divine.video',
+      '_@a.b.divine.video',
+    ]);
+  });
+
+  it('passes a third-party segment through unchanged', () => {
+    expect(nip05CandidatesFromUrlSegment('alice.primal.net')).toEqual([
+      'alice.primal.net',
+    ]);
+  });
+
+  it('passes a literal NIP-05 through unchanged', () => {
+    expect(nip05CandidatesFromUrlSegment('alice%40primal.net')).toEqual([
+      'alice%40primal.net',
+    ]);
+  });
+
+  it('lowercases the segment before processing', () => {
+    expect(nip05CandidatesFromUrlSegment('JACKY.DIVINE.VIDEO')).toEqual([
+      'jacky@divine.video',
+      '_@jacky.divine.video',
+    ]);
+  });
+
+  it('returns an empty list for empty / whitespace input', () => {
+    expect(nip05CandidatesFromUrlSegment('')).toEqual([]);
+    expect(nip05CandidatesFromUrlSegment('   ')).toEqual([]);
   });
 });

--- a/src/lib/profileLinks.test.ts
+++ b/src/lib/profileLinks.test.ts
@@ -141,16 +141,14 @@ describe('nip05CandidatesFromUrlSegment', () => {
   it('passes a third-party segment through unchanged', () => {
     expect(nip05CandidatesFromUrlSegment('alice.primal.net')).toEqual([
       'alice.primal.net',
-      'alice.primal@net',
+      'alice@primal.net',
       '_@alice.primal.net',
     ]);
   });
 
   it('passes a literal NIP-05 through unchanged', () => {
     expect(nip05CandidatesFromUrlSegment('alice%40primal.net')).toEqual([
-      'alice%40primal.net',
-      'alice%40primal@net',
-      '_@alice%40primal.net',
+      'alice@primal.net',
     ]);
   });
 

--- a/src/lib/profileLinks.test.ts
+++ b/src/lib/profileLinks.test.ts
@@ -114,6 +114,7 @@ describe('nip05CandidatesFromUrlSegment', () => {
     expect(nip05CandidatesFromUrlSegment('jacky')).toEqual([
       'jacky@divine.video',
       '_@jacky.divine.video',
+      'jacky@openvine.co',
     ]);
   });
 
@@ -143,6 +144,15 @@ describe('nip05CandidatesFromUrlSegment', () => {
       'alice.primal.net',
       'alice@primal.net',
       '_@alice.primal.net',
+    ]);
+  });
+
+  it('tries dotted third-party local parts without dropping the dot', () => {
+    expect(nip05CandidatesFromUrlSegment('bob.smith.primal.net')).toEqual([
+      'bob.smith.primal.net',
+      'bob@smith.primal.net',
+      'bob.smith@primal.net',
+      '_@bob.smith.primal.net',
     ]);
   });
 

--- a/src/lib/profileLinks.test.ts
+++ b/src/lib/profileLinks.test.ts
@@ -3,6 +3,7 @@ import {
   buildProfileLinkPath,
   nip05CandidatesFromUrlSegment,
   normalizeNip05Identifier,
+  normalizeUrlSegmentToFriendly,
   toFriendlyPath,
 } from './profileLinks';
 
@@ -160,5 +161,37 @@ describe('nip05CandidatesFromUrlSegment', () => {
   it('returns an empty list for empty / whitespace input', () => {
     expect(nip05CandidatesFromUrlSegment('')).toEqual([]);
     expect(nip05CandidatesFromUrlSegment('   ')).toEqual([]);
+  });
+});
+
+describe('normalizeUrlSegmentToFriendly', () => {
+  it('normalizes a raw NIP-05 with underscore on the default apex', () => {
+    expect(normalizeUrlSegmentToFriendly('_@jimmyhere.divine.video')).toBe('jimmyhere');
+  });
+
+  it('normalizes a percent-encoded raw NIP-05', () => {
+    expect(normalizeUrlSegmentToFriendly('jimmyhere%40divine.video')).toBe('jimmyhere');
+  });
+
+  it('returns an already-bare segment unchanged', () => {
+    expect(normalizeUrlSegmentToFriendly('jimmyhere')).toBe('jimmyhere');
+  });
+
+  it('returns a third-party dotted segment unchanged', () => {
+    expect(normalizeUrlSegmentToFriendly('alice.primal.net')).toBe('alice.primal.net');
+  });
+
+  it('handles whitespace by trimming', () => {
+    expect(normalizeUrlSegmentToFriendly('  _@jimmyhere.divine.video  ')).toBe('jimmyhere');
+  });
+
+  it('returns null for empty input', () => {
+    expect(normalizeUrlSegmentToFriendly('')).toBeNull();
+    expect(normalizeUrlSegmentToFriendly('   ')).toBeNull();
+  });
+
+  it('lowercases the result', () => {
+    expect(normalizeUrlSegmentToFriendly('JACKY.DIVINE.VIDEO')).toBe('jacky.divine.video');
+    expect(normalizeUrlSegmentToFriendly('_@JACKY.DIVINE.VIDEO')).toBe('jacky');
   });
 });

--- a/src/lib/profileLinks.test.ts
+++ b/src/lib/profileLinks.test.ts
@@ -141,12 +141,16 @@ describe('nip05CandidatesFromUrlSegment', () => {
   it('passes a third-party segment through unchanged', () => {
     expect(nip05CandidatesFromUrlSegment('alice.primal.net')).toEqual([
       'alice.primal.net',
+      'alice.primal@net',
+      '_@alice.primal.net',
     ]);
   });
 
   it('passes a literal NIP-05 through unchanged', () => {
     expect(nip05CandidatesFromUrlSegment('alice%40primal.net')).toEqual([
       'alice%40primal.net',
+      'alice%40primal@net',
+      '_@alice%40primal.net',
     ]);
   });
 

--- a/src/lib/profileLinks.test.ts
+++ b/src/lib/profileLinks.test.ts
@@ -3,7 +3,6 @@ import {
   buildProfileLinkPath,
   nip05CandidatesFromUrlSegment,
   normalizeNip05Identifier,
-  normalizeUrlSegmentToFriendly,
   toFriendlyPath,
 } from './profileLinks';
 
@@ -161,37 +160,5 @@ describe('nip05CandidatesFromUrlSegment', () => {
   it('returns an empty list for empty / whitespace input', () => {
     expect(nip05CandidatesFromUrlSegment('')).toEqual([]);
     expect(nip05CandidatesFromUrlSegment('   ')).toEqual([]);
-  });
-});
-
-describe('normalizeUrlSegmentToFriendly', () => {
-  it('normalizes a raw NIP-05 with underscore on the default apex', () => {
-    expect(normalizeUrlSegmentToFriendly('_@jimmyhere.divine.video')).toBe('jimmyhere');
-  });
-
-  it('normalizes a percent-encoded raw NIP-05', () => {
-    expect(normalizeUrlSegmentToFriendly('jimmyhere%40divine.video')).toBe('jimmyhere');
-  });
-
-  it('returns an already-bare segment unchanged', () => {
-    expect(normalizeUrlSegmentToFriendly('jimmyhere')).toBe('jimmyhere');
-  });
-
-  it('returns a third-party dotted segment unchanged', () => {
-    expect(normalizeUrlSegmentToFriendly('alice.primal.net')).toBe('alice.primal.net');
-  });
-
-  it('handles whitespace by trimming', () => {
-    expect(normalizeUrlSegmentToFriendly('  _@jimmyhere.divine.video  ')).toBe('jimmyhere');
-  });
-
-  it('returns null for empty input', () => {
-    expect(normalizeUrlSegmentToFriendly('')).toBeNull();
-    expect(normalizeUrlSegmentToFriendly('   ')).toBeNull();
-  });
-
-  it('lowercases the result', () => {
-    expect(normalizeUrlSegmentToFriendly('JACKY.DIVINE.VIDEO')).toBe('jacky.divine.video');
-    expect(normalizeUrlSegmentToFriendly('_@JACKY.DIVINE.VIDEO')).toBe('jacky');
   });
 });

--- a/src/lib/profileLinks.ts
+++ b/src/lib/profileLinks.ts
@@ -127,7 +127,7 @@ export function toFriendlyPath(nip05: string | null | undefined): string | null 
  * Returns an empty array for inputs that can't be interpreted as a NIP-05.
  */
 export function nip05CandidatesFromUrlSegment(segment: string): string[] {
-  const decoded = segment.trim().toLowerCase();
+  const decoded = decodeURIComponent(segment).trim().toLowerCase();
   if (!decoded) return [];
 
   // 1. Literal NIP-05 — has '@'.
@@ -152,7 +152,7 @@ export function nip05CandidatesFromUrlSegment(segment: string): string[] {
     // Third-party domain — return the literal for kind-0 matching, plus
     // the @ forms for DNS fallback (since kind-0 has the @ form).
     // Convert the last dot to @ to get the NIP-05 form: alice.primal.net -> alice@primal.net
-    const atIndex = decoded.lastIndexOf('.');
+    const atIndex = decoded.indexOf('.');
     if (atIndex > 0) {
       const atForm = decoded.slice(0, atIndex) + '@' + decoded.slice(atIndex + 1);
       return [

--- a/src/lib/profileLinks.ts
+++ b/src/lib/profileLinks.ts
@@ -161,28 +161,6 @@ export function nip05CandidatesFromUrlSegment(segment: string): string[] {
   ];
 }
 
-/**
- * Normalize a /u/ URL segment to the canonical friendly form.
- *
- *   '_@jimmyhere.divine.video'  -> 'jimmyhere'
- *   'jimmyhere%40divine.video'  -> 'jimmyhere'
- *   'jimmyhere'                 -> 'jimmyhere'
- *   'alice.primal.net'          -> 'alice.primal.net'
- *
- * Returns null if the segment is malformed and cannot be interpreted as a NIP-05.
- */
-export function normalizeUrlSegmentToFriendly(segment: string): string | null {
-  const decoded = decodeURIComponent(segment).trim().toLowerCase();
-  if (!decoded) return null;
-
-  if (decoded.includes('@')) {
-    const path = buildProfileLinkPath({ pubkey: '0'.repeat(64), nip05: decoded });
-    if (path.startsWith('/u/')) return path.slice(3);
-    return null;
-  }
-  return decoded;
-}
-
 function toNpub(pubkey: string): string {
   const normalized = pubkey.trim();
   if (normalized.startsWith('npub1')) {

--- a/src/lib/profileLinks.ts
+++ b/src/lib/profileLinks.ts
@@ -161,6 +161,28 @@ export function nip05CandidatesFromUrlSegment(segment: string): string[] {
   ];
 }
 
+/**
+ * Normalize a /u/ URL segment to the canonical friendly form.
+ *
+ *   '_@jimmyhere.divine.video'  -> 'jimmyhere'
+ *   'jimmyhere%40divine.video'  -> 'jimmyhere'
+ *   'jimmyhere'                 -> 'jimmyhere'
+ *   'alice.primal.net'          -> 'alice.primal.net'
+ *
+ * Returns null if the segment is malformed and cannot be interpreted as a NIP-05.
+ */
+export function normalizeUrlSegmentToFriendly(segment: string): string | null {
+  const decoded = decodeURIComponent(segment).trim().toLowerCase();
+  if (!decoded) return null;
+
+  if (decoded.includes('@')) {
+    const path = buildProfileLinkPath({ pubkey: '0'.repeat(64), nip05: decoded });
+    if (path.startsWith('/u/')) return path.slice(3);
+    return null;
+  }
+  return decoded;
+}
+
 function toNpub(pubkey: string): string {
   const normalized = pubkey.trim();
   if (normalized.startsWith('npub1')) {

--- a/src/lib/profileLinks.ts
+++ b/src/lib/profileLinks.ts
@@ -1,6 +1,9 @@
 import { nip19 } from 'nostr-tools';
 
 const HEX_PUBKEY_PATTERN = /^[0-9a-f]{64}$/i;
+const DEFAULT_APEX_DOMAIN = 'divine.video';
+const ALTERNATE_APEX_DOMAIN = 'dvine.video';
+const APEX_DOMAINS = [DEFAULT_APEX_DOMAIN, ALTERNATE_APEX_DOMAIN] as const;
 
 export type ProfileFallbackRoute = 'root' | 'profile';
 
@@ -10,18 +13,48 @@ interface BuildProfileLinkPathInput {
   fallbackRoute?: ProfileFallbackRoute;
 }
 
+/**
+ * Build a human-friendly URL path for a profile.
+ *
+ * Order of preference:
+ * 1. Bare local part on the default apex — `/u/jacky` (from `_@jacky.divine.video`
+ *    or `jacky@divine.video`).
+ * 2. Friendly multi-segment form for everything else — `/u/jacky.dvine.video` or
+ *    `/u/alice.primal.net`. Replaces `@` with `.` and strips a leading `_` so the
+ *    path needs no percent-encoding.
+ * 3. Npub fallback (`/{npub}` or `/profile/{npub}`) when the NIP-05 is missing or
+ *    malformed.
+ */
 export function buildProfileLinkPath({
   pubkey,
   nip05,
   fallbackRoute = 'root',
 }: BuildProfileLinkPathInput): string {
-  const normalizedNip05 = normalizeNip05Identifier(nip05);
-  if (normalizedNip05) {
-    return `/u/${encodeURIComponent(normalizedNip05)}`;
+  const friendly = toFriendlyPath(nip05);
+  if (friendly) {
+    const bareName = bareLocalFromFriendly(friendly);
+    if (bareName) {
+      return `/u/${bareName}`;
+    }
+    return `/u/${friendly}`;
   }
 
   const npub = toNpub(pubkey);
   return fallbackRoute === 'profile' ? `/profile/${npub}` : `/${npub}`;
+}
+
+function bareLocalFromFriendly(friendly: string): string | null {
+  for (const apex of APEX_DOMAINS) {
+    const suffix = `.${apex}`;
+    if (friendly === apex) return null;
+    if (friendly.endsWith(suffix)) {
+      const local = friendly.slice(0, -suffix.length);
+      if (local && !local.includes('.') && apex === DEFAULT_APEX_DOMAIN) {
+        return local;
+      }
+    }
+  }
+  return null;
 }
 
 export function normalizeNip05Identifier(nip05?: string | null): string | null {
@@ -40,6 +73,92 @@ export function normalizeNip05Identifier(nip05?: string | null): string | null {
   }
 
   return normalized;
+}
+
+/**
+ * Convert a NIP-05 identifier to a single URL-safe path segment.
+ *
+ *   _@jacky.divine.video   -> 'jacky.divine.video'   (then bare-name form collapses it)
+ *   jacky@divine.video     -> 'jacky.divine.video'
+ *   _@jacky.dvine.video    -> 'jacky.dvine.video'
+ *   _@alice.primal.net     -> 'alice.primal.net'
+ *   alice@primal.net       -> 'alice.primal.net'
+ *   _@divine.video         -> 'divine.video'         (degenerate but unambiguous)
+ *   malformed / no @       -> null
+ *
+ * The leading `_` (NIP-05 self-name) is dropped from the local part. `@` is replaced
+ * with `.`. The result is always lowercase, ASCII, and safe to use in a URL without
+ * encoding.
+ */
+export function toFriendlyPath(nip05: string | null | undefined): string | null {
+  const normalized = nip05?.trim().toLowerCase() ?? '';
+  if (!normalized) return null;
+
+  const atIndex = normalized.lastIndexOf('@');
+  if (atIndex <= 0 || atIndex === normalized.length - 1) return null;
+  if (normalized.indexOf('@') !== atIndex) return null;
+
+  const local = normalized.slice(0, atIndex);
+  const domain = normalized.slice(atIndex + 1);
+
+  if (!/^[a-z0-9.-]+$/.test(domain)) return null;
+
+  const cleanLocal = local === '_' ? '' : local;
+  if (cleanLocal && !/^[a-z0-9._-]+$/.test(cleanLocal)) return null;
+
+  if (!cleanLocal) return domain;
+  return `${cleanLocal}.${domain}`;
+}
+
+/**
+ * Inverse of {@link buildProfileLinkPath} for the friendly-path branch.
+ *
+ * Given a URL segment from `/u/:userId`, return the canonical NIP-05 strings we
+ * should try to match against a kind-0 profile's `nip05` field (or resolve via
+ * NIP-05 DNS). Always returns lowercased forms.
+ *
+ *   'jacky'                      -> ['jacky@divine.video', '_@jacky.divine.video']
+ *   'jacky.divine.video'         -> ['jacky@divine.video', '_@jacky.divine.video']
+ *   'jacky.dvine.video'          -> ['jacky@dvine.video',  '_@jacky.dvine.video']
+ *   'a.b.divine.video'           -> ['a.b@divine.video',   '_@a.b.divine.video']
+ *   'alice.primal.net'           -> ['alice.primal.net']   (no @ to insert)
+ *   'jacky.divine.video'         (third-party case)       -> ['jacky.divine.video']
+ *
+ * Returns an empty array for inputs that can't be interpreted as a NIP-05.
+ */
+export function nip05CandidatesFromUrlSegment(segment: string): string[] {
+  const decoded = segment.trim().toLowerCase();
+  if (!decoded) return [];
+
+  // 1. Literal NIP-05 — has '@'.
+  if (decoded.includes('@')) {
+    return [decoded];
+  }
+
+  // 2. Multi-dot path with a recognized apex suffix — split into local + domain.
+  if (decoded.includes('.')) {
+    for (const apex of APEX_DOMAINS) {
+      const suffix = `.${apex}`;
+      if (decoded.endsWith(suffix)) {
+        const local = decoded.slice(0, -suffix.length);
+        if (local && !local.includes('@')) {
+          return [
+            `${local}@${apex}`,
+            `_@${local}.${apex}`,
+          ];
+        }
+      }
+    }
+    // Third-party domain — keep the segment as-is for kind-0 matching and let
+    // callers attempt DNS resolution with `${local}@${domain}` derived separately.
+    return [decoded];
+  }
+
+  // 3. Bare local part — assume the default apex.
+  return [
+    `${decoded}@${DEFAULT_APEX_DOMAIN}`,
+    `_@${decoded}.${DEFAULT_APEX_DOMAIN}`,
+  ];
 }
 
 function toNpub(pubkey: string): string {

--- a/src/lib/profileLinks.ts
+++ b/src/lib/profileLinks.ts
@@ -3,6 +3,7 @@ import { nip19 } from 'nostr-tools';
 const HEX_PUBKEY_PATTERN = /^[0-9a-f]{64}$/i;
 const DEFAULT_APEX_DOMAIN = 'divine.video';
 const ALTERNATE_APEX_DOMAIN = 'dvine.video';
+const LEGACY_OPENVINE_DOMAIN = 'openvine.co';
 const APEX_DOMAINS = [DEFAULT_APEX_DOMAIN, ALTERNATE_APEX_DOMAIN] as const;
 
 export type ProfileFallbackRoute = 'root' | 'profile';
@@ -117,11 +118,11 @@ export function toFriendlyPath(nip05: string | null | undefined): string | null 
  * should try to match against a kind-0 profile's `nip05` field (or resolve via
  * NIP-05 DNS). Always returns lowercased forms.
  *
- *   'jacky'                      -> ['jacky@divine.video', '_@jacky.divine.video']
+ *   'jacky'                      -> ['jacky@divine.video', '_@jacky.divine.video', 'jacky@openvine.co']
  *   'jacky.divine.video'         -> ['jacky@divine.video', '_@jacky.divine.video']
  *   'jacky.dvine.video'          -> ['jacky@dvine.video',  '_@jacky.dvine.video']
  *   'a.b.divine.video'           -> ['a.b@divine.video',   '_@a.b.divine.video']
- *   'alice.primal.net'           -> ['alice.primal.net']   (no @ to insert)
+ *   'alice.primal.net'           -> ['alice.primal.net', 'alice@primal.net', '_@alice.primal.net']
  *   'jacky.divine.video'         (third-party case)       -> ['jacky.divine.video']
  *
  * Returns an empty array for inputs that can't be interpreted as a NIP-05.
@@ -149,26 +150,33 @@ export function nip05CandidatesFromUrlSegment(segment: string): string[] {
         }
       }
     }
-    // Third-party domain — return the literal for kind-0 matching, plus
-    // the @ forms for DNS fallback (since kind-0 has the @ form).
-    // Convert the last dot to @ to get the NIP-05 form: alice.primal.net -> alice@primal.net
-    const atIndex = decoded.indexOf('.');
-    if (atIndex > 0) {
-      const atForm = decoded.slice(0, atIndex) + '@' + decoded.slice(atIndex + 1);
-      return [
-        decoded,
-        atForm,
-        `_@${decoded}`,
-      ];
-    }
-    return [decoded];
+    // Third-party domain — keep the literal for older friendly metadata, then
+    // try every split whose domain side still looks domain-shaped.
+    return [
+      decoded,
+      ...thirdPartyNip05Candidates(decoded),
+      `_@${decoded}`,
+    ];
   }
 
   // 3. Bare local part — assume the default apex.
   return [
     `${decoded}@${DEFAULT_APEX_DOMAIN}`,
     `_@${decoded}.${DEFAULT_APEX_DOMAIN}`,
+    `${decoded}@${LEGACY_OPENVINE_DOMAIN}`,
   ];
+}
+
+function thirdPartyNip05Candidates(decoded: string): string[] {
+  const candidates: string[] = [];
+  for (let index = decoded.indexOf('.'); index > 0; index = decoded.indexOf('.', index + 1)) {
+    const local = decoded.slice(0, index);
+    const domain = decoded.slice(index + 1);
+    if (domain.includes('.')) {
+      candidates.push(`${local}@${domain}`);
+    }
+  }
+  return candidates;
 }
 
 function toNpub(pubkey: string): string {

--- a/src/lib/profileLinks.ts
+++ b/src/lib/profileLinks.ts
@@ -149,8 +149,18 @@ export function nip05CandidatesFromUrlSegment(segment: string): string[] {
         }
       }
     }
-    // Third-party domain — keep the segment as-is for kind-0 matching and let
-    // callers attempt DNS resolution with `${local}@${domain}` derived separately.
+    // Third-party domain — return the literal for kind-0 matching, plus
+    // the @ forms for DNS fallback (since kind-0 has the @ form).
+    // Convert the last dot to @ to get the NIP-05 form: alice.primal.net -> alice@primal.net
+    const atIndex = decoded.lastIndexOf('.');
+    if (atIndex > 0) {
+      const atForm = decoded.slice(0, atIndex) + '@' + decoded.slice(atIndex + 1);
+      return [
+        decoded,
+        atForm,
+        `_@${decoded}`,
+      ];
+    }
     return [decoded];
   }
 

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -33,14 +33,14 @@ import { PinnedVideosSection } from '@/components/PinnedVideosSection';
 import { useLoginDialog } from '@/contexts/LoginDialogContext';
 import { toast } from '@/hooks/useToast';
 import { debugLog } from '@/lib/debug';
-import { getDivineNip05Info } from '@/lib/nip05Utils';
 import { useNip05Validation } from '@/hooks/useNip05Validation';
 import { genUserName } from '@/lib/genUserName';
 import { parseLegacySocials } from '@/lib/legacySocials';
 import { buildProfileStats } from '@/lib/profileStats';
+import { buildProfileLinkPath } from '@/lib/profileLinks';
 import type { SortMode } from '@/types/nostr';
 
-export function ProfilePage() {
+export function ProfilePage({ pubkeyOverride }: { pubkeyOverride?: string } = {}) {
   const { t } = useTranslation();
   const { npub, nip19: nip19Param } = useParams<{ npub?: string; nip19?: string }>();
   const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
@@ -53,8 +53,11 @@ export function ProfilePage() {
   // Get the identifier from route params, or from subdomain user if rendered at /
   const subdomainUser = getSubdomainUser();
   const resolved = useResolveSubdomainPubkey();
-  // Use resolved pubkey when KV store mapping is stale
-  const identifier = npub || nip19Param || (resolved.isResolved ? resolved.npub : subdomainUser?.npub);
+  // Use override from UniversalUserPage if provided (e.g., /u/jacky -> resolved pubkey)
+  const identifier = pubkeyOverride
+    || npub
+    || nip19Param
+    || (resolved.isResolved ? resolved.npub : subdomainUser?.npub);
 
   // Decode npub to get pubkey. Accepts npub1..., 64-char hex, or a NIP-05 (name@domain).
   let pubkey: string | null = null;
@@ -157,27 +160,34 @@ export function ProfilePage() {
     _stillLoadingName: stillLoadingName,
   };
 
-  // Redirect to subdomain if user has a verified divine.video NIP-05 and we're on the apex domain
+  // Rewrite the URL to the vanity /u/:username form when the user has a
+  // verified divine.video NIP-05 and we're already on the apex domain.
   const nip05 = metadata.nip05;
   const nip05Validation = useNip05Validation(
     !subdomainUser ? nip05 : undefined,
     pubkey || '',
   );
   useEffect(() => {
-    // Skip redirect in development mode
     if (import.meta.env.DEV) return;
-    // Only redirect if we're on the apex domain (not already on a subdomain)
     if (subdomainUser) return;
     if (!nip05) return;
-    // Only redirect after NIP-05 is verified to belong to this pubkey
     if (!nip05Validation.isValid) return;
 
-    const divineInfo = getDivineNip05Info(nip05);
-    if (divineInfo) {
-      debugLog('[ProfilePage] Redirecting to subdomain:', divineInfo.href);
-      window.location.href = divineInfo.href;
+    const friendlyPath = buildProfileLinkPath({ pubkey: pubkey || '', nip05, fallbackRoute: 'profile' });
+    if (!friendlyPath.startsWith('/u/')) return;
+
+    const { pathname, search, hash } = window.location;
+    if (pathname === friendlyPath) return;
+    if (!pathname.startsWith('/profile/')
+        && !pathname.startsWith('/npub1')
+        && !/^\/[0-9a-fA-F]{64}$/.test(pathname)) {
+      return;
     }
-  }, [nip05, subdomainUser, nip05Validation.isValid]);
+    if (pathname.startsWith('/u/')) return;
+
+    debugLog('[ProfilePage] Rewriting URL to vanity form:', friendlyPath);
+    window.history.replaceState(null, '', `${friendlyPath}${search}${hash}`);
+  }, [nip05, subdomainUser, nip05Validation.isValid, pubkey]);
 
   // Use actual loaded video count once all pages are loaded (API video_count may be inflated by dups)
   const allLoaded = !hasNextPage && videos.length > 0;

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -178,12 +178,8 @@ export function ProfilePage({ pubkeyOverride }: { pubkeyOverride?: string } = {}
 
     const { pathname, search, hash } = window.location;
     if (pathname === friendlyPath) return;
-    if (!pathname.startsWith('/profile/')
-        && !pathname.startsWith('/npub1')
-        && !/^\/[0-9a-fA-F]{64}$/.test(pathname)) {
-      return;
-    }
     if (pathname.startsWith('/u/')) return;
+    if (!pathname.startsWith('/profile/')) return;
 
     debugLog('[ProfilePage] Rewriting URL to vanity form:', friendlyPath);
     window.history.replaceState(null, '', `${friendlyPath}${search}${hash}`);

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -182,6 +182,8 @@ export function ProfilePage({ pubkeyOverride }: { pubkeyOverride?: string } = {}
     if (!pathname.startsWith('/profile/')) return;
 
     debugLog('[ProfilePage] Rewriting URL to vanity form:', friendlyPath);
+    // Keep the already-loaded profile mounted; a router navigation would remount
+    // through UniversalUserPage and repeat the same lookup.
     window.history.replaceState(null, '', `${friendlyPath}${search}${hash}`);
   }, [nip05, subdomainUser, nip05Validation.isValid, pubkey]);
 

--- a/src/pages/SearchPage.test.tsx
+++ b/src/pages/SearchPage.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, useLocation } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type {
   ButtonHTMLAttributes,
   HTMLAttributes,
@@ -20,6 +21,7 @@ const {
   mockNostrQuery,
   mockUseInfiniteSearchVideos,
   mockUseSearchUsers,
+  mockUseNip05Validation,
   mockEnterFullscreen,
   mockSetVideosForFullscreen,
   mockUpdateVideos,
@@ -30,6 +32,7 @@ const {
   mockNostrQuery: vi.fn(),
   mockUseInfiniteSearchVideos: vi.fn(),
   mockUseSearchUsers: vi.fn(),
+  mockUseNip05Validation: vi.fn(),
   mockEnterFullscreen: vi.fn(),
   mockSetVideosForFullscreen: vi.fn(),
   mockUpdateVideos: vi.fn(),
@@ -159,6 +162,10 @@ vi.mock('@/hooks/useSearchUsers', () => ({
   useSearchUsers: mockUseSearchUsers,
 }));
 
+vi.mock('@/hooks/useNip05Validation', () => ({
+  useNip05Validation: mockUseNip05Validation,
+}));
+
 vi.mock('@/hooks/useSearchHashtags', () => ({
   useSearchHashtags: ({ query }: { query: string }) => ({
     data: query ? [] : [],
@@ -176,11 +183,16 @@ vi.mock('@/lib/eventLookup', () => ({
 }));
 
 function renderPage(initialEntries: string[] = ['/search']) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
   return render(
-    <MemoryRouter initialEntries={initialEntries}>
-      <SearchPage />
-      <LocationDisplay />
-    </MemoryRouter>
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={initialEntries}>
+        <SearchPage />
+        <LocationDisplay />
+      </MemoryRouter>
+    </QueryClientProvider>
   );
 }
 
@@ -219,6 +231,14 @@ describe('SearchPage', () => {
       data: [],
       isLoading: false,
       error: null,
+    });
+    // Default: NIP-05 not yet validated, so cards show the legacy @username.
+    mockUseNip05Validation.mockReturnValue({
+      isValid: false,
+      isLoading: false,
+      isInvalid: true,
+      state: 'invalid',
+      nip05: undefined,
     });
   });
 
@@ -662,6 +682,9 @@ describe('SearchPage', () => {
   });
 
   it('shows the divine NIP-05 as the secondary identifier on user cards, not the legacy Vine username', () => {
+    mockUseNip05Validation.mockReturnValue({
+      isValid: true, isLoading: false, isInvalid: false, state: 'valid', nip05: '_@jacky.divine.video',
+    });
     mockUseSearchUsers.mockReturnValue({
       data: [
         {
@@ -685,6 +708,9 @@ describe('SearchPage', () => {
   });
 
   it('shows the third-party NIP-05 in friendly form on user cards', () => {
+    mockUseNip05Validation.mockReturnValue({
+      isValid: true, isLoading: false, isInvalid: false, state: 'valid', nip05: 'alice@primal.net',
+    });
     mockUseSearchUsers.mockReturnValue({
       data: [
         {

--- a/src/pages/SearchPage.test.tsx
+++ b/src/pages/SearchPage.test.tsx
@@ -19,6 +19,7 @@ const {
   mockFetchVideoById,
   mockNostrQuery,
   mockUseInfiniteSearchVideos,
+  mockUseSearchUsers,
   mockEnterFullscreen,
   mockSetVideosForFullscreen,
   mockUpdateVideos,
@@ -28,6 +29,7 @@ const {
   mockFetchVideoById: vi.fn(),
   mockNostrQuery: vi.fn(),
   mockUseInfiniteSearchVideos: vi.fn(),
+  mockUseSearchUsers: vi.fn(),
   mockEnterFullscreen: vi.fn(),
   mockSetVideosForFullscreen: vi.fn(),
   mockUpdateVideos: vi.fn(),
@@ -154,11 +156,7 @@ vi.mock('@/hooks/useInfiniteSearchVideos', () => ({
 }));
 
 vi.mock('@/hooks/useSearchUsers', () => ({
-  useSearchUsers: () => ({
-    data: [],
-    isLoading: false,
-    error: null,
-  }),
+  useSearchUsers: mockUseSearchUsers,
 }));
 
 vi.mock('@/hooks/useSearchHashtags', () => ({
@@ -214,6 +212,11 @@ describe('SearchPage', () => {
       data: { pages: [{ videos: [] }] },
       fetchNextPage: vi.fn(),
       hasNextPage: false,
+      isLoading: false,
+      error: null,
+    });
+    mockUseSearchUsers.mockReturnValue({
+      data: [],
       isLoading: false,
       error: null,
     });
@@ -656,5 +659,90 @@ describe('SearchPage', () => {
     await waitFor(() => {
       expect(screen.getByTestId('location-display').textContent).not.toContain('sort=');
     });
+  });
+
+  it('shows the divine NIP-05 as the secondary identifier on user cards, not the legacy Vine username', () => {
+    mockUseSearchUsers.mockReturnValue({
+      data: [
+        {
+          pubkey: '1'.repeat(64),
+          metadata: {
+            display_name: 'Jacky!',
+            name: 'Minimal Mouse 1',
+            nip05: '_@jacky.divine.video',
+            about: 'Neo-Bwa Kale',
+          },
+        },
+      ],
+      isLoading: false,
+      error: null,
+    });
+
+    renderPage(['/search?q=jacky&filter=users']);
+
+    expect(screen.getAllByText('@jacky.divine.video').length).toBeGreaterThan(0);
+    expect(screen.queryAllByText('@Minimal Mouse 1')).toHaveLength(0);
+  });
+
+  it('shows the third-party NIP-05 in friendly form on user cards', () => {
+    mockUseSearchUsers.mockReturnValue({
+      data: [
+        {
+          pubkey: '2'.repeat(64),
+          metadata: {
+            display_name: 'Alice',
+            name: 'alice_vine',
+            nip05: 'alice@primal.net',
+          },
+        },
+      ],
+      isLoading: false,
+      error: null,
+    });
+
+    renderPage(['/search?q=alice&filter=users']);
+
+    expect(screen.getAllByText('@alice.primal.net').length).toBeGreaterThan(0);
+  });
+
+  it('falls back to the legacy Vine username when no NIP-05 is set', () => {
+    mockUseSearchUsers.mockReturnValue({
+      data: [
+        {
+          pubkey: '3'.repeat(64),
+          metadata: {
+            display_name: 'bob_legacy',
+            name: 'bob_legacy',
+          },
+        },
+      ],
+      isLoading: false,
+      error: null,
+    });
+
+    renderPage(['/search?q=bob&filter=users']);
+
+    expect(screen.getAllByText('@bob_legacy').length).toBeGreaterThan(0);
+  });
+
+  it('uses the friendly-path profile link for users with a NIP-05', () => {
+    mockUseSearchUsers.mockReturnValue({
+      data: [
+        {
+          pubkey: '4'.repeat(64),
+          metadata: {
+            display_name: 'Sam',
+            nip05: '_@sam.dvine.video',
+          },
+        },
+      ],
+      isLoading: false,
+      error: null,
+    });
+
+    renderPage(['/search?q=sam&filter=users']);
+
+    fireEvent.click(screen.getAllByRole('button', { name: /view profile of sam/i })[0]!);
+    expect(mockNavigate).toHaveBeenCalledWith('/u/sam.dvine.video');
   });
 });

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -46,6 +46,7 @@ import {
 } from '@/lib/compilationPlayback';
 import { buildProfileLinkPath, toFriendlyPath } from '@/lib/profileLinks';
 import { getDivineNip05Info } from '@/lib/nip05Utils';
+import { useNip05Validation } from '@/hooks/useNip05Validation';
 
 type SearchFilter = 'all' | 'videos' | 'users' | 'hashtags';
 
@@ -760,10 +761,10 @@ function UserCard({ user }: { user: { pubkey: string; metadata?: UserCardMetadat
   const displayName = user.metadata?.display_name || user.metadata?.name || genUserName(user.pubkey);
   const username = user.metadata?.name || genUserName(user.pubkey);
   const nip05 = user.metadata?.nip05;
-  // Prefer the NIP-05 as the user-visible identifier when it's set. A NIP-05 is
-  // a network-routable handle and a stable identity; the legacy Vine username is
-  // only useful for context. Match the display format ProfileHeader uses.
-  const nip05Display = nip05
+  const { state: nip05State } = useNip05Validation(nip05, user.pubkey);
+  // Only show NIP-05 as the user-visible identifier when it's validated.
+  // Unvalidated NIP-05s could be spoofed by anyone claiming a handle.
+  const nip05Display = nip05 && nip05State === 'valid'
     ? (getDivineNip05Info(nip05)?.displayName ?? `@${toFriendlyPath(nip05) ?? nip05}`)
     : null;
   const about = user.metadata?.about;

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -44,7 +44,8 @@ import {
   buildCompilationPlaybackUrl,
   parseCompilationPlaybackParams,
 } from '@/lib/compilationPlayback';
-import { buildProfileLinkPath } from '@/lib/profileLinks';
+import { buildProfileLinkPath, toFriendlyPath } from '@/lib/profileLinks';
+import { getDivineNip05Info } from '@/lib/nip05Utils';
 
 type SearchFilter = 'all' | 'videos' | 'users' | 'hashtags';
 
@@ -758,11 +759,18 @@ function UserCard({ user }: { user: { pubkey: string; metadata?: UserCardMetadat
   const navigate = useSubdomainNavigate();
   const displayName = user.metadata?.display_name || user.metadata?.name || genUserName(user.pubkey);
   const username = user.metadata?.name || genUserName(user.pubkey);
+  const nip05 = user.metadata?.nip05;
+  // Prefer the NIP-05 as the user-visible identifier when it's set. A NIP-05 is
+  // a network-routable handle and a stable identity; the legacy Vine username is
+  // only useful for context. Match the display format ProfileHeader uses.
+  const nip05Display = nip05
+    ? (getDivineNip05Info(nip05)?.displayName ?? `@${toFriendlyPath(nip05) ?? nip05}`)
+    : null;
   const about = user.metadata?.about;
   const picture = getSafeProfileImage(user.metadata?.picture);
   const profilePath = buildProfileLinkPath({
     pubkey: user.pubkey,
-    nip05: user.metadata?.nip05,
+    nip05,
   });
 
   const handleClick = () => {
@@ -793,7 +801,11 @@ function UserCard({ user }: { user: { pubkey: string; metadata?: UserCardMetadat
           </Avatar>
           <div className="flex-1 min-w-0">
             <h3 className="font-semibold truncate">{displayName}</h3>
-            <p className="text-sm text-muted-foreground truncate">@{username}</p>
+            {nip05Display ? (
+              <p className="text-sm text-muted-foreground truncate">{nip05Display}</p>
+            ) : (
+              <p className="text-sm text-muted-foreground truncate">@{username}</p>
+            )}
             {about && (
               <p className="text-xs text-muted-foreground mt-1 line-clamp-2">
                 {about}

--- a/src/pages/UniversalUserPage.test.tsx
+++ b/src/pages/UniversalUserPage.test.tsx
@@ -37,6 +37,12 @@ vi.mock('@/components/ui/card', () => ({
   CardContent: ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
 }));
 
+vi.mock('./ProfilePage', () => ({
+  default: ({ pubkeyOverride }: { pubkeyOverride?: string }) => (
+    <div data-testid="profile-page" data-pubkey-override={pubkeyOverride}>Profile Page</div>
+  ),
+}));
+
 function renderPage(initialEntry: string) {
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -51,10 +57,9 @@ function renderPage(initialEntry: string) {
       <MemoryRouter initialEntries={[initialEntry]}>
         <Routes>
           <Route path="/u/:userId" element={<UniversalUserPage />} />
-          <Route path="/:npub" element={<div data-testid="profile-page">Profile page</div>} />
         </Routes>
       </MemoryRouter>
-    </QueryClientProvider>
+    </QueryClientProvider>,
   );
 }
 
@@ -90,7 +95,7 @@ describe('UniversalUserPage', () => {
     vi.useRealTimers();
   });
 
-  it('resolves numeric Vine user IDs from vine metadata', async () => {
+  it('resolves numeric Vine user IDs from vine metadata and renders ProfilePage', async () => {
     const pubkey = 'a'.repeat(64);
     mockNostrQuery.mockResolvedValue([
       createProfileEvent(pubkey, {
@@ -104,8 +109,13 @@ describe('UniversalUserPage', () => {
     renderPage('/u/1080167736266633216');
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith(`/${nip19.npubEncode(pubkey)}`, { replace: true });
+      expect(screen.getByTestId('profile-page')).toBeInTheDocument();
     });
+    expect(screen.getByTestId('profile-page').dataset.pubkeyOverride).toBe(pubkey);
+    expect(mockNavigate).not.toHaveBeenCalledWith(
+      `/${nip19.npubEncode(pubkey)}`,
+      expect.anything(),
+    );
   });
 
   it('prefers exact legacy Vine username matches over the default-apex NIP-05 candidates', async () => {
@@ -127,8 +137,9 @@ describe('UniversalUserPage', () => {
     renderPage('/u/someuser');
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith(`/${nip19.npubEncode(legacyPubkey)}`, { replace: true });
+      expect(screen.getByTestId('profile-page')).toBeInTheDocument();
     });
+    expect(screen.getByTestId('profile-page').dataset.pubkeyOverride).toBe(legacyPubkey);
   });
 
   it('resolves legacy Vine usernames from vine profile website urls', async () => {
@@ -143,8 +154,9 @@ describe('UniversalUserPage', () => {
     renderPage('/u/someuser');
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith(`/${nip19.npubEncode(pubkey)}`, { replace: true });
+      expect(screen.getByTestId('profile-page')).toBeInTheDocument();
     });
+    expect(screen.getByTestId('profile-page').dataset.pubkeyOverride).toBe(pubkey);
   });
 
   it('falls back to the default-apex NIP-05 candidates when there is no legacy Vine username match', async () => {
@@ -159,8 +171,9 @@ describe('UniversalUserPage', () => {
     renderPage('/u/someuser');
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith(`/${nip19.npubEncode(pubkey)}`, { replace: true });
+      expect(screen.getByTestId('profile-page')).toBeInTheDocument();
     });
+    expect(screen.getByTestId('profile-page').dataset.pubkeyOverride).toBe(pubkey);
   });
 
   it('shows the not-found state when no legacy or NIP-05 match exists', async () => {
@@ -175,7 +188,7 @@ describe('UniversalUserPage', () => {
 
     expect(await screen.findByText('User Not Found')).toBeInTheDocument();
     expect(screen.getByText(/missinguser/)).toBeInTheDocument();
-    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('profile-page')).not.toBeInTheDocument();
   });
 
   it('resolves a bare-name URL via the default-apex NIP-05 candidate list', async () => {
@@ -190,8 +203,9 @@ describe('UniversalUserPage', () => {
     renderPage('/u/jacky');
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith(`/${nip19.npubEncode(pubkey)}`, { replace: true });
+      expect(screen.getByTestId('profile-page')).toBeInTheDocument();
     });
+    expect(screen.getByTestId('profile-page').dataset.pubkeyOverride).toBe(pubkey);
   });
 
   it('resolves an explicit default-apex URL when only the non-underscore variant is set', async () => {
@@ -206,8 +220,9 @@ describe('UniversalUserPage', () => {
     renderPage('/u/alice.divine.video');
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith(`/${nip19.npubEncode(pubkey)}`, { replace: true });
+      expect(screen.getByTestId('profile-page')).toBeInTheDocument();
     });
+    expect(screen.getByTestId('profile-page').dataset.pubkeyOverride).toBe(pubkey);
   });
 
   it('resolves an explicit alternate-apex URL', async () => {
@@ -222,8 +237,9 @@ describe('UniversalUserPage', () => {
     renderPage('/u/sam.dvine.video');
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith(`/${nip19.npubEncode(pubkey)}`, { replace: true });
+      expect(screen.getByTestId('profile-page')).toBeInTheDocument();
     });
+    expect(screen.getByTestId('profile-page').dataset.pubkeyOverride).toBe(pubkey);
   });
 
   it('falls back to NIP-05 DNS when no kind-0 profile matches a bare name', async () => {
@@ -240,8 +256,9 @@ describe('UniversalUserPage', () => {
       renderPage('/u/jacky');
 
       await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith(`/${nip19.npubEncode(pubkey)}`, { replace: true });
+        expect(screen.getByTestId('profile-page')).toBeInTheDocument();
       });
+      expect(screen.getByTestId('profile-page').dataset.pubkeyOverride).toBe(pubkey);
       expect(fetchMock).toHaveBeenCalled();
     } finally {
       globalThis.fetch = originalFetch;
@@ -266,7 +283,32 @@ describe('UniversalUserPage', () => {
     renderPage('/u/jacky.divine.video');
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith(`/${nip19.npubEncode(pubkey)}`, { replace: true });
+      expect(screen.getByTestId('profile-page')).toBeInTheDocument();
     });
+    expect(screen.getByTestId('profile-page').dataset.pubkeyOverride).toBe(pubkey);
+  });
+
+  it('normalizes a raw NIP-05 URL segment to the canonical friendly form', () => {
+    const originalReplaceState = window.history.replaceState;
+    const replaceStateSpy = vi.fn();
+    window.history.replaceState = replaceStateSpy;
+
+    renderPage('/u/_@jimmyhere.divine.video');
+
+    expect(replaceStateSpy).toHaveBeenCalledWith(null, '', '/u/jimmyhere');
+
+    window.history.replaceState = originalReplaceState;
+  });
+
+  it('does not normalize an already-canonical URL segment', () => {
+    const originalReplaceState = window.history.replaceState;
+    const replaceStateSpy = vi.fn();
+    window.history.replaceState = replaceStateSpy;
+
+    renderPage('/u/jimmyhere');
+
+    expect(replaceStateSpy).not.toHaveBeenCalled();
+
+    window.history.replaceState = originalReplaceState;
   });
 });

--- a/src/pages/UniversalUserPage.test.tsx
+++ b/src/pages/UniversalUserPage.test.tsx
@@ -108,7 +108,7 @@ describe('UniversalUserPage', () => {
     });
   });
 
-  it('prefers exact legacy Vine username matches before the openvine fallback', async () => {
+  it('prefers exact legacy Vine username matches over the default-apex NIP-05 candidates', async () => {
     const legacyPubkey = 'b'.repeat(64);
     const fallbackPubkey = 'c'.repeat(64);
     mockNostrQuery.mockResolvedValue([
@@ -147,12 +147,12 @@ describe('UniversalUserPage', () => {
     });
   });
 
-  it('falls back to openvine NIP-05 when there is no legacy Vine username match', async () => {
+  it('falls back to the default-apex NIP-05 candidates when there is no legacy Vine username match', async () => {
     const pubkey = 'e'.repeat(64);
     mockNostrQuery.mockResolvedValue([
       createProfileEvent(pubkey, {
-        name: 'OpenVine User',
-        nip05: 'someuser@openvine.co',
+        name: 'Default Apex User',
+        nip05: 'someuser@divine.video',
       }),
     ]);
 
@@ -176,5 +176,97 @@ describe('UniversalUserPage', () => {
     expect(await screen.findByText('User Not Found')).toBeInTheDocument();
     expect(screen.getByText(/missinguser/)).toBeInTheDocument();
     expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('resolves a bare-name URL via the default-apex NIP-05 candidate list', async () => {
+    const pubkey = '1'.repeat(64);
+    mockNostrQuery.mockResolvedValue([
+      createProfileEvent(pubkey, {
+        name: 'Jacky!',
+        nip05: '_@jacky.divine.video',
+      }),
+    ]);
+
+    renderPage('/u/jacky');
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(`/${nip19.npubEncode(pubkey)}`, { replace: true });
+    });
+  });
+
+  it('resolves an explicit default-apex URL when only the non-underscore variant is set', async () => {
+    const pubkey = '2'.repeat(64);
+    mockNostrQuery.mockResolvedValue([
+      createProfileEvent(pubkey, {
+        name: 'Alice',
+        nip05: 'alice@divine.video',
+      }),
+    ]);
+
+    renderPage('/u/alice.divine.video');
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(`/${nip19.npubEncode(pubkey)}`, { replace: true });
+    });
+  });
+
+  it('resolves an explicit alternate-apex URL', async () => {
+    const pubkey = '3'.repeat(64);
+    mockNostrQuery.mockResolvedValue([
+      createProfileEvent(pubkey, {
+        name: 'Sam',
+        nip05: '_@sam.dvine.video',
+      }),
+    ]);
+
+    renderPage('/u/sam.dvine.video');
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(`/${nip19.npubEncode(pubkey)}`, { replace: true });
+    });
+  });
+
+  it('falls back to NIP-05 DNS when no kind-0 profile matches a bare name', async () => {
+    const pubkey = '4'.repeat(64);
+    mockNostrQuery.mockResolvedValue([]);
+
+    const originalFetch = globalThis.fetch;
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ names: { _: pubkey } }),
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    try {
+      renderPage('/u/jacky');
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith(`/${nip19.npubEncode(pubkey)}`, { replace: true });
+      });
+      expect(fetchMock).toHaveBeenCalled();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('does not try the legacy Vine branch for subdomain-shaped inputs', async () => {
+    const pubkey = '5'.repeat(64);
+    mockNostrQuery.mockResolvedValue([
+      createProfileEvent('6'.repeat(64), {
+        name: 'Wrong Match',
+        vine_metadata: {
+          username: 'jacky.divine.video',
+        },
+      }),
+      createProfileEvent(pubkey, {
+        name: 'Jacky!',
+        nip05: '_@jacky.divine.video',
+      }),
+    ]);
+
+    renderPage('/u/jacky.divine.video');
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(`/${nip19.npubEncode(pubkey)}`, { replace: true });
+    });
   });
 });

--- a/src/pages/UniversalUserPage.test.tsx
+++ b/src/pages/UniversalUserPage.test.tsx
@@ -176,7 +176,29 @@ describe('UniversalUserPage', () => {
     expect(screen.getByTestId('profile-page').dataset.pubkeyOverride).toBe(pubkey);
   });
 
+  it('falls back to legacy openvine.co NIP-05 when there is no newer bare-name match', async () => {
+    const pubkey = '7'.repeat(64);
+    mockNostrQuery.mockResolvedValue([
+      createProfileEvent(pubkey, {
+        name: 'OpenVine User',
+        nip05: 'someuser@openvine.co',
+      }),
+    ]);
+
+    renderPage('/u/someuser');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('profile-page')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('profile-page').dataset.pubkeyOverride).toBe(pubkey);
+  });
+
   it('shows the not-found state when no legacy or NIP-05 match exists', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+    }) as unknown as typeof fetch;
     mockNostrQuery.mockResolvedValue([
       createProfileEvent('f'.repeat(64), {
         name: 'Someone Else',
@@ -184,11 +206,15 @@ describe('UniversalUserPage', () => {
       }),
     ]);
 
-    renderPage('/u/missinguser');
+    try {
+      renderPage('/u/missinguser');
 
-    expect(await screen.findByText('User Not Found')).toBeInTheDocument();
-    expect(screen.getByText(/missinguser/)).toBeInTheDocument();
-    expect(screen.queryByTestId('profile-page')).not.toBeInTheDocument();
+      expect(await screen.findByText('User Not Found')).toBeInTheDocument();
+      expect(screen.getByText(/missinguser/)).toBeInTheDocument();
+      expect(screen.queryByTestId('profile-page')).not.toBeInTheDocument();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 
   it('resolves a bare-name URL via the default-apex NIP-05 candidate list', async () => {

--- a/src/pages/UniversalUserPage.test.tsx
+++ b/src/pages/UniversalUserPage.test.tsx
@@ -289,15 +289,9 @@ describe('UniversalUserPage', () => {
   });
 
   it('normalizes a raw NIP-05 URL segment to the canonical friendly form', () => {
-    const originalReplaceState = window.history.replaceState;
-    const replaceStateSpy = vi.fn();
-    window.history.replaceState = replaceStateSpy;
-
     renderPage('/u/_@jimmyhere.divine.video');
 
-    expect(replaceStateSpy).toHaveBeenCalledWith(null, '', '/u/jimmyhere');
-
-    window.history.replaceState = originalReplaceState;
+    expect(mockNavigate).toHaveBeenCalledWith('/u/jimmyhere', { replace: true });
   });
 
   it('does not normalize an already-canonical URL segment', () => {
@@ -313,15 +307,9 @@ describe('UniversalUserPage', () => {
   });
 
   it('normalizes a percent-encoded raw NIP-05 URL segment to the canonical friendly form', () => {
-    const originalReplaceState = window.history.replaceState;
-    const replaceStateSpy = vi.fn();
-    window.history.replaceState = replaceStateSpy;
-
     renderPage('/u/jimmyhere%40divine.video');
 
-    expect(replaceStateSpy).toHaveBeenCalledWith(null, '', '/u/jimmyhere');
-
-    window.history.replaceState = originalReplaceState;
+    expect(mockNavigate).toHaveBeenCalledWith('/u/jimmyhere', { replace: true });
   });
 
   it('does not normalize a third-party dotted segment that is already canonical', () => {

--- a/src/pages/UniversalUserPage.test.tsx
+++ b/src/pages/UniversalUserPage.test.tsx
@@ -311,4 +311,28 @@ describe('UniversalUserPage', () => {
 
     window.history.replaceState = originalReplaceState;
   });
+
+  it('normalizes a percent-encoded raw NIP-05 URL segment to the canonical friendly form', () => {
+    const originalReplaceState = window.history.replaceState;
+    const replaceStateSpy = vi.fn();
+    window.history.replaceState = replaceStateSpy;
+
+    renderPage('/u/jimmyhere%40divine.video');
+
+    expect(replaceStateSpy).toHaveBeenCalledWith(null, '', '/u/jimmyhere');
+
+    window.history.replaceState = originalReplaceState;
+  });
+
+  it('does not normalize a third-party dotted segment that is already canonical', () => {
+    const originalReplaceState = window.history.replaceState;
+    const replaceStateSpy = vi.fn();
+    window.history.replaceState = replaceStateSpy;
+
+    renderPage('/u/alice.primal.net');
+
+    expect(replaceStateSpy).not.toHaveBeenCalled();
+
+    window.history.replaceState = originalReplaceState;
+  });
 });

--- a/src/pages/UniversalUserPage.tsx
+++ b/src/pages/UniversalUserPage.tsx
@@ -199,7 +199,7 @@ function getNotFoundDescription(identifier: string, t: TFunction): string {
  * unchanged and the lookup below will report not-found.
  */
 const NIP05_ENVELOPE_PATTERN = new RegExp(
-  `^(_@([^.]+)\\.(?:${DIVINE_APEX_DOMAINS.map(a => a.replace('.', '\\.')).join('|')})|([^@]+)@(?:${DIVINE_APEX_DOMAINS.map(a => a.replace('.', '\\.')).join('|')})$`,
+  `^(_@([^.]+)\\.(?:${DIVINE_APEX_DOMAINS.map(a => a.replace('.', '\\.')).join('|')})|([^@]+)@(?:${DIVINE_APEX_DOMAINS.map(a => a.replace('.', '\\.')).join('|')}))$`,
   'i',
 );
 

--- a/src/pages/UniversalUserPage.tsx
+++ b/src/pages/UniversalUserPage.tsx
@@ -5,14 +5,14 @@ import { useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useNostr } from '@nostrify/react';
 import { useQuery } from '@tanstack/react-query';
-import { nip19 } from 'nostr-tools';
 import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
 import { Card, CardContent } from '@/components/ui/card';
 import { WarningCircle as AlertCircle, CircleNotch as Loader2 } from '@phosphor-icons/react';
 import { debugLog } from '@/lib/debug';
-import { nip05CandidatesFromUrlSegment } from '@/lib/profileLinks';
+import { nip05CandidatesFromUrlSegment, normalizeUrlSegmentToFriendly } from '@/lib/profileLinks';
 import { resolveNip05ToPubkey } from '@/lib/nip05Resolve';
+import ProfilePage from './ProfilePage';
 
 const VINE_USER_ID_PATTERN = /^\d{15,20}$/;
 const VINE_HOSTNAME_PATTERN = /(^|\.)vine\.co$/i;
@@ -303,13 +303,16 @@ export function UniversalUserPage() {
   const { data, isLoading, error } = useUniversalUserLookup(userId);
 
   useEffect(() => {
-    if (data?.pubkey) {
-      // Redirect to the Nostr profile page
-      const npub = nip19.npubEncode(data.pubkey);
-      debugLog(`[UniversalUserPage] Redirecting to profile: ${npub}`);
-      navigate(`/${npub}`, { replace: true });
-    }
-  }, [data, navigate]);
+    if (!userId) return;
+    const canonical = normalizeUrlSegmentToFriendly(userId);
+    if (!canonical || canonical === userId) return;
+    const { search, hash } = window.location;
+    window.history.replaceState(null, '', `/u/${canonical}${search}${hash}`);
+  }, [userId]);
+
+  if (data?.pubkey) {
+    return <ProfilePage pubkeyOverride={data.pubkey} />;
+  }
 
   if (isLoading) {
     return (
@@ -359,7 +362,6 @@ export function UniversalUserPage() {
     );
   }
 
-  // While redirecting
   return (
     <div className="container max-w-4xl mx-auto px-4 py-8">
       <Card className="border-dashed">

--- a/src/pages/UniversalUserPage.tsx
+++ b/src/pages/UniversalUserPage.tsx
@@ -11,6 +11,8 @@ import type { TFunction } from 'i18next';
 import { Card, CardContent } from '@/components/ui/card';
 import { WarningCircle as AlertCircle, CircleNotch as Loader2 } from '@phosphor-icons/react';
 import { debugLog } from '@/lib/debug';
+import { nip05CandidatesFromUrlSegment } from '@/lib/profileLinks';
+import { resolveNip05ToPubkey } from '@/lib/nip05Resolve';
 
 const VINE_USER_ID_PATTERN = /^\d{15,20}$/;
 const VINE_HOSTNAME_PATTERN = /(^|\.)vine\.co$/i;
@@ -166,7 +168,9 @@ function getLookupLabel(identifier: string, t: TFunction): string {
     return t('universalUserPage.lookupLabel.vineId');
   }
 
-  return decodeIdentifier(identifier).includes('@')
+  const decoded = decodeIdentifier(identifier);
+  const looksLikeNip05 = decoded.includes('@') || decoded.includes('.');
+  return looksLikeNip05
     ? t('universalUserPage.lookupLabel.nip05')
     : t('universalUserPage.lookupLabel.legacyOrNip05');
 }
@@ -176,7 +180,9 @@ function getNotFoundDescription(identifier: string, t: TFunction): string {
     return t('universalUserPage.notFoundDescription.vine');
   }
 
-  return decodeIdentifier(identifier).includes('@')
+  const decoded = decodeIdentifier(identifier);
+  const looksLikeNip05 = decoded.includes('@') || decoded.includes('.');
+  return looksLikeNip05
     ? t('universalUserPage.notFoundDescription.nip05')
     : t('universalUserPage.notFoundDescription.legacy');
 }
@@ -206,7 +212,6 @@ function useUniversalUserLookup(identifier: string | undefined) {
       const profiles = getParsedProfiles(events);
 
       if (isVineUserId(decodedIdentifier)) {
-        // Handle Vine user ID lookup
         debugLog(`[UniversalUserPage] Looking up Vine user ID: ${decodedIdentifier}`);
         debugLog(`[UniversalUserPage] Searching through ${profiles.length} profiles for Vine ID`);
 
@@ -222,42 +227,67 @@ function useUniversalUserLookup(identifier: string | undefined) {
         }
 
         throw new UserNotFoundError(`No user found with Vine ID: ${decodedIdentifier}`);
-      } else {
-        debugLog(`[UniversalUserPage] Looking up username or NIP-05: ${decodedIdentifier}`);
+      }
 
-        const normalizedIdentifier = decodedIdentifier.toLowerCase();
-        if (!decodedIdentifier.includes('@')) {
-          for (const profile of profiles) {
-            const legacyUsername = extractLegacyVineUsername(profile.metadata);
-            if (legacyUsername?.toLowerCase() === normalizedIdentifier) {
-              debugLog(`[UniversalUserPage] Found legacy Vine user: ${profile.metadata.name}`);
-              return {
-                pubkey: profile.pubkey,
-                metadata: profile.metadata,
-                type: 'vine',
-              } satisfies ProfileLookupResult;
-            }
-          }
-        }
+      debugLog(`[UniversalUserPage] Looking up username or NIP-05: ${decodedIdentifier}`);
 
-        const nip05Identifier = decodedIdentifier.includes('@')
-          ? decodedIdentifier
-          : `${decodedIdentifier}@openvine.co`;
-
+      // Legacy Vine username: no '@' and no '.' — try matching against
+      // `vine_metadata.username` / `website` profiles.
+      const normalizedIdentifier = decodedIdentifier.toLowerCase();
+      if (!decodedIdentifier.includes('@') && !decodedIdentifier.includes('.')) {
         for (const profile of profiles) {
-          const nip05 = getStringRecordValue(profile.metadata, 'nip05');
-          if (nip05?.toLowerCase() === nip05Identifier.toLowerCase()) {
-            debugLog(`[UniversalUserPage] Found NIP-05 user: ${profile.metadata.name}`);
+          const legacyUsername = extractLegacyVineUsername(profile.metadata);
+          if (legacyUsername?.toLowerCase() === normalizedIdentifier) {
+            debugLog(`[UniversalUserPage] Found legacy Vine user: ${profile.metadata.name}`);
             return {
               pubkey: profile.pubkey,
               metadata: profile.metadata,
-              type: 'nip05',
+              type: 'vine',
             } satisfies ProfileLookupResult;
           }
         }
-
-        throw new UserNotFoundError(`No user found with NIP-05: ${nip05Identifier}`);
       }
+
+      // NIP-05 path: expand the URL segment into the canonical NIP-05 strings we
+      // expect to find in kind-0 metadata (or resolve via NIP-05 DNS).
+      const nip05Candidates = nip05CandidatesFromUrlSegment(decodedIdentifier);
+      debugLog(`[UniversalUserPage] NIP-05 candidates for "${decodedIdentifier}": ${JSON.stringify(nip05Candidates)}`);
+
+      const normalizedCandidates = new Set(nip05Candidates.map(c => c.toLowerCase()));
+      for (const profile of profiles) {
+        const nip = getStringRecordValue(profile.metadata, 'nip05');
+        if (nip && normalizedCandidates.has(nip.toLowerCase())) {
+          debugLog(`[UniversalUserPage] Found NIP-05 user: ${profile.metadata.name}`);
+          return {
+            pubkey: profile.pubkey,
+            metadata: profile.metadata,
+            type: 'nip05',
+          } satisfies ProfileLookupResult;
+        }
+      }
+
+      // DNS NIP-05 fallback. We only attempt this for candidates that contain an
+      // '@' (third-party segments with no '@' can't be resolved via DNS — they
+      // are tried against kind-0 above and reported as not-found if no match).
+      for (const candidate of nip05Candidates) {
+        if (!candidate.includes('@')) continue;
+        try {
+          const pubkey = await resolveNip05ToPubkey(candidate, { signal });
+          if (pubkey) {
+            debugLog(`[UniversalUserPage] Resolved NIP-05 via DNS: ${candidate} -> ${pubkey}`);
+            return {
+              pubkey,
+              metadata: {},
+              type: 'nip05',
+            } satisfies ProfileLookupResult;
+          }
+        } catch (err) {
+          if (err instanceof DOMException && err.name === 'AbortError') throw err;
+          debugLog(`[UniversalUserPage] DNS NIP-05 lookup failed for ${candidate}: ${(err as Error).message}`);
+        }
+      }
+
+      throw new UserNotFoundError(`No user found for identifier: ${decodedIdentifier}`);
     },
     enabled: !!identifier,
     staleTime: 300000,

--- a/src/pages/UniversalUserPage.tsx
+++ b/src/pages/UniversalUserPage.tsx
@@ -10,8 +10,9 @@ import type { TFunction } from 'i18next';
 import { Card, CardContent } from '@/components/ui/card';
 import { WarningCircle as AlertCircle, CircleNotch as Loader2 } from '@phosphor-icons/react';
 import { debugLog } from '@/lib/debug';
-import { nip05CandidatesFromUrlSegment, normalizeUrlSegmentToFriendly } from '@/lib/profileLinks';
+import { nip05CandidatesFromUrlSegment } from '@/lib/profileLinks';
 import { resolveNip05ToPubkey } from '@/lib/nip05Resolve';
+import { DIVINE_APEX_DOMAINS } from '@/lib/nip05Utils';
 import ProfilePage from './ProfilePage';
 
 const VINE_USER_ID_PATTERN = /^\d{15,20}$/;
@@ -190,6 +191,25 @@ function getNotFoundDescription(identifier: string, t: TFunction): string {
 /**
  * Looks up a user by either NIP-05 or Vine user ID
  */
+/**
+ * Strip the NIP-05 envelope from a /u/ URL segment, leaving the bare local
+ * part. We deliberately do NOT resolve the raw NIP-05 string itself — only
+ * the canonical /u/<sub> path runs through the lookup. Third-party segments
+ * (anything that doesn't match a known divine.video apex) pass through
+ * unchanged and the lookup below will report not-found.
+ */
+const NIP05_ENVELOPE_PATTERN = new RegExp(
+  `^(_@([^.]+)\\.(?:${DIVINE_APEX_DOMAINS.join('|')})|([^@]+)@${DIVINE_APEX_DOMAINS.map(a => a.replace('.', '\\.')).join('|')})$`,
+  'i',
+);
+
+function stripNip05Envelope(segment: string): string | null {
+  const decoded = decodeURIComponent(segment).trim();
+  const match = decoded.match(NIP05_ENVELOPE_PATTERN);
+  if (!match) return null;
+  return (match[2] ?? match[3]).toLowerCase();
+}
+
 function useUniversalUserLookup(identifier: string | undefined) {
   const { nostr } = useNostr();
 
@@ -304,10 +324,10 @@ export function UniversalUserPage() {
 
   useEffect(() => {
     if (!userId) return;
-    const canonical = normalizeUrlSegmentToFriendly(userId);
-    if (!canonical || canonical === userId) return;
+    const normalized = stripNip05Envelope(userId);
+    if (normalized === null) return;
     const { search, hash } = window.location;
-    window.history.replaceState(null, '', `/u/${canonical}${search}${hash}`);
+    window.history.replaceState(null, '', `/u/${normalized}${search}${hash}`);
   }, [userId]);
 
   if (data?.pubkey) {

--- a/src/pages/UniversalUserPage.tsx
+++ b/src/pages/UniversalUserPage.tsx
@@ -199,7 +199,7 @@ function getNotFoundDescription(identifier: string, t: TFunction): string {
  * unchanged and the lookup below will report not-found.
  */
 const NIP05_ENVELOPE_PATTERN = new RegExp(
-  `^(_@([^.]+)\\.(?:${DIVINE_APEX_DOMAINS.join('|')})|([^@]+)@${DIVINE_APEX_DOMAINS.map(a => a.replace('.', '\\.')).join('|')})$`,
+  `^(_@([^.]+)\\.(?:${DIVINE_APEX_DOMAINS.map(a => a.replace('.', '\\.')).join('|')})|([^@]+)@(?:${DIVINE_APEX_DOMAINS.map(a => a.replace('.', '\\.')).join('|')})$`,
   'i',
 );
 
@@ -207,7 +207,9 @@ function stripNip05Envelope(segment: string): string | null {
   const decoded = decodeURIComponent(segment).trim();
   const match = decoded.match(NIP05_ENVELOPE_PATTERN);
   if (!match) return null;
-  return (match[2] ?? match[3]).toLowerCase();
+  const captured = match[2] ?? match[3];
+  if (!captured) return null;
+  return captured.toLowerCase();
 }
 
 function useUniversalUserLookup(identifier: string | undefined) {
@@ -327,8 +329,8 @@ export function UniversalUserPage() {
     const normalized = stripNip05Envelope(userId);
     if (normalized === null) return;
     const { search, hash } = window.location;
-    window.history.replaceState(null, '', `/u/${normalized}${search}${hash}`);
-  }, [userId]);
+    navigate(`/u/${normalized}${search}${hash}`, { replace: true });
+  }, [userId, navigate]);
 
   if (data?.pubkey) {
     return <ProfilePage pubkeyOverride={data.pubkey} />;


### PR DESCRIPTION
Closes #402

## Summary

- `/u/_%40jacky.divine.video` and similar percent-encoded NIP-05 URLs now resolve, and the same profile is reachable as `/u/jacky`, `/u/jacky.divine.video`, and `/u/jacky.dvine.video`. Bare local part on the default apex means the default apex. Third-party NIP-05s become `/u/alice.primal.net`.
- Search result cards show a NIP-05 secondary identifier only after `useNip05Validation` reports it valid, so unverified kind-0 metadata does not claim a verified-looking handle.
- Bare-name `/u/<name>` lookup still checks the legacy `<name>@openvine.co` fallback after newer Divine candidates, preserving old profile reachability.

## Motivation

Two layered bugs combined to make the URL in the issue fail end-to-end. First, every in-app author link was produced by `buildProfileLinkPath` as `/u/${encodeURIComponent(nip05)}`, which for `_@jacky.divine.video` yielded the ugly `%40...` form. Second, the lookup at `useUniversalUserLookup` only matched the literal `metadata.nip05` field on a kind-0 event and did not understand the friendly path aliases. The search card compounded the confusion by only showing the kind-0 `name` field and never a validated NIP-05, so a user had no way to know that a legacy handle was the same identity as `jacky.divine.video`.

## What changed

- `src/lib/profileLinks.ts`: new `toFriendlyPath(nip05)` helper and new `nip05CandidatesFromUrlSegment(segment)` inverse. `buildProfileLinkPath` emits `/u/jacky` for `_@jacky.divine.video` / `jacky@divine.video`, `/u/jacky.dvine.video` for the alternate apex, `/u/alice.primal.net` for third-party NIP-05s, and falls back to `/{npub}` when the NIP-05 is missing or malformed.
- `src/lib/profileLinks.ts`: bare names include the legacy `openvine.co` candidate after the default-apex candidates, and third-party dotted local parts now generate every plausible domain-shaped split, so `bob.smith.primal.net` can match `bob.smith@primal.net`.
- `src/pages/UniversalUserPage.tsx`: `useUniversalUserLookup` expands URL segments into the candidate list, matches kind-0 metadata against any candidate, falls back to NIP-05 DNS resolution for candidates containing `@`, and only skips legacy Vine username matching for subdomain-shaped inputs.
- `src/pages/SearchPage.tsx`: `UserCard` validates `metadata.nip05` before displaying it as the secondary line, formatted via `getDivineNip05Info` for Divine NIP-05s and via `toFriendlyPath` for third-party NIP-05s. Legacy `metadata.name` is still shown when no valid NIP-05 is available.
- `src/pages/ProfilePage.tsx`: documents the intentional `replaceState` URL rewrite so the already-loaded profile stays mounted instead of remounting through `UniversalUserPage`.
- `URL_GUIDE.md`: documents the new friendly-path forms and removes the now-satisfied "NIP-05 username lookups in `/u/` route" future-enhancement bullet.

## Testing

- [x] `npm run test` — 171 test files passed, 1120 tests passed, production build completed.
- [x] Focused regression run: `npx vitest run src/lib/profileLinks.test.ts src/pages/UniversalUserPage.test.tsx src/pages/SearchPage.test.tsx` — 63 tests passed.
- [x] `git diff --check` — no whitespace errors.
- [ ] Manual verification on staging: visit `/u/jacky` and confirm the user profile loads; visit `/u/_%40jacky.divine.video` and confirm it lands on the same profile.

## Visuals

- [ ] UI change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved