### PR TITLE
fix(profile-links): use direct npub links in notifications, user lists, and leaderboard

### DIFF
--- a/src/components/FullscreenVideoItem.test.tsx
+++ b/src/components/FullscreenVideoItem.test.tsx
@@ -1,0 +1,259 @@
+// ABOUTME: Tests for FullscreenVideoItem author profile link behavior
+// ABOUTME: Guards against routing through the unreliable /u/<nip05> resolver
+
+import { render, screen } from '@testing-library/react';
+import type {
+  ButtonHTMLAttributes,
+  HTMLAttributes,
+  ImgHTMLAttributes,
+  ReactNode,
+} from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { nip19 } from 'nostr-tools';
+import type { ParsedVideoData } from '@/types/video';
+import { initializeI18n } from '@/lib/i18n';
+import { FullscreenVideoItem } from './FullscreenVideoItem';
+
+const { authorMocks } = vi.hoisted(() => ({
+  authorMocks: {
+    metadata: {
+      name: 'Video Author',
+      picture: 'https://example.com/avatar.jpg',
+    } as Record<string, unknown>,
+  },
+}));
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+vi.mock('@/components/ui/avatar', () => ({
+  Avatar: ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => (
+    <div {...props}>{children}</div>
+  ),
+  AvatarImage: (props: ImgHTMLAttributes<HTMLImageElement>) => <img {...props} />,
+  AvatarFallback: ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => (
+    <div {...props}>{children}</div>
+  ),
+}));
+
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuSeparator: () => <div />,
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/components/VideoPlayer', () => ({
+  VideoPlayer: () => <div data-testid="video-player" />,
+}));
+
+vi.mock('@/components/VideoCommentsModal', () => ({
+  VideoCommentsModal: () => null,
+}));
+
+vi.mock('@/components/VideoReactionsModal', () => ({
+  VideoReactionsModal: () => null,
+}));
+
+vi.mock('@/components/NoteContent', () => ({
+  NoteContent: ({ event }: { event: { content: string } }) => (
+    <div>{event.content}</div>
+  ),
+}));
+
+vi.mock('@/components/AddToListDialog', () => ({
+  AddToListDialog: () => null,
+}));
+
+vi.mock('@/components/ReportContentDialog', () => ({
+  ReportContentDialog: () => null,
+}));
+
+vi.mock('@/components/DeleteVideoDialog', () => ({
+  DeleteVideoDialog: () => null,
+}));
+
+vi.mock('@/components/ViewSourceDialog', () => ({
+  ViewSourceDialog: () => null,
+}));
+
+vi.mock('@/components/InlineBadges', () => ({
+  InlineBadges: () => null,
+}));
+
+vi.mock('@/components/VideoVerificationBadgeRow', () => ({
+  VideoVerificationBadgeRow: () => null,
+}));
+
+vi.mock('@/components/SmartLink', () => ({
+  SmartLink: ({
+    children,
+    ownerPubkey: _ownerPubkey,
+    to,
+    ...props
+  }: HTMLAttributes<HTMLAnchorElement> & { ownerPubkey?: string; to: string }) => (
+    <a href={to} {...props}>{children}</a>
+  ),
+}));
+
+vi.mock('@/hooks/useAuthor', () => ({
+  useAuthor: () => ({
+    data: { metadata: authorMocks.metadata },
+    isLoading: false,
+  }),
+}));
+
+vi.mock('@/hooks/useVideoPlayback', () => ({
+  useVideoPlayback: () => ({
+    globalMuted: true,
+    setGlobalMuted: vi.fn(),
+    setActiveVideo: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useVideoReactions', () => ({
+  useVideoReactions: () => ({ data: null }),
+}));
+
+vi.mock('@/hooks/useVideoLists', () => ({
+  useVideosInLists: () => ({ data: [] }),
+}));
+
+vi.mock('@/hooks/useModeration', () => ({
+  useMuteItem: () => ({ mutateAsync: vi.fn() }),
+}));
+
+vi.mock('@/hooks/useDeleteVideo', () => ({
+  useDeleteVideo: () => ({ mutate: vi.fn(), isPending: false }),
+  useCanDeleteVideo: () => false,
+}));
+
+vi.mock('@/hooks/useDirectMessages', () => ({
+  useDmCapability: () => ({ canUseDirectMessages: false }),
+}));
+
+vi.mock('@/hooks/useToast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+vi.mock('@/hooks/useSubdomainNavigate', () => ({
+  useSubdomainNavigate: () => vi.fn(),
+}));
+
+vi.mock('@/hooks/useBadges', () => ({
+  useBadges: () => ({ data: [] }),
+}));
+
+vi.mock('@/hooks/useBandwidthTier', () => ({
+  useBandwidthTier: () => 'default',
+}));
+
+vi.mock('@/hooks/useSubtitles', () => ({
+  useSubtitles: () => ({ cues: [], hasSubtitles: false }),
+}));
+
+vi.mock('@/lib/generateProfile', () => ({
+  enhanceAuthorData: (
+    data: { metadata?: Record<string, unknown> } | undefined,
+    pubkey: string,
+  ) => ({
+    metadata: data?.metadata ?? { name: pubkey },
+  }),
+}));
+
+vi.mock('@/lib/genUserName', () => ({
+  genUserName: () => 'Generated User',
+}));
+
+vi.mock('@/lib/imageUtils', () => ({
+  getSafeProfileImage: (url?: string) => url ?? '',
+}));
+
+vi.mock('@/lib/bandwidthTracker', () => ({
+  getOptimalVideoUrl: (url: string) => url,
+}));
+
+const AUTHOR_PUBKEY = 'f'.repeat(64);
+
+const baseVideo = {
+  id: 'video-1',
+  kind: 34236,
+  pubkey: AUTHOR_PUBKEY,
+  authorName: 'Video Author',
+  authorAvatar: 'https://example.com/avatar.jpg',
+  videoUrl: 'https://example.com/video.mp4',
+  thumbnailUrl: 'https://example.com/thumb.jpg',
+  duration: 6,
+  createdAt: 1_700_000_000,
+  hashtags: [],
+  reposts: [],
+  content: '',
+  title: 'Test Video',
+  isVineMigrated: false,
+  ageRestricted: false,
+  vineId: 'vine-id-1',
+  fallbackVideoUrls: [],
+} as unknown as ParsedVideoData;
+
+function renderItem() {
+  return render(
+    <FullscreenVideoItem
+      video={baseVideo}
+      isActive={false}
+      onBack={vi.fn()}
+      onLike={vi.fn()}
+      onRepost={vi.fn()}
+      onShare={vi.fn()}
+      onDownload={vi.fn()}
+      isLiked={false}
+      isReposted={false}
+      likeCount={0}
+      repostCount={0}
+      commentCount={0}
+    />,
+  );
+}
+
+describe('FullscreenVideoItem', () => {
+  beforeEach(async () => {
+    const storage = new Map<string, string>();
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: (key: string) => storage.get(key) ?? null,
+        setItem: (key: string, value: string) => storage.set(key, value),
+        removeItem: (key: string) => storage.delete(key),
+        clear: () => storage.clear(),
+      } satisfies Pick<Storage, 'getItem' | 'setItem' | 'removeItem' | 'clear'>,
+    });
+    await initializeI18n({ force: true, languages: ['en-US'] });
+    authorMocks.metadata = {
+      name: 'Video Author',
+      picture: 'https://example.com/avatar.jpg',
+    };
+  });
+
+  it('links the author directly to their npub profile', () => {
+    renderItem();
+
+    const link = screen.getByText('Video Author').closest('a');
+    expect(link).toHaveAttribute('href', `/${nip19.npubEncode(AUTHOR_PUBKEY)}`);
+  });
+
+  it('keeps the direct npub link when author metadata includes a NIP-05 alias', () => {
+    authorMocks.metadata = {
+      name: 'Video Author',
+      picture: 'https://example.com/avatar.jpg',
+      nip05: 'video-author@divine.video',
+    };
+
+    renderItem();
+
+    const link = screen.getByText('Video Author').closest('a');
+    expect(link).toHaveAttribute('href', `/${nip19.npubEncode(AUTHOR_PUBKEY)}`);
+  });
+});

--- a/src/components/FullscreenVideoItem.tsx
+++ b/src/components/FullscreenVideoItem.tsx
@@ -145,7 +145,6 @@ export function FullscreenVideoItem({
   );
   const profileUrl = buildProfileLinkPath({
     pubkey: video.pubkey,
-    nip05: rawMetadata?.nip05,
   });
 
   // Format timestamp

--- a/src/components/NotificationItem.test.tsx
+++ b/src/components/NotificationItem.test.tsx
@@ -1,0 +1,88 @@
+// ABOUTME: Tests for NotificationItem profile navigation behavior
+// ABOUTME: Guards against routing through the unreliable /u/<nip05> resolver
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { nip19 } from 'nostr-tools';
+import type { Notification } from '@/types/notification';
+import { NotificationItem } from './NotificationItem';
+
+const { mockNavigate, authorMocks } = vi.hoisted(() => ({
+  mockNavigate: vi.fn(),
+  authorMocks: {
+    metadata: { display_name: 'Follower' } as Record<string, unknown>,
+  },
+}));
+
+vi.mock('@/hooks/useSubdomainNavigate', () => ({
+  useSubdomainNavigate: () => mockNavigate,
+}));
+
+vi.mock('@/hooks/useAuthor', () => ({
+  useAuthor: () => ({
+    data: { metadata: authorMocks.metadata },
+    isLoading: false,
+  }),
+}));
+
+const ACTOR_PUBKEY = 'a'.repeat(64);
+
+function buildNotification(overrides: Partial<Notification> = {}): Notification {
+  return {
+    id: 'notification-1',
+    type: 'follow',
+    actorPubkey: ACTOR_PUBKEY,
+    timestamp: 1_700_000_000,
+    isRead: true,
+    sourceEventId: 'b'.repeat(64),
+    sourceKind: 3,
+    ...overrides,
+  };
+}
+
+describe('NotificationItem', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authorMocks.metadata = { display_name: 'Follower' };
+  });
+
+  it('navigates follow notifications directly to the actor npub profile', () => {
+    render(<NotificationItem notification={buildNotification()} />);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      `/profile/${nip19.npubEncode(ACTOR_PUBKEY)}`,
+    );
+  });
+
+  it('keeps the direct npub link when actor metadata includes a NIP-05 alias', () => {
+    authorMocks.metadata = {
+      display_name: 'Follower',
+      nip05: 'follower@divine.video',
+    };
+
+    render(<NotificationItem notification={buildNotification()} />);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      `/profile/${nip19.npubEncode(ACTOR_PUBKEY)}`,
+    );
+  });
+
+  it('navigates to the target video for non-follow notifications', () => {
+    render(
+      <NotificationItem
+        notification={buildNotification({
+          type: 'like',
+          targetEventId: 'c'.repeat(64),
+        })}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(mockNavigate).toHaveBeenCalledWith(`/video/${'c'.repeat(64)}`);
+  });
+});

