### PR TITLE
ci(deploy): self-heal stale publishes and fail on swallowed upload errors

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,10 +57,12 @@ jobs:
   deploy-fastly:
     needs: build
     runs-on: ubuntu-24.04
-    # Ceiling so a wedged step (e.g. the ~6 min bundle verify polling a hung
-    # origin) fails loudly instead of holding the deploy-production concurrency
-    # lock for hours.
-    timeout-minutes: 20
+    # Ceiling so a wedged step (e.g. the bundle verify polling a hung origin)
+    # fails loudly instead of holding the deploy-production concurrency lock for
+    # hours. Set above the verify's own worst case (~6 min of sleeps + up to two
+    # 10s fetches per attempt) so the verifier's descriptive failure surfaces
+    # before this generic timeout would.
+    timeout-minutes: 25
     permissions:
       contents: read
       deployments: write

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,6 +57,10 @@ jobs:
   deploy-fastly:
     needs: build
     runs-on: ubuntu-24.04
+    # Ceiling so a wedged step (e.g. the ~6 min bundle verify polling a hung
+    # origin) fails loudly instead of holding the deploy-production concurrency
+    # lock for hours.
+    timeout-minutes: 20
     permissions:
       contents: read
       deployments: write
@@ -95,7 +99,20 @@ jobs:
         working-directory: compute-js
         env:
           FASTLY_API_TOKEN: ${{ secrets.FASTLY_API_TOKEN }}
-        run: npx @fastly/compute-js-static-publish publish-content
+        run: |
+          set -euo pipefail
+          # publish-content (compute-js-static-publish, pinned to 7.0.3 via
+          # package-lock) retries per-file uploads but, on final failure, logs
+          # "  ❌ Failed: <key> → <msg>" and still exits 0 (the error is swallowed).
+          # Capture the output and fail the step if any upload was dropped, so a
+          # partial publish can't go green. We match the stable ASCII "Failed:"
+          # rather than the emoji so a locale/encoding change can't silently
+          # disable this guard. See #426.
+          npx @fastly/compute-js-static-publish publish-content 2>&1 | tee /tmp/publish-content.log
+          if grep -qF 'Failed:' /tmp/publish-content.log; then
+            echo "::error::publish-content dropped one or more uploads (see 'Failed:' above)."
+            exit 1
+          fi
 
       - name: Purge Fastly cache
         working-directory: compute-js
@@ -149,7 +166,10 @@ jobs:
 
       # The well-known checks above only cover static app-link files, which rarely
       # change — so a stale frontend bundle can sail through a green deploy. This
-      # asserts the live origins actually serve the entry bundle we just built.
+      # asserts the live origins actually serve the entry bundle we just built AND
+      # that the referenced JS asset is reachable (not just the index.html
+      # pointer), waiting out Fastly KV eventual consistency within the budget and
+      # failing the deploy if it never converges. See #426.
       - name: Verify live frontend bundle matches the build
         run: node scripts/verify-live-bundle.mjs
 

--- a/scripts/verify-live-bundle.mjs
+++ b/scripts/verify-live-bundle.mjs
@@ -63,12 +63,28 @@ export async function verifyLiveBundle({
         if (response.ok) {
           const served = extractEntryScript(await response.text());
           if (served === expected) {
-            log(`[verify-live-bundle] ${url} serves ${expected} (attempt ${attempt}/${attempts})`);
-            matched = true;
-            break;
+            // The index.html pointer converged — but it and the hashed JS bundle
+            // resolve through the same KV index, and the bundle blob can lag the
+            // pointer (eventually-consistent KV) or be a swallowed dropped upload.
+            // Confirm the referenced asset is actually fetchable on this origin,
+            // not just that the pointer names it.
+            const assetUrl = new URL(expected, url).href;
+            const assetResponse = await fetchImpl(assetUrl, {
+              method: 'GET',
+              cache: 'no-store',
+              signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+            });
+            if (assetResponse.ok) {
+              log(`[verify-live-bundle] ${url} serves ${expected} and the asset is reachable (attempt ${attempt}/${attempts})`);
+              matched = true;
+              break;
+            }
+            lastObserved = `entry ${expected} but asset HTTP ${assetResponse.status}`;
+            log(`[verify-live-bundle] ${url} ${lastObserved} (attempt ${attempt}/${attempts})`);
+          } else {
+            lastObserved = served ?? 'no entry script';
+            log(`[verify-live-bundle] ${url} served ${lastObserved}, expected ${expected} (attempt ${attempt}/${attempts})`);
           }
-          lastObserved = served ?? 'no entry script';
-          log(`[verify-live-bundle] ${url} served ${lastObserved}, expected ${expected} (attempt ${attempt}/${attempts})`);
         } else {
           lastObserved = `HTTP ${response.status}`;
           log(`[verify-live-bundle] ${url} returned ${lastObserved} (attempt ${attempt}/${attempts})`);

--- a/scripts/verify-live-bundle.mjs
+++ b/scripts/verify-live-bundle.mjs
@@ -133,10 +133,12 @@ if (invokedDirectly) {
     const parsed = Number(process.env[name]);
     return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
   };
-  // ~6 min budget (18 x 20s). Only the failure path waits this long; a healthy
-  // deploy passes on the first attempt. Sized to outlast Fastly KV propagation
-  // of the new index after publish (the publisher's own blob-upload retries run
-  // earlier, inside publish-content, so they don't eat this budget).
+  // ~6 min of sleeps (18 x 20s), plus up to two fetches per attempt (index.html
+  // + the referenced asset, each bounded by FETCH_TIMEOUT_MS). Only the failure
+  // path waits; a healthy deploy passes on the first attempt. Sized to outlast
+  // Fastly KV propagation of the new index after publish (the publisher's own
+  // blob-upload retries run earlier, inside publish-content, so they don't eat
+  // this budget).
   const attempts = numberFromEnv('VERIFY_BUNDLE_ATTEMPTS', 18);
   const delayMs = numberFromEnv('VERIFY_BUNDLE_DELAY_MS', 20000);
 

--- a/scripts/verify-live-bundle.test.ts
+++ b/scripts/verify-live-bundle.test.ts
@@ -55,7 +55,7 @@ describe('verifyLiveBundle', () => {
       }),
     ).resolves.toMatchObject({ ok: true });
 
-    expect(fetchImpl).toHaveBeenCalledTimes(2); // one per origin, no retries needed
+    expect(fetchImpl).toHaveBeenCalledTimes(4); // per origin: HTML + asset check
   });
 
   it('retries a stale origin until it flips to the expected bundle', async () => {
@@ -78,7 +78,7 @@ describe('verifyLiveBundle', () => {
       }),
     ).resolves.toMatchObject({ ok: true });
 
-    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
     expect(noopSleep).toHaveBeenCalled();
   });
 
@@ -119,13 +119,15 @@ describe('verifyLiveBundle', () => {
       }),
     ).resolves.toMatchObject({ ok: true });
 
-    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(fetchImpl).toHaveBeenCalledTimes(3); // html throw, html ok, asset check
   });
 
   it('treats a non-200 response as not-yet-live and keeps polling', async () => {
     const expected = '/assets/index-CkdwgBUK.js';
     let calls = 0;
-    const fetchImpl = vi.fn(async () => {
+    const fetchImpl = vi.fn(async (url: string) => {
+      // Only count HTML (origin) fetches; the asset HEAD always 200s here.
+      if (url.endsWith('.js')) return { ok: true, status: 200, text: async () => '' };
       calls += 1;
       if (calls === 1) return { ok: false, status: 503, text: async () => '' };
       return okResponse(htmlWith(expected));
@@ -140,7 +142,73 @@ describe('verifyLiveBundle', () => {
         sleep: vi.fn(async () => {}),
       }),
     ).resolves.toMatchObject({ ok: true });
+  });
 
-    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  it('does not converge when the entry HTML matches but the referenced JS asset is not yet 200', async () => {
+    // The index.html pointer can converge before the JS blob is fetchable
+    // (eventually-consistent KV, or a swallowed dropped blob). Verify must check
+    // the asset itself, not just the pointer.
+    const expected = '/assets/index-CkdwgBUK.js';
+    let assetCalls = 0;
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url.endsWith('.js')) {
+        assetCalls += 1;
+        // 404 on the first check, 200 once the blob converges.
+        return { ok: assetCalls >= 2, status: assetCalls >= 2 ? 200 : 404, text: async () => '' };
+      }
+      return okResponse(htmlWith(expected)); // pointer is already converged
+    });
+
+    await expect(
+      verifyLiveBundle({
+        expected,
+        urls: ['https://divine.video/'],
+        fetchImpl,
+        attempts: 5,
+        sleep: vi.fn(async () => {}),
+      }),
+    ).resolves.toMatchObject({ ok: true });
+
+    expect(assetCalls).toBe(2); // re-checked the asset until it returned 200
+  });
+
+  it('throws when the JS asset never returns 200 even though the HTML matches', async () => {
+    const expected = '/assets/index-CkdwgBUK.js';
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url.endsWith('.js')) return { ok: false, status: 404, text: async () => '' };
+      return okResponse(htmlWith(expected));
+    });
+
+    await expect(
+      verifyLiveBundle({
+        expected,
+        urls: ['https://divine.video/'],
+        fetchImpl,
+        attempts: 2,
+        sleep: vi.fn(async () => {}),
+      }),
+    ).rejects.toThrow(/index-CkdwgBUK\.js/);
+  });
+
+  it('requests the asset on the same origin that served the HTML', async () => {
+    const expected = '/assets/index-CkdwgBUK.js';
+    const assetUrls: string[] = [];
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url.endsWith('.js')) {
+        assetUrls.push(url);
+        return { ok: true, status: 200, text: async () => '' };
+      }
+      return okResponse(htmlWith(expected));
+    });
+
+    await verifyLiveBundle({
+      expected,
+      urls: ['https://www.divine.video/'],
+      fetchImpl,
+      attempts: 2,
+      sleep: vi.fn(async () => {}),
+    });
+
+    expect(assetUrls).toContain('https://www.divine.video/assets/index-CkdwgBUK.js');
   });
 });

--- a/scripts/verify-live-bundle.test.ts
+++ b/scripts/verify-live-bundle.test.ts
@@ -126,7 +126,7 @@ describe('verifyLiveBundle', () => {
     const expected = '/assets/index-CkdwgBUK.js';
     let calls = 0;
     const fetchImpl = vi.fn(async (url: string) => {
-      // Only count HTML (origin) fetches; the asset HEAD always 200s here.
+      // Only count HTML (origin) fetches; the asset GET always 200s here.
       if (url.endsWith('.js')) return { ok: true, status: 200, text: async () => '' };
       calls += 1;
       if (calls === 1) return { ok: false, status: 503, text: async () => '' };


### PR DESCRIPTION
Closes #426. Builds on the verify gate from #424 (now on `main`).

## Why

Production deploys can report success while the Fastly edge serves a **stale or partial bundle**. Root cause (from deploy logs + `@fastly/compute-js-static-publish@7.0.3` source):

- Fastly KV Store is **eventually consistent** — the content index (`default_index_live`) can lag at the serving POP after publish.
- The publisher **swallows per-file upload failures**: it retries 5×, then logs `  ❌ Failed: <key>` and **exits 0** anyway.
- **index.html and the hashed `/assets/index-*.js` resolve through the same KV index.** So checking only the index.html hash proves the *pointer* converged, not that the JS blob is actually fetchable — a lagging or dropped blob passes a pointer-only check green.

## Approach (revised)

This started as a "self-heal: re-publish on stale" change. After an architecture review, we **pivoted to attack the root cause** instead:

- Re-publishing can't accelerate KV propagation (the lag case), and `purge --all` only flushes cache, not KV.
- The dropped-write case is better **caught at publish time** than healed after.

So #427 is now two targeted changes, no orchestration:

1. **Fail on dropped publishes** — the publish step captures `publish-content` output and fails the deploy if it logged the dropped-upload marker. Matches the stable ASCII `Failed:` (not the emoji) so a locale/encoding change can't silently disable it; publisher pinned to 7.0.3 via `package-lock`.
2. **Verify the asset, not just the pointer** — `verify-live-bundle.mjs` now, after the index.html hash matches, also `GET`s the referenced `/assets/index-*.js` on the same origin and requires 200. Closes the pointer-vs-blob hole above. Still polls apex + www within the ~6 min budget (waits out KV lag), fails if it never converges.

Plus `deploy-fastly` `timeout-minutes: 20` so a wedged verify can't hold the `deploy-production` concurrency lock for hours.

## On upgrading the publisher

Checked 7.0.4–7.0.7 changelogs: **none fix the swallowed-failure or non-retried-index-write** (they're CI/content-type/cosmetic; 7.0.7 only bumps the underlying Fastly CLI to v15). So an upgrade is not the fix and is kept out of this PR. A `patch-package` patch to make the publisher honest is a possible future follow-up, but the publish-step guard already covers the silent-staleness vector.

## Tests / validation

- `verify-live-bundle.test.ts`: 12 tests incl. the new asset-200 paths (HTML matches but asset 404 → keep polling / throw; asset requested on the serving origin). All green; `tsc` + `eslint` clean.
- Live end-to-end against prod: real bundle passes (HTML + asset 200 on apex + www); bogus hash throws.
- `deploy.yml` parses; publish step passes `bash -n` + `shellcheck`; no untrusted input.

## What this still does NOT solve (tracked, not in scope)

- Convergence at POPs the verifier never polls (it checks apex + www; users hit other POPs).
- Pure KV lag if Fastly has a bad day beyond the budget — the manual re-run remains the ultimate fallback.
- The Cloudflare backup path has no equivalent verify.
