### PR TITLE
fix(deploy): prevent cached self redirects

### DIFF
--- a/compute-js/src/hostRedirect.js
+++ b/compute-js/src/hostRedirect.js
@@ -1,0 +1,28 @@
+// ABOUTME: Host redirect helpers for Fastly Compute request handling.
+// ABOUTME: Prevents cached self-redirects when forwarded host metadata differs from the URL.
+
+export function buildWwwRedirectResponse(url, hostnameToUse) {
+  if (!hostnameToUse.startsWith('www.')) {
+    return null;
+  }
+
+  const targetUrl = new URL(url);
+  targetUrl.hostname = hostnameToUse.slice(4);
+
+  if (targetUrl.toString() === url.toString()) {
+    return null;
+  }
+
+  return redirectNoStore(targetUrl.toString(), 301);
+}
+
+function redirectNoStore(location, status) {
+  return new Response(null, {
+    status,
+    headers: {
+      Location: location,
+      'Cache-Control': 'no-store',
+      Vary: 'X-Original-Host, X-Forwarded-Host',
+    },
+  });
+}

--- a/compute-js/src/hostRedirect.test.js
+++ b/compute-js/src/hostRedirect.test.js
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { buildWwwRedirectResponse } from './hostRedirect.js';
+
+describe('buildWwwRedirectResponse', () => {
+  it('redirects a real www request to the apex host without caching the redirect', () => {
+    const response = buildWwwRedirectResponse(new URL('https://www.divine.video/kids?x=1'), 'www.divine.video');
+
+    expect(response?.status).toBe(301);
+    expect(response?.headers.get('Location')).toBe('https://divine.video/kids?x=1');
+    expect(response?.headers.get('Cache-Control')).toBe('no-store');
+    expect(response?.headers.get('Vary')).toContain('X-Original-Host');
+    expect(response?.headers.get('Vary')).toContain('X-Forwarded-Host');
+  });
+
+  it('does not emit a self-redirect when forwarded host metadata already resolves to the current URL', () => {
+    const response = buildWwwRedirectResponse(new URL('https://divine.video/'), 'www.divine.video');
+
+    expect(response).toBeNull();
+  });
+
+  it('does not redirect non-www hosts', () => {
+    const response = buildWwwRedirectResponse(new URL('https://divine.video/'), 'divine.video');
+
+    expect(response).toBeNull();
+  });
+});

--- a/compute-js/src/index.js
+++ b/compute-js/src/index.js
@@ -12,6 +12,7 @@ import { handleAuthPersistCookie } from './authPersistCookie.js';
 import { isJsonWellKnownPath, shouldServeWellKnownBeforeWwwRedirect } from './wellKnownPaths.js';
 import { buildCrawlerHtml, escapeHtml, cleanText, truncateText } from './ogTags.js';
 import { hexToNpub, decodeNpubToHex } from './bech32.js';
+import { buildWwwRedirectResponse } from './hostRedirect.js';
 import { applyStaticResponseHeaders } from './staticResponseHeaders.js';
 import {
   handleAtUsernameOg,
@@ -64,10 +65,9 @@ async function handleRequest(event) {
   }
 
   // 1. Redirect www.* to apex domain (e.g., www.divine.video -> divine.video)
-  if (hostnameToUse.startsWith('www.')) {
-    const newUrl = new URL(url);
-    newUrl.hostname = hostnameToUse.slice(4); // remove 'www.'
-    return Response.redirect(newUrl.toString(), 301);
+  const wwwRedirect = buildWwwRedirectResponse(url, hostnameToUse);
+  if (wwwRedirect) {
+    return wwwRedirect;
   }
 
   // 2. Check if this is a subdomain request (e.g., alice.dvine.video)


### PR DESCRIPTION
## Summary

- Prevent www-to-apex redirect handling from emitting a same-URL 301 when forwarded host metadata differs from the request URL.
- Mark real host redirects as `Cache-Control: no-store` and vary them by forwarded/original host headers.
- Add focused tests for real redirects, self-redirect prevention, and non-www hosts.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- After the Fastly HTML cache fix, the live apex could return a cached 301 whose `Location` was the same URL, causing redirect loops and preventing reliable deploy verification.
- The production deploy needs the apex to serve the fresh built bundle instead of a stale bundle or self-redirect response.

## Related Issue

- N/A

## Testing

- [x] `npm run test`
- [x] Manual verification completed: `npx vitest run compute-js/src/hostRedirect.test.js compute-js/src/staticResponseHeaders.test.js scripts/verify-live-bundle.test.ts`
- [x] Manual verification completed: `npx vitest run compute-js/src`

## Visuals

- [ ] UI change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved