### PR TITLE
perf: defer video prefetch until playback

### DIFF
--- a/src/components/VideoFeed.test.tsx
+++ b/src/components/VideoFeed.test.tsx
@@ -6,12 +6,20 @@ import type { ButtonHTMLAttributes, HTMLAttributes, ReactNode } from 'react';
 import { initializeI18n } from '@/lib/i18n';
 import { VideoFeed } from './VideoFeed';
 
-const { mockNavigate, mockUseVideoProvider, mockEnterFullscreen, mockSetVideosForFullscreen, mockUpdateVideos } = vi.hoisted(() => ({
+const {
+  mockNavigate,
+  mockUseVideoProvider,
+  mockEnterFullscreen,
+  mockSetVideosForFullscreen,
+  mockUpdateVideos,
+  mockUseVideoPrefetch,
+} = vi.hoisted(() => ({
   mockNavigate: vi.fn(),
   mockUseVideoProvider: vi.fn(),
   mockEnterFullscreen: vi.fn(),
   mockSetVideosForFullscreen: vi.fn(),
   mockUpdateVideos: vi.fn(),
+  mockUseVideoPrefetch: vi.fn(),
 }));
 
 vi.mock('@/hooks/useVideoProvider', () => ({
@@ -59,7 +67,7 @@ vi.mock('@/hooks/useVideoPlayback', () => ({
 }));
 
 vi.mock('@/hooks/useVideoPrefetch', () => ({
-  useVideoPrefetch: vi.fn(),
+  useVideoPrefetch: mockUseVideoPrefetch,
 }));
 
 vi.mock('@/lib/debug', () => ({
@@ -173,6 +181,20 @@ describe('VideoFeed', () => {
     expect(mockEnterFullscreen).toHaveBeenCalledWith(
       [expect.objectContaining({ id: 'video-1' })],
       0,
+    );
+  });
+
+  it('does not prefetch full video files before first playback', () => {
+    render(
+      <MemoryRouter initialEntries={['/popular']}>
+        <VideoFeed feedType="popular" />
+      </MemoryRouter>
+    );
+
+    expect(mockUseVideoPrefetch).toHaveBeenCalledWith(
+      null,
+      [expect.objectContaining({ id: 'video-1' })],
+      { prefetchVideos: false },
     );
   });
 });

--- a/src/components/VideoFeed.tsx
+++ b/src/components/VideoFeed.tsx
@@ -77,6 +77,7 @@ export function VideoFeed({
   const location = useLocation();
   const [showCommentsForVideo, setShowCommentsForVideo] = useState<string | null>(null);
   const [showListDialog, setShowListDialog] = useState<{ videoId: string; videoPubkey: string } | null>(null);
+  const [hasFirstPlayback, setHasFirstPlayback] = useState(false);
   const mountTimeRef = useRef<number | null>(null);
 
   const { checkContent } = useContentModeration();
@@ -205,9 +206,9 @@ export function VideoFeed({
   // Prefetch all authors in a single query
   useBatchedAuthors(authorPubkeys);
 
-  // Prefetch next 2-3 video URLs while current video plays
+  // Prefetch upcoming media after the first video is actually playing.
   const { activeVideoId } = useVideoPlayback();
-  useVideoPrefetch(activeVideoId, filteredVideos);
+  useVideoPrefetch(activeVideoId, filteredVideos, { prefetchVideos: hasFirstPlayback });
 
   // Auto-navigate to discovery if home feed is empty
   useEffect(() => {
@@ -296,6 +297,7 @@ export function VideoFeed({
   }, [filteredVideos, enterFullscreen]);
 
   const handlePlaybackStarted = useCallback((video: ParsedVideoData) => {
+    setHasFirstPlayback(true);
     trackFirstPlayback({
       renderedVideos: filteredVideos.length,
       totalVideos: allVideos.length,

--- a/src/hooks/useVideoPrefetch.test.ts
+++ b/src/hooks/useVideoPrefetch.test.ts
@@ -68,4 +68,24 @@ describe('useVideoPrefetch', () => {
     expect(prefetchHrefs).toContain('https://media.divine.video/public-video');
     expect(prefetchHrefs).toContain('https://media.divine.video/public-video.jpg');
   });
+
+  it('prefetches thumbnails but not video files when video prefetching is disabled', () => {
+    renderHook(() =>
+      useVideoPrefetch('video-1', [
+        makeVideo({ id: 'video-1' }),
+        makeVideo({
+          id: 'public-video',
+          ageRestricted: false,
+          videoUrl: 'https://media.divine.video/public-video',
+          thumbnailUrl: 'https://media.divine.video/public-video.jpg',
+        }),
+      ], { prefetchVideos: false }),
+    );
+
+    const prefetchHrefs = Array.from(document.head.querySelectorAll('link[rel="prefetch"]'))
+      .map((link) => (link as HTMLLinkElement).href);
+
+    expect(prefetchHrefs).not.toContain('https://media.divine.video/public-video');
+    expect(prefetchHrefs).toContain('https://media.divine.video/public-video.jpg');
+  });
 });

--- a/src/hooks/useVideoPrefetch.ts
+++ b/src/hooks/useVideoPrefetch.ts
@@ -7,6 +7,10 @@ import { debugLog } from '@/lib/debug';
 
 const PREFETCH_COUNT = 5;
 
+interface VideoPrefetchOptions {
+  prefetchVideos?: boolean;
+}
+
 function isProtectedDivineMediaUrl(url: string): boolean {
   try {
     return new URL(url).hostname === 'media.divine.video';
@@ -34,7 +38,8 @@ function preconnectToMediaDomains() {
  */
 export function useVideoPrefetch(
   activeVideoId: string | null,
-  videos: ParsedVideoData[]
+  videos: ParsedVideoData[],
+  { prefetchVideos = true }: VideoPrefetchOptions = {}
 ) {
   const prefetchLinksRef = useRef<HTMLLinkElement[]>([]);
 
@@ -72,7 +77,7 @@ export function useVideoPrefetch(
     for (const video of nextVideos) {
       const shouldSkipProtectedMediaPrefetch = !!video.ageRestricted;
 
-      if (video.videoUrl && !(shouldSkipProtectedMediaPrefetch && isProtectedDivineMediaUrl(video.videoUrl))) {
+      if (prefetchVideos && video.videoUrl && !(shouldSkipProtectedMediaPrefetch && isProtectedDivineMediaUrl(video.videoUrl))) {
         urlsToPrefetch.push({ url: video.videoUrl, as: 'video' });
       }
       if (video.thumbnailUrl && !(shouldSkipProtectedMediaPrefetch && isProtectedDivineMediaUrl(video.thumbnailUrl))) {
@@ -100,5 +105,5 @@ export function useVideoPrefetch(
     );
 
     return cleanup;
-  }, [activeVideoId, videos]);
+  }, [activeVideoId, prefetchVideos, videos]);
 }


### PR DESCRIPTION
## Summary

- Defer full-video prefetching until the feed has observed the first actual playback event.
- Keep media-domain preconnect and thumbnail prefetch behavior so upcoming cards can still paint quickly.
- Add regression coverage for the prefetch hook and feed wiring.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- The popular feed could start prefetching several upcoming full video files before the first active video reached playback.
- On constrained or slow media delivery, those prefetches can compete with the first video range requests and delay first frame startup.
- The feed already records first playback, so the prefetcher can wait for that signal before spending bandwidth on upcoming video files.

## Related Issue

- N/A

## Testing

- [x] `npm run test`
- [ ] Manual verification completed

## Visuals

- [ ] UI change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved
