### PR TITLE
docs(age-review): point under-13 Greenlight link to on-page section

### DIFF
--- a/src/pages/AgeReviewPage.tsx
+++ b/src/pages/AgeReviewPage.tsx
@@ -119,7 +119,7 @@ export function AgeReviewPage() {
               when you're 13 or older. If you're 13 to 15, you'll need to
               complete the{" "}
               <a
-                href="/kids#13-15"
+                href="https://divine.video/age-review#path-13-15"
                 className="text-brand-dark-green dark:text-brand-green underline underline-offset-2 hover:opacity-80"
               >
                 Divine Greenlight


### PR DESCRIPTION
## Summary
The "Divine Greenlight" link in the **"A note for anyone under 13 reading this"** card on the age-review page pointed to `/kids#13-15`. Point it to the Divine Greenlight section on the same page instead.

- Before: `href="/kids#13-15"`
- After: `href="https://divine.video/age-review#path-13-15"`

## Testing
Copy-only link change; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)