### PR TITLE
fix(profile-urls): decouple /u/ NIP-05 DNS fallback from relay query budget

### DIFF
--- a/src/pages/UniversalUserPage.test.tsx
+++ b/src/pages/UniversalUserPage.test.tsx
@@ -345,6 +345,42 @@ describe('UniversalUserPage', () => {
     }
   });
 
+  it('retries after a DNS timeout and resolves on the next attempt', async () => {
+    const pubkey = 'a9'.repeat(32);
+    let dnsTimeouts = 0;
+    vi.spyOn(AbortSignal, 'timeout').mockImplementation((milliseconds: number) => {
+      const controller = new AbortController();
+      if (milliseconds === 6000 && dnsTimeouts++ === 0) {
+        controller.abort(new DOMException('Timeout', 'TimeoutError'));
+      }
+      return controller.signal;
+    });
+    mockNostrQuery.mockResolvedValue([]);
+
+    const originalFetch = globalThis.fetch;
+    const fetchMock = vi.fn((_: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.signal?.aborted) {
+        return Promise.reject(new DOMException('Timeout', 'TimeoutError'));
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({ names: { jacky: pubkey } }),
+      });
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    try {
+      renderPage('/u/jacky', { retry: 2, retryDelay: 0 });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('profile-page')).toBeInTheDocument();
+      });
+      expect(screen.getByTestId('profile-page').dataset.pubkeyOverride).toBe(pubkey);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it('does not try the legacy Vine branch for subdomain-shaped inputs', async () => {
     const pubkey = '5'.repeat(64);
     mockNostrQuery.mockResolvedValue([

--- a/src/pages/UniversalUserPage.test.tsx
+++ b/src/pages/UniversalUserPage.test.tsx
@@ -43,12 +43,13 @@ vi.mock('./ProfilePage', () => ({
   ),
 }));
 
-function renderPage(initialEntry: string) {
+function renderPage(
+  initialEntry: string,
+  queryDefaults: Record<string, unknown> = { retry: false },
+) {
   const queryClient = new QueryClient({
     defaultOptions: {
-      queries: {
-        retry: false,
-      },
+      queries: queryDefaults,
     },
   });
 
@@ -286,6 +287,59 @@ describe('UniversalUserPage', () => {
       });
       expect(screen.getByTestId('profile-page').dataset.pubkeyOverride).toBe(pubkey);
       expect(fetchMock).toHaveBeenCalled();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('resolves a NIP-05 handle via DNS when the relay kind-0 query fails', async () => {
+    // Repro for the resolution race: the relay sample query and the NIP-05 DNS
+    // fallback must not share a single budget. When the relay query fails or is
+    // aborted (e.g. it exhausted the timeout), the deterministic DNS lookup must
+    // still run instead of being starved, otherwise a divine.video handle 404s.
+    const pubkey = '8'.repeat(64);
+    mockNostrQuery.mockRejectedValue(new DOMException('Aborted', 'AbortError'));
+
+    const originalFetch = globalThis.fetch;
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ names: { jacky: pubkey } }),
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    try {
+      renderPage('/u/jacky');
+
+      await waitFor(() => {
+        expect(screen.getByTestId('profile-page')).toBeInTheDocument();
+      });
+      expect(screen.getByTestId('profile-page').dataset.pubkeyOverride).toBe(pubkey);
+      expect(fetchMock).toHaveBeenCalled();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('retries after a transient relay failure and resolves once the relay recovers', async () => {
+    // The hook's retry predicate retries non-UserNotFound errors. A transient
+    // relay failure (with no DNS match to recover) should rethrow as retryable
+    // and resolve on the next attempt, rather than showing a definitive not-found.
+    const pubkey = '9'.repeat(64);
+    mockNostrQuery
+      .mockRejectedValueOnce(new DOMException('Aborted', 'AbortError'))
+      .mockResolvedValue([
+        createProfileEvent(pubkey, { name: 'Recovered', nip05: 'recovered@divine.video' }),
+      ]);
+
+    const originalFetch = globalThis.fetch;
+    // No DNS match on the first attempt, so the relay error is what propagates.
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, status: 404 }) as unknown as typeof fetch;
+    try {
+      renderPage('/u/recovered', { retry: 2, retryDelay: 0 });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('profile-page')).toBeInTheDocument();
+      });
+      expect(screen.getByTestId('profile-page').dataset.pubkeyOverride).toBe(pubkey);
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/src/pages/UniversalUserPage.tsx
+++ b/src/pages/UniversalUserPage.tsx
@@ -189,9 +189,6 @@ function getNotFoundDescription(identifier: string, t: TFunction): string {
 }
 
 /**
- * Looks up a user by either NIP-05 or Vine user ID
- */
-/**
  * Strip the NIP-05 envelope from a /u/ URL segment, leaving the bare local
  * part. We deliberately do NOT resolve the raw NIP-05 string itself — only
  * the canonical /u/<sub> path runs through the lookup. Third-party segments
@@ -345,8 +342,10 @@ function useUniversalUserLookup(identifier: string | undefined) {
             } satisfies ProfileLookupResult;
           }
         } catch (err) {
-          // A caller-driven abort ends the lookup; a DNS timeout just moves on.
+          // A caller-driven abort ends the lookup; a DNS budget timeout is
+          // transient and should retry rather than become a definitive not-found.
           if (context.signal.aborted) throw err;
+          if (dnsSignal.aborted) throw err;
           debugLog(`[UniversalUserPage] DNS NIP-05 lookup failed for ${candidate}: ${(err as Error).message}`);
         }
       }

--- a/src/pages/UniversalUserPage.tsx
+++ b/src/pages/UniversalUserPage.tsx
@@ -212,6 +212,14 @@ function stripNip05Envelope(segment: string): string | null {
   return captured.toLowerCase();
 }
 
+// Independent budgets for the two resolution paths. They are deliberately NOT
+// shared: a slow relay query must not consume the budget the DNS fallback needs.
+// They run sequentially, so an all-timeouts unhappy lookup is bounded at roughly
+// RELAY + DNS per attempt (then retried per the useQuery config below); the
+// common path resolves in well under a second.
+const RELAY_QUERY_TIMEOUT_MS = 8000;
+const NIP05_DNS_TIMEOUT_MS = 6000;
+
 function useUniversalUserLookup(identifier: string | undefined) {
   const { nostr } = useNostr();
 
@@ -223,15 +231,36 @@ function useUniversalUserLookup(identifier: string | undefined) {
       }
 
       const decodedIdentifier = decodeIdentifier(identifier).trim();
-      const signal = AbortSignal.any([
+
+      // The relay kind-0 sample query and the NIP-05 DNS fallback get INDEPENDENT
+      // abort budgets. They used to share a single 10s AbortSignal, with DNS
+      // running only after the relay query settled — so a slow or failing relay
+      // query consumed the whole budget and the deterministic DNS lookup was
+      // called with an already-aborted signal (it never fired), leaving valid
+      // divine.video handles 404ing on the first try and only resolving on retry.
+      // Note: this does NOT address the unfiltered `limit: 500` sample itself,
+      // which is a separate reliability gap for legacy Vine-username links (no
+      // DNS path to recover with). Out of scope for this race fix.
+      const relaySignal = AbortSignal.any([
         context.signal,
-        AbortSignal.timeout(10000),
+        AbortSignal.timeout(RELAY_QUERY_TIMEOUT_MS),
       ]);
-      const events = await nostr.query([{
-        kinds: [0],
-        limit: 500,
-      }], { signal });
-      const profiles = getParsedProfiles(events);
+      let profiles: ParsedProfile[] = [];
+      let relayError: unknown = null;
+      try {
+        const events = await nostr.query([{
+          kinds: [0],
+          limit: 500,
+        }], { signal: relaySignal });
+        profiles = getParsedProfiles(events);
+      } catch (err) {
+        // Caller navigated away — abort the whole lookup, don't mask it.
+        if (context.signal.aborted) throw err;
+        // Relay was slow/unavailable. Remember it so a transient failure stays
+        // retryable, but continue: the NIP-05 DNS fallback may still resolve.
+        relayError = err;
+        debugLog(`[UniversalUserPage] relay kind-0 query failed, continuing to NIP-05 DNS fallback: ${(err as Error).message}`);
+      }
 
       if (isVineUserId(decodedIdentifier)) {
         debugLog(`[UniversalUserPage] Looking up Vine user ID: ${decodedIdentifier}`);
@@ -248,6 +277,9 @@ function useUniversalUserLookup(identifier: string | undefined) {
           }
         }
 
+        // Numeric Vine IDs have no DNS fallback. If the relay query itself failed,
+        // surface that (retryable) rather than a definitive not-found.
+        if (relayError) throw relayError;
         throw new UserNotFoundError(`No user found with Vine ID: ${decodedIdentifier}`);
       }
 
@@ -291,10 +323,19 @@ function useUniversalUserLookup(identifier: string | undefined) {
       // DNS NIP-05 fallback. We only attempt this for candidates that contain an
       // '@' (third-party segments with no '@' can't be resolved via DNS — they
       // are tried against kind-0 above and reported as not-found if no match).
+      // One budget for the whole DNS phase, independent of the relay query above
+      // (so a slow relay can't starve it). We deliberately do NOT give each
+      // candidate its own timeout: candidates are in priority order (the canonical
+      // divine.video handle first), so paying N× timeouts for the rarely-useful
+      // fallback candidates isn't worth the added worst-case latency.
+      const dnsSignal = AbortSignal.any([
+        context.signal,
+        AbortSignal.timeout(NIP05_DNS_TIMEOUT_MS),
+      ]);
       for (const candidate of nip05Candidates) {
         if (!candidate.includes('@')) continue;
         try {
-          const pubkey = await resolveNip05ToPubkey(candidate, { signal });
+          const pubkey = await resolveNip05ToPubkey(candidate, { signal: dnsSignal });
           if (pubkey) {
             debugLog(`[UniversalUserPage] Resolved NIP-05 via DNS: ${candidate} -> ${pubkey}`);
             return {
@@ -304,11 +345,15 @@ function useUniversalUserLookup(identifier: string | undefined) {
             } satisfies ProfileLookupResult;
           }
         } catch (err) {
-          if (err instanceof DOMException && err.name === 'AbortError') throw err;
+          // A caller-driven abort ends the lookup; a DNS timeout just moves on.
+          if (context.signal.aborted) throw err;
           debugLog(`[UniversalUserPage] DNS NIP-05 lookup failed for ${candidate}: ${(err as Error).message}`);
         }
       }
 
+      // Nothing resolved. If the relay query failed, surface that (retryable)
+      // instead of a definitive not-found, so a transient relay blip can recover.
+      if (relayError) throw relayError;
       throw new UserNotFoundError(`No user found for identifier: ${decodedIdentifier}`);
     },
     enabled: !!identifier,


### PR DESCRIPTION
Closes #421

## Problem

Web search results landing on "user not found" when clicking through to a profile (e.g. `/u/divinehq`), intermittently, with retry sometimes working. Root cause is a resolution race in `UniversalUserPage`.

The `/u/<handle>` lookup runs two things under a single shared 10s `AbortSignal`:
1. an unfiltered `{kinds:[0], limit:500}` relay sample, scanned in memory, then
2. a NIP-05 DNS fallback, but only *after* the relay query settles.

When the relay is slow, it consumes the shared budget and the DNS `fetch` is called with an already-aborted signal, so it never fires. A valid divine.video handle 404s on first load and only resolves on retry. Confirmed in prod: loading `/u/divinehq` showed not-found with **zero** well-known requests fired.

## Fix

- Relay query and DNS fallback get **independent** abort budgets (named constants `RELAY_QUERY_TIMEOUT_MS`, `NIP05_DNS_TIMEOUT_MS`).
- A failed/slow relay query is **caught** and the lookup continues to the DNS fallback instead of throwing the whole query.
- The DNS phase uses **one shared budget across candidates** (still independent of the relay): it can't be starved by a slow relay, and it also can't stack N sequential per-candidate timeouts. Candidates are priority-ordered (canonical divine.video handle first), so paying N timeouts for rarely-useful fallbacks isn't worth the latency.
- A transient relay failure stays **retryable** rather than surfacing a definitive not-found.
- A transient DNS budget timeout also stays **retryable** rather than becoming a definitive not-found.

## Tests

- `resolves a NIP-05 handle via DNS when the relay kind-0 query fails` — RED→GREEN; fails against the old code (relay rejection killed the lookup before DNS ran).
- `retries after a transient relay failure and resolves once the relay recovers` — covers the retryable-relay-error path.
- `retries after a DNS timeout and resolves on the next attempt` — covers the DNS-timeout retryability edge.
- Full file 18/18, suite 1124/1124, `tsc`, `eslint`, and build clean via `npm run test`.

## Out of scope

Does **not** change the unfiltered `limit:500` kind-0 sample, which is a separate reliability gap for legacy Vine-username links (no DNS path to recover with). Candidate remedies (pubkey passthrough from search, or a targeted query) are deferred.

## Note for reviewers

The simultaneous-cancel + relay-timeout race is reasoned about but not unit-tested. Happy-path, relay-failure, DNS-timeout retry, and retry paths are covered.
