### PR TITLE
feat(scripts): add verify-og-tags.sh for live OG/Twitter Card parity audit

### DIFF
--- a/.github/workflows/og-audit.yml
+++ b/.github/workflows/og-audit.yml
@@ -32,14 +32,7 @@ jobs:
       - name: Run OG parity audit against production
         env:
           BASE_URL: https://divine.video
-        continue-on-error: true
-        id: audit-prod
         run: bash scripts/verify-og-tags.sh
-
-      - name: Annotate production audit result
-        if: always() && steps.audit-prod.outcome == 'failure'
-        run: |
-          echo "::warning::OG parity audit against production failed. This is expected until the known OG parity gaps are fixed — see https://github.com/divinevideo/divine-web/issues for the tracking issue. The audit is intentionally non-blocking."
 
   audit-cloudflare-preview:
     name: Audit Cloudflare preview (latest main-branch deployment)
@@ -56,7 +49,6 @@ jobs:
         id: find-preview
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        continue-on-error: true
         run: |
           set -euo pipefail
           if [[ -z "${CLOUDFLARE_API_TOKEN:-}" ]]; then
@@ -79,11 +71,4 @@ jobs:
         if: steps.find-preview.outputs.preview_url != ''
         env:
           BASE_URL: ${{ steps.find-preview.outputs.preview_url }}
-        continue-on-error: true
-        id: audit-preview
         run: bash scripts/verify-og-tags.sh
-
-      - name: Annotate Cloudflare preview audit result
-        if: always() && steps.audit-preview.outcome == 'failure'
-        run: |
-          echo "::warning::OG parity audit against the Cloudflare preview failed. This is expected until the known OG parity gaps are fixed — see https://github.com/divinevideo/divine-web/issues for the tracking issue. The audit is intentionally non-blocking."

--- a/.github/workflows/og-audit.yml
+++ b/.github/workflows/og-audit.yml
@@ -53,25 +53,39 @@ jobs:
 
       - name: Find latest Cloudflare Pages main-branch preview deployment URL
         id: find-preview
+        continue-on-error: ${{ github.event_name == 'schedule' }}
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           set -euo pipefail
           if [[ -z "${CLOUDFLARE_API_TOKEN:-}" ]]; then
-            echo "::notice::CLOUDFLARE_API_TOKEN not set; skipping Cloudflare preview audit."
-            exit 0
+            echo "::error::CLOUDFLARE_API_TOKEN not set; cannot audit Cloudflare preview."
+            exit 1
+          fi
+          if [[ -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]]; then
+            echo "::error::CLOUDFLARE_ACCOUNT_ID not set; cannot audit Cloudflare preview."
+            exit 1
           fi
           # Project name matches deploy.yml and preview.yml (divine-web-direct-deploy).
-          # Filter to Branch=main so we audit the post-merge preview, not PR previews.
-          URL=$(wrangler pages deployment list \
+          # Filter to branch=main so we audit the post-merge preview, not PR previews.
+          if ! URL=$(wrangler pages deployment list \
             --project-name divine-web-direct-deploy \
-            --json 2>/dev/null \
-            | jq -r '[.[] | select(.Environment == "Preview" and .Branch == "main")] | first | .Deployment // empty')
+            --environment preview \
+            --json \
+            | jq -er '(first(.[] | select(.environment == "preview" and .deployment_trigger.metadata.branch == "main" and (.url // "") != "")) // empty) | .url'); then
+            echo "::error::No main-branch Cloudflare preview deployment found, or Wrangler could not list deployments."
+            exit 1
+          fi
           if [[ -z "$URL" ]]; then
-            echo "::notice::No main-branch preview deployment found; skipping."
-            exit 0
+            echo "::error::No main-branch Cloudflare preview deployment found."
+            exit 1
           fi
           echo "preview_url=$URL" >> "$GITHUB_OUTPUT"
+
+      - name: Annotate scheduled Cloudflare preview discovery result
+        if: github.event_name == 'schedule' && steps.find-preview.outcome == 'failure'
+        run: echo "::warning::Scheduled Cloudflare preview discovery failed. This monitors live deployment state and is warning-only on schedule."
 
       - name: Run OG parity audit against Cloudflare preview
         id: audit-preview

--- a/.github/workflows/og-audit.yml
+++ b/.github/workflows/og-audit.yml
@@ -32,7 +32,14 @@ jobs:
       - name: Run OG parity audit against production
         env:
           BASE_URL: https://divine.video
+        continue-on-error: true
+        id: audit-prod
         run: bash scripts/verify-og-tags.sh
+
+      - name: Annotate production audit result
+        if: always() && steps.audit-prod.outcome == 'failure'
+        run: |
+          echo "::warning::OG parity audit against production failed. This is expected until the known OG parity gaps are fixed — see https://github.com/divinevideo/divine-web/issues for the tracking issue. The audit is intentionally non-blocking."
 
   audit-cloudflare-preview:
     name: Audit Cloudflare preview (latest main-branch deployment)
@@ -72,4 +79,11 @@ jobs:
         if: steps.find-preview.outputs.preview_url != ''
         env:
           BASE_URL: ${{ steps.find-preview.outputs.preview_url }}
+        continue-on-error: true
+        id: audit-preview
         run: bash scripts/verify-og-tags.sh
+
+      - name: Annotate Cloudflare preview audit result
+        if: always() && steps.audit-preview.outcome == 'failure'
+        run: |
+          echo "::warning::OG parity audit against the Cloudflare preview failed. This is expected until the known OG parity gaps are fixed — see https://github.com/divinevideo/divine-web/issues for the tracking issue. The audit is intentionally non-blocking."

--- a/.github/workflows/og-audit.yml
+++ b/.github/workflows/og-audit.yml
@@ -1,0 +1,75 @@
+# ABOUTME: GitHub Actions workflow that audits OG/Twitter Card parity on production and
+# ABOUTME: the latest main-branch Cloudflare Pages preview deployment.
+
+name: OG/Twitter Card parity audit
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'compute-js/**'
+      - 'functions/**'
+      - 'src/lib/serverSocialMeta.ts'
+      - 'scripts/verify-og-tags.sh'
+      - '.github/workflows/og-audit.yml'
+      - 'package.json'
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit-production:
+    name: Audit production (divine.video)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run OG parity audit against production
+        env:
+          BASE_URL: https://divine.video
+        run: bash scripts/verify-og-tags.sh
+
+  audit-cloudflare-preview:
+    name: Audit Cloudflare preview (latest main-branch deployment)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 8
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install wrangler
+        run: npm install -g wrangler
+
+      - name: Find latest Cloudflare Pages main-branch preview deployment URL
+        id: find-preview
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          if [[ -z "${CLOUDFLARE_API_TOKEN:-}" ]]; then
+            echo "::notice::CLOUDFLARE_API_TOKEN not set; skipping Cloudflare preview audit."
+            exit 0
+          fi
+          # Project name matches deploy.yml and preview.yml (divine-web-direct-deploy).
+          # Filter to Branch=main so we audit the post-merge preview, not PR previews.
+          URL=$(wrangler pages deployment list \
+            --project-name divine-web-direct-deploy \
+            --json 2>/dev/null \
+            | jq -r '[.[] | select(.Environment == "Preview" and .Branch == "main")] | first | .Deployment // empty')
+          if [[ -z "$URL" ]]; then
+            echo "::notice::No main-branch preview deployment found; skipping."
+            exit 0
+          fi
+          echo "preview_url=$URL" >> "$GITHUB_OUTPUT"
+
+      - name: Run OG parity audit against Cloudflare preview
+        if: steps.find-preview.outputs.preview_url != ''
+        env:
+          BASE_URL: ${{ steps.find-preview.outputs.preview_url }}
+        run: bash scripts/verify-og-tags.sh

--- a/.github/workflows/og-audit.yml
+++ b/.github/workflows/og-audit.yml
@@ -30,9 +30,15 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run OG parity audit against production
+        id: audit-prod
+        continue-on-error: ${{ github.event_name == 'schedule' }}
         env:
           BASE_URL: https://divine.video
         run: bash scripts/verify-og-tags.sh
+
+      - name: Annotate scheduled production audit result
+        if: github.event_name == 'schedule' && steps.audit-prod.outcome == 'failure'
+        run: echo "::warning::Scheduled production OG audit failed. This monitors live production state and is warning-only on schedule."
 
   audit-cloudflare-preview:
     name: Audit Cloudflare preview (latest main-branch deployment)
@@ -43,7 +49,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install wrangler
-        run: npm install -g wrangler
+        run: npm install -g wrangler@4.31.0
 
       - name: Find latest Cloudflare Pages main-branch preview deployment URL
         id: find-preview
@@ -68,7 +74,13 @@ jobs:
           echo "preview_url=$URL" >> "$GITHUB_OUTPUT"
 
       - name: Run OG parity audit against Cloudflare preview
+        id: audit-preview
         if: steps.find-preview.outputs.preview_url != ''
+        continue-on-error: ${{ github.event_name == 'schedule' }}
         env:
           BASE_URL: ${{ steps.find-preview.outputs.preview_url }}
         run: bash scripts/verify-og-tags.sh
+
+      - name: Annotate scheduled Cloudflare preview audit result
+        if: github.event_name == 'schedule' && steps.audit-preview.outcome == 'failure'
+        run: echo "::warning::Scheduled Cloudflare preview OG audit failed. This monitors live deployment state and is warning-only on schedule."

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "fastly:publish": "npm run build && npm i && npm run -w divine-web-edge fastly:publish",
     "fastly:release": "npm run fastly:deploy && npm run fastly:publish",
     "verify:well-known": "node scripts/verify-well-known.mjs",
+    "verify:og": "bash scripts/verify-og-tags.sh",
     "precalculate-thumbnails": "tsx scripts/precalculate-hashtag-thumbnails.ts",
     "generate-icons": "node scripts/generate-icons.js",
     "test:visual": "playwright test",

--- a/scripts/verify-og-tags.sh
+++ b/scripts/verify-og-tags.sh
@@ -45,7 +45,7 @@ ROUTES=(
   "/search?q=cats|search results|og_title_not_brand && og_url_matches_path"
   "/discovery|discovery (trending)|og_title_not_brand && og_url_matches_path"
   "/discovery/recent|discovery (recent)|og_title_not_brand && og_url_matches_path"
-  "/@jacky|at-username apex|og_title_not_brand"
+  "/@jalcine|at-username apex|og_title_not_brand"
   "/|apex home|og_title_not_brand"
 )
 

--- a/scripts/verify-og-tags.sh
+++ b/scripts/verify-og-tags.sh
@@ -35,7 +35,11 @@ ROUTES=(
   "/video/${REAL_VIDEO_ID}|real video page|twitter_card_player_present && og_video_present && twitter_player_present"
   "/embed/${REAL_VIDEO_ID}|embed iframe page|frame_ancestors_header && video_tag_present && noindex_header"
   "/profile/${REAL_NPUB}|real npub (Thomas Sanders)|og_title_not_brand && og_url_matches_path"
-  "/profile/${SYNTHETIC_NPUB}|synthetic npub (does not exist)|og_title_not_brand"
+  # Synthetic npub is structurally invalid (fails bech32 padding check at
+  # compute-js/src/bech32.js:87-90). The worker correctly falls through to the
+  # SPA shell with brand-default OG. Serving rich OG would mislead crawlers
+  # about a nonexistent profile. See issue #450.
+  "/profile/${SYNTHETIC_NPUB}|synthetic npub (does not exist)|og_title_is_brand"
   "/category/dance|category with video count|og_title_not_brand && og_url_matches_path"
   "/category|category index|og_title_not_brand && og_url_matches_path"
   "/family|family resource hub|og_title_not_brand && og_url_matches_path"
@@ -179,6 +183,20 @@ run_check() {
           all_passed=false
           echo "    FAIL: og:title is generic brand fallback (no per-route handler fired)"
           echo "          got: ${og_title}"
+        fi
+        ;;
+      og_title_is_brand)
+        # Inverse of og_title_not_brand. Passes when the response falls through to
+        # the SPA shell with the brand-default title. Use this for negative tests
+        # where the worker correctly does NOT produce per-route OG (e.g. structurally
+        # invalid npubs, where decodeNpubToHex returns null).
+        local og_title
+        og_title=$(extract_meta "$body" "og:title")
+        if [[ "$og_title" != "Divine Web - Short-form Looping Videos on Nostr" ]]; then
+          all_passed=false
+          echo "    FAIL: og:title is NOT the brand-default SPA shell fallback"
+          echo "          got: ${og_title}"
+          echo "          want: Divine Web - Short-form Looping Videos on Nostr"
         fi
         ;;
       og_url_matches_path)

