### PR TITLE
refactor(relays): remove relay.ditto.pub from fan-out lists (#415)

### DIFF
--- a/src/config/relays.test.ts
+++ b/src/config/relays.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { getFunnelcakeUrl, hasFunnelcake } from './relays';
+import { getFunnelcakeUrl, hasFunnelcake, PROFILE_RELAYS, PRESET_RELAYS, EVENT_LOOKUP_RELAYS } from './relays';
 
 describe('hasFunnelcake', () => {
   it('recognizes the production Divine relay', () => {
@@ -27,5 +27,19 @@ describe('getFunnelcakeUrl', () => {
 
   it('returns null for non-Divine relays', () => {
     expect(getFunnelcakeUrl('wss://relay.damus.io')).toBeNull();
+  });
+});
+
+describe('relay.ditto.pub removal (#415)', () => {
+  it('is not in PROFILE_RELAYS', () => {
+    expect(PROFILE_RELAYS.map((r) => r.url)).not.toContain('wss://relay.ditto.pub');
+  });
+
+  it('is not in PRESET_RELAYS', () => {
+    expect(PRESET_RELAYS.map((r) => r.url)).not.toContain('wss://relay.ditto.pub');
+  });
+
+  it('is not in EVENT_LOOKUP_RELAYS', () => {
+    expect(EVENT_LOOKUP_RELAYS.map((r) => r.url)).not.toContain('wss://relay.ditto.pub');
   });
 });

--- a/src/config/relays.ts
+++ b/src/config/relays.ts
@@ -89,11 +89,6 @@ export const PROFILE_RELAYS: RelayConfig[] = [
     purpose: 'profile',
   },
   {
-    url: 'wss://relay.ditto.pub',
-    name: 'Ditto',
-    purpose: 'profile',
-  },
-  {
     url: 'wss://relay.primal.net',
     name: 'Primal',
     purpose: 'profile',
@@ -114,10 +109,6 @@ export const PRESET_RELAYS: RelayConfig[] = [
     url: 'wss://relay.divine.video',
     name: 'Divine',
     capabilities: { nip50: true, funnelcake: true },
-  },
-  {
-    url: 'wss://relay.ditto.pub',
-    name: 'Ditto',
   },
   {
     url: 'wss://relay.damus.io',
@@ -176,11 +167,6 @@ export const EVENT_LOOKUP_RELAYS: RelayConfig[] = [
   {
     url: 'wss://relay.primal.net',
     name: 'Primal',
-    purpose: 'backup',
-  },
-  {
-    url: 'wss://relay.ditto.pub',
-    name: 'Ditto',
     purpose: 'backup',
   },
   {

--- a/src/hooks/useVideoProvider.test.ts
+++ b/src/hooks/useVideoProvider.test.ts
@@ -118,7 +118,7 @@ describe('chooseVideoDataSource', () => {
   });
 
   it('falls back to canonical Funnelcake for hot feeds on relays without video-sort support', () => {
-    relayUrl = 'wss://relay.ditto.pub';
+    relayUrl = 'wss://relay.damus.io';
 
     const decision = chooseVideoDataSource({
       feedType: 'trending',

--- a/src/lib/relayCapabilities.test.ts
+++ b/src/lib/relayCapabilities.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { getOptimisticRelayCapabilities } from './relayCapabilities';
+
+describe('getOptimisticRelayCapabilities (after #415 ditto.pub removal)', () => {
+  it('returns the default (unrecognized-host) shape for relay.ditto.pub', () => {
+    const caps = getOptimisticRelayCapabilities('wss://relay.ditto.pub');
+    expect(caps.url).toBe('wss://relay.ditto.pub');
+    expect(caps.supportsNIP50).toBe(false);
+    expect(caps.supportsVideoSorts).toBe(false);
+    expect(caps.supportsSearch).toBe(false);
+    expect(caps.supportsCategoryFeed).toBe(false);
+    expect(caps.supportedSortModes).toEqual([]);
+    expect(caps.source).toBe('optimistic');
+  });
+});

--- a/src/lib/relayCapabilities.ts
+++ b/src/lib/relayCapabilities.ts
@@ -74,7 +74,6 @@ export function getOptimisticRelayCapabilities(relayUrl: string): RelayCapabilit
         source: 'optimistic',
       });
 
-    case 'relay.ditto.pub':
     case 'relay.nostr.wine':
     case 'relay.openvine.co':
     case 'relay2.openvine.co':


### PR DESCRIPTION
Removes `wss://relay.ditto.pub` from the centralized relay config. `relay.ditto.pub` is unreachable from some user networks, and queries that fan out across `PROFILE_RELAYS` (5 relays) hang indefinitely waiting for it (#415). The remaining 4 profile relays (`relay.divine.video`, `purplepag.es`, `relay.damus.io`, `relay.primal.net`) cover the same kinds; kind:10011 events replicate because the publish fan-out already targets `PROFILE_RELAYS`.

**Changes (5 sites):**
- `src/config/relays.ts`: drop the ditto.pub entry from `PROFILE_RELAYS`, `PRESET_RELAYS`, and `EVENT_LOOKUP_RELAYS` (3 entries).
- `src/lib/relayCapabilities.ts`: remove the `case 'relay.ditto.pub':` branch in `getOptimisticRelayCapabilities`. Default case handles it (unrecognized host → empty capabilities).
- `src/hooks/useVideoProvider.test.ts`: swap the test fixture from `wss://relay.ditto.pub` to `wss://relay.damus.io`.

**New tests:**
- `src/config/relays.test.ts`: 3 assertions locking the list shape (no ditto.pub in PROFILE_RELAYS / PRESET_RELAYS / EVENT_LOOKUP_RELAYS).
- `src/lib/relayCapabilities.test.ts` (new file): 1 assertion that `getOptimisticRelayCapabilities('wss://relay.ditto.pub')` returns the default (unrecognized-host) shape.

**Follow-up:** A second PR on branch `feat/relay-health` (to be opened once this lands) adds adaptive relay health + sticky video routing so future relay outages degrade gracefully instead of hanging queries.

Part of divinevideo/divine-web#415.