### PR TITLE
fix(worker): configure local Fastly backends

### DIFF
--- a/compute-js/fastly.toml
+++ b/compute-js/fastly.toml
@@ -25,6 +25,15 @@ service_id = "WfOrPTFYmwwxRvqrfralLA"
       file = "./test-data/secrets.json"
       format = "json"
 
+  [local_server.backends]
+    [local_server.backends.funnelcake]
+      url = "https://relay.divine.video"
+      override_host = "relay.divine.video"
+
+    [local_server.backends.funnelcake_staging]
+      url = "https://relay.staging.divine.video"
+      override_host = "relay.staging.divine.video"
+
 [scripts]
   build = "npm run build"
 


### PR DESCRIPTION
## Summary

- Add Viceroy `[local_server.backends]` entries for `funnelcake` and `funnelcake_staging` so `fastly compute serve` can fetch the same relays the deployed worker uses.
- Leaves the existing `[[backends]]` (deploy) section untouched.

## Why

Viceroy reads local backends from `[local_server.backends]`, not from `[[backends]]`, so feed injection silently skipped relay fetches during local smoke tests. With both sections present, local runs match the deploy routing shape and surface real relay errors during development.

## Testing

- [x] `npm run test`
- [x] `fastly compute serve --skip-build` reports both local backends up
- [x] `curl http://127.0.0.1:7677/` returns HTML containing `window.__DIVINE_FEED__` and `window.__DIVINE_FEED_TYPE__="trending"`