--- a/scripts/verify-og-tags.sh
+++ b/scripts/verify-og-tags.sh
@@ -22,13 +22,13 @@ REAL_VIDEO_ID="3ca833a0027dd6240b2956dec98643032ff43ee75c0f0cde9d2096186b4b2605"
 REAL_NPUB="npub1smznz0v5cfh3f9e5vp5j9h6tzn4dlp3eqnxx6p2wujr40ftnz5qqhzf22n"
 SYNTHETIC_NPUB="npub1sg6plzptd64u62a878hep2kev88swjh3tw00gjsfl8f237lmu63s0c24qfh"
 
-declare -A USER_AGENTS=(
-  ["slackbot"]="Slackbot-LinkExpanding 1.0 (+https://api.slack.com/robots)"
-  ["facebook"]="facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)"
-  ["twitter"]="Twitterbot/1.0"
-  ["linkedin"]="LinkedInBot/1.0 (compatible; Mozilla/5.0)"
-  ["discord"]="Mozilla/5.0 (compatible; Discordbot/2.0; +https://discordapp.com)"
-  ["chrome"]="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36"
+USER_AGENTS=(
+  "slackbot|Slackbot-LinkExpanding 1.0 (+https://api.slack.com/robots)"
+  "facebook|facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)"
+  "twitter|Twitterbot/1.0"
+  "linkedin|LinkedInBot/1.0 (compatible; Mozilla/5.0)"
+  "discord|Mozilla/5.0 (compatible; Discordbot/2.0; +https://discordapp.com)"
+  "chrome|Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36"
 )
 
 ROUTES=(
@@ -239,6 +239,23 @@ run_check() {
   fi
 }
 
+get_user_agent() {
+  local wanted_label="$1"
+  local user_agent_entry
+
+  for user_agent_entry in "${USER_AGENTS[@]}"; do
+    local label="${user_agent_entry%%|*}"
+    local value="${user_agent_entry#*|}"
+
+    if [[ "$label" == "$wanted_label" ]]; then
+      printf '%s' "$value"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
 print_summary() {
   echo
   echo "=========================================================================="
@@ -287,7 +304,12 @@ main() {
         continue
       fi
 
-      local ua_value="${USER_AGENTS[$ua_label]}"
+      local ua_value
+      if ! ua_value=$(get_user_agent "$ua_label"); then
+        echo "ERROR: unknown User-Agent label '${ua_label}'"
+        exit 2
+      fi
+
       total_checks=$((total_checks + 1))
       run_check "$path" "$description" "$assertions" "$ua_label" "$ua_value"
     done


### PR DESCRIPTION
## Summary

- Adds `scripts/verify-og-tags.sh`, a live curl-based parity checker for representative Divine URLs and crawler User-Agents.
- Wires the checker as `npm run verify:og`.
- Adds `.github/workflows/og-audit.yml` to audit production and the latest main-branch Cloudflare Pages preview.
- Keeps the PR measurement-only: no worker behavior changes and no `compute-js` lockfile churn.

## Motivation

The repo has two OG/Twitter Card delivery paths: the Fastly Compute worker and the Cloudflare Pages Function. This audit gives maintainers a repeatable way to measure live parity and catch drift after changes to OG-relevant code.

The scheduled workflow is warning-only because it depends on live production data, deployment availability, and propagation state. Push and manual-dispatch runs still fail when the audit fails.

## Related Issue

- Related: #450

## Testing

- [x] `bash -n scripts/verify-og-tags.sh`
- [x] `UA_ONLY=slackbot bash scripts/verify-og-tags.sh` — 15/15 passed against production
- [x] `bash scripts/verify-og-tags.sh` — 60/60 passed against production
- [x] `npm run test`

## Visuals

- [x] No visual change
