### PR TITLE
ci(deploy): verify the live frontend bundle matches the build after deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -128,6 +128,12 @@ jobs:
           check_json_endpoint "https://divine.video/.well-known/assetlinks.json"
           check_json_endpoint "https://www.divine.video/.well-known/assetlinks.json"
 
+      # The well-known checks above only cover static app-link files, which rarely
+      # change — so a stale frontend bundle can sail through a green deploy. This
+      # asserts the live origins actually serve the entry bundle we just built.
+      - name: Verify live frontend bundle matches the build
+        run: node scripts/verify-live-bundle.mjs
+
   deploy-cloudflare:
     needs: build
     runs-on: ubuntu-24.04

--- a/scripts/verify-live-bundle.mjs
+++ b/scripts/verify-live-bundle.mjs
@@ -38,8 +38,8 @@ export async function verifyLiveBundle({
   expected,
   urls,
   fetchImpl = fetch,
-  attempts = 12,
-  delayMs = 10000,
+  attempts = 18,
+  delayMs = 20000,
   sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
   log = () => {},
 }) {
@@ -117,8 +117,12 @@ if (invokedDirectly) {
     const parsed = Number(process.env[name]);
     return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
   };
-  const attempts = numberFromEnv('VERIFY_BUNDLE_ATTEMPTS', 12);
-  const delayMs = numberFromEnv('VERIFY_BUNDLE_DELAY_MS', 10000);
+  // ~6 min budget (18 x 20s). Only the failure path waits this long; a healthy
+  // deploy passes on the first attempt. Sized to outlast Fastly KV propagation
+  // of the new index after publish (the publisher's own blob-upload retries run
+  // earlier, inside publish-content, so they don't eat this budget).
+  const attempts = numberFromEnv('VERIFY_BUNDLE_ATTEMPTS', 18);
+  const delayMs = numberFromEnv('VERIFY_BUNDLE_DELAY_MS', 20000);
 
   try {
     await verifyLiveBundle({ expected, urls, attempts, delayMs, log: (message) => console.log(message) });

--- a/scripts/verify-live-bundle.mjs
+++ b/scripts/verify-live-bundle.mjs
@@ -1,0 +1,130 @@
+// ABOUTME: Post-deploy guardrail — confirms the live origin actually serves the
+// ABOUTME: freshly built entry bundle, so a green deploy can't silently serve stale assets.
+
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Vite emits a single hashed module entry as <script type="module" src="/assets/index-<hash>.js">.
+// Other chunks are referenced via <link rel="modulepreload">, which we ignore (we only match
+// <script src>). Assumes a single-entry SPA with no @vitejs/plugin-legacy: a `nomodule`
+// polyfill <script> would precede the entry and be matched instead. Revisit if that plugin
+// is ever added (vite.config.ts plugins is currently just react()).
+const ENTRY_SCRIPT_RE = /<script\b[^>]*\bsrc=["'](\/assets\/[^"']+\.js)["'][^>]*>/i;
+
+// Per-request ceiling so a hung origin (connection accepted, no response — the brownout
+// class this guard targets) counts as a failed attempt and retries, rather than blocking
+// the await until the GitHub Actions job timeout.
+const FETCH_TIMEOUT_MS = 10000;
+
+/**
+ * Extract the hashed entry bundle path (e.g. "/assets/index-CkdwgBUK.js") from an
+ * index.html string. Returns null when no entry <script> is present.
+ */
+export function extractEntryScript(html) {
+  const match = typeof html === 'string' ? html.match(ENTRY_SCRIPT_RE) : null;
+  return match ? match[1] : null;
+}
+
+/**
+ * Poll each live origin until it serves the expected entry bundle, or fail.
+ *
+ * `index.html` is served `cache-control: no-store` (read live from the Compute
+ * worker/KV), so a successful publish is reflected within seconds; the retry
+ * budget only covers KV propagation. A persistent mismatch means the deploy
+ * reported success while the edge keeps serving a stale bundle.
+ */
+export async function verifyLiveBundle({
+  expected,
+  urls,
+  fetchImpl = fetch,
+  attempts = 12,
+  delayMs = 10000,
+  sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  log = () => {},
+}) {
+  if (!expected) {
+    throw new Error('verifyLiveBundle: expected entry bundle is required');
+  }
+  if (!Array.isArray(urls) || urls.length === 0) {
+    throw new Error('verifyLiveBundle: at least one url is required');
+  }
+
+  for (const url of urls) {
+    let lastObserved = 'none';
+    let matched = false;
+
+    for (let attempt = 1; attempt <= attempts; attempt += 1) {
+      try {
+        const response = await fetchImpl(url, {
+          cache: 'no-store',
+          signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+        });
+        if (response.ok) {
+          const served = extractEntryScript(await response.text());
+          if (served === expected) {
+            log(`[verify-live-bundle] ${url} serves ${expected} (attempt ${attempt}/${attempts})`);
+            matched = true;
+            break;
+          }
+          lastObserved = served ?? 'no entry script';
+          log(`[verify-live-bundle] ${url} served ${lastObserved}, expected ${expected} (attempt ${attempt}/${attempts})`);
+        } else {
+          lastObserved = `HTTP ${response.status}`;
+          log(`[verify-live-bundle] ${url} returned ${lastObserved} (attempt ${attempt}/${attempts})`);
+        }
+      } catch (err) {
+        lastObserved = `fetch error: ${err?.message ?? err}`;
+        log(`[verify-live-bundle] ${url} ${lastObserved} (attempt ${attempt}/${attempts})`);
+      }
+
+      if (attempt < attempts) {
+        await sleep(delayMs);
+      }
+    }
+
+    if (!matched) {
+      throw new Error(
+        `Live bundle mismatch at ${url}: expected ${expected}, last observed ${lastObserved} ` +
+        `after ${attempts} attempts. The deploy reported success but the edge is serving a stale bundle.`,
+      );
+    }
+  }
+
+  return { ok: true, expected, urls };
+}
+
+const invokedDirectly =
+  Boolean(process.argv[1]) && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (invokedDirectly) {
+  const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+  const distIndex = path.join(projectRoot, 'dist', 'index.html');
+
+  const html = await readFile(distIndex, 'utf8');
+  const expected = extractEntryScript(html);
+  if (!expected) {
+    console.error(`✗ Could not find a hashed entry bundle in ${distIndex}`);
+    process.exit(1);
+  }
+
+  const urls = (process.env.VERIFY_BUNDLE_URLS ?? 'https://divine.video/,https://www.divine.video/')
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  const numberFromEnv = (name, fallback) => {
+    const parsed = Number(process.env[name]);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+  };
+  const attempts = numberFromEnv('VERIFY_BUNDLE_ATTEMPTS', 12);
+  const delayMs = numberFromEnv('VERIFY_BUNDLE_DELAY_MS', 10000);
+
+  try {
+    await verifyLiveBundle({ expected, urls, attempts, delayMs, log: (message) => console.log(message) });
+    console.log(`✓ Live origins serve the freshly built bundle ${expected}`);
+  } catch (err) {
+    console.error(`✗ ${err.message}`);
+    process.exit(1);
+  }
+}

--- a/scripts/verify-live-bundle.test.ts
+++ b/scripts/verify-live-bundle.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from 'vitest';
+import { extractEntryScript, verifyLiveBundle } from './verify-live-bundle.mjs';
+
+const htmlWith = (entry: string) =>
+  `<!doctype html><html><head>` +
+  `<meta charset="utf-8">` +
+  `<link rel="modulepreload" href="/assets/vendor-deadbeef.js">` +
+  `<script type="module" crossorigin src="${entry}"></script>` +
+  `</head><body><div id="root"></div></body></html>`;
+
+const okResponse = (body: string) => ({ ok: true, status: 200, text: async () => body });
+
+describe('extractEntryScript', () => {
+  it('returns the hashed entry bundle path from the module script tag', () => {
+    expect(extractEntryScript(htmlWith('/assets/index-CkdwgBUK.js'))).toBe('/assets/index-CkdwgBUK.js');
+  });
+
+  it('ignores modulepreload chunks and only returns the entry script src', () => {
+    // The vendor chunk appears first as a modulepreload link; it must not win.
+    expect(extractEntryScript(htmlWith('/assets/index-Dm1dxfK-.js'))).toBe('/assets/index-Dm1dxfK-.js');
+  });
+
+  it('returns null when there is no hashed entry script', () => {
+    expect(extractEntryScript('<html><head></head><body></body></html>')).toBeNull();
+  });
+
+  it('extracts the entry from a realistic head with several modulepreloads', () => {
+    // Vite hoists modulepreload <link>s for chunks ahead of the entry <script>.
+    // None of those <link>s should win — only the <script src> entry.
+    const html =
+      `<!doctype html><html><head><meta charset="utf-8">` +
+      `<link rel="modulepreload" href="/assets/react-vendor-1111aaaa.js">` +
+      `<link rel="modulepreload" href="/assets/query-2222bbbb.js">` +
+      `<link rel="stylesheet" href="/assets/index-3333cccc.css">` +
+      `<script type="module" crossorigin src="/assets/index-CkdwgBUK.js"></script>` +
+      `</head><body><div id="root"></div></body></html>`;
+    expect(extractEntryScript(html)).toBe('/assets/index-CkdwgBUK.js');
+  });
+});
+
+describe('verifyLiveBundle', () => {
+  const noopSleep = vi.fn(async () => {});
+
+  it('passes when every origin already serves the expected bundle', async () => {
+    const expected = '/assets/index-CkdwgBUK.js';
+    const fetchImpl = vi.fn(async () => okResponse(htmlWith(expected)));
+
+    await expect(
+      verifyLiveBundle({
+        expected,
+        urls: ['https://divine.video/', 'https://www.divine.video/'],
+        fetchImpl,
+        attempts: 3,
+        sleep: noopSleep,
+      }),
+    ).resolves.toMatchObject({ ok: true });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2); // one per origin, no retries needed
+  });
+
+  it('retries a stale origin until it flips to the expected bundle', async () => {
+    const expected = '/assets/index-CkdwgBUK.js';
+    const stale = '/assets/index-Dm1dxfK-.js';
+    let calls = 0;
+    const fetchImpl = vi.fn(async () => {
+      calls += 1;
+      // First poll serves the stale bundle, second poll serves the fresh one.
+      return okResponse(htmlWith(calls === 1 ? stale : expected));
+    });
+
+    await expect(
+      verifyLiveBundle({
+        expected,
+        urls: ['https://divine.video/'],
+        fetchImpl,
+        attempts: 5,
+        sleep: noopSleep,
+      }),
+    ).resolves.toMatchObject({ ok: true });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(noopSleep).toHaveBeenCalled();
+  });
+
+  it('throws after exhausting attempts when an origin never serves the expected bundle', async () => {
+    const expected = '/assets/index-CkdwgBUK.js';
+    const stale = '/assets/index-Dm1dxfK-.js';
+    const fetchImpl = vi.fn(async () => okResponse(htmlWith(stale)));
+
+    await expect(
+      verifyLiveBundle({
+        expected,
+        urls: ['https://divine.video/'],
+        fetchImpl,
+        attempts: 3,
+        sleep: vi.fn(async () => {}),
+      }),
+    ).rejects.toThrow(/index-CkdwgBUK\.js/);
+
+    expect(fetchImpl).toHaveBeenCalledTimes(3); // attempts exhausted
+  });
+
+  it('treats a thrown fetch (e.g. timeout) as a failed attempt and keeps polling', async () => {
+    const expected = '/assets/index-CkdwgBUK.js';
+    let calls = 0;
+    const fetchImpl = vi.fn(async () => {
+      calls += 1;
+      if (calls === 1) throw new DOMException('The operation timed out.', 'TimeoutError');
+      return okResponse(htmlWith(expected));
+    });
+
+    await expect(
+      verifyLiveBundle({
+        expected,
+        urls: ['https://divine.video/'],
+        fetchImpl,
+        attempts: 4,
+        sleep: vi.fn(async () => {}),
+      }),
+    ).resolves.toMatchObject({ ok: true });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('treats a non-200 response as not-yet-live and keeps polling', async () => {
+    const expected = '/assets/index-CkdwgBUK.js';
+    let calls = 0;
+    const fetchImpl = vi.fn(async () => {
+      calls += 1;
+      if (calls === 1) return { ok: false, status: 503, text: async () => '' };
+      return okResponse(htmlWith(expected));
+    });
+
+    await expect(
+      verifyLiveBundle({
+        expected,
+        urls: ['https://divine.video/'],
+        fetchImpl,
+        attempts: 4,
+        sleep: vi.fn(async () => {}),
+      }),
+    ).resolves.toMatchObject({ ok: true });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
Closes #422

## Problem

Production deploys can report success while the Fastly edge keeps serving a **stale frontend bundle**. The existing post-deploy verification only checks the static `.well-known` app-link files (apple-app-site-association, assetlinks.json), which rarely change — so a stale app bundle sails through a green deploy. This is what served a pre-#403 bundle for ~3 days behind two green "Deploy to Production" runs, and caused the `/u/<handle>` "user not found" reports.

## Fix

A post-publish step that asserts the live origins actually serve the bundle we just built:

1. Parse the hashed entry bundle (`/assets/index-<hash>.js`) from the freshly built `dist/index.html`.
2. Poll the live origins (apex **and** `www.`) until each serves that exact bundle.
3. Fail the deploy loudly if they don't converge within the retry budget.

`index.html` is served `cache-control: no-store` (read live from the Compute worker/KV), so propagation is just KV write latency. The step runs **after** publish + purge, so it's a post-publish gate: a failure means the content was published but isn't being served, turning silent staleness into a red, alerting build. It doesn't block or roll back (the Cloudflare backup job is parallel and unaffected).

## Verify budget / timing (~6 min, justified)

Default is **18 attempts × 20s ≈ 6 min**, overridable via `VERIFY_BUNDLE_ATTEMPTS` / `VERIFY_BUNDLE_DELAY_MS`.

- **It almost never costs anything.** A healthy deploy serves the new bundle on the **first** attempt, so the step passes in seconds. The budget is only consumed on the failure path — exactly when we want to wait rather than false-fail.
- **Why this long:** Fastly KV Store is eventually consistent. After `publish-content` writes the new `default_index_live`, the new index can take minutes to become visible at the serving POP. The footer deploy (#420) observed multi-minute staleness, so the old 2-min budget would risk false-failing a healthy-but-laggy deploy.
- **Why not longer:** the publisher's own blob-upload retries (up to 5 × 60s) run *inside* `publish-content`, before this step, so they don't eat this budget. ~6 min comfortably covers post-publish KV propagation with margin; beyond that, a non-converging deploy is a genuine failure worth flagging.

## Implementation

- `scripts/verify-live-bundle.mjs` — `extractEntryScript(html)` (pure) + `verifyLiveBundle({ expected, urls, fetchImpl, attempts, delayMs, sleep })` (injected fetch/sleep, no real network or timers). Per-request fetch timeout so a hung origin counts as a failed attempt; env-tunable budget. Matches the repo's existing `verify-*.mjs` convention.
- `scripts/verify-live-bundle.test.ts` — 9 tests: entry extraction (incl. realistic multi-modulepreload fixture), happy path, retry-until-flip, exhaustion-throws, thrown-fetch-retries, non-200-keeps-polling.
- `deploy.yml` — one new step, `node scripts/verify-live-bundle.mjs`, after the well-known checks. No untrusted input.

## Verification

- 9/9 unit tests; full suite green; `tsc` + `eslint` clean; `deploy.yml` parses and the verify step is the final gate in `deploy-fastly`.
- Ran the verifier against **live prod**: the real hash passes on apex + www; a bogus hash correctly throws; env overrides honored.

## Notes

- This is a **convergence gate**, not just detection: it waits out KV propagation and catches a genuinely-dropped publish. The deeper root cause and remediation (self-heal re-publish, failing on the publisher's swallowed errors) are tracked in #426 and build on this step.
- The prod deploy workflow only runs on push-to-main, so this step's first live execution is the deploy after merge; its logic is covered by the `test` job here and the live-site run above.
- `workflow_dispatch` manual-trigger capability was split into #425.
