### PR TITLE
fix(video): stop auth preflight from blocking video playback

### DIFF
--- a/src/components/VideoPlayer.test.tsx
+++ b/src/components/VideoPlayer.test.tsx
@@ -760,4 +760,85 @@ describe('VideoPlayer', () => {
       );
     });
   });
+
+  describe('playback is not blocked by auth', () => {
+    // Helper: track every truthy value assigned to a <video> element's src.
+    const trackVideoSrc = (srcValues: string[]) => {
+      const originalCreateElement = document.createElement.bind(document);
+      vi.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
+        const element = originalCreateElement(tagName);
+        if (tagName === 'video') {
+          let currentSrc = '';
+          Object.defineProperty(element, 'src', {
+            get: () => currentSrc,
+            set: (value: string) => {
+              currentSrc = value;
+              if (value) srcValues.push(value);
+            },
+            configurable: true,
+          });
+        }
+        return element;
+      });
+    };
+
+    it('sets src for a public video even when the auth preflight never resolves', async () => {
+      // Regression: checkMediaAuth ran *before* loadVideoSource, so a slow or hanging
+      // HEAD preflight delayed (or fully blocked) playback for every non-verified viewer.
+      // Public playback must never wait on the auth probe.
+      const { checkMediaAuth } = await import('@/hooks/useAdultVerification');
+      let resolveProbe: ((value: { authorized: boolean; status: number }) => void) | undefined;
+      (checkMediaAuth as ReturnType<typeof vi.fn>).mockReturnValue(
+        new Promise((resolve) => {
+          resolveProbe = resolve;
+        }),
+      );
+
+      const src = 'https://example.com/public-no-auth.mp4';
+      const srcValues: string[] = [];
+      trackVideoSrc(srcValues);
+
+      render(<VideoPlayer videoId="public-no-auth" src={src} />);
+
+      // src must be set without the probe ever resolving.
+      await waitFor(() => {
+        expect(srcValues).toContain(src);
+      }, { timeout: 1000 });
+
+      // Sanity: the probe really was still pending when src was set.
+      expect(resolveProbe).toBeDefined();
+    });
+
+    it('does not restart a public video load when getAuthHeader changes reference', async () => {
+      // Regression: getAuthHeader (keyed on the signer) was in the load effect's deps.
+      // A late-injecting signer/extension produced a new getAuthHeader reference, which
+      // re-ran the effect and aborted the in-flight load — repeatedly — stalling playback.
+      const { useAdultVerification } = await import('@/hooks/useAdultVerification');
+      (useAdultVerification as ReturnType<typeof vi.fn>).mockImplementation(() => ({
+        isVerified: false,
+        isLoading: false,
+        hasSigner: false,
+        // NEW reference on every render, simulating a resolving signer.
+        getAuthHeader: vi.fn().mockResolvedValue(null),
+      }));
+
+      const src = 'https://example.com/stable-public.mp4';
+      const srcValues: string[] = [];
+      trackVideoSrc(srcValues);
+
+      const { rerender } = render(<VideoPlayer videoId="stable-public" src={src} />);
+
+      await waitFor(() => {
+        expect(srcValues).toContain(src);
+      }, { timeout: 1000 });
+
+      // Force re-renders: each hands the component a fresh getAuthHeader reference.
+      rerender(<VideoPlayer videoId="stable-public" src={src} />);
+      rerender(<VideoPlayer videoId="stable-public" src={src} />);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // The source must have been assigned exactly once — no abort/reload churn.
+      expect(srcValues.filter((value) => value === src)).toHaveLength(1);
+    });
+  });
 });

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -133,6 +133,12 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
 
     // Adult verification hook
     const { isVerified: isAdultVerified, getAuthHeader } = useAdultVerification();
+    // Keep the latest auth-header generator in a ref. getAuthHeader is keyed on the
+    // signer, so a late-resolving signer (e.g. a browser extension that injects after
+    // load) hands us a new reference. Reading it through a ref keeps it out of the load
+    // effect's dependency array, so resolving auth never aborts an in-flight video load.
+    const getAuthHeaderRef = useRef(getAuthHeader);
+    getAuthHeaderRef.current = getAuthHeader;
     const isKnownAgeRestricted = videoData?.ageRestricted === true || discoveredAgeRestricted;
     const { mediaUrl: authenticatedPosterUrl } = useAuthenticatedMediaUrl(poster, {
       enabled: !!poster && !requiresAuth && !authCheckPending,
@@ -751,30 +757,43 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
         hlsRef.current = null;
       }
 
-      // Preflight auth check for HLS URL
-      const checkAuth = async () => {
-        const urlToCheck = hlsUrl || allUrls[currentUrlIndex];
-        if (urlToCheck && !isAdultVerified) {
-          const authResult = await checkMediaAuth(urlToCheck);
-          setAuthCheckPending(false);
-          if (authResult && !authResult.authorized && (authResult.status === 401 || authResult.status === 403)) {
-            verboseLog(`[VideoPlayer ${videoId}] Preflight check: auth required (${authResult.status})`);
-            setRequiresAuth(true);
-            setIsLoading(false);
-            return false;
-          }
-        } else {
-          // Already verified or no URL to check
-          setAuthCheckPending(false);
+      // Playback must never wait on the auth probe. The previous code awaited a HEAD
+      // request to checkMediaAuth before setting video.src, which delayed (and on a
+      // slow probe, effectively blocked) the first frame for every non-verified viewer.
+      const urlToCheck = hlsUrl || allUrls[currentUrlIndex];
+
+      const handleProbeResult = (authResult: Awaited<ReturnType<typeof checkMediaAuth>> | undefined) => {
+        if (abortController.signal.aborted) return;
+        setAuthCheckPending(false);
+        if (authResult && !authResult.authorized && (authResult.status === 401 || authResult.status === 403)) {
+          verboseLog(`[VideoPlayer ${videoId}] Auth required (${authResult.status})`);
+          setRequiresAuth(true);
+          setIsLoading(false);
         }
-        return true;
       };
 
-      // Run preflight check then load video
-      checkAuth().then((authorized) => {
-        if (!authorized) return;
+      if (isKnownAgeRestricted && !isAdultVerified && urlToCheck) {
+        // Known age-restricted media keeps the blocking gate: show the age check
+        // before ever requesting the protected blob.
+        checkMediaAuth(urlToCheck).then((authResult) => {
+          if (abortController.signal.aborted) return;
+          handleProbeResult(authResult);
+          if (!(authResult && !authResult.authorized && (authResult.status === 401 || authResult.status === 403))) {
+            loadVideoSource();
+          }
+        });
+      } else {
+        // Fast path: start playback immediately. For unmarked media we still probe in
+        // the background — if it's actually protected, the probe (or the element's own
+        // error handler) flips requiresAuth and swaps in the age gate. Public media just
+        // plays without waiting on anything.
         loadVideoSource();
-      });
+        if (urlToCheck && !isAdultVerified) {
+          checkMediaAuth(urlToCheck).then(handleProbeResult);
+        } else {
+          setAuthCheckPending(false);
+        }
+      }
 
       function loadVideoSource() {
         if (!video) return; // Guard for TypeScript - video was checked before calling
@@ -802,7 +821,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
         // rejects any malformed auth header with 401 even when the blob is public.
         if (isAdultVerified && isKnownAgeRestricted) {
           verboseLog(`[VideoPlayer ${videoId}] Using NIP-98 auth loader for each HLS request`);
-          hlsConfig.loader = createAuthLoader(getAuthHeader);
+          hlsConfig.loader = createAuthLoader(getAuthHeaderRef.current);
         }
 
         const hls = new Hls(hlsConfig);
@@ -874,7 +893,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
               try {
                 // NIP-98 (not BUD-01): Blossom's viewer auth path only accepts
                 // BUD-01 list events, rejecting get events with an action mismatch.
-                const authHeader = await getAuthHeader(currentUrl, 'GET');
+                const authHeader = await getAuthHeaderRef.current(currentUrl, 'GET');
                 // Check if request was aborted while getting auth header
                 if (abortController.signal.aborted) {
                   verboseLog(`[VideoPlayer ${videoId}] Fetch aborted before starting`);
@@ -952,7 +971,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
         }
       };
 
-    }, [hlsUrl, currentUrlIndex, allUrls, videoId, requiresAuth, isAdultVerified, authRetryCount, getAuthHeader, isKnownAgeRestricted]); // React to HLS URL, fallback, and auth changes
+    }, [hlsUrl, currentUrlIndex, allUrls, videoId, requiresAuth, isAdultVerified, authRetryCount, isKnownAgeRestricted]); // React to HLS URL, fallback, and auth changes (getAuthHeader is read via ref to avoid restarting loads on signer churn)
 
     // Cleanup on unmount
     useEffect(() => {


### PR DESCRIPTION
## Problem

On `/discovery/new`, videos took **~20 seconds** to reach the first frame even though the feed itself rendered in ~1.1s. Console from a real session showed `first_video_playback: 20884ms` while the feed data query was only `1087ms`.

The gap was entirely inside `VideoPlayer`, before the `<video>` element ever got a `src` it could keep.

## Root causes

**1. A blocking auth HEAD gated `video.src`.** The source-loading effect awaited `checkMediaAuth(url)` — a `HEAD` request with no timeout (`useAdultVerification.ts`) — *before* calling `loadVideoSource()`. This ran for **every** video whenever the viewer wasn't adult-verified, which is the default for essentially all logged-out viewers. A slow probe delayed (or effectively blocked) playback.

**2. A resolving signer aborted the in-flight load, repeatedly.** The same effect listed `getAuthHeader` in its dependency array. `getAuthHeader` is keyed on the signer (`useCurrentUser` → `useAdultVerification`), so a late-injecting extension/signer handed it a new reference. Each change re-ran the effect, whose cleanup `abortController.abort()` + `hls.destroy()` threw away the in-flight download and restarted it — over and over until auth state settled. (The session in question showed `"Browser extension not available"` followed by the extension later signing — exactly this late-resolve.)

## Fix

- **Don't block on the probe.** Start playback immediately and run `checkMediaAuth` in the background for unmarked media. Only **known age-restricted** media (`videoData.ageRestricted === true` or already discovered) keeps the blocking gate, so the age check still appears before requesting a protected blob. Genuinely-protected-but-unmarked URLs are still caught by the element's existing `onError` handler, which flips `requiresAuth`.
- **Read `getAuthHeader` via a ref** so a resolving signer no longer restarts/aborts an in-flight load. Removed it from the effect deps.

## Tests

Added two regression tests in `VideoPlayer.test.tsx`:
- a public video sets `src` even when the auth preflight **never resolves**;
- the load is **not restarted** when `getAuthHeader` changes reference across renders.

Both fail on `main` (reproducing the 20s stall and the abort/restart churn) and pass with this change.

## Verification

- `npx vitest run` — **1137 passed (172 files)**
- `npx tsc --noEmit` — clean
- `npx eslint src/components/VideoPlayer.tsx` — no new warnings (3 pre-existing `handleError` deps warnings unchanged)

## Notes / follow-up

This addresses the primary ask: **public videos play without waiting on auth.** The secondary question — *why the auth/signer resolution itself is slow* (late extension injection, the `persist-cookie 400`, "Skipped invalid login") — is left for a separate investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)