### PR TITLE
fix(deploy): bypass cached html during bundle verification

### DIFF
--- a/compute-js/src/index.js
+++ b/compute-js/src/index.js
@@ -38,7 +38,6 @@ const EXTERNAL_REDIRECTS = {
   '/discord': { url: 'https://discord.gg/d6HpB6XnHp', status: 302 },
 };
 
-// eslint-disable-next-line no-restricted-globals
 addEventListener("fetch", (event) => event.respondWith(handleRequest(event)));
 
 async function handleRequest(event) {
@@ -315,6 +314,10 @@ async function handleRequest(event) {
     // Add Vary: X-Original-Host so CDN doesn't mix subdomain and apex cached responses
     const headers = new Headers(response.headers);
     headers.append('Vary', 'X-Original-Host');
+    if (response.headers.get('Content-Type')?.includes('text/html')) {
+      headers.set('Cache-Control', 'no-cache, no-store, must-revalidate');
+      headers.set('Surrogate-Control', 'no-store');
+    }
 
     // Inject feed data into HTML pages for faster LCP
     if (shouldInjectFeed && response.headers.get('Content-Type')?.includes('text/html')) {

--- a/scripts/verify-live-bundle.mjs
+++ b/scripts/verify-live-bundle.mjs
@@ -29,10 +29,10 @@ export function extractEntryScript(html) {
 /**
  * Poll each live origin until it serves the expected entry bundle, or fail.
  *
- * `index.html` is served `cache-control: no-store` (read live from the Compute
- * worker/KV), so a successful publish is reflected within seconds; the retry
- * budget only covers KV propagation. A persistent mismatch means the deploy
- * reported success while the edge keeps serving a stale bundle.
+ * `index.html` is served `cache-control: no-store` and requested with
+ * `Cache-Control: no-cache` so verification reads through the Compute worker/KV.
+ * The retry budget only covers KV propagation. A persistent mismatch means the
+ * deploy reported success while the edge keeps serving a stale bundle.
  */
 export async function verifyLiveBundle({
   expected,
@@ -58,6 +58,10 @@ export async function verifyLiveBundle({
       try {
         const response = await fetchImpl(url, {
           cache: 'no-store',
+          headers: {
+            'Cache-Control': 'no-cache',
+            Pragma: 'no-cache',
+          },
           signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
         });
         if (response.ok) {

--- a/scripts/verify-live-bundle.test.ts
+++ b/scripts/verify-live-bundle.test.ts
@@ -211,4 +211,31 @@ describe('verifyLiveBundle', () => {
 
     expect(assetUrls).toContain('https://www.divine.video/assets/index-CkdwgBUK.js');
   });
+
+  it('requests live HTML with no-cache headers', async () => {
+    const expected = '/assets/index-CkdwgBUK.js';
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url.endsWith('.js')) return { ok: true, status: 200, text: async () => '' };
+      return okResponse(htmlWith(expected));
+    });
+
+    await verifyLiveBundle({
+      expected,
+      urls: ['https://divine.video/'],
+      fetchImpl,
+      attempts: 2,
+      sleep: vi.fn(async () => {}),
+    });
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://divine.video/',
+      expect.objectContaining({
+        cache: 'no-store',
+        headers: {
+          'Cache-Control': 'no-cache',
+          Pragma: 'no-cache',
+        },
+      }),
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- Prevent Fastly from caching SPA HTML shell responses that need to reflect the latest KV content index.
- Make the live bundle verifier send explicit no-cache request headers when polling production HTML.
- Add verifier coverage for the no-cache request contract.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- A production deploy failed after the edge kept serving an older HTML bundle pointer during post-deploy verification, even though the static publish later converged.
- The verifier assumed HTML was not cached, but live response headers showed cached HTML could be served through the retry window.

## Related Issue

- Closes #433

## Testing

- [x] npx vitest run scripts/verify-live-bundle.test.ts
- [x] npm test

## Visuals

- [ ] UI change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved