### PR TITLE
fix(worker): re-implement feed-injection to read HTML from KV (#435)

### DIFF
--- a/compute-js/src/index.js
+++ b/compute-js/src/index.js
@@ -317,10 +317,14 @@ async function handleRequest(event) {
     const headers = new Headers(response.headers);
     headers.append('Vary', 'X-Original-Host');
 
-    // Inject feed data into HTML pages for faster LCP
+    // Inject feed data into the homepage / discovery HTML for faster LCP.
+    // The HTML is read directly from KV (readSpaIndexHtml): the body of the
+    // serveRequest response reads back empty in the worker, which previously
+    // blanked these pages (#435). On ANY failure we fall through to the untouched
+    // publisher response below, so injection can never blank the page.
     if (shouldInjectFeed && response.headers.get('Content-Type')?.includes('text/html')) {
       try {
-        let html = await response.text();
+        let html = await readSpaIndexHtml();
         const feedType = discoveryFeedType || 'trending';
         const feedData = await fetchFeedData(feedType, funnelcakeTarget);
         if (feedData) {
@@ -336,10 +340,18 @@ async function handleRequest(event) {
           }
           html = html.replace('</head>', injection + '</head>');
         }
-        return new Response(html, { status: response.status, headers });
+        // readSpaIndexHtml returns identity (uncompressed) HTML, but `headers` was
+        // copied from the publisher response and describes its (possibly br/gzip)
+        // body. Drop the body-specific headers so we don't mislabel the plain string.
+        const injectedHeaders = new Headers(headers);
+        injectedHeaders.delete('Content-Encoding');
+        injectedHeaders.delete('Content-Length');
+        injectedHeaders.delete('ETag');
+        injectedHeaders.set('Content-Type', 'text/html; charset=utf-8');
+        return new Response(html, { status: response.status, headers: injectedHeaders });
       } catch (err) {
         console.error('Feed injection error:', err.message);
-        // Fall through to serve unmodified response
+        // Fall through to serve the untouched publisher response (never blank).
       }
     }
 

--- a/compute-js/src/index.js
+++ b/compute-js/src/index.js
@@ -326,6 +326,8 @@ async function handleRequest(event) {
     if (shouldInjectFeed && response.status === 200 && response.headers.get('Content-Type')?.includes('text/html')) {
       try {
         let html = await readSpaIndexHtml();
+        // feedType is a closed, server-controlled enum (discoveryFeedType or 'trending'),
+        // so interpolating it unescaped into the inline script below is safe.
         const feedType = discoveryFeedType || 'trending';
         const feedData = await fetchFeedData(feedType, funnelcakeTarget);
         if (feedData) {
@@ -346,14 +348,16 @@ async function handleRequest(event) {
         // readSpaIndexHtml returns identity (uncompressed) HTML, but `headers` was
         // copied from the publisher response and describes its (possibly br/gzip)
         // body. Drop the body-specific headers so we don't mislabel the plain string.
-        // Cache-Control is intentionally inherited: the injected feed is the global
-        // "trending" snapshot (not per-user) and fetchFeedData already caches it ~60s,
-        // so brief edge caching of the injected page is fine.
         const injectedHeaders = new Headers(headers);
         injectedHeaders.delete('Content-Encoding');
         injectedHeaders.delete('Content-Length');
         injectedHeaders.delete('ETag');
         injectedHeaders.set('Content-Type', 'text/html; charset=utf-8');
+        // The injected page carries the dynamic trending feed, but the apex inherits
+        // no Cache-Control from the publisher (Fastly's long default edge TTL would
+        // pin a stale feed). Set an explicit short cache matching fetchFeedData's ~60s
+        // snapshot, applied uniformly to apex and discovery.
+        injectedHeaders.set('Cache-Control', 'public, max-age=60');
         return new Response(html, { status: response.status, headers: injectedHeaders });
       } catch (err) {
         console.error('Feed injection error:', err.message);

--- a/compute-js/src/index.js
+++ b/compute-js/src/index.js
@@ -322,13 +322,16 @@ async function handleRequest(event) {
     // serveRequest response reads back empty in the worker, which previously
     // blanked these pages (#435). On ANY failure we fall through to the untouched
     // publisher response below, so injection can never blank the page.
-    if (shouldInjectFeed && response.headers.get('Content-Type')?.includes('text/html')) {
+    // status === 200 so we only inject into the SPA index, never the 404 fallback.
+    if (shouldInjectFeed && response.status === 200 && response.headers.get('Content-Type')?.includes('text/html')) {
       try {
         let html = await readSpaIndexHtml();
         const feedType = discoveryFeedType || 'trending';
         const feedData = await fetchFeedData(feedType, funnelcakeTarget);
         if (feedData) {
-          let injection = `<script>window.__DIVINE_FEED__=${JSON.stringify(feedData)};window.__DIVINE_FEED_TYPE__="${feedType}";</script>`;
+          // Escape '<' in the JSON so a feed value containing '</script>' cannot break out of the inline script.
+          const feedJson = JSON.stringify(feedData).replace(/</g, '\\u003c');
+          let injection = `<script>window.__DIVINE_FEED__=${feedJson};window.__DIVINE_FEED_TYPE__="${feedType}";</script>`;
           const firstVideo = feedData.videos?.[0] || feedData[0];
           const firstVideoUrl = firstVideo?.video_url;
           const firstThumbnail = firstVideo?.thumbnail;
@@ -343,6 +346,9 @@ async function handleRequest(event) {
         // readSpaIndexHtml returns identity (uncompressed) HTML, but `headers` was
         // copied from the publisher response and describes its (possibly br/gzip)
         // body. Drop the body-specific headers so we don't mislabel the plain string.
+        // Cache-Control is intentionally inherited: the injected feed is the global
+        // "trending" snapshot (not per-user) and fetchFeedData already caches it ~60s,
+        // so brief edge caching of the injected page is fine.
         const injectedHeaders = new Headers(headers);
         injectedHeaders.delete('Content-Encoding');
         injectedHeaders.delete('Content-Length');

--- a/compute-js/src/index.js
+++ b/compute-js/src/index.js
@@ -21,6 +21,7 @@ import {
 } from './crawlerHandlers.js';
 import { transformVideoApiResponse } from './videoMetadata.js';
 import { renderEmbedPage } from './embedPage.js';
+import { readSpaIndexHtml } from './spaIndex.js';
 
 const publisherServer = PublisherServer.fromStaticPublishRc(rc);
 const DEFAULT_OG_IMAGE = 'https://divine.video/og.png';
@@ -837,36 +838,10 @@ async function handleSubdomainProfile(subdomain, url, request, originalHostname)
     }
   }
 
-  // Read index.html directly from KV store
-  // (PublisherServer.serveRequest returns empty body for synthetic requests)
+  // Read index.html directly from KV (see readSpaIndexHtml / #435).
   let html;
   try {
-    const contentStore = new KVStore('divine-web-content');
-
-    // Read the file index: publishId_index_collectionName
-    const indexEntry = await contentStore.get('default_index_live');
-    if (!indexEntry) {
-      throw new Error('Content index not found in KV');
-    }
-    const kvIndex = JSON.parse(await indexEntry.text());
-
-    // Find index.html in the index and get its content hash
-    const htmlAsset = kvIndex['/index.html'];
-    if (!htmlAsset) {
-      throw new Error('index.html not in content index');
-    }
-    // Asset format: { key: "sha256:<hash>", size, contentType, variants }
-    // KV content key format: default_files_sha256_<hash>
-    const assetKey = htmlAsset.key; // e.g. "sha256:abc123..."
-    const sha256 = assetKey.replace('sha256:', '');
-    const contentKey = `default_files_sha256_${sha256}`;
-    console.log('Reading index.html from KV, sha256:', sha256.slice(0, 16) + '...');
-    const contentEntry = await contentStore.get(contentKey);
-    if (!contentEntry) {
-      throw new Error(`Content not found: ${contentKey}`);
-    }
-    html = await contentEntry.text();
-    console.log('Got index.html from KV, length:', html.length);
+    html = await readSpaIndexHtml();
   } catch (err) {
     console.error('KV read error:', err.message);
     const profileUrl = `https://${apexDomain}/profile/${npub}`;

--- a/compute-js/src/spaIndex.js
+++ b/compute-js/src/spaIndex.js
@@ -1,0 +1,42 @@
+// ABOUTME: Reads the built index.html directly from the KV content store as an identity string.
+// ABOUTME: Needed because PublisherServer.serveRequest()'s response body reads back empty in-worker (#435).
+
+import { KVStore } from 'fastly:kv-store';
+
+const CONTENT_STORE = 'divine-web-content';
+
+/**
+ * Read the built index.html directly from the KV content store, as an identity
+ * (uncompressed) string.
+ *
+ * Any worker path that needs the page HTML as a mutable string must read the KV
+ * entry directly: the body of a `publisherServer.serveRequest()` response reads
+ * back empty via `.text()` in the worker runtime, which silently blanks pages
+ * that mutate the HTML (see #435). Throws if the index or content entry is
+ * missing so callers can decide how to degrade.
+ *
+ * @returns {Promise<string>} the full index.html
+ */
+export async function readSpaIndexHtml() {
+  const contentStore = new KVStore(CONTENT_STORE);
+
+  // File index written by compute-js-static-publish: publishId_index_collectionName.
+  const indexEntry = await contentStore.get('default_index_live');
+  if (!indexEntry) {
+    throw new Error('Content index not found in KV');
+  }
+  const kvIndex = JSON.parse(await indexEntry.text());
+
+  // Asset format: { key: "sha256:<hash>", ... }; content lives at default_files_sha256_<hash>.
+  const htmlAsset = kvIndex['/index.html'];
+  if (!htmlAsset) {
+    throw new Error('index.html not in content index');
+  }
+  const sha256 = htmlAsset.key.replace('sha256:', '');
+  const contentKey = `default_files_sha256_${sha256}`;
+  const contentEntry = await contentStore.get(contentKey);
+  if (!contentEntry) {
+    throw new Error(`Content not found: ${contentKey}`);
+  }
+  return await contentEntry.text();
+}

--- a/compute-js/src/spaIndex.js
+++ b/compute-js/src/spaIndex.js
@@ -12,8 +12,10 @@ const CONTENT_STORE = 'divine-web-content';
  * Any worker path that needs the page HTML as a mutable string must read the KV
  * entry directly: the body of a `publisherServer.serveRequest()` response reads
  * back empty via `.text()` in the worker runtime, which silently blanks pages
- * that mutate the HTML (see #435). Throws if the index or content entry is
- * missing so callers can decide how to degrade.
+ * that mutate the HTML (see #435). This is the same read that handleSubdomainProfile
+ * has used in production to dodge that gotcha; extracting it here makes the proven
+ * approach shared and tested rather than a one-off. Throws if the index or content
+ * entry is missing so callers can decide how to degrade.
  *
  * @returns {Promise<string>} the full index.html
  */

--- a/compute-js/src/spaIndex.js
+++ b/compute-js/src/spaIndex.js
@@ -38,5 +38,7 @@ export async function readSpaIndexHtml() {
   if (!contentEntry) {
     throw new Error(`Content not found: ${contentKey}`);
   }
-  return await contentEntry.text();
+  const html = await contentEntry.text();
+  console.log('Read index.html from KV, sha256:', sha256.slice(0, 16) + '...', 'length:', html.length);
+  return html;
 }

--- a/compute-js/src/spaIndex.test.ts
+++ b/compute-js/src/spaIndex.test.ts
@@ -1,0 +1,49 @@
+// ABOUTME: Vitest unit tests for readSpaIndexHtml (reads index.html directly from the KV content store)
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// Module-level store the mock factory closes over. Per crawlerHandlers.test.ts:
+// the factory must not reference a name 'KVStore' (vi.mock hoists above imports).
+const _kvStore = new Map<string, string>();
+
+vi.mock('fastly:kv-store', () => {
+  class MockKVStore {
+    constructor(_name: string) {}
+    async get(key: string): Promise<{ text(): Promise<string> } | null> {
+      const val = _kvStore.get(key);
+      if (val === undefined) return null;
+      return { text: async () => val };
+    }
+  }
+  return { KVStore: MockKVStore };
+});
+
+import { readSpaIndexHtml } from './spaIndex.js';
+
+const HASH = 'abc123def456';
+const HTML = '<!DOCTYPE html><html><head></head><body><div id="root"></div></body></html>';
+
+describe('readSpaIndexHtml', () => {
+  beforeEach(() => {
+    _kvStore.clear();
+  });
+
+  it('resolves index.html through the KV index pointer and returns its content', async () => {
+    _kvStore.set('default_index_live', JSON.stringify({ '/index.html': { key: `sha256:${HASH}` } }));
+    _kvStore.set(`default_files_sha256_${HASH}`, HTML);
+    await expect(readSpaIndexHtml()).resolves.toBe(HTML);
+  });
+
+  it('throws when the content index is missing', async () => {
+    await expect(readSpaIndexHtml()).rejects.toThrow('Content index not found in KV');
+  });
+
+  it('throws when index.html is not listed in the index', async () => {
+    _kvStore.set('default_index_live', JSON.stringify({ '/other.html': { key: 'sha256:x' } }));
+    await expect(readSpaIndexHtml()).rejects.toThrow('index.html not in content index');
+  });
+
+  it('throws when the content blob is missing', async () => {
+    _kvStore.set('default_index_live', JSON.stringify({ '/index.html': { key: `sha256:${HASH}` } }));
+    await expect(readSpaIndexHtml()).rejects.toThrow(`Content not found: default_files_sha256_${HASH}`);
+  });
+});


### PR DESCRIPTION
> [!WARNING]
> **Draft. Do not merge or deploy while divine-web is stable during VidCon.** Merging triggers a production deploy. Hold until the event is over and the freeze lifts, then verify on staging first.

Closes #435.

## What

The proper fix for the 2026-06-25 blank-homepage incident: re-enable the apex/discovery edge feed-injection, reading the page HTML directly from KV so it can never serve a blank.

## Commits

1. **refactor: extract index.html KV read into a tested `spaIndex` module** — pure refactor; pulls the KV read `handleSubdomainProfile` already did into a shared, unit-tested `readSpaIndexHtml()`.
2. **fix: inject feed by reading HTML from KV so the apex never blanks** — the fix.

## Why

`await response.text()` on the publisher's `serveRequest` response returns an empty string in the worker runtime, so the injection block re-emitted a blank page (verified in #435). Reading the HTML from KV directly returns the real HTML. The injected response is returned as identity with stale `Content-Encoding`/`Content-Length`/`ETag` stripped, and any failure falls through to the untouched publisher response, so injection can never blank the page.

## Relationship to the hotfix (#436)

This **supersedes** the emergency hotfix in #436 (which simply disabled injection). When this lands, close #436. If you would rather keep injection off than fix it, merge #436 instead.

## Verification

- **Unit:** `spaIndex.test.ts` (4 tests) covers the KV read; full worker suite green (87 tests); lint + worker build clean.
- **Local (Viceroy):** `/`, `/index.html`, `/discovery/<tab>` serve the full page across identity/gzip/br (were 0 bytes); degrade to the plain page when the feed backend is unavailable; `/terms` and other routes unaffected.
- **Not yet exercised:** feed JSON injection itself, because the local funnelcake backend is unreachable (feedData was null in the repro). Verify on staging with a reachable backend before deploy, per #435.

## #435 acceptance criteria

- [x] Apex/discovery serve full on fresh MISS across identity/gzip/br (local).
- [ ] Feed JSON actually injected (needs staging with reachable backend).
- [x] Feed-fetch failure degrades to the plain page, never blank (local).
- [ ] Multi-POP verification (post-deploy).
- [x] Reconcile committed state (this PR; supersedes disable-only #436).
