### PR TITLE
fix(search): use direct profile links for NIP-05 metadata

### DIFF
--- a/src/components/NoteContent.test.tsx
+++ b/src/components/NoteContent.test.tsx
@@ -1,13 +1,19 @@
-import { describe, it, expect, vi } from 'vitest';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { nip19 } from 'nostr-tools';
 import { NoteContent } from './NoteContent';
 import type { NostrEvent } from '@nostrify/nostrify';
 
+const authorMocks = vi.hoisted(() => ({
+  metadata: {
+    display_name: 'rabble',
+  } as Record<string, unknown>,
+}));
+
 vi.mock('@/hooks/useAuthor', () => ({
   useAuthor: () => ({
-    data: { metadata: { display_name: 'rabble' } },
+    data: { metadata: authorMocks.metadata },
     isLoading: false,
   }),
 }));
@@ -40,11 +46,26 @@ function renderContent(content: string) {
 }
 
 describe('NoteContent — bare nostr identifiers', () => {
+  beforeEach(() => {
+    authorMocks.metadata = { display_name: 'rabble' };
+  });
+
   it('linkifies a bare npub1... as @mention', () => {
     renderContent(`hello ${NPUB}`);
     const link = screen.getByRole('link');
     expect(link).toHaveAttribute('href', `/${NPUB}`);
     expect(link.textContent).toBe('@rabble');
+  });
+
+  it('keeps npub mention links direct when author metadata includes a NIP-05 alias', () => {
+    authorMocks.metadata = {
+      display_name: 'rabble',
+      nip05: '_@rabble.divine.video',
+    };
+
+    renderContent(`hello ${NPUB}`);
+
+    expect(screen.getByRole('link', { name: '@rabble' })).toHaveAttribute('href', `/${NPUB}`);
   });
 
   it('linkifies a bare note1...', () => {

--- a/src/components/NoteContent.tsx
+++ b/src/components/NoteContent.tsx
@@ -122,7 +122,6 @@ function NostrMention({ pubkey }: { pubkey: string }) {
   const displayName = author.data?.metadata?.name || author.data?.metadata?.display_name || genUserName(pubkey);
   const profilePath = buildProfileLinkPath({
     pubkey,
-    nip05: author.data?.metadata?.nip05,
   });
 
   return (

--- a/src/components/VideoCard.test.tsx
+++ b/src/components/VideoCard.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+import { nip19 } from 'nostr-tools';
 import type {
   ButtonHTMLAttributes,
   HTMLAttributes,
@@ -28,6 +29,13 @@ const authMocks = vi.hoisted(() => ({
   confirmAdult: vi.fn(),
   useCurrentUser: vi.fn(),
   useAdultVerification: vi.fn(),
+}));
+
+const authorMocks = vi.hoisted(() => ({
+  metadata: {
+    name: 'Video Author',
+    picture: 'https://example.com/avatar.jpg',
+  } as Record<string, unknown>,
 }));
 
 vi.mock('@/components/ui/card', () => ({
@@ -165,19 +173,17 @@ vi.mock('@/components/SmartLink', () => ({
   SmartLink: ({
     children,
     ownerPubkey: _ownerPubkey,
+    to,
     ...props
-  }: HTMLAttributes<HTMLAnchorElement> & { ownerPubkey?: string }) => (
-    <a {...props}>{children}</a>
+  }: HTMLAttributes<HTMLAnchorElement> & { ownerPubkey?: string; to: string }) => (
+    <a href={to} {...props}>{children}</a>
   ),
 }));
 
 vi.mock('@/hooks/useAuthor', () => ({
   useAuthor: () => ({
     data: {
-      metadata: {
-        name: 'Video Author',
-        picture: 'https://example.com/avatar.jpg',
-      },
+      metadata: authorMocks.metadata,
     },
     isLoading: false,
   }),
@@ -387,6 +393,10 @@ describe('VideoCard', () => {
     playbackMocks.navigate.mockClear();
     playbackMocks.toast.mockClear();
     playbackMocks.share.mockClear();
+    authorMocks.metadata = {
+      name: 'Video Author',
+      picture: 'https://example.com/avatar.jpg',
+    };
     authMocks.openLoginDialog.mockClear();
     authMocks.confirmAdult.mockClear();
     authMocks.useCurrentUser.mockReturnValue({ user: null });
@@ -407,6 +417,22 @@ describe('VideoCard', () => {
 
     expect(playbackMocks.setActiveVideo).toHaveBeenCalledWith(baseVideo.id);
     expect(screen.getByTestId(`video-player-${baseVideo.id}`)).toBeTruthy();
+  });
+
+  it('links the author name directly to the known profile pubkey when metadata has a NIP-05 alias', () => {
+    authorMocks.metadata = {
+      name: 'Video Author',
+      picture: 'https://example.com/avatar.jpg',
+      nip05: '_@video-author.divine.video',
+    };
+    const expectedNpub = nip19.npubEncode(baseVideo.pubkey);
+
+    render(<VideoCard video={baseVideo} />);
+
+    expect(screen.getByRole('link', { name: 'Video Author' })).toHaveAttribute(
+      'href',
+      `/profile/${expectedNpub}`,
+    );
   });
 
   it('keeps the thumbnail visible until inline playback actually starts', () => {

--- a/src/components/VideoCard.tsx
+++ b/src/components/VideoCard.tsx
@@ -297,7 +297,7 @@ export function VideoCard({
   );
   const profileUrl = buildProfileLinkPath({
     pubkey: video.pubkey,
-    nip05: rawMetadata?.nip05,
+    fallbackRoute: 'profile',
   });
 
   const reposterName = reposterData.isLoading


### PR DESCRIPTION
## Summary

- Route video-card author links through known npub profile paths when NIP-05 metadata is present.
- Keep rendered npub mentions direct instead of switching to `/u/_%40...` alias paths.
- Add regression coverage for NIP-05 alias metadata in search-result profile links.

## Motivation

- Search results could render NIP-05-based `/u/_%40...` links that fail even though the component already knows the profile pubkey.
- This is an alternate direct-npub strategy for the same bug tracked in #402. If #403 is accepted as the canonical friendly `/u/` strategy, this PR should be closed or reworked instead of merged so profile URL behavior stays consistent across surfaces.

## Related Issue

Closes #402

## Testing

- [x] `npm run test`
- [x] Manual verification completed: local search results no longer rendered `/u/_%40...` profile anchors; author links used `/profile/npub...` and mention links used `/npub...`

## Visuals

- [ ] UI change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved