### PR TITLE
fix(worker): disable apex feed-injection that blanked the homepage (#435)

### DIFF
--- a/compute-js/src/index.js
+++ b/compute-js/src/index.js
@@ -316,8 +316,14 @@ async function handleRequest(event) {
     const headers = new Headers(response.headers);
     headers.append('Vary', 'X-Original-Host');
 
-    // Inject feed data into HTML pages for faster LCP
-    if (shouldInjectFeed && response.headers.get('Content-Type')?.includes('text/html')) {
+    // HOTFIX (2026-06-25 incident, see #435): apex feed injection DISABLED.
+    // `await response.text()` on the publisher's serveRequest response returns an empty
+    // string (verified by local repro; encoding-independent and NOT feed-dependent), so
+    // this block emitted a blank `/`, `/index.html`, and `/discovery/<tab>` while every
+    // non-injected route served fine. Short-circuit with `false` so these fall through to
+    // the untouched `new Response(response.body, ...)` below (same path as all other
+    // routes). Re-enable only after injection reads the page directly from KV (see #435).
+    if (false && shouldInjectFeed && response.headers.get('Content-Type')?.includes('text/html')) {
       try {
         let html = await response.text();
         const feedType = discoveryFeedType || 'trending';


### PR DESCRIPTION
> [!WARNING]
> **DO NOT MERGE OR DEPLOY while divine-web seems stable during VidCon.** Merging triggers a production deploy. This PR exists to **reconcile git with prod**, not to ship a change: the hotfix is already live (worker v423, deployed via CLI during the incident). Hold until the event is over and the deploy freeze lifts.

## What

Disables the apex/discovery edge feed-injection, which was serving an empty body on `/`, `/index.html`, and `/discovery/<tab>`. Root cause of the 2026-06-25 blank-homepage incident.

## Why

`await response.text()` on the publisher's `serveRequest` response returns an empty string (verified by local Viceroy repro: encoding-independent, not feed-dependent), so the injection block re-emitted a blank page. Every non-injected route was unaffected. Disabling injection makes the apex serve the page via the same untouched path as `/discovery`.

## State / trade-off

- **Already live on prod** as worker v423 (CLI deploy during the incident). This commit just brings `main` in line with what is deployed.
- Drops the feed-preload LCP optimization. The proper fix (re-implement injection to read the HTML directly from KV, mirroring `handleSubdomainProfile`) is tracked in **#435**, to be done after the event.

## Verification

- Local repro (Viceroy, `@fastly/compute-js-static-publish` 7.0.3): injection enabled -> apex 0 bytes for identity/gzip/br; disabled -> full page.
- Live: apex serves the full page on fresh cache-MISS since v423.

See #435 for the durable fix and full root-cause writeup.