--- a/src/components/NotificationItem.tsx
+++ b/src/components/NotificationItem.tsx
@@ -42,7 +42,6 @@ export function NotificationItem({ notification }: NotificationItemProps) {
     if (notification.type === 'follow') {
       navigate(buildProfileLinkPath({
         pubkey: notification.actorPubkey,
-        nip05: metadata?.nip05,
         fallbackRoute: 'profile',
       }));
     } else if (notification.targetEventId) {

--- a/src/components/UserListDialog.test.tsx
+++ b/src/components/UserListDialog.test.tsx
@@ -1,5 +1,6 @@
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { nip19 } from 'nostr-tools';
 import { UserListDialog } from './UserListDialog';
 
 const {
@@ -34,6 +35,41 @@ vi.mock('@/lib/sentry', () => ({
 }));
 
 describe('UserListDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStartInactiveSpan.mockReturnValue({
+      end: vi.fn(),
+      setAttribute: vi.fn(),
+    });
+  });
+
+  it('navigates directly to the npub profile even when metadata has a NIP-05 alias', async () => {
+    const pubkey = 'a'.repeat(64);
+    mockUseBatchedAuthors.mockReturnValue({
+      data: {
+        [pubkey]: {
+          metadata: { name: 'alice', nip05: 'alice@divine.video' },
+        },
+      },
+    });
+
+    render(
+      <UserListDialog
+        open
+        onOpenChange={vi.fn()}
+        title="Followers"
+        pubkeys={[pubkey]}
+      />,
+    );
+
+    fireEvent.click(await screen.findByText('alice'));
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      `/profile/${nip19.npubEncode(pubkey)}`,
+      { ownerPubkey: pubkey },
+    );
+  });
+
   it('renders visible fallback rows before author metadata resolves', async () => {
     mockUseBatchedAuthors.mockReturnValue({ data: {} });
 

--- a/src/components/UserListDialog.tsx
+++ b/src/components/UserListDialog.tsx
@@ -35,7 +35,7 @@ interface UserListDialogProps {
 interface UserRowProps {
   pubkey: string;
   metadata?: NostrMetadata;
-  onNavigate: (pubkey: string, nip05?: string) => void;
+  onNavigate: (pubkey: string) => void;
 }
 
 const UserRow = memo(function UserRow({ pubkey, metadata, onNavigate }: UserRowProps) {
@@ -45,7 +45,7 @@ const UserRow = memo(function UserRow({ pubkey, metadata, onNavigate }: UserRowP
   return (
     <button
       className="flex items-center gap-3 w-full p-2 rounded-lg hover:bg-muted transition-colors text-left"
-      onClick={() => onNavigate(pubkey, metadata?.nip05)}
+      onClick={() => onNavigate(pubkey)}
     >
       <Avatar size="md" className="shrink-0">
         <AvatarImage src={profileImage} alt={displayName} />
@@ -150,11 +150,10 @@ export function UserListDialog({
   const { data: authorsData } = useBatchedAuthors(open ? visiblePubkeys : []);
 
   const handleNavigate = useCallback(
-    (pubkey: string, nip05?: string) => {
+    (pubkey: string) => {
       onOpenChange(false);
       navigate(buildProfileLinkPath({
         pubkey,
-        nip05,
         fallbackRoute: 'profile',
       }), { ownerPubkey: pubkey });
     },

--- a/src/components/VideoReactionsModal.test.tsx
+++ b/src/components/VideoReactionsModal.test.tsx
@@ -1,0 +1,99 @@
+// ABOUTME: Tests for VideoReactionsModal profile link behavior
+// ABOUTME: Guards against routing through the unreliable /u/<nip05> resolver
+
+import { render, screen } from '@testing-library/react';
+import type { HTMLAttributes } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { nip19 } from 'nostr-tools';
+import type { VideoReactions } from '@/hooks/useVideoReactions';
+import { VideoReactionsModal } from './VideoReactionsModal';
+
+const { authorMocks } = vi.hoisted(() => ({
+  authorMocks: {
+    metadata: { display_name: 'Alice' } as Record<string, unknown>,
+  },
+}));
+
+vi.mock('@/components/SmartLink', () => ({
+  SmartLink: ({
+    children,
+    ownerPubkey: _ownerPubkey,
+    to,
+    ...props
+  }: HTMLAttributes<HTMLAnchorElement> & { ownerPubkey?: string; to: string }) => (
+    <a href={to} {...props}>{children}</a>
+  ),
+}));
+
+vi.mock('@/hooks/useAuthor', () => ({
+  useAuthor: () => ({
+    data: { metadata: authorMocks.metadata },
+    isLoading: false,
+  }),
+}));
+
+vi.mock('@/hooks/useBatchedAuthors', () => ({
+  useBatchedAuthors: () => ({ data: {} }),
+}));
+
+vi.mock('@/lib/generateProfile', () => ({
+  enhanceAuthorData: (
+    data: { metadata?: Record<string, unknown> } | undefined,
+    pubkey: string,
+  ) => ({
+    metadata: data?.metadata ?? { name: pubkey },
+  }),
+}));
+
+const LIKER_PUBKEY = 'a'.repeat(64);
+
+const reactions: VideoReactions = {
+  likes: [
+    {
+      pubkey: LIKER_PUBKEY,
+      eventId: 'e'.repeat(64),
+      timestamp: 1_700_000_000,
+      type: 'like',
+    },
+  ],
+  reposts: [],
+};
+
+describe('VideoReactionsModal', () => {
+  beforeEach(() => {
+    authorMocks.metadata = { display_name: 'Alice' };
+  });
+
+  it('links reaction users directly to their npub profile', () => {
+    render(
+      <VideoReactionsModal
+        open
+        onOpenChange={vi.fn()}
+        reactions={reactions}
+        type="likes"
+      />,
+    );
+
+    const link = screen.getByText('Alice').closest('a');
+    expect(link).toHaveAttribute('href', `/${nip19.npubEncode(LIKER_PUBKEY)}`);
+  });
+
+  it('keeps the direct npub link when metadata includes a NIP-05 alias', () => {
+    authorMocks.metadata = {
+      display_name: 'Alice',
+      nip05: 'alice@divine.video',
+    };
+
+    render(
+      <VideoReactionsModal
+        open
+        onOpenChange={vi.fn()}
+        reactions={reactions}
+        type="likes"
+      />,
+    );
+
+    const link = screen.getByText('Alice').closest('a');
+    expect(link).toHaveAttribute('href', `/${nip19.npubEncode(LIKER_PUBKEY)}`);
+  });
+});

--- a/src/components/VideoReactionsModal.tsx
+++ b/src/components/VideoReactionsModal.tsx
@@ -31,7 +31,6 @@ function ReactionUserItem({ pubkey, timestamp }: { pubkey: string; timestamp: nu
   const profileImage = getSafeProfileImage(metadata?.picture);
   const profileUrl = buildProfileLinkPath({
     pubkey,
-    nip05: metadata?.nip05,
   });
 
   const date = new Date(timestamp * 1000);

--- a/src/pages/LeaderboardPage.test.tsx
+++ b/src/pages/LeaderboardPage.test.tsx
@@ -1,0 +1,90 @@
+// ABOUTME: Tests for LeaderboardPage creator profile links
+// ABOUTME: Guards against routing through the unreliable /u/<nip05> resolver
+
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { nip19 } from 'nostr-tools';
+import { initializeI18n } from '@/lib/i18n';
+import LeaderboardPage from './LeaderboardPage';
+
+vi.mock('@unhead/react', () => ({
+  useSeoMeta: vi.fn(),
+}));
+
+const CREATOR_PUBKEY = 'c'.repeat(64);
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <LeaderboardPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('LeaderboardPage', () => {
+  beforeEach(async () => {
+    const storage = new Map<string, string>();
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: (key: string) => storage.get(key) ?? null,
+        setItem: (key: string, value: string) => storage.set(key, value),
+        removeItem: (key: string) => storage.delete(key),
+        clear: () => storage.clear(),
+      } satisfies Pick<Storage, 'getItem' | 'setItem' | 'removeItem' | 'clear'>,
+    });
+    await initializeI18n({ force: true, languages: ['en-US'] });
+
+    window.location.hash = '#creators-alltime';
+
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/api/leaderboard/creators')) {
+        return {
+          ok: true,
+          json: async () => ({
+            period: 'alltime',
+            entries: [
+              {
+                pubkey: CREATOR_PUBKEY,
+                name: 'alice',
+                display_name: 'Alice Creator',
+                picture: 'https://example.com/alice.jpg',
+                nip05: 'alice@divine.video',
+                views: 1000,
+                unique_viewers: 100,
+                loops: 500,
+                videos_with_views: 5,
+              },
+            ],
+          }),
+        } as Response;
+      }
+
+      return {
+        ok: true,
+        json: async () => ({ entries: [] }),
+      } as Response;
+    }));
+  });
+
+  it('links creators directly to their npub profile even when the API returns a NIP-05 alias', async () => {
+    renderPage();
+
+    const creatorName = await screen.findByText('Alice Creator');
+    const link = creatorName.closest('a');
+
+    expect(link).toHaveAttribute(
+      'href',
+      `/profile/${nip19.npubEncode(CREATOR_PUBKEY)}`,
+    );
+  });
+});

--- a/src/pages/LeaderboardPage.tsx
+++ b/src/pages/LeaderboardPage.tsx
@@ -353,7 +353,6 @@ function CreatorLeaderboard({ period }: { period: TimePeriod }) {
       {creators.map((creator, index) => {
         const creatorProfilePath = buildProfileLinkPath({
           pubkey: creator.pubkey,
-          nip05: creator.nip05,
           fallbackRoute: 'profile',
         });
 

--- a/src/pages/SearchPage.test.tsx
+++ b/src/pages/SearchPage.test.tsx
@@ -19,6 +19,7 @@ const {
   mockFetchVideoById,
   mockNostrQuery,
   mockUseInfiniteSearchVideos,
+  mockUseSearchUsers,
   mockEnterFullscreen,
   mockSetVideosForFullscreen,
   mockUpdateVideos,
@@ -28,6 +29,7 @@ const {
   mockFetchVideoById: vi.fn(),
   mockNostrQuery: vi.fn(),
   mockUseInfiniteSearchVideos: vi.fn(),
+  mockUseSearchUsers: vi.fn(),
   mockEnterFullscreen: vi.fn(),
   mockSetVideosForFullscreen: vi.fn(),
   mockUpdateVideos: vi.fn(),
@@ -154,11 +156,7 @@ vi.mock('@/hooks/useInfiniteSearchVideos', () => ({
 }));
 
 vi.mock('@/hooks/useSearchUsers', () => ({
-  useSearchUsers: () => ({
-    data: [],
-    isLoading: false,
-    error: null,
-  }),
+  useSearchUsers: mockUseSearchUsers,
 }));
 
 vi.mock('@/hooks/useSearchHashtags', () => ({
@@ -217,6 +215,11 @@ describe('SearchPage', () => {
       isLoading: false,
       error: null,
     });
+    mockUseSearchUsers.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+    });
   });
 
   afterEach(() => {
@@ -241,6 +244,32 @@ describe('SearchPage', () => {
     unmount();
 
     expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('navigates user results directly to the npub profile even when metadata has a NIP-05 alias', () => {
+    const pubkey = 'd'.repeat(64);
+    mockUseSearchUsers.mockReturnValue({
+      data: [
+        {
+          pubkey,
+          metadata: {
+            name: 'alice',
+            display_name: 'Alice',
+            nip05: 'alice@divine.video',
+          },
+        },
+      ],
+      isLoading: false,
+      error: null,
+    });
+
+    renderPage(['/search?q=alice']);
+
+    fireEvent.click(
+      screen.getAllByRole('button', { name: 'View profile of Alice' })[0],
+    );
+
+    expect(mockNavigate).toHaveBeenCalledWith(`/${nip19.npubEncode(pubkey)}`);
   });
 
   it('navigates directly when the query is an npub', () => {

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -762,7 +762,6 @@ function UserCard({ user }: { user: { pubkey: string; metadata?: UserCardMetadat
   const picture = getSafeProfileImage(user.metadata?.picture);
   const profilePath = buildProfileLinkPath({
     pubkey: user.pubkey,
-    nip05: user.metadata?.nip05,
   });
 
   const handleClick = () => {


### PR DESCRIPTION
## Summary

Follow-up to #404, which switched `VideoCard` and `NoteContent` to link directly to known-pubkey routes instead of passing `nip05` to `buildProfileLinkPath`. The `/u/<nip05>` resolver (`UniversalUserPage`) only scans a 500-event kind-0 sample, so `/u/...` links are unreliable when the pubkey is already known.

This PR sweeps the remaining call sites that still passed `nip05` alongside a known pubkey:

- `src/components/NotificationItem.tsx` — follow-notification click now navigates to `/profile/<npub>`
- `src/components/UserListDialog.tsx` — follower/following rows now navigate to `/profile/<npub>` (the unused `nip05` parameter was removed from `onNavigate`)
- `src/pages/LeaderboardPage.tsx` — creator leaderboard rows now link to `/profile/<npub>`
- `src/components/FullscreenVideoItem.tsx` — author overlay link now points to `/<npub>`
- `src/components/VideoReactionsModal.tsx` — likes/reposts user rows now link to `/<npub>`
- `src/pages/SearchPage.tsx` (`UserCard`) — user search results now navigate to `/<npub>`

Each call site keeps its existing fallback route (`profile` vs root); only the `nip05` pass-through was removed, mirroring #404's pattern.

## Testing

- [x] Regression tests added for every swept component, asserting the direct npub link is kept even when metadata includes a NIP-05 alias (mirrors the SmartLink `to`-as-`href` mock pattern from #404's `VideoCard.test.tsx` / `NoteContent.test.tsx`)
  - New: `NotificationItem.test.tsx`, `VideoReactionsModal.test.tsx`, `FullscreenVideoItem.test.tsx`, `LeaderboardPage.test.tsx`
  - Extended: `UserListDialog.test.tsx`, `SearchPage.test.tsx`
- [x] `npx vitest run` on the touched test files: 30 passed, 0 failed
- [x] `npx tsc --noEmit`: clean
- [x] `npx eslint` on all touched files: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)