### PR TITLE
fix(deploy): recover Fastly apex HTML from KV

### DIFF
--- a/compute-js/src/index.js
+++ b/compute-js/src/index.js
@@ -14,6 +14,7 @@ import { buildCrawlerHtml, escapeHtml, cleanText, truncateText } from './ogTags.
 import { hexToNpub, decodeNpubToHex } from './bech32.js';
 import { buildWwwRedirectResponse } from './hostRedirect.js';
 import { applyStaticResponseHeaders } from './staticResponseHeaders.js';
+import { hasViteEntryScript, readPublishedStaticFile } from './staticContent.js';
 import {
   handleAtUsernameOg,
   handleHashtagOgTags,
@@ -321,6 +322,10 @@ async function handleRequest(event) {
       let html;
       try {
         html = await response.text();
+        if (!html || !hasViteEntryScript(html)) {
+          console.error('Publisher returned unusable HTML for', url.pathname, 'length:', html?.length ?? 0);
+          html = await readIndexHtmlFromKv();
+        }
         const feedType = discoveryFeedType || 'trending';
         const feedData = await fetchFeedData(feedType, funnelcakeTarget);
         if (feedData) {
@@ -844,31 +849,9 @@ async function handleSubdomainProfile(subdomain, url, request, originalHostname)
   // (PublisherServer.serveRequest returns empty body for synthetic requests)
   let html;
   try {
-    const contentStore = new KVStore('divine-web-content');
-
-    // Read the file index: publishId_index_collectionName
-    const indexEntry = await contentStore.get('default_index_live');
-    if (!indexEntry) {
-      throw new Error('Content index not found in KV');
-    }
-    const kvIndex = JSON.parse(await indexEntry.text());
-
-    // Find index.html in the index and get its content hash
-    const htmlAsset = kvIndex['/index.html'];
-    if (!htmlAsset) {
-      throw new Error('index.html not in content index');
-    }
-    // Asset format: { key: "sha256:<hash>", size, contentType, variants }
-    // KV content key format: default_files_sha256_<hash>
-    const assetKey = htmlAsset.key; // e.g. "sha256:abc123..."
-    const sha256 = assetKey.replace('sha256:', '');
-    const contentKey = `default_files_sha256_${sha256}`;
+    const { body, sha256 } = await readPublishedStaticFile('/index.html');
     console.log('Reading index.html from KV, sha256:', sha256.slice(0, 16) + '...');
-    const contentEntry = await contentStore.get(contentKey);
-    if (!contentEntry) {
-      throw new Error(`Content not found: ${contentKey}`);
-    }
-    html = await contentEntry.text();
+    html = body;
     console.log('Got index.html from KV, length:', html.length);
   } catch (err) {
     console.error('KV read error:', err.message);
@@ -937,6 +920,12 @@ async function handleSubdomainProfile(subdomain, url, request, originalHostname)
       'X-Divine-Subdomain': subdomain, // Debug header to verify subdomain handling
     },
   });
+}
+
+async function readIndexHtmlFromKv() {
+  const { body, sha256 } = await readPublishedStaticFile('/index.html');
+  console.log('Got index.html from KV fallback, sha256:', sha256.slice(0, 16) + '...', 'length:', body.length);
+  return body;
 }
 
 /**

--- a/compute-js/src/staticContent.js
+++ b/compute-js/src/staticContent.js
@@ -1,0 +1,51 @@
+import { KVStore } from 'fastly:kv-store';
+
+const DEFAULT_CONTENT_STORE = 'divine-web-content';
+const DEFAULT_PUBLISH_ID = 'default';
+const DEFAULT_COLLECTION = 'live';
+
+function normalizeStaticPath(pathname) {
+  return pathname.startsWith('/') ? pathname : `/${pathname}`;
+}
+
+export function hasViteEntryScript(html) {
+  return /\/assets\/index-[^"']+\.js/.test(html);
+}
+
+export async function readPublishedStaticFile(pathname, options = {}) {
+  const {
+    store = new KVStore(DEFAULT_CONTENT_STORE),
+    publishId = DEFAULT_PUBLISH_ID,
+    collection = DEFAULT_COLLECTION,
+  } = options;
+
+  const normalizedPathname = normalizeStaticPath(pathname);
+  const indexEntry = await store.get(`${publishId}_index_${collection}`);
+  if (!indexEntry) {
+    throw new Error(`Content index not found: ${publishId}_index_${collection}`);
+  }
+
+  const kvIndex = JSON.parse(await indexEntry.text());
+  const asset = kvIndex[normalizedPathname];
+  if (!asset?.key) {
+    throw new Error(`${normalizedPathname} not in content index`);
+  }
+
+  const [algorithm, hash] = asset.key.split(':');
+  if (algorithm !== 'sha256' || !hash) {
+    throw new Error(`Unsupported content key for ${normalizedPathname}: ${asset.key}`);
+  }
+
+  const contentKey = `${publishId}_files_sha256_${hash}`;
+  const contentEntry = await store.get(contentKey);
+  if (!contentEntry) {
+    throw new Error(`Content not found: ${contentKey}`);
+  }
+
+  return {
+    body: await contentEntry.text(),
+    asset,
+    contentKey,
+    sha256: hash,
+  };
+}

--- a/compute-js/src/staticContent.test.js
+++ b/compute-js/src/staticContent.test.js
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { hasViteEntryScript, readPublishedStaticFile } from './staticContent.js';
+
+function createStore(entries) {
+  return {
+    async get(key) {
+      const value = entries.get(key);
+      return value == null ? null : { text: async () => value };
+    },
+  };
+}
+
+describe('hasViteEntryScript', () => {
+  it('detects the Vite index bundle in published HTML', () => {
+    expect(hasViteEntryScript('<script type="module" src="/assets/index-abc123.js"></script>')).toBe(true);
+  });
+
+  it('rejects empty or scriptless HTML', () => {
+    expect(hasViteEntryScript('')).toBe(false);
+    expect(hasViteEntryScript('<!doctype html><html></html>')).toBe(false);
+  });
+});
+
+describe('readPublishedStaticFile', () => {
+  it('reads a published static file through the static-publish KV index', async () => {
+    const entries = new Map([
+      ['default_index_live', JSON.stringify({
+        '/index.html': {
+          key: 'sha256:abc123',
+          size: 49,
+          contentType: 'text/html; charset=utf-8',
+        },
+      })],
+      ['default_files_sha256_abc123', '<script type="module" src="/assets/index-abc123.js">'],
+    ]);
+
+    const result = await readPublishedStaticFile('/index.html', { store: createStore(entries) });
+
+    expect(result.body).toContain('/assets/index-abc123.js');
+    expect(result.contentKey).toBe('default_files_sha256_abc123');
+    expect(result.sha256).toBe('abc123');
+  });
+
+  it('throws when the requested file is missing from the content index', async () => {
+    const entries = new Map([
+      ['default_index_live', JSON.stringify({})],
+    ]);
+
+    await expect(readPublishedStaticFile('/index.html', { store: createStore(entries) }))
+      .rejects.toThrow('/index.html not in content index');
+  });
+});


### PR DESCRIPTION
## Summary
- add a tested helper for reading the currently published static file from Fastly static-publish KV
- fall back to KV-backed index.html when the publisher returns empty/scriptless apex HTML
- reuse the helper for subdomain profile HTML reads

## Tests
- npx vitest run compute-js/src
- npm run test