### PR TITLE
fix(deploy): prevent stale Fastly HTML cache

### DIFF
--- a/compute-js/src/index.js
+++ b/compute-js/src/index.js
@@ -12,6 +12,7 @@ import { handleAuthPersistCookie } from './authPersistCookie.js';
 import { isJsonWellKnownPath, shouldServeWellKnownBeforeWwwRedirect } from './wellKnownPaths.js';
 import { buildCrawlerHtml, escapeHtml, cleanText, truncateText } from './ogTags.js';
 import { hexToNpub, decodeNpubToHex } from './bech32.js';
+import { applyStaticResponseHeaders } from './staticResponseHeaders.js';
 import {
   handleAtUsernameOg,
   handleHashtagOgTags,
@@ -312,12 +313,11 @@ async function handleRequest(event) {
 
   const response = await publisherServer.serveRequest(request);
   if (response != null) {
-    // Add Vary: X-Original-Host so CDN doesn't mix subdomain and apex cached responses
-    const headers = new Headers(response.headers);
-    headers.append('Vary', 'X-Original-Host');
+    const isHtmlResponse = response.headers.get('Content-Type')?.includes('text/html') ?? false;
+    const headers = applyStaticResponseHeaders(response.headers, { isHtml: isHtmlResponse });
 
     // Inject feed data into HTML pages for faster LCP
-    if (shouldInjectFeed && response.headers.get('Content-Type')?.includes('text/html')) {
+    if (shouldInjectFeed && isHtmlResponse) {
       try {
         let html = await response.text();
         const feedType = discoveryFeedType || 'trending';

--- a/compute-js/src/staticResponseHeaders.js
+++ b/compute-js/src/staticResponseHeaders.js
@@ -1,0 +1,13 @@
+// ABOUTME: Header normalization for static content served through Fastly Compute.
+// ABOUTME: Keeps HTML fresh while preserving long-lived caching for hashed assets.
+
+export function applyStaticResponseHeaders(headers, { isHtml = false } = {}) {
+  const next = new Headers(headers);
+  next.append('Vary', 'X-Original-Host');
+
+  if (isHtml) {
+    next.set('Cache-Control', 'no-store');
+  }
+
+  return next;
+}

--- a/compute-js/src/staticResponseHeaders.test.js
+++ b/compute-js/src/staticResponseHeaders.test.js
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { applyStaticResponseHeaders } from './staticResponseHeaders.js';
+
+describe('applyStaticResponseHeaders', () => {
+  it('forces HTML responses to be revalidated from the Compute worker', () => {
+    const headers = applyStaticResponseHeaders(new Headers({
+      'Content-Type': 'text/html; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600',
+    }), { isHtml: true });
+
+    expect(headers.get('Cache-Control')).toBe('no-store');
+    expect(headers.get('Vary')).toContain('X-Original-Host');
+  });
+
+  it('preserves cache headers for hashed static assets', () => {
+    const headers = applyStaticResponseHeaders(new Headers({
+      'Content-Type': 'application/javascript',
+      'Cache-Control': 'public, max-age=31536000, immutable',
+    }), { isHtml: false });
+
+    expect(headers.get('Cache-Control')).toBe('public, max-age=31536000, immutable');
+    expect(headers.get('Vary')).toContain('X-Original-Host');
+  });
+});


### PR DESCRIPTION
## Summary

- Force Fastly Compute-served HTML responses to use `Cache-Control: no-store`.
- Preserve existing long-lived cache headers for hashed static assets.
- Add focused tests for the static response header behavior.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- Production deploys were publishing successfully, but live verification kept seeing a stale `index.html` that pointed at the previous entry bundle.
- The live-bundle verifier assumes HTML is fetched fresh from the Compute worker/KV; this change makes that cache policy explicit at the edge.

## Related Issue

- N/A

## Testing

- [x] `npm run test`
- [x] Manual verification completed: `npx vitest run compute-js/src/staticResponseHeaders.test.js scripts/verify-live-bundle.test.ts`
- [x] Manual verification completed: `npx vitest run compute-js/src`

## Visuals

- [ ] UI change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved