### PR TITLE
ci(deploy): retry Fastly worker publish

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,7 +95,21 @@ jobs:
         working-directory: compute-js
         env:
           FASTLY_API_TOKEN: ${{ secrets.FASTLY_API_TOKEN }}
-        run: fastly compute publish --non-interactive --token=$FASTLY_API_TOKEN
+        run: |
+          set -euo pipefail
+          for attempt in $(seq 1 5); do
+            if fastly compute publish --non-interactive --token="$FASTLY_API_TOKEN"; then
+              exit 0
+            fi
+
+            if [ "$attempt" -lt 5 ]; then
+              echo "Fastly compute publish failed on attempt $attempt/5; retrying in 45 seconds."
+              sleep 45
+            fi
+          done
+
+          echo "::error::Fastly compute publish failed after 5 attempts."
+          exit 1
 
       - name: Publish static content to KV Store
         working-directory: compute-js


### PR DESCRIPTION
## Summary

- Retry `fastly compute publish` up to five times before failing the production deploy.
- Keep static content publish, purge, and live verification gates unchanged.

## Motivation

- The worker package builds successfully, but Fastly returned repeated transient `503 Service Unavailable` responses at publish time.
- A bounded retry keeps temporary provider-side API failures from failing an otherwise valid production deploy immediately.

## Related Issue

- N/A

## Testing

- [x] Manual verification completed: YAML parse of `.github/workflows/deploy.yml`
- [x] Manual verification completed: deploy reruns confirmed the failure is Fastly API 503 after successful package build

## Visuals

- [ ] UI change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved