### PR TITLE
feat(kids): name the teen 13-15 path "Divine Greenlight"

### DIFF
--- a/src/lib/serverSocialMeta.ts
+++ b/src/lib/serverSocialMeta.ts
@@ -325,7 +325,7 @@ export function buildKidsPolicyPageMeta(url: URL): PageMeta {
   return {
     title: 'Kids on Divine — How accounts work for under-16s',
     description:
-      'How Divine handles accounts for people under 16 — the rules, the reasoning, and what families can do together regardless of age.',
+      'How Divine handles accounts for people under 16 — the rules, the reasoning, Divine Greenlight for teens 13-15, and what families can do together regardless of age.',
     ogType: 'website',
     url: url.toString(),
     image: DEFAULT_OG_IMAGE,

--- a/src/pages/AgeReviewPage.tsx
+++ b/src/pages/AgeReviewPage.tsx
@@ -1,5 +1,5 @@
 // ABOUTME: External moderation-flow page at /age-review for accounts flagged as possibly under 16
-// ABOUTME: Deadline-shaped: 15-day window, 13–15 parent video, 16+ mistake-flag; policy context lives at /kids
+// ABOUTME: Deadline-shaped: 15-day window, Divine Greenlight (13-15) parent video, 16+ mistake-flag; policy context lives at /kids
 
 import {
   Info,
@@ -30,17 +30,18 @@ const SUPPORT_EMAIL = "support@divine.video";
 const REVIEW_WINDOW_DAYS = 15;
 
 const SECTIONS: SectionAnchor[] = [
-  { id: "path-13-15", title: "If you're 13 to 15" },
+  { id: "path-13-15", title: "Divine Greenlight (13-15)" },
   { id: "path-mistake", title: "If you're 16 or older" },
   { id: "no-response", title: "If we don't hear from you" },
 ];
 
-// Mirrors the 13-15 parent-consent email in divine-mobile
+// Mirrors the Divine Greenlight (13-15) parent-consent email in divine-mobile
 // (minorAccountReviewParentConsentEmailSubject / ...Body) so the in-app flow
-// and this page open the same prefilled message.
-const TEEN_REVIEW_EMAIL_SUBJECT = "13-15 account review help";
+// and this page open the same prefilled message. NOTE: divine-mobile must be
+// updated to match this Divine Greenlight subject/body or the two will diverge.
+const TEEN_REVIEW_EMAIL_SUBJECT = "Divine Greenlight review help (ages 13-15)";
 const TEEN_REVIEW_EMAIL_BODY =
-  "Hi Divine support,\n\nI am contacting Divine about an account for a teen who is 13 to 15.\n\nI have attached a short private video that shows:\n- the teen\n- a parent or guardian speaking on camera\n- that the teen has permission to use Divine\n- that the parent or guardian knows about the account and will supervise its use\n\nCountry/ies of residence:\n\nHelpful context:\n\nThanks.";
+  "Hi Divine support,\n\nI am contacting Divine about Divine Greenlight for a teen who is 13-15.\n\nI have attached a short private video that shows:\n- the teen\n- a parent or guardian speaking on camera\n- that the teen has permission to use Divine\n- that the parent or guardian knows about the account and will supervise its use\n\nCountry/ies of residence:\n\nHelpful context:\n\nThanks.";
 const TEEN_REVIEW_MAILTO = buildMailtoLink(
   SUPPORT_EMAIL,
   TEEN_REVIEW_EMAIL_SUBJECT,
@@ -98,7 +99,7 @@ export function AgeReviewPage() {
       <div className="container mx-auto px-4 py-14 md:py-16 max-w-4xl space-y-14">
         {/* Note for under-13 readers—placed first so a kid
             reading the page lands on this before scrolling through the
-            13–15 instructions and assuming a parent video might apply.
+            13-15 instructions and assuming a parent video might apply.
             Intentionally not a path-shaped card (no CardHeader, no
             mailto button)—the action paths below don't apply, and
             emailing doesn't pause the clock for under-13. */}
@@ -121,10 +122,10 @@ export function AgeReviewPage() {
         {/* 1. 13-15 path */}
         <Anchor id="path-13-15">
           <SectionHero
-            eyebrow="If you're 13 to 15"
+            eyebrow="If you're 13-15"
             icon={<VideoCamera weight="fill" className="h-7 w-7" />}
-            title="A guided start"
-            lead={`Where local rules allow it, teens 13 to 15 can use Divine with a parent or guardian who's aware and involved. To keep the account open, a parent or guardian sends a short private video confirming the situation. The email needs to land within ${REVIEW_WINDOW_DAYS} days of the in-app notice.`}
+            title="Divine Greenlight: a guided start"
+            lead={`Where local rules allow it, teens 13-15 can use Divine through Divine Greenlight, with a parent or guardian who's aware and involved. To keep the account open, a parent or guardian sends a short private video confirming the situation. The email needs to land within ${REVIEW_WINDOW_DAYS} days of the in-app notice.`}
           />
 
           <div className="grid gap-6 md:grid-cols-2">
@@ -365,7 +366,7 @@ export function AgeReviewPage() {
                 </li>
               </ul>
               <p className="text-sm text-muted-foreground pt-2">
-                For 13-to-15 accounts, an email to{" "}
+                For Divine Greenlight (13-15) accounts, an email to{" "}
                 <a
                   href={`mailto:${SUPPORT_EMAIL}`}
                   className="text-brand-dark-green dark:text-brand-green underline underline-offset-2 hover:opacity-80 break-all"

--- a/src/pages/KidsPolicyPage.tsx
+++ b/src/pages/KidsPolicyPage.tsx
@@ -30,7 +30,7 @@ const SECTIONS: SectionAnchor[] = [
   { id: "tiers", title: "At a glance" },
   { id: "why", title: "Why we work this way" },
   { id: "under-13", title: "Under-13 accounts" },
-  { id: "13-15", title: "13 to 15 accounts" },
+  { id: "13-15", title: "Divine Greenlight (13-15)" },
   { id: "family-account", title: "Families on Divine" },
   { id: "family-guidance", title: "More family guidance" },
 ];
@@ -118,12 +118,13 @@ export function KidsPolicyPage() {
               <CardHeader>
                 <CardTitle className="flex items-center gap-2 text-xl">
                   <VideoCamera weight="fill" className="h-5 w-5 text-brand-green" />
-                  13 to 15
+                  13-15
                 </CardTitle>
               </CardHeader>
               <CardContent className="space-y-2 text-base leading-relaxed">
                 <p>
-                  Where local rules allow it, Divine offers a parent-supported path for teens 13 to 15.
+                  Where local rules allow it, Divine offers{" "}
+                  <strong>Divine Greenlight</strong>, a parent-supported path for teens 13-15.
                 </p>
                 <p className="text-muted-foreground text-sm">
                   This path requires a short private video from the teen and a parent or guardian confirming the teen’s age, permission to use Divine, and parent or guardian awareness and supervision. In some places, including countries with under-16 social media restrictions or stricter age-assurance rules, this path may not be available or may require additional steps.
@@ -178,7 +179,8 @@ export function KidsPolicyPage() {
                 are.
               </p>
               <p>
-                Where the rules allow, Divine offers a different path for teens 13 to 15: a short private
+                Where the rules allow, Divine offers a different path for teens 13-15,
+                called <strong>Divine Greenlight</strong>: a short private
                 video with a parent or guardian on camera. It's a real
                 human check, but it doesn't require Divine to operate an
                 ID-and-payment verification pipeline, and it doesn't
@@ -303,8 +305,8 @@ export function KidsPolicyPage() {
           <SectionHero
             eyebrow="13-15 accounts"
             icon={<VideoCamera weight="fill" className="h-7 w-7" />}
-            title="Teen-held accounts need a parent or guardian video"
-            lead="Where permitted by law, teens 13 to 15 can use Divine with a parent or guardian who's aware and involved. The video is how Divine knows that consent and supervision are real, without running an intrusive verification system. Depending on where the teen lives, Divine may require additional or different age-assurance, parental-consent, privacy, or account-safety steps before the account can stay open."
+            title="Divine Greenlight: teen-held accounts need a parent or guardian video"
+            lead="Where permitted by law, teens 13-15 can use Divine through Divine Greenlight, with a parent or guardian who's aware and involved. The video is how Divine knows that consent and supervision are real, without running an intrusive verification system. Depending on where the teen lives, Divine may require additional or different age-assurance, parental-consent, privacy, or account-safety steps before the account can stay open."
           />
 
           <Card variant="brand" accent="green">
@@ -392,8 +394,8 @@ export function KidsPolicyPage() {
               <p>
                 What Divine won't host is a solo account in a child's
                 hands. Under 13, the account has to be the parent or
-                guardian's. From 13 to 15, the account can be the teen's
-                with the video step above, subject to any additional requirements that apply based on the teen's location. Pick whichever path fits your
+                guardian's. For ages 13-15, the account can be the teen's
+                through Divine Greenlight, the video step above, subject to any additional requirements that apply based on the teen's location. Pick whichever path fits your
                 family.
               </p>
               <p className="text-muted-foreground">


### PR DESCRIPTION
## Summary

Introduces the **Divine Greenlight** brand name for the parent-supported account path for teens **13-15**, across the `/kids` policy page and the `/age-review` action page. Also normalizes the age range to "13-15" consistently and surfaces the name in the `/kids` SEO description.

## Changes

**`/kids` — `src/pages/KidsPolicyPage.tsx`**
- Names "Divine Greenlight" in the at-a-glance card, the "why we work this way" section, the 13-15 section heading/lead, the families section, and the anchor nav
- Normalizes "13 to 15" → "13-15"

**`/age-review` — `src/pages/AgeReviewPage.tsx`**
- Section nav title, eyebrow, heading, and lead now name "Divine Greenlight"
- No-response section references "Divine Greenlight (13-15) accounts"
- Prefilled email subject/body use the Divine Greenlight wording
- Normalizes "13 to 15" / "13–15" / "13-to-15" → "13-15" throughout (incl. comments)

**SEO — `src/lib/serverSocialMeta.ts`**
- `/kids` page description mentions "Divine Greenlight for teens 13-15"

## ⚠️ Follow-up needed
- **divine-mobile** must be updated to match the new email subject/body (`minorAccountReviewParentConsentEmailSubject` / `...Body`), or the in-app flow and this page will diverge. A code comment flags this.
- The age-review email **subject line** changed ("Divine Greenlight review help (ages 13-15)"). Confirm with the support team if their inbox routing/filters key off the old "13-15 account review help" subject.

## Testing
- `npx tsc --noEmit` — passes
- `serverSocialMeta` + `static-pages-i18n` tests — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)