### PR TITLE
ci(deploy): add workflow_dispatch for manual production deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,5 @@
 # ABOUTME: GitHub Actions workflow for deploying to Fastly (primary) and Cloudflare Pages (backup)
-# ABOUTME: Triggers on push to main branch
+# ABOUTME: Triggers on push to main, or manual dispatch
 
 name: Deploy to Production
 
@@ -7,6 +7,10 @@ on:
   push:
     branches:
       - main
+  # Allow manually re-running a clean production deploy of the current main
+  # through the approved workflow (build -> publish -> purge -> verify) instead
+  # of re-running a past run.
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,8 +12,23 @@ on:
   # of re-running a past run.
   workflow_dispatch:
 
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
 jobs:
+  guard-main-ref:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Verify production deploy ref
+        run: |
+          test "${{ github.ref }}" = "refs/heads/main" || {
+            echo "Production deploys must run from refs/heads/main, got ${{ github.ref }}" >&2
+            exit 1
+          }
+
   build:
+    needs: guard-main-ref
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` to the production deploy workflow so the current `main` build can be redeployed manually through the normal pipeline.
- Serializes production deploy workflow runs and adds a main-ref guard so manual dispatch cannot deploy a selected feature branch.

## Motivation

- Re-deploying current `main` should not require rerunning an older workflow run.
- Manual production deploys need to preserve the same branch safety and avoid overlapping publish/purge races.

## Related Issue

- Closes #428

## Testing

- [x] `npm run test`
- [x] Manual verification completed: parsed `.github/workflows/deploy.yml` as YAML and reviewed the workflow diff.

## Visuals

- [ ] UI change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved