### PR TITLE
fix(deploy): preserve HTML when feed injection fails

### DIFF
--- a/compute-js/src/index.js
+++ b/compute-js/src/index.js
@@ -318,8 +318,9 @@ async function handleRequest(event) {
 
     // Inject feed data into HTML pages for faster LCP
     if (shouldInjectFeed && isHtmlResponse) {
+      let html;
       try {
-        let html = await response.text();
+        html = await response.text();
         const feedType = discoveryFeedType || 'trending';
         const feedData = await fetchFeedData(feedType, funnelcakeTarget);
         if (feedData) {
@@ -338,7 +339,9 @@ async function handleRequest(event) {
         return new Response(html, { status: response.status, headers });
       } catch (err) {
         console.error('Feed injection error:', err.message);
-        // Fall through to serve unmodified response
+        if (html !== undefined) {
+          return new Response(html, { status: response.status, headers });
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

- Preserve the already-read HTML fallback when edge feed injection fails.
- Avoid returning a drained response body for apex/discovery HTML pages.

## Motivation

- The latest Fastly deploy served `200 text/html` with an empty body at the apex.
- The feed-injection path can consume `response.text()`, hit an error fetching/injecting feed data, then fall through to return `response.body`, which has already been consumed.

## Related Issue

- N/A

## Testing

- [x] `npm run test`
- [x] Manual verification completed: `npx vitest run compute-js/src`

## Visuals

- [ ] UI change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved