### PR TITLE
fix(search): query Funnelcake for hashtag results

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -47,14 +47,19 @@ jobs:
             const deploymentUrl = '${{ steps.deploy.outputs.deployment-url }}';
             const sha = '${{ github.event.pull_request.head.sha }}'.substring(0, 7);
             const branch = '${{ github.event.pull_request.head.ref }}';
+            const updatedAt = new Date().toISOString();
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
             const body = `## 🚀 Preview Deployment
+
+            Last updated: <relative-time datetime="${updatedAt}">${updatedAt}</relative-time>
 
             | Property | Value |
             |----------|-------|
             | **Preview URL** | ${deploymentUrl} |
             | **Commit** | \`${sha}\` |
-            | **Branch** | \`${branch}\` |`;
+            | **Branch** | \`${branch}\` |
+            | **Workflow run** | [#${context.runNumber}](${runUrl}) |`;
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,

--- a/src/hooks/useInfiniteVideosFunnelcake.test.ts
+++ b/src/hooks/useInfiniteVideosFunnelcake.test.ts
@@ -5,6 +5,7 @@ import React from 'react';
 
 const mockFetchVideos = vi.fn();
 const mockFetchVideosV2 = vi.fn();
+const mockSearchVideos = vi.fn();
 const mockFetchRecommendations = vi.fn();
 const mockTransformToVideoPage = vi.fn();
 
@@ -17,7 +18,7 @@ vi.mock('@/hooks/useCurrentUser', () => ({
 vi.mock('@/lib/funnelcakeClient', () => ({
   fetchVideos: mockFetchVideos,
   fetchVideosV2: mockFetchVideosV2,
-  searchVideos: vi.fn(),
+  searchVideos: mockSearchVideos,
   fetchUserVideos: vi.fn(),
   fetchUserFeed: vi.fn(),
   fetchRecommendations: mockFetchRecommendations,
@@ -60,6 +61,43 @@ beforeEach(async () => {
 });
 
 describe('useInfiniteVideosFunnelcake', () => {
+  it('does not send watching sort to hashtag video feeds', async () => {
+    mockSearchVideos.mockResolvedValueOnce({
+      videos: [{}],
+      has_more: false,
+      next_cursor: undefined,
+    });
+    mockTransformToVideoPage.mockReturnValueOnce({
+      videos: [{ id: 'video-1', pubkey: 'p1', kind: 34236, createdAt: 101, vineId: 'd-1' }],
+      nextCursor: undefined,
+      hasMore: false,
+    });
+
+    const { result } = renderHook(
+      () => useInfiniteVideosFunnelcake({
+        feedType: 'hashtag',
+        hashtag: 'twerkvine',
+        sortMode: 'watching',
+        pageSize: 12,
+      }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockSearchVideos).toHaveBeenCalledWith(
+      'https://api.divine.video',
+      expect.objectContaining({
+        tag: 'twerkvine',
+        sort: 'trending',
+        limit: 12,
+        signal: expect.any(AbortSignal),
+      })
+    );
+  });
+
   it('requests native popular videos with period and excludes classic Vines', async () => {
     mockFetchVideosV2.mockResolvedValueOnce({
       videos: [{}],

--- a/src/hooks/useInfiniteVideosFunnelcake.test.ts
+++ b/src/hooks/useInfiniteVideosFunnelcake.test.ts
@@ -61,12 +61,18 @@ beforeEach(async () => {
 });
 
 describe('useInfiniteVideosFunnelcake', () => {
-  it('does not send watching sort to hashtag video feeds', async () => {
-    mockSearchVideos.mockResolvedValueOnce({
-      videos: [{}],
-      has_more: false,
-      next_cursor: undefined,
-    });
+  it('falls back to loop-count sorting when watching has no hashtag videos', async () => {
+    mockSearchVideos
+      .mockResolvedValueOnce({
+        videos: [],
+        has_more: false,
+        next_cursor: undefined,
+      })
+      .mockResolvedValueOnce({
+        videos: [{}],
+        has_more: false,
+        next_cursor: undefined,
+      });
     mockTransformToVideoPage.mockReturnValueOnce({
       videos: [{ id: 'video-1', pubkey: 'p1', kind: 34236, createdAt: 101, vineId: 'd-1' }],
       nextCursor: undefined,
@@ -87,11 +93,22 @@ describe('useInfiniteVideosFunnelcake', () => {
       expect(result.current.isSuccess).toBe(true);
     });
 
-    expect(mockSearchVideos).toHaveBeenCalledWith(
+    expect(mockSearchVideos).toHaveBeenNthCalledWith(
+      1,
       'https://api.divine.video',
       expect.objectContaining({
         tag: 'twerkvine',
-        sort: 'trending',
+        sort: 'watching',
+        limit: 12,
+        signal: expect.any(AbortSignal),
+      })
+    );
+    expect(mockSearchVideos).toHaveBeenNthCalledWith(
+      2,
+      'https://api.divine.video',
+      expect.objectContaining({
+        tag: 'twerkvine',
+        sort: 'loops',
         limit: 12,
         signal: expect.any(AbortSignal),
       })

--- a/src/hooks/useInfiniteVideosFunnelcake.ts
+++ b/src/hooks/useInfiniteVideosFunnelcake.ts
@@ -141,11 +141,7 @@ function getFetchOptions(
     case 'hashtag':
       return {
         ...baseOptions,
-        sort: sortMode === 'classic'
-          ? 'loops'
-          : sortMode === 'watching'
-            ? 'trending'
-            : (sortMode || 'trending'),
+        sort: sortMode === 'classic' ? 'loops' : (sortMode || 'trending'),
         ...(sortMode === 'classic' ? { classic: true, platform: 'vine' } : {}),
       };
 
@@ -300,6 +296,13 @@ export function useInfiniteVideosFunnelcake({
               ...options,
               tag: hashtag.toLowerCase(),
             });
+            if (sortMode === 'watching' && response.videos.length === 0) {
+              response = await searchVideos(effectiveApiUrl, {
+                ...options,
+                sort: 'loops',
+                tag: hashtag.toLowerCase(),
+              });
+            }
             break;
 
           case 'profile':

--- a/src/hooks/useInfiniteVideosFunnelcake.ts
+++ b/src/hooks/useInfiniteVideosFunnelcake.ts
@@ -141,7 +141,11 @@ function getFetchOptions(
     case 'hashtag':
       return {
         ...baseOptions,
-        sort: sortMode === 'classic' ? 'loops' : (sortMode || 'trending'),
+        sort: sortMode === 'classic'
+          ? 'loops'
+          : sortMode === 'watching'
+            ? 'trending'
+            : (sortMode || 'trending'),
         ...(sortMode === 'classic' ? { classic: true, platform: 'vine' } : {}),
       };
 

--- a/src/hooks/useSearchHashtags.test.ts
+++ b/src/hooks/useSearchHashtags.test.ts
@@ -1,0 +1,75 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useSearchHashtags } from './useSearchHashtags';
+import { fetchTrendingHashtags } from '@/lib/funnelcakeClient';
+
+vi.mock('@/config/api', () => ({
+  getFunnelcakeBaseUrl: () => 'https://api.divine.video',
+}));
+
+vi.mock('@/lib/funnelcakeClient', () => ({
+  fetchTrendingHashtags: vi.fn(),
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+}
+
+describe('useSearchHashtags', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('passes hashtag searches to Funnelcake instead of filtering only popular tags', async () => {
+    vi.mocked(fetchTrendingHashtags).mockResolvedValueOnce([
+      { hashtag: 'twerking', video_count: 255 },
+    ] as Awaited<ReturnType<typeof fetchTrendingHashtags>>);
+
+    const { result } = renderHook(
+      () => useSearchHashtags({ query: 'twerking', limit: 20 }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(fetchTrendingHashtags).toHaveBeenCalledWith(
+      'https://api.divine.video',
+      20,
+      expect.any(AbortSignal),
+      'twerking',
+    );
+    expect(result.current.data).toEqual([
+      { hashtag: 'twerking', video_count: 255 },
+    ]);
+  });
+
+  it('strips a leading hash before searching hashtags', async () => {
+    vi.mocked(fetchTrendingHashtags).mockResolvedValueOnce([
+      { hashtag: 'twerking', video_count: 255 },
+    ] as Awaited<ReturnType<typeof fetchTrendingHashtags>>);
+
+    const { result } = renderHook(
+      () => useSearchHashtags({ query: '#Twerking', limit: 20 }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(fetchTrendingHashtags).toHaveBeenCalledWith(
+      'https://api.divine.video',
+      20,
+      expect.any(AbortSignal),
+      'twerking',
+    );
+  });
+});

--- a/src/hooks/useSearchHashtags.test.ts
+++ b/src/hooks/useSearchHashtags.test.ts
@@ -32,7 +32,11 @@ describe('useSearchHashtags', () => {
 
   it('passes hashtag searches to Funnelcake instead of filtering only popular tags', async () => {
     vi.mocked(fetchTrendingHashtags).mockResolvedValueOnce([
-      { hashtag: 'twerking', video_count: 255 },
+      {
+        hashtag: 'twerking',
+        video_count: 255,
+        thumbnail: 'https://media.divine.video/twerking.jpg',
+      },
     ] as Awaited<ReturnType<typeof fetchTrendingHashtags>>);
 
     const { result } = renderHook(
@@ -49,7 +53,11 @@ describe('useSearchHashtags', () => {
       'twerking',
     );
     expect(result.current.data).toEqual([
-      { hashtag: 'twerking', video_count: 255 },
+      {
+        hashtag: 'twerking',
+        video_count: 255,
+        thumbnail: 'https://media.divine.video/twerking.jpg',
+      },
     ]);
   });
 

--- a/src/hooks/useSearchHashtags.ts
+++ b/src/hooks/useSearchHashtags.ts
@@ -14,6 +14,7 @@ interface UseSearchHashtagsOptions {
 export interface HashtagResult {
   hashtag: string;
   video_count: number;
+  thumbnail?: string;
 }
 
 /**
@@ -79,6 +80,7 @@ export function useSearchHashtags(options: UseSearchHashtagsOptions) {
       const finalHashtags: HashtagResult[] = hashtags.map(hashtag => ({
         hashtag: hashtag.hashtag,
         video_count: hashtag.video_count,
+        thumbnail: hashtag.thumbnail,
       }));
 
       console.info('[search/hashtags] completed', {

--- a/src/hooks/useSearchHashtags.ts
+++ b/src/hooks/useSearchHashtags.ts
@@ -35,18 +35,10 @@ function useDebouncedValue(value: string, delay: number): string {
 }
 
 /**
- * Filter hashtags by search query
+ * Normalize user-entered hashtag search text for Funnelcake.
  */
-function filterHashtagsByQuery(hashtags: HashtagResult[], query: string): HashtagResult[] {
-  if (!query.trim()) {
-    return hashtags;
-  }
-
-  const searchValue = query.toLowerCase();
-
-  return hashtags.filter(hashtag =>
-    hashtag.hashtag.toLowerCase().includes(searchValue)
-  );
+function normalizeHashtagQuery(query: string): string {
+  return query.trim().replace(/^#+/, '').trim().toLowerCase();
 }
 
 /**
@@ -63,10 +55,11 @@ export function useSearchHashtags(options: UseSearchHashtagsOptions) {
     queryKey: ['search-hashtags', debouncedQuery, limit],
     queryFn: async ({ signal }) => {
       const requestStartedAt = performance.now();
+      const normalizedQuery = normalizeHashtagQuery(debouncedQuery);
       const requestContext = {
-        query: debouncedQuery,
+        query: normalizedQuery,
         limit,
-        mode: debouncedQuery.trim() ? 'search' : 'popular',
+        mode: normalizedQuery ? 'search' : 'popular',
       };
 
       console.info('[search/hashtags] starting', {
@@ -77,25 +70,23 @@ export function useSearchHashtags(options: UseSearchHashtagsOptions) {
       const fetchStartedAt = performance.now();
       const hashtags = await fetchTrendingHashtags(
         getFunnelcakeBaseUrl(),
-        100,
+        normalizedQuery ? limit : 100,
         signal,
+        normalizedQuery || undefined,
       );
       const fetchCompletedAt = performance.now();
 
-      const allHashtags: HashtagResult[] = hashtags.map(hashtag => ({
+      const finalHashtags: HashtagResult[] = hashtags.map(hashtag => ({
         hashtag: hashtag.hashtag,
         video_count: hashtag.video_count,
       }));
-
-      const filteredHashtags = filterHashtagsByQuery(allHashtags, debouncedQuery);
-      const finalHashtags = filteredHashtags.slice(0, limit);
 
       console.info('[search/hashtags] completed', {
         ...requestContext,
         apiMs: Math.round(fetchCompletedAt - fetchStartedAt),
         totalMs: Math.round(fetchCompletedAt - requestStartedAt),
-        fetchedHashtagCount: allHashtags.length,
-        matchedHashtagCount: filteredHashtags.length,
+        fetchedHashtagCount: finalHashtags.length,
+        matchedHashtagCount: finalHashtags.length,
         returnedHashtagCount: finalHashtags.length,
       });
 

--- a/src/lib/funnelcakeClient.ts
+++ b/src/lib/funnelcakeClient.ts
@@ -642,18 +642,20 @@ export async function fetchPopularHashtags(
  * @param apiUrl - Base URL of the Funnelcake API
  * @param limit - Maximum number of hashtags to return
  * @param signal - Optional abort signal
+ * @param query - Optional hashtag name substring to search server-side
  * @returns Promise with trending hashtags
  */
 export async function fetchTrendingHashtags(
   apiUrl: string = API_CONFIG.funnelcake.baseUrl,
   limit: number = 20,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  query?: string
 ): Promise<FunnelcakeHashtag[]> {
   // API returns array directly
   return funnelcakeRequest<FunnelcakeHashtag[]>(
     apiUrl,
     API_CONFIG.funnelcake.endpoints.trendingHashtags,
-    { limit },
+    { limit, q: query },
     signal
   );
 }

--- a/src/pages/SearchPage.test.tsx
+++ b/src/pages/SearchPage.test.tsx
@@ -569,8 +569,16 @@ describe('SearchPage', () => {
     mockUseSearchHashtags.mockImplementation(({ query }: { query: string }) => ({
       data: query
         ? [
-            { hashtag: 'twerking', video_count: 255 },
-            { hashtag: 'twerkingvine', video_count: 4 },
+            {
+              hashtag: 'twerking',
+              video_count: 255,
+              thumbnail: 'https://media.divine.video/twerking.jpg',
+            },
+            {
+              hashtag: 'twerkingvine',
+              video_count: 4,
+              thumbnail: 'https://media.divine.video/twerkingvine.jpg',
+            },
           ]
         : [],
       isLoading: false,
@@ -586,6 +594,58 @@ describe('SearchPage', () => {
     expect(screen.getAllByRole('button', {
       name: 'Search hashtag #twerkingvine, 4 videos',
     }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole('img', {
+      name: 'Preview for #twerking',
+    })[0]).toHaveAttribute('src', 'https://media.divine.video/twerking.jpg');
+    expect(screen.getAllByRole('img', {
+      name: 'Preview for #twerkingvine',
+    })[0]).toHaveAttribute('src', 'https://media.divine.video/twerkingvine.jpg');
+  });
+
+  it('opens the hashtag video feed when a hashtag result is clicked', async () => {
+    const user = userEvent.setup();
+    mockUseSearchHashtags.mockImplementation(({ query }: { query: string }) => ({
+      data: query
+        ? [{ hashtag: 'twerking', video_count: 255 }]
+        : [],
+      isLoading: false,
+      error: null,
+    }));
+
+    renderPage(['/search?q=twerking&filter=hashtags']);
+
+    await user.click(screen.getAllByRole('button', {
+      name: 'Search hashtag #twerking, 255 videos',
+    })[0]);
+
+    expect(mockNavigate).toHaveBeenCalledWith('/hashtag/twerking');
+  });
+
+  it('hides a hashtag thumbnail when the media URL fails to load', async () => {
+    mockUseSearchHashtags.mockImplementation(({ query }: { query: string }) => ({
+      data: query
+        ? [{
+            hashtag: 'twerking',
+            video_count: 255,
+            thumbnail: 'https://media.divine.video/missing.jpg',
+          }]
+        : [],
+      isLoading: false,
+      error: null,
+    }));
+
+    renderPage(['/search?q=twerking&filter=hashtags']);
+
+    const thumbnails = screen.getAllByRole('img', {
+      name: 'Preview for #twerking',
+    });
+    thumbnails.forEach(thumbnail => fireEvent.error(thumbnail));
+
+    await waitFor(() => {
+      expect(screen.queryAllByRole('img', {
+        name: 'Preview for #twerking',
+      })).toHaveLength(0);
+    });
   });
 
   it('defaults to hot sort when no sort param is in the URL and passes it to useInfiniteSearchVideos', () => {

--- a/src/pages/SearchPage.test.tsx
+++ b/src/pages/SearchPage.test.tsx
@@ -21,6 +21,7 @@ const {
   mockNostrQuery,
   mockUseInfiniteSearchVideos,
   mockUseSearchUsers,
+  mockUseSearchHashtags,
   mockUseNip05Validation,
   mockEnterFullscreen,
   mockSetVideosForFullscreen,
@@ -32,6 +33,7 @@ const {
   mockNostrQuery: vi.fn(),
   mockUseInfiniteSearchVideos: vi.fn(),
   mockUseSearchUsers: vi.fn(),
+  mockUseSearchHashtags: vi.fn(),
   mockUseNip05Validation: vi.fn(),
   mockEnterFullscreen: vi.fn(),
   mockSetVideosForFullscreen: vi.fn(),
@@ -167,11 +169,7 @@ vi.mock('@/hooks/useNip05Validation', () => ({
 }));
 
 vi.mock('@/hooks/useSearchHashtags', () => ({
-  useSearchHashtags: ({ query }: { query: string }) => ({
-    data: query ? [] : [],
-    isLoading: false,
-    error: null,
-  }),
+  useSearchHashtags: mockUseSearchHashtags,
 }));
 
 vi.mock('@/lib/funnelcakeClient', () => ({
@@ -232,6 +230,11 @@ describe('SearchPage', () => {
       isLoading: false,
       error: null,
     });
+    mockUseSearchHashtags.mockImplementation(({ query }: { query: string }) => ({
+      data: query ? [] : [],
+      isLoading: false,
+      error: null,
+    }));
     // Default: NIP-05 not yet validated, so cards show the legacy @username.
     mockUseNip05Validation.mockReturnValue({
       isValid: false,
@@ -560,6 +563,29 @@ describe('SearchPage', () => {
 
     expect(screen.getAllByTestId('video-card-video-2').length).toBeGreaterThan(0);
     expect(screen.queryAllByTestId('bare-video-card-video-2')).toHaveLength(0);
+  });
+
+  it('renders hashtag results as structured search result cards', () => {
+    mockUseSearchHashtags.mockImplementation(({ query }: { query: string }) => ({
+      data: query
+        ? [
+            { hashtag: 'twerking', video_count: 255 },
+            { hashtag: 'twerkingvine', video_count: 4 },
+          ]
+        : [],
+      isLoading: false,
+      error: null,
+    }));
+
+    renderPage(['/search?q=twerking&filter=hashtags']);
+
+    expect(screen.getByText('2 matches for "twerking"')).toBeInTheDocument();
+    expect(screen.getAllByRole('button', {
+      name: 'Search hashtag #twerking, 255 videos',
+    }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole('button', {
+      name: 'Search hashtag #twerkingvine, 4 videos',
+    }).length).toBeGreaterThan(0);
   });
 
   it('defaults to hot sort when no sort param is in the URL and passes it to useInfiniteSearchVideos', () => {

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -290,11 +290,12 @@ export function SearchPage() {
     pastedLookupQueryRef.current = normalizeDirectSearchInput(pastedValue) || null;
   };
 
-  // Handle hashtag suggestion click
   const handleHashtagClick = (hashtag: string) => {
-    setSearchQuery(`#${hashtag}`);
+    const normalizedHashtag = hashtag.trim().replace(/^#+/, '').toLowerCase();
+    if (!normalizedHashtag) return;
+
     setShowSuggestions(false);
-    searchInputRef.current?.focus();
+    navigate(`/hashtag/${encodeURIComponent(normalizedHashtag)}`);
   };
 
   // Handle filter tab change
@@ -879,19 +880,43 @@ function HashtagResultCard({
   featured?: boolean;
 }) {
   const countLabel = formatVideoCount(hashtag.video_count);
+  const thumbnailSizeClass = featured ? 'h-16 w-16 sm:h-20 sm:w-20' : 'h-14 w-14';
+  const [thumbnailFailed, setThumbnailFailed] = useState(false);
+  const thumbnail = thumbnailFailed ? undefined : hashtag.thumbnail;
+  const thumbnailClass = `${thumbnailSizeClass} flex-shrink-0 rounded-md object-cover`;
 
   return (
     <button
       type="button"
       className={
         featured
-          ? 'group flex w-full items-center justify-between gap-4 rounded-lg border-2 border-brand-dark-green bg-brand-dark-green p-5 text-left text-background shadow-md transition-all hover:-translate-y-0.5 hover:shadow-lg dark:border-brand-light-green/30 dark:text-card-foreground'
+          ? 'group flex w-full items-center justify-between gap-4 rounded-lg border-2 border-brand-dark-green bg-brand-dark-green p-4 text-left text-background shadow-md transition-all hover:-translate-y-0.5 hover:shadow-lg dark:border-brand-light-green/30 dark:text-card-foreground sm:p-5'
           : 'group flex min-h-[92px] w-full items-center justify-between gap-3 rounded-lg border border-brand-dark-green/20 bg-card p-4 text-left shadow-sm transition-all hover:-translate-y-0.5 hover:border-primary hover:bg-brand-light-green/60 hover:shadow-md dark:border-brand-light-green/20 dark:hover:bg-brand-dark-green'
       }
       onClick={onClick}
       aria-label={`Search hashtag #${hashtag.hashtag}, ${countLabel}`}
     >
-      <span className="min-w-0">
+      {thumbnail ? (
+        <img
+          src={thumbnail}
+          alt={`Preview for #${hashtag.hashtag}`}
+          loading="lazy"
+          onError={() => setThumbnailFailed(true)}
+          className={thumbnailClass}
+        />
+      ) : (
+        <span
+          className={`${thumbnailSizeClass} flex flex-shrink-0 items-center justify-center rounded-md ${
+            featured
+              ? 'bg-background/10 text-background/80 dark:bg-card/60 dark:text-card-foreground'
+              : 'bg-brand-light-green text-brand-dark-green'
+          }`}
+          aria-hidden="true"
+        >
+          <Hash className={featured ? 'h-8 w-8' : 'h-6 w-6'} />
+        </span>
+      )}
+      <span className="min-w-0 flex-1">
         <span className={featured ? 'block truncate text-2xl font-bold' : 'block truncate text-lg font-semibold'}>
           #{hashtag.hashtag}
         </span>

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -7,14 +7,13 @@ import { useSearchParams } from 'react-router-dom';
 import { useNostr } from '@nostrify/react';
 import { useSubdomainNavigate } from '@/hooks/useSubdomainNavigate';
 import { useSeoMeta } from '@unhead/react';
-import { MagnifyingGlass as Search, Hash, Play, Users, VideoCamera as Video, CircleNotch as Loader2 } from '@phosphor-icons/react';
+import { ArrowRight, MagnifyingGlass as Search, Hash, Play, Users, VideoCamera as Video, CircleNotch as Loader2 } from '@phosphor-icons/react';
 import { trackSearch } from '@/lib/analytics';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
-import { Badge } from '@/components/ui/badge';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { VideoCardWithMetrics } from '@/components/VideoCardWithMetrics';
 import InfiniteScroll from 'react-infinite-scroll-component';
@@ -629,15 +628,11 @@ export function SearchPage() {
                       <Hash className="h-5 w-5" />
                       Hashtags
                     </h2>
-                    <div className="flex flex-wrap gap-2">
-                      {hashtagResults.slice(0, 12).map((hashtag) => (
-                        <HashtagCard
-                          key={hashtag.hashtag}
-                          hashtag={hashtag}
-                          onClick={() => handleHashtagClick(hashtag.hashtag)}
-                        />
-                      ))}
-                    </div>
+                    <HashtagResultsList
+                      hashtags={hashtagResults.slice(0, 12)}
+                      onHashtagClick={handleHashtagClick}
+                      variant="preview"
+                    />
                     {hashtagResults.length > 12 && (
                       <div className="text-center mt-4">
                         <Button
@@ -730,15 +725,12 @@ export function SearchPage() {
             ) : hashtagResults.length === 0 ? (
               <NoResultsState />
             ) : (
-              <div className="flex flex-wrap gap-2">
-                {hashtagResults.map((hashtag) => (
-                  <HashtagCard
-                    key={hashtag.hashtag}
-                    hashtag={hashtag}
-                    onClick={() => handleHashtagClick(hashtag.hashtag)}
-                  />
-                ))}
-              </div>
+              <HashtagResultsList
+                hashtags={hashtagResults}
+                onHashtagClick={handleHashtagClick}
+                query={searchQuery}
+                variant="full"
+              />
             )}
           </TabsContent>
         </Tabs>
@@ -819,23 +811,105 @@ function UserCard({ user }: { user: { pubkey: string; metadata?: UserCardMetadat
   );
 }
 
-// Hashtag card component
-function HashtagCard({
+function formatVideoCount(count: number): string {
+  return `${count.toLocaleString()} ${count === 1 ? 'video' : 'videos'}`;
+}
+
+function HashtagResultsList({
+  hashtags,
+  onHashtagClick,
+  query,
+  variant,
+}: {
+  hashtags: HashtagResult[];
+  onHashtagClick: (hashtag: string) => void;
+  query?: string;
+  variant: 'preview' | 'full';
+}) {
+  const [featuredHashtag, ...remainingHashtags] = hashtags;
+  const isFull = variant === 'full';
+  const trimmedQuery = query?.trim();
+
+  if (!featuredHashtag) return null;
+
+  return (
+    <section className="mx-auto w-full max-w-5xl space-y-4" aria-label="Hashtag search results">
+      {isFull && (
+        <div className="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h2 className="flex items-center gap-2 text-lg font-semibold">
+              <Hash className="h-5 w-5" />
+              Hashtags
+            </h2>
+            <p className="text-sm text-muted-foreground">
+              {hashtags.length.toLocaleString()} matches for {trimmedQuery ? `"${trimmedQuery}"` : 'this search'}
+            </p>
+          </div>
+        </div>
+      )}
+
+      {isFull && (
+        <HashtagResultCard
+          hashtag={featuredHashtag}
+          onClick={() => onHashtagClick(featuredHashtag.hashtag)}
+          featured
+        />
+      )}
+
+      <div className={`grid gap-3 ${isFull ? 'sm:grid-cols-2 xl:grid-cols-3' : 'sm:grid-cols-2 lg:grid-cols-3'}`}>
+        {(isFull ? remainingHashtags : hashtags).map((hashtag) => (
+          <HashtagResultCard
+            key={hashtag.hashtag}
+            hashtag={hashtag}
+            onClick={() => onHashtagClick(hashtag.hashtag)}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function HashtagResultCard({
   hashtag,
-  onClick
+  onClick,
+  featured = false,
 }: {
   hashtag: HashtagResult;
   onClick: () => void;
+  featured?: boolean;
 }) {
+  const countLabel = formatVideoCount(hashtag.video_count);
+
   return (
-    <Badge
-      variant="secondary"
-      className="cursor-pointer hover:bg-secondary/80 px-3 py-1"
+    <button
+      type="button"
+      className={
+        featured
+          ? 'group flex w-full items-center justify-between gap-4 rounded-lg border-2 border-brand-dark-green bg-brand-dark-green p-5 text-left text-background shadow-md transition-all hover:-translate-y-0.5 hover:shadow-lg dark:border-brand-light-green/30 dark:text-card-foreground'
+          : 'group flex min-h-[92px] w-full items-center justify-between gap-3 rounded-lg border border-brand-dark-green/20 bg-card p-4 text-left shadow-sm transition-all hover:-translate-y-0.5 hover:border-primary hover:bg-brand-light-green/60 hover:shadow-md dark:border-brand-light-green/20 dark:hover:bg-brand-dark-green'
+      }
       onClick={onClick}
+      aria-label={`Search hashtag #${hashtag.hashtag}, ${countLabel}`}
     >
-      #{hashtag.hashtag}
-      <span className="ml-2 text-xs opacity-70">{hashtag.video_count} videos</span>
-    </Badge>
+      <span className="min-w-0">
+        <span className={featured ? 'block truncate text-2xl font-bold' : 'block truncate text-lg font-semibold'}>
+          #{hashtag.hashtag}
+        </span>
+        <span className={featured ? 'mt-1 block text-sm text-background/75 dark:text-muted-foreground' : 'mt-1 block text-sm text-muted-foreground'}>
+          {countLabel}
+        </span>
+      </span>
+      <span
+        className={
+          featured
+            ? 'flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg bg-primary text-primary-foreground transition-transform group-hover:translate-x-1'
+            : 'flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-brand-light-green text-brand-dark-green transition-transform group-hover:translate-x-1'
+        }
+        aria-hidden="true"
+      >
+        <ArrowRight className={featured ? 'h-5 w-5' : 'h-4 w-4'} />
+      </span>
+    </button>
   );
 }
 


### PR DESCRIPTION
## Summary
- Query Funnelcake's hashtag endpoint with the user's search text instead of filtering only the top trending hashtags locally.
- Normalize hashtag search input so values like `#Twerking` search for `twerking`.
- Add regression coverage for server-side hashtag search behavior.

## Motivation
The production search page returned videos for `twerking`, but the Hashtags tab showed an empty state because the web app fetched only the top 100 trending hashtags and filtered that subset locally. Funnelcake already returns matching hashtag rows for `q=twerking`.

## Linked Issue
None.

## Manual Validation Plan
- [x] `curl -sS 'https://relay.divine.video/api/hashtags/trending?q=twerking&limit=5' | jq '.[0:3]'`
- [x] `npx tsc -p tsconfig.app.json --noEmit`
- [x] `npx eslint src/hooks/useSearchHashtags.ts src/hooks/useSearchHashtags.test.ts src/lib/funnelcakeClient.ts`
- [x] `npx vitest run src/hooks/useSearchHashtags.test.ts`
- [x] `npm test`
