### PR TITLE
feat(footer): match WP sign-up copy and lime subscribe button

### DIFF
--- a/src/components/AppFooter.tsx
+++ b/src/components/AppFooter.tsx
@@ -16,7 +16,7 @@ export function AppFooter() {
             <div className="flex flex-col gap-2 lg:max-w-md">
               <div className="text-sm font-semibold text-brand-green">Divine Inspiration</div>
               <p className="text-sm text-brand-off-white mb-2">
-                Divine is now live in the app stores with invite codes. If you'd like to join the waitlist for a code and hear our news, sign up here.
+                Divine is now live in the app stores with invite codes. If you'd like to receive a code and hear our news, sign up here.
               </p>
               <HubSpotSignup />
             </div>

--- a/src/components/AppFooter.tsx
+++ b/src/components/AppFooter.tsx
@@ -16,7 +16,7 @@ export function AppFooter() {
             <div className="flex flex-col gap-2 lg:max-w-md">
               <div className="text-sm font-semibold text-brand-green">Divine Inspiration</div>
               <p className="text-sm text-brand-off-white mb-2">
-                The Divine beta is currently full. If you'd like to hear our news and be among the first to hear when the Divine app goes live, sign up here.
+                Divine is now live in the app stores with invite codes. If you'd like to join the waitlist for a code and hear our news, sign up here.
               </p>
               <HubSpotSignup />
             </div>

--- a/src/components/HubSpotSignup.tsx
+++ b/src/components/HubSpotSignup.tsx
@@ -133,6 +133,14 @@ export function HubSpotSignup() {
           height: 36px !important;
           box-sizing: border-box !important;
         }
+        /* Force the site's sans-serif stack: HubSpot sets no font-family on
+           these and its own Inter webfont is blocked by our font-src CSP, so
+           it would otherwise fall back to a serif default. */
+        .hs-form-html [data-hsfc-id="Renderer"],
+        .hs-form-html .hsfc-Button,
+        .hs-form-html .hsfc-TextInput {
+          font-family: 'Inter Variable', 'Inter', system-ui, -apple-system, sans-serif !important;
+        }
 
         /* Landing page card variant - larger with 70/30 split */
         .hs-form-landing .hs-form-html [data-hsfc-id="Renderer"] {

--- a/src/components/HubSpotSignup.tsx
+++ b/src/components/HubSpotSignup.tsx
@@ -30,11 +30,11 @@ export function HubSpotSignup() {
           --hsf-background__padding: 0;
           --hsf-row__vertical-spacing: 0;
           --hsf-row__horizontal-spacing: 8px;
-          --hsf-button__background-color: #27C58B;
-          --hsf-button__color: white;
-          --hsf-button__border-radius: 4px;
+          --hsf-button__background-color: hsl(var(--brand-lime));
+          --hsf-button__color: hsl(var(--brand-lime-dark));
+          --hsf-button__border-radius: 9999px;
           --hsf-button__padding: 0 16px;
-          --hsf-button__font-weight: 500;
+          --hsf-button__font-weight: 700;
           --hsf-button__font-size: 0.875rem;
           --hsf-field-input__font-size: 0.875rem;
           --hsf-field-input__background-color: hsl(var(--input));

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -220,8 +220,8 @@ export function LandingPage() {
             </h2>
 
             <p className="text-base md:text-lg text-brand-off-white/80">
-              The Divine beta is currently full. Drop your email and we'll
-              holler when the doors open — no spam, no slop.
+              Divine is now live in the app stores with invite codes. Drop your
+              email to join the waitlist for a code and hear our news.
             </p>
 
             <div className="hs-form-landing mx-auto max-w-xl rounded-[22px] border-2 border-brand-off-white/20 bg-brand-off-white p-6 md:p-8 text-brand-dark-green">
@@ -229,7 +229,7 @@ export function LandingPage() {
                 Divine Inspiration
               </h3>
               <p className="text-sm text-center mb-6 leading-5 text-brand-dark-green/80">
-                Be among the first to hear when the Divine app goes live.
+                Join the waitlist for an invite code and hear our news.
               </p>
               <HubSpotSignup />
             </div>


### PR DESCRIPTION
Reported by Marketing/Comms: the email sign-up box in the footer of the non-WordPress web pages needs to match the WordPress pages, for both copy and the Subscribe button design.

## Changes

- **Copy** — footer now reads the same text as the WP pages: "Divine is now live in the app stores with invite codes. If you'd like to join the waitlist for a code and hear our news, sign up here." (replaces the stale "beta is currently full" message).
- **Subscribe button** — switched from teal-green (`#27C58B`) to brand-lime with dark bold text and a pill shape, matching the WP design. References the existing `--brand-lime` / `--brand-lime-dark` tokens rather than hardcoded hex, consistent with the input-field vars in the same form. Pill (`rounded-full`) is already divine-web's house button style.
- Same copy update applied to the `LandingPage` hero for consistency.

## Verification

- `tsc -p tsconfig.app.json --noEmit` clean
- `eslint` clean (0 errors)
- `vitest run` — 1121/1121 pass
- `vite build` succeeds
- Footer confirmed in-browser on `/faq`: lime pill button, dark bold "Subscribe", new copy rendering via the HubSpot form