### PR TITLE
fix(worker): restore Content-Encoding strip and feed-JSON escape on injected HTML

### DIFF
--- a/compute-js/src/index.js
+++ b/compute-js/src/index.js
@@ -10,7 +10,7 @@ import rc from '../static-publish.rc.js';
 import { buildFunnelcakeUrl, getFunnelcakeOriginForApiHost } from './funnelcakeOrigin.js';
 import { handleAuthPersistCookie } from './authPersistCookie.js';
 import { isJsonWellKnownPath, shouldServeWellKnownBeforeWwwRedirect } from './wellKnownPaths.js';
-import { buildCrawlerHtml, escapeHtml, cleanText, truncateText } from './ogTags.js';
+import { buildCrawlerHtml, escapeHtml, escapeFeedJson, cleanText, truncateText } from './ogTags.js';
 import { hexToNpub, decodeNpubToHex } from './bech32.js';
 import { buildWwwRedirectResponse } from './hostRedirect.js';
 import { applyStaticResponseHeaders } from './staticResponseHeaders.js';
@@ -319,6 +319,10 @@ async function handleRequest(event) {
 
     // Inject feed data into HTML pages for faster LCP
     if (shouldInjectFeed && isHtmlResponse) {
+      // response.text() below decodes the body to an identity (plain) string, so the
+      // returned bytes are no longer brotli/gzip. Strip the compression-coupled headers
+      // (Content-Encoding/Content-Length/ETag) or the browser fails to decode -> #435.
+      const decodedHeaders = applyStaticResponseHeaders(response.headers, { isHtml: true, decoded: true });
       let html;
       try {
         html = await response.text();
@@ -329,7 +333,11 @@ async function handleRequest(event) {
         const feedType = discoveryFeedType || 'trending';
         const feedData = await fetchFeedData(feedType, funnelcakeTarget);
         if (feedData) {
-          let injection = `<script>window.__DIVINE_FEED__=${JSON.stringify(feedData)};window.__DIVINE_FEED_TYPE__="${feedType}";</script>`;
+          // feedData carries user-controlled strings (video titles etc), so escape it for
+          // safe <script> embedding. feedType is a fixed allowlist value
+          // (getDiscoveryFeedType), so it needs no escaping.
+          const feedJson = escapeFeedJson(feedData);
+          let injection = `<script>window.__DIVINE_FEED__=${feedJson};window.__DIVINE_FEED_TYPE__="${feedType}";</script>`;
           const firstVideo = feedData.videos?.[0] || feedData[0];
           const firstVideoUrl = firstVideo?.video_url;
           const firstThumbnail = firstVideo?.thumbnail;
@@ -341,11 +349,11 @@ async function handleRequest(event) {
           }
           html = html.replace('</head>', injection + '</head>');
         }
-        return new Response(html, { status: response.status, headers });
+        return new Response(html, { status: response.status, headers: decodedHeaders });
       } catch (err) {
         console.error('Feed injection error:', err.message);
         if (html !== undefined) {
-          return new Response(html, { status: response.status, headers });
+          return new Response(html, { status: response.status, headers: decodedHeaders });
         }
       }
     }

--- a/compute-js/src/ogTags.js
+++ b/compute-js/src/ogTags.js
@@ -11,6 +11,18 @@ export function escapeHtml(str) {
     .replace(/'/g, '&#039;');
 }
 
+// Serialize a value to JSON for safe embedding inside an inline <script> element.
+// JSON.stringify alone is unsafe here: it leaves `<` raw (so a string containing
+// `</script>` breaks out of the tag) and leaves the JS line terminators U+2028/U+2029
+// raw (valid in JSON, but they terminate a script's string literals). Escaping those
+// three keeps the embedded data inert while still parsing back to the original value.
+export function escapeFeedJson(value) {
+  return JSON.stringify(value)
+    .replace(/</g, "\\u003c")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+}
+
 export function cleanText(value) {
   return (value || '').replace(/\s+/g, ' ').trim();
 }

--- a/compute-js/src/ogTags.test.ts
+++ b/compute-js/src/ogTags.test.ts
@@ -1,6 +1,6 @@
-// ABOUTME: Vitest unit tests for buildCrawlerHtml, escapeHtml, and truncateText
+// ABOUTME: Vitest unit tests for buildCrawlerHtml, escapeHtml, escapeFeedJson, and truncateText
 import { describe, expect, it } from 'vitest';
-import { buildCrawlerHtml, escapeHtml, truncateText } from './ogTags.js';
+import { buildCrawlerHtml, escapeHtml, escapeFeedJson, truncateText } from './ogTags.js';
 
 const baseArgs = {
   title: 'Hello',
@@ -134,6 +134,38 @@ describe('escapeHtml', () => {
   });
   it('coerces non-string input safely', () => {
     expect(escapeHtml(42)).toBe('42');
+  });
+});
+
+describe('escapeFeedJson', () => {
+  // Built via fromCharCode so the literal line terminators never appear in this
+  // source file (they would break the test module the same way they break a <script>).
+  const LS = String.fromCharCode(0x2028);
+  const PS = String.fromCharCode(0x2029);
+
+  it('escapes < so a </script> payload cannot break out of the tag', () => {
+    const out = escapeFeedJson({ title: 'evil</script><script>alert(1)</script>' });
+    expect(out).not.toContain('</script>');
+    expect(out).not.toContain('<');
+    expect(out).toContain('\\u003c');
+  });
+
+  it('escapes the U+2028/U+2029 line terminators JSON.stringify leaves raw', () => {
+    const out = escapeFeedJson({ sep: `a${LS}b${PS}c` });
+    expect(out).not.toContain(LS);
+    expect(out).not.toContain(PS);
+    expect(out).toContain('\\u2028');
+    expect(out).toContain('\\u2029');
+  });
+
+  it('round-trips to the original value once embedded and evaluated', () => {
+    const value = { videos: [{ title: 'hi</script>', sep: `x${LS}y` }], n: 3 };
+    const evaluated = (0, eval)(`(${escapeFeedJson(value)})`);
+    expect(evaluated).toEqual(value);
+  });
+
+  it('leaves ordinary content untouched apart from the escapes', () => {
+    expect(escapeFeedJson({ a: 1, b: 'plain' })).toBe('{"a":1,"b":"plain"}');
   });
 });
 

--- a/compute-js/src/staticResponseHeaders.js
+++ b/compute-js/src/staticResponseHeaders.js
@@ -1,12 +1,24 @@
 // ABOUTME: Header normalization for static content served through Fastly Compute.
 // ABOUTME: Keeps HTML fresh while preserving long-lived caching for hashed assets.
 
-export function applyStaticResponseHeaders(headers, { isHtml = false } = {}) {
+export function applyStaticResponseHeaders(headers, { isHtml = false, decoded = false } = {}) {
   const next = new Headers(headers);
   next.append('Vary', 'X-Original-Host');
 
   if (isHtml) {
     next.set('Cache-Control', 'no-store');
+  }
+
+  // When the caller has read the body back as a string (e.g. response.text() to
+  // inject feed data), it is now identity-encoded plain text. The original headers
+  // were copied from the compressed publisher response, so they still advertise
+  // Content-Encoding: br/gzip plus a now-wrong Content-Length/ETag. Serving identity
+  // bytes under those headers makes the browser fail to decompress -> "Content
+  // Encoding Error". Drop the headers that are coupled to the original byte stream.
+  if (decoded) {
+    next.delete('Content-Encoding');
+    next.delete('Content-Length');
+    next.delete('ETag');
   }
 
   return next;

--- a/compute-js/src/staticResponseHeaders.test.js
+++ b/compute-js/src/staticResponseHeaders.test.js
@@ -21,4 +21,29 @@ describe('applyStaticResponseHeaders', () => {
     expect(headers.get('Cache-Control')).toBe('public, max-age=31536000, immutable');
     expect(headers.get('Vary')).toContain('X-Original-Host');
   });
+
+  it('strips compression-coupled headers when the body was decoded for rewriting', () => {
+    // Regression for #435: feed injection reads the body back as a plain string, so the
+    // returned bytes are identity-encoded and must not advertise the original br/gzip.
+    const headers = applyStaticResponseHeaders(new Headers({
+      'Content-Type': 'text/html; charset=utf-8',
+      'Content-Encoding': 'br',
+      'Content-Length': '18641',
+      'ETag': '"abc123"',
+    }), { isHtml: true, decoded: true });
+
+    expect(headers.get('Content-Encoding')).toBeNull();
+    expect(headers.get('Content-Length')).toBeNull();
+    expect(headers.get('ETag')).toBeNull();
+    expect(headers.get('Cache-Control')).toBe('no-store');
+  });
+
+  it('keeps Content-Encoding intact when the body is passed through untouched', () => {
+    const headers = applyStaticResponseHeaders(new Headers({
+      'Content-Type': 'text/html; charset=utf-8',
+      'Content-Encoding': 'br',
+    }), { isHtml: true });
+
+    expect(headers.get('Content-Encoding')).toBe('br');
+  });
 });


### PR DESCRIPTION
## What

The merged KV-read fix for the apex blank-page bug (#442, #443) recovered the homepage but dropped two safeguards the in-review hotfix (#438) carried. This restores both, layered on top of the merged scaffolding (`staticContent.js` / `readIndexHtmlFromKv`) rather than re-implementing it.

### 1. Content-Encoding mismatch, the live "Content Encoding Error"

The inject path reads the page body with `response.text()`, which decodes it to identity (plain) text, then returns it under the publisher's original `Content-Encoding: br/gzip` header. Browsers tried to brotli/gzip-decode plain text and failed. I added a `decoded` flag to `applyStaticResponseHeaders` that strips `Content-Encoding` / `Content-Length` / `ETag` on the rewritten response. Undecoded passthrough responses (hashed assets) keep their encoding.

### 2. Stored XSS via feed JSON (flagged HIGH by security review)

`JSON.stringify(feedData)` was interpolated straight into the inline `<script>`, so a video title containing a closing script tag could break out of the element. `escapeFeedJson()` unicode-escapes the angle bracket plus the U+2028/U+2029 line terminators that `JSON.stringify` leaves raw. `feedType` is a fixed allowlist value from `getDiscoveryFeedType`, so it is left as-is.

## Why this instead of the original #438

#438 and #436 re-implemented the same KV read that Liz already landed in #443. Rather than rebase a duplicate module on top, this keeps her `staticContent.js` and adds only the two missing safeguards, as a minimal surgical diff. I'll close #438 and #436 as superseded.

## Verification

- Unit: `applyStaticResponseHeaders` strips on decode and keeps encoding on passthrough; `escapeFeedJson` blocks the breakout, escapes the terminators, and round-trips. Full `compute-js` suite 98/98, build and eslint clean.
- End-to-end with `fastly compute serve` against the local KV store:
  - apex `/` with `Accept-Encoding: br` returns no `Content-Encoding` header and plain HTML (the exact live-broken case)
  - a hashed JS asset still returns `Content-Encoding: br` (passthrough intact)
  - a malicious feed title seeded into the KV cache is injected in escaped form, with no raw closing-script breakout

Refs #435
