### PR TITLE
ci: alert #divine-alerts on failed deploys and outages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -198,3 +198,70 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy dist --project-name=divine-web-direct-deploy --branch=main
+
+  # A failed production deploy currently only emails the one person who
+  # triggered it (easy to miss, and reads like routine flaky-CI noise). This
+  # surfaces it to the whole team in #divine-alerts AND probes the live apex
+  # so the alert states the real-world impact — is the site actually serving a
+  # page, or handing visitors a blank one? Fires only when a deploy job fails.
+  #
+  # Graceful by design: no-ops (logs and exits 0) when the
+  # SLACK_DIVINE_ALERTS_WEBHOOK secret isn't set, so it can land before the
+  # webhook exists, and a Slack post failure never masks the original deploy
+  # failure. Posts via an Incoming Webhook (single channel, no token/scopes).
+  notify-failure:
+    needs: [deploy-fastly, deploy-cloudflare]
+    # failure() is true if any ancestor job failed (incl. build/guard, whose
+    # failure skips the deploy jobs) — so any broken production-deploy run pings
+    # the channel, not just a failed Fastly/Cloudflare step.
+    if: failure()
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Probe live site and alert #divine-alerts
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_DIVINE_ALERTS_WEBHOOK }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          COMMIT_SHA: ${{ github.sha }}
+          # Empty on workflow_dispatch (no head_commit); handled below.
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+        run: |
+          set -uo pipefail
+
+          if [ -z "${SLACK_WEBHOOK:-}" ]; then
+            echo "SLACK_DIVINE_ALERTS_WEBHOOK not set; skipping Slack notification."
+            exit 0
+          fi
+
+          # index.html is served cache-control: no-store, so this probe reflects
+          # what real visitors get right now. The outage class we care about is a
+          # 200 OK with an empty/short body (the bundle pointer resolved but the
+          # body isn't served), so we check status, size, AND the root element.
+          probe_url="https://divine.video/?ci-probe=${GITHUB_RUN_ID}"
+          : > /tmp/probe-body
+          status="$(curl -sS -o /tmp/probe-body -w '%{http_code}' --max-time 15 "$probe_url" 2>/dev/null || true)"
+          status="${status:-000}"
+          bytes="$(wc -c < /tmp/probe-body | tr -d ' ')"
+
+          if [ "$status" = "200" ] && [ "${bytes:-0}" -gt 100 ] && grep -q 'id="root"' /tmp/probe-body; then
+            site_line="🟡 Live site still appears to serve a real page (HTTP ${status}, ${bytes} bytes). The deploy failed but visitors may be unaffected — confirm before standing down."
+          else
+            site_line="🔴 Live site looks BROKEN (HTTP ${status}, ${bytes} bytes). Visitors may be seeing a blank page. Re-run the deploy or roll back."
+          fi
+
+          commit_short="${COMMIT_SHA:0:8}"
+          commit_subject="$(printf '%s' "${COMMIT_MSG:-(manual run)}" | head -n1)"
+
+          # Literal backticks are intentional (Slack `code` markdown); the format
+          # string must stay single-quoted, so no expansion is expected here.
+          # shellcheck disable=SC2016
+          text="$(printf '*Production deploy failed* — divine-web\n%s\n\nCommit `%s` — %s\n<%s|View the failed run>  ·  confirm at https://divine.video' \
+            "$site_line" "$commit_short" "$commit_subject" "$RUN_URL")"
+
+          payload="$(jq -n --arg t "$text" '{text: $t}')"
+
+          if curl -sS -X POST -H 'Content-type: application/json' \
+               --max-time 15 --data "$payload" "$SLACK_WEBHOOK" >/dev/null; then
+            echo "Posted deploy-failure alert to #divine-alerts."
+          else
+            echo "WARNING: failed to POST to Slack webhook (deploy failure still stands)."
+          fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -210,12 +210,17 @@ jobs:
   # webhook exists, and a Slack post failure never masks the original deploy
   # failure. Posts via an Incoming Webhook (single channel, no token/scopes).
   notify-failure:
-    needs: [deploy-fastly, deploy-cloudflare]
-    # failure() is true if any ancestor job failed (incl. build/guard, whose
-    # failure skips the deploy jobs) — so any broken production-deploy run pings
-    # the channel, not just a failed Fastly/Cloudflare step.
-    if: failure()
+    # List every upstream job so a failure anywhere in the run is detectable.
+    # When guard/build fails, the deploy jobs are *skipped* (not failed), and a
+    # bare `if: failure()` over skipped needs would not fire — so a broken build
+    # would produce no alert. always() lets this job run despite skipped needs;
+    # contains(needs.*.result, 'failure') fires on any failed ancestor while
+    # staying silent on an all-success (or cancelled) run.
+    needs: [guard-main-ref, build, deploy-fastly, deploy-cloudflare]
+    if: ${{ always() && contains(needs.*.result, 'failure') }}
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - name: Probe live site and alert #divine-alerts
         env:

--- a/.github/workflows/uptime-heartbeat.yml
+++ b/.github/workflows/uptime-heartbeat.yml
@@ -1,0 +1,90 @@
+# ABOUTME: Scheduled uptime heartbeat — probes the live divine.video apex every
+# ABOUTME: 15 min and alerts #divine-alerts if it's down, independent of deploys.
+
+name: Uptime heartbeat
+
+# The deploy workflow only alerts at deploy time. This catches an outage that
+# happens with no deploy in flight (e.g. the 2026-06-25 blank-page incident sat
+# broken ~12h with no new pushes to re-trigger anything). Posts to the same
+# #divine-alerts webhook as the deploy notify-failure job.
+
+on:
+  schedule:
+    # Every 15 minutes. GitHub cron is best-effort and can lag under load, which
+    # is fine here: the goal is catching a multi-hour outage within ~15 min, not
+    # second-precision. A sustained outage re-pings each run until it recovers
+    # (Actions is stateless between runs, so there is no down/up dedup by design).
+    - cron: '*/15 * * * *'
+  # Manual trigger, including a self-test that forces an alert so the Slack wiring
+  # can be verified without faking an outage.
+  workflow_dispatch:
+    inputs:
+      test_alert:
+        description: 'Send a test alert to #divine-alerts regardless of site status'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  heartbeat:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Probe divine.video and alert on sustained failure
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_DIVINE_ALERTS_WEBHOOK }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          TEST_ALERT: ${{ github.event.inputs.test_alert }}
+        run: |
+          set -uo pipefail
+
+          if [ -z "${SLACK_WEBHOOK:-}" ]; then
+            echo "SLACK_DIVINE_ALERTS_WEBHOOK not set; skipping heartbeat."
+            exit 0
+          fi
+
+          post() {
+            # $1 = message text. Built via jq --arg so no input can break the JSON.
+            payload="$(jq -n --arg t "$1" '{text: $t}')"
+            if curl -sS -X POST -H 'Content-type: application/json' \
+                 --max-time 15 --data "$payload" "$SLACK_WEBHOOK" >/dev/null; then
+              echo "Posted to #divine-alerts."
+            else
+              echo "WARNING: failed to POST to Slack webhook."
+            fi
+          }
+
+          if [ "${TEST_ALERT:-false}" = "true" ]; then
+            post "$(printf '🧪 *uptime heartbeat test* — wiring OK, please ignore.\n<%s|heartbeat run>' "$RUN_URL")"
+            exit 0
+          fi
+
+          # index.html is served cache-control: no-store, so this is what real
+          # visitors get right now. The outage class is a 200 with an empty/short
+          # body (pointer resolved, body not served), so check status, size, AND
+          # the root element. Probe 3x to ride out a transient blip; only a 3/3
+          # failure pages the channel.
+          status=000
+          bytes=0
+          up=0
+          for attempt in 1 2 3; do
+            : > /tmp/probe-body
+            status="$(curl -sS -o /tmp/probe-body -w '%{http_code}' --max-time 15 "https://divine.video/?hb=${GITHUB_RUN_ID}-${attempt}" 2>/dev/null || true)"
+            status="${status:-000}"
+            bytes="$(wc -c < /tmp/probe-body | tr -d ' ')"
+            if [ "$status" = "200" ] && [ "${bytes:-0}" -gt 100 ] && grep -q 'id="root"' /tmp/probe-body; then
+              up=1
+              break
+            fi
+            echo "Probe ${attempt}: HTTP ${status}, ${bytes} bytes — not healthy."
+            if [ "$attempt" -lt 3 ]; then sleep 10; fi
+          done
+
+          if [ "$up" = "1" ]; then
+            echo "Site healthy (HTTP ${status}, ${bytes} bytes). No alert."
+            exit 0
+          fi
+
+          echo "Site DOWN after 3 probes (last: HTTP ${status}, ${bytes} bytes). Alerting."
+          post "$(printf '🔴 *divine.video appears DOWN* — uptime heartbeat\n3/3 probes failed (last: HTTP %s, %s bytes). Visitors are likely seeing a blank or error page.\n<%s|heartbeat run>  ·  check https://divine.video' "$status" "$bytes" "$RUN_URL")"


### PR DESCRIPTION
## Why

Last night a production deploy left the site serving a blank white page, and it stayed broken for ~12 hours. The existing CI safety checks correctly flagged the bad deploy (the live-bundle verifier from #424 failed the run), but the only signal was a red run in the Actions tab plus an email to the one person who triggered the deploy. Nobody saw it.

Two gaps caused the long outage:

1. A failed deploy is not surfaced to the team, only to the triggering actor's inbox, where it reads like routine flaky-CI noise.
2. Nothing watches the site when there is no deploy in flight. Last night had no new pushes for ~12 hours, so even a deploy-time alert would have gone quiet after the initial failure.

This PR closes both.

## What

**1. Deploy-failure alert (`deploy.yml`)**
A `notify-failure` job that fires on any failed production-deploy run (`if: failure()`, `needs: [deploy-fastly, deploy-cloudflare]`). It probes the live apex and classifies real-world impact:

- 🔴 broken (non-200, or 200 with an empty/short body, the outage class from #426)
- 🟡 deploy failed but the old bundle is still serving

It posts that, the failing commit, and a link to the red run to #divine-alerts.

**2. Uptime heartbeat (`uptime-heartbeat.yml`)**
A scheduled workflow (every 15 min) that probes `divine.video` and alerts the same channel when the site is down, independent of deploys. It probes 3x per run and only alerts on a 3/3 failure to filter transient blips. Stateless between runs by design, so a sustained outage re-pings each run (~every 15 min) until recovery.

Together: the heartbeat catches an outage within ~15 min regardless of cause; the deploy alert flags a bad deploy to the whole channel with its real impact.

## Safety / rollout

- Both no-op (log, exit 0) when `SLACK_DIVINE_ALERTS_WEBHOOK` is unset, so this can merge before or after the webhook secret is added. They activate the moment the secret exists.
- No workflow-command injection: the commit message is passed via `env` and escaped through `jq --arg`, never inlined into a shell command. The heartbeat takes no untrusted input.
- A Slack post failure never masks the original deploy failure.
- Cost: divine-web is public, so scheduled Actions on standard runners are free.

## Testing

- YAML parses; the bash in both workflows is shellcheck-clean.
- `workflow_dispatch` on the heartbeat takes a `test_alert` input that posts a verification message to #divine-alerts on demand (available once the workflow is on `main`).

## Not in scope (follow-ups)

- Auto-rollback on a failed verify.
- Cross-run down/up dedup for the heartbeat (a dedicated external monitor is the better tool if the repeat-pings become noisy).
- Root-causing why the publish reported success while serving empty bodies (the #427 swallowed-error guard did not trip on this variant).
