### PR TITLE
feat(minor-safety): protected-minor state on web (#452)

### DIFF
--- a/src/hooks/useProtectedMinorStatus.test.ts
+++ b/src/hooks/useProtectedMinorStatus.test.ts
@@ -50,7 +50,9 @@ describe('useProtectedMinorStatus', () => {
       wrapper: makeWrapper(),
     });
 
+    expect(result.current.state).toBe('not_protected');
     expect(result.current.isProtectedMinor).toBe(false);
+    expect(result.current.isKnown).toBe(true);
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
@@ -117,12 +119,14 @@ describe('useProtectedMinorStatus', () => {
 
     mockUseDivineSession.mockReturnValue({ session: { token: 'minor' } });
 
-    // First mount: the fetch fails, so the flag reads not-protected.
+    // First mount: the fetch fails, so the status is explicitly unknown.
     const failing = vi.fn().mockResolvedValue({ ok: false, status: 500 });
     vi.stubGlobal('fetch', failing);
-    const first = renderHook(() => useIsProtectedMinor(), { wrapper });
+    const first = renderHook(() => useProtectedMinorStatus(), { wrapper });
     await waitFor(() => expect(failing).toHaveBeenCalled());
-    expect(first.result.current).toBe(false);
+    expect(first.result.current.state).toBe('unknown');
+    expect(first.result.current.isProtectedMinor).toBe(false);
+    expect(first.result.current.isKnown).toBe(false);
     first.unmount();
 
     // Recovery: the fetch now succeeds; because staleTime is 0 the remount
@@ -135,35 +139,39 @@ describe('useProtectedMinorStatus', () => {
         json: async () => ({ verified_minor: true }),
       }),
     );
-    const second = renderHook(() => useIsProtectedMinor(), { wrapper });
-    await waitFor(() => expect(second.result.current).toBe(true));
+    const second = renderHook(() => useProtectedMinorStatus(), { wrapper });
+    await waitFor(() => expect(second.result.current.state).toBe('protected'));
+    expect(second.result.current.isProtectedMinor).toBe(true);
   });
 
-  it('stays not protected when the fetch fails for an authenticated session', async () => {
+  it('is unknown when the fetch fails for an authenticated session', async () => {
     mockUseDivineSession.mockReturnValue({ session: { token: 'tok' } });
     const fetchSpy = vi.fn().mockResolvedValue({ ok: false, status: 500 });
     vi.stubGlobal('fetch', fetchSpy);
 
-    const { result } = renderHook(() => useIsProtectedMinor(), {
+    const { result } = renderHook(() => useProtectedMinorStatus(), {
       wrapper: makeWrapper(),
     });
 
+    expect(result.current.state).toBe('unknown');
+    expect(result.current.isProtectedMinor).toBe(false);
+    expect(result.current.isKnown).toBe(false);
     await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
-    expect(result.current).toBe(false);
+    expect(result.current.state).toBe('unknown');
   });
 
   it('self-heals on window focus (refetchOnWindowFocus override)', async () => {
     focusManager.setFocused(true);
     mockUseDivineSession.mockReturnValue({ session: { token: 'minor' } });
 
-    // First load fails, so the flag reads not-protected (cached under the key).
+    // First load fails, so the explicit unknown state is cached under the key.
     const failing = vi.fn().mockResolvedValue({ ok: false, status: 500 });
     vi.stubGlobal('fetch', failing);
-    const { result } = renderHook(() => useIsProtectedMinor(), {
+    const { result } = renderHook(() => useProtectedMinorStatus(), {
       wrapper: makeWrapper(),
     });
     await waitFor(() => expect(failing).toHaveBeenCalled());
-    expect(result.current).toBe(false);
+    expect(result.current.state).toBe('unknown');
 
     // The fetch now succeeds. Regaining window focus must trigger a refetch —
     // which only happens because the hook sets refetchOnWindowFocus:true (the
@@ -179,6 +187,7 @@ describe('useProtectedMinorStatus', () => {
     focusManager.setFocused(false);
     focusManager.setFocused(true);
 
-    await waitFor(() => expect(result.current).toBe(true));
+    await waitFor(() => expect(result.current.state).toBe('protected'));
+    expect(result.current.isProtectedMinor).toBe(true);
   });
 });

--- a/src/hooks/useProtectedMinorStatus.test.ts
+++ b/src/hooks/useProtectedMinorStatus.test.ts
@@ -59,4 +59,42 @@ describe('useProtectedMinorStatus', () => {
 
     await waitFor(() => expect(result.current).toBe(true));
   });
+
+  it('refetches and updates when the session token changes (no cross-user leak)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url: string, opts?: RequestInit) => {
+        const auth = (opts?.headers as Record<string, string> | undefined)
+          ?.Authorization;
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ verified_minor: auth === 'Bearer minor' }),
+        };
+      }),
+    );
+
+    mockUseDivineSession.mockReturnValue({ session: { token: 'minor' } });
+    const { result, rerender } = renderHook(() => useIsProtectedMinor(), {
+      wrapper: makeWrapper(),
+    });
+    await waitFor(() => expect(result.current).toBe(true));
+
+    mockUseDivineSession.mockReturnValue({ session: { token: 'adult' } });
+    rerender();
+    await waitFor(() => expect(result.current).toBe(false));
+  });
+
+  it('stays not protected when the fetch fails for an authenticated session', async () => {
+    mockUseDivineSession.mockReturnValue({ session: { token: 'tok' } });
+    const fetchSpy = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const { result } = renderHook(() => useIsProtectedMinor(), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+    expect(result.current).toBe(false);
+  });
 });

--- a/src/hooks/useProtectedMinorStatus.test.ts
+++ b/src/hooks/useProtectedMinorStatus.test.ts
@@ -12,9 +12,19 @@ vi.mock('@/hooks/useDivineSession', () => ({
   useDivineSession: () => mockUseDivineSession(),
 }));
 
+// Mirror the app-global QueryClient defaults (src/App.tsx) so these tests only
+// pass BECAUSE the hook overrides staleTime/refetchOnWindowFocus. If the hook
+// dropped those overrides, the self-heal/refetch tests would fail here instead
+// of silently passing on React Query's permissive library defaults.
 function makeWrapper() {
   const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
+    defaultOptions: {
+      queries: {
+        staleTime: 60_000,
+        refetchOnWindowFocus: false,
+        retry: false,
+      },
+    },
   });
   return ({ children }: { children: ReactNode }) =>
     createElement(QueryClientProvider, { client: queryClient }, children);
@@ -95,11 +105,10 @@ describe('useProtectedMinorStatus', () => {
   });
 
   it('self-heals: a transient failure recovers on remount', async () => {
-    const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-    const wrapper = ({ children }: { children: ReactNode }) =>
-      createElement(QueryClientProvider, { client: queryClient }, children);
+    // One wrapper (one shared QueryClient) reused across mount/unmount/remount,
+    // using the app-global defaults — so recovery on remount can only happen
+    // because the hook overrides staleTime to 0.
+    const wrapper = makeWrapper();
 
     mockUseDivineSession.mockReturnValue({ session: { token: 'minor' } });
 

--- a/src/hooks/useProtectedMinorStatus.test.ts
+++ b/src/hooks/useProtectedMinorStatus.test.ts
@@ -1,0 +1,62 @@
+import { createElement, type ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  useIsProtectedMinor,
+  useProtectedMinorStatus,
+} from './useProtectedMinorStatus';
+
+const mockUseDivineSession = vi.fn();
+vi.mock('@/hooks/useDivineSession', () => ({
+  useDivineSession: () => mockUseDivineSession(),
+}));
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+describe('useProtectedMinorStatus', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('is not protected and does not fetch when signed out', () => {
+    mockUseDivineSession.mockReturnValue({ session: null });
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const { result } = renderHook(() => useProtectedMinorStatus(), {
+      wrapper: makeWrapper(),
+    });
+
+    expect(result.current.isProtectedMinor).toBe(false);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('is protected when an authenticated session reports verified_minor', async () => {
+    mockUseDivineSession.mockReturnValue({ session: { token: 'tok123' } });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          verified_minor: true,
+          verified_minor_at: '2026-06-30T12:00:00Z',
+        }),
+      }),
+    );
+
+    const { result } = renderHook(() => useIsProtectedMinor(), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current).toBe(true));
+  });
+});

--- a/src/hooks/useProtectedMinorStatus.test.ts
+++ b/src/hooks/useProtectedMinorStatus.test.ts
@@ -1,5 +1,9 @@
 import { createElement, type ReactNode } from 'react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  focusManager,
+  QueryClient,
+  QueryClientProvider,
+} from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
@@ -34,6 +38,7 @@ describe('useProtectedMinorStatus', () => {
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
+    focusManager.setFocused(undefined); // back to default focus tracking
   });
 
   it('is not protected and does not fetch when signed out', () => {
@@ -145,5 +150,35 @@ describe('useProtectedMinorStatus', () => {
 
     await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
     expect(result.current).toBe(false);
+  });
+
+  it('self-heals on window focus (refetchOnWindowFocus override)', async () => {
+    focusManager.setFocused(true);
+    mockUseDivineSession.mockReturnValue({ session: { token: 'minor' } });
+
+    // First load fails, so the flag reads not-protected (cached under the key).
+    const failing = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+    vi.stubGlobal('fetch', failing);
+    const { result } = renderHook(() => useIsProtectedMinor(), {
+      wrapper: makeWrapper(),
+    });
+    await waitFor(() => expect(failing).toHaveBeenCalled());
+    expect(result.current).toBe(false);
+
+    // The fetch now succeeds. Regaining window focus must trigger a refetch —
+    // which only happens because the hook sets refetchOnWindowFocus:true (the
+    // wrapper default, mirroring the app, is false). No remount here.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ verified_minor: true }),
+      }),
+    );
+    focusManager.setFocused(false);
+    focusManager.setFocused(true);
+
+    await waitFor(() => expect(result.current).toBe(true));
   });
 });

--- a/src/hooks/useProtectedMinorStatus.test.ts
+++ b/src/hooks/useProtectedMinorStatus.test.ts
@@ -60,29 +60,69 @@ describe('useProtectedMinorStatus', () => {
     await waitFor(() => expect(result.current).toBe(true));
   });
 
-  it('refetches and updates when the session token changes (no cross-user leak)', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async (_url: string, opts?: RequestInit) => {
-        const auth = (opts?.headers as Record<string, string> | undefined)
-          ?.Authorization;
-        return {
-          ok: true,
-          status: 200,
-          json: async () => ({ verified_minor: auth === 'Bearer minor' }),
-        };
-      }),
-    );
+  it('refetches with the new token on account switch (no cross-user leak)', async () => {
+    const fetchMock = vi.fn(async (_url: string, opts?: RequestInit) => {
+      const auth = (opts?.headers as Record<string, string> | undefined)
+        ?.Authorization;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ verified_minor: auth === 'Bearer minor' }),
+      };
+    });
+    vi.stubGlobal('fetch', fetchMock);
 
     mockUseDivineSession.mockReturnValue({ session: { token: 'minor' } });
     const { result, rerender } = renderHook(() => useIsProtectedMinor(), {
       wrapper: makeWrapper(),
     });
+    // Only true once the 'minor' fetch actually resolves (not a default).
     await waitFor(() => expect(result.current).toBe(true));
 
     mockUseDivineSession.mockReturnValue({ session: { token: 'adult' } });
     rerender();
+    // Prove the new token was fetched (refetch + isolation), not just the
+    // key-change transient, then that it resolves to not-protected.
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: 'Bearer adult' }),
+        }),
+      ),
+    );
     await waitFor(() => expect(result.current).toBe(false));
+  });
+
+  it('self-heals: a transient failure recovers on remount', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+
+    mockUseDivineSession.mockReturnValue({ session: { token: 'minor' } });
+
+    // First mount: the fetch fails, so the flag reads not-protected.
+    const failing = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+    vi.stubGlobal('fetch', failing);
+    const first = renderHook(() => useIsProtectedMinor(), { wrapper });
+    await waitFor(() => expect(failing).toHaveBeenCalled());
+    expect(first.result.current).toBe(false);
+    first.unmount();
+
+    // Recovery: the fetch now succeeds; because staleTime is 0 the remount
+    // refetches instead of serving the stale not-protected value.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ verified_minor: true }),
+      }),
+    );
+    const second = renderHook(() => useIsProtectedMinor(), { wrapper });
+    await waitFor(() => expect(second.result.current).toBe(true));
   });
 
   it('stays not protected when the fetch fails for an authenticated session', async () => {

--- a/src/hooks/useProtectedMinorStatus.ts
+++ b/src/hooks/useProtectedMinorStatus.ts
@@ -7,40 +7,41 @@ import {
   fetchProtectedMinorStatus,
   NOT_PROTECTED,
   type ProtectedMinorStatus,
+  UNKNOWN_PROTECTED_MINOR_STATUS,
 } from '@/lib/protectedMinor';
 
 /**
  * Non-blocking protected-minor state for the current session.
  *
- * Signed-out sessions and any fetch failure resolve to {@link NOT_PROTECTED}
- * (#452 is detection-only; web protections in #175/#176 set their own fail-safe
- * posture). Keyed on the session token, so it refetches when the account
- * changes; invalidate `['protected-minor']` if fresh state is needed mid-session
- * (e.g. right after an approval).
+ * Signed-out sessions resolve to {@link NOT_PROTECTED}; authenticated sessions
+ * with loading or failed checks resolve to {@link UNKNOWN_PROTECTED_MINOR_STATUS}
+ * so protections in #175/#176 can fail closed while this detection-only PR stays
+ * non-blocking. Keyed on the session token, so it refetches when the account
+ * changes; invalidate `['protected-minor']` if fresh state is needed mid-session.
  */
 export function useProtectedMinorStatus(): ProtectedMinorStatus {
   const { session } = useDivineSession();
   const token = session?.token ?? null;
 
-  // queryFn never throws, so a transient failure resolves to NOT_PROTECTED. Keep
-  // that self-healing rather than sticky: set staleTime 0 + refetch-on-focus
-  // explicitly here, overriding the app-global defaults (staleTime 60s,
-  // refetchOnWindowFocus false) which would otherwise pin a false-negative for
-  // the mounted lifetime. Protections (#175/#176) lean on this seam, so a stale
-  // "not protected" must recover on the next mount or focus.
+  // queryFn never throws, so a transient failure resolves to an explicit unknown
+  // state. Keep that self-healing rather than sticky: set staleTime 0 +
+  // refetch-on-focus explicitly here, overriding the app-global defaults
+  // (staleTime 60s, refetchOnWindowFocus false) which would otherwise pin a
+  // failed check for the mounted lifetime.
   const { data } = useQuery({
     queryKey: ['protected-minor', token],
     enabled: !!token,
     staleTime: 0,
     refetchOnWindowFocus: true,
     queryFn: ({ signal }) =>
-      fetchProtectedMinorStatus(token as string, fetch, signal),
+      fetchProtectedMinorStatus(token ?? '', fetch, signal),
   });
 
-  return data ?? NOT_PROTECTED;
+  if (!token) return NOT_PROTECTED;
+  return data ?? UNKNOWN_PROTECTED_MINOR_STATUS;
 }
 
-/** Convenience boolean seam for the web protections (#175/#176). */
+/** Convenience boolean for display-only callers; safety gates should inspect state. */
 export function useIsProtectedMinor(): boolean {
   return useProtectedMinorStatus().isProtectedMinor;
 }

--- a/src/hooks/useProtectedMinorStatus.ts
+++ b/src/hooks/useProtectedMinorStatus.ts
@@ -1,0 +1,37 @@
+// ABOUTME: React Query hook exposing the non-blocking protected-minor (13-15)
+// ABOUTME: state from keycast's verified_minor flag, for #175/#176 web parity.
+
+import { useQuery } from '@tanstack/react-query';
+import { useDivineSession } from '@/hooks/useDivineSession';
+import {
+  fetchProtectedMinorStatus,
+  NOT_PROTECTED,
+  type ProtectedMinorStatus,
+} from '@/lib/protectedMinor';
+
+/**
+ * Non-blocking protected-minor state for the current session.
+ *
+ * Signed-out sessions and any fetch failure resolve to {@link NOT_PROTECTED}
+ * (#452 is detection-only; web protections in #175/#176 set their own fail-safe
+ * posture). Keyed on the session token, so it refetches when the account
+ * changes; invalidate `['protected-minor']` if fresh state is needed mid-session
+ * (e.g. right after an approval).
+ */
+export function useProtectedMinorStatus(): ProtectedMinorStatus {
+  const { session } = useDivineSession();
+  const token = session?.token ?? null;
+
+  const { data } = useQuery({
+    queryKey: ['protected-minor', token],
+    enabled: !!token,
+    queryFn: () => fetchProtectedMinorStatus(token as string),
+  });
+
+  return data ?? NOT_PROTECTED;
+}
+
+/** Convenience boolean seam for the web protections (#175/#176). */
+export function useIsProtectedMinor(): boolean {
+  return useProtectedMinorStatus().isProtectedMinor;
+}

--- a/src/hooks/useProtectedMinorStatus.ts
+++ b/src/hooks/useProtectedMinorStatus.ts
@@ -22,14 +22,19 @@ export function useProtectedMinorStatus(): ProtectedMinorStatus {
   const { session } = useDivineSession();
   const token = session?.token ?? null;
 
-  // No staleTime on purpose: the flag changes ~never, but because queryFn never
-  // throws, a transient failure resolves to NOT_PROTECTED and self-heals on the
-  // next refetch/focus. A long staleTime would instead make that false-negative
-  // stick, so leave it at the default until refetch churn is an actual concern.
+  // queryFn never throws, so a transient failure resolves to NOT_PROTECTED. Keep
+  // that self-healing rather than sticky: set staleTime 0 + refetch-on-focus
+  // explicitly here, overriding the app-global defaults (staleTime 60s,
+  // refetchOnWindowFocus false) which would otherwise pin a false-negative for
+  // the mounted lifetime. Protections (#175/#176) lean on this seam, so a stale
+  // "not protected" must recover on the next mount or focus.
   const { data } = useQuery({
     queryKey: ['protected-minor', token],
     enabled: !!token,
-    queryFn: () => fetchProtectedMinorStatus(token as string),
+    staleTime: 0,
+    refetchOnWindowFocus: true,
+    queryFn: ({ signal }) =>
+      fetchProtectedMinorStatus(token as string, fetch, signal),
   });
 
   return data ?? NOT_PROTECTED;

--- a/src/hooks/useProtectedMinorStatus.ts
+++ b/src/hooks/useProtectedMinorStatus.ts
@@ -22,6 +22,10 @@ export function useProtectedMinorStatus(): ProtectedMinorStatus {
   const { session } = useDivineSession();
   const token = session?.token ?? null;
 
+  // No staleTime on purpose: the flag changes ~never, but because queryFn never
+  // throws, a transient failure resolves to NOT_PROTECTED and self-heals on the
+  // next refetch/focus. A long staleTime would instead make that false-negative
+  // stick, so leave it at the default until refetch churn is an actual concern.
   const { data } = useQuery({
     queryKey: ['protected-minor', token],
     enabled: !!token,

--- a/src/lib/protectedMinor.test.ts
+++ b/src/lib/protectedMinor.test.ts
@@ -23,7 +23,9 @@ describe('fetchProtectedMinorStatus', () => {
 
     const status = await fetchProtectedMinorStatus('tok123', fetchImpl);
 
+    expect(status.state).toBe('protected');
     expect(status.isProtectedMinor).toBe(true);
+    expect(status.isKnown).toBe(true);
     expect(status.verifiedMinorAt).toEqual(new Date('2026-06-30T12:00:00Z'));
     expect(fetchImpl).toHaveBeenCalledWith(
       ACCOUNT_URL,
@@ -38,7 +40,9 @@ describe('fetchProtectedMinorStatus', () => {
 
     const status = await fetchProtectedMinorStatus('', fetchSpy);
 
+    expect(status.state).toBe('not_protected');
     expect(status.isProtectedMinor).toBe(false);
+    expect(status.isKnown).toBe(true);
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
@@ -58,6 +62,7 @@ describe('fetchProtectedMinorStatus', () => {
     );
 
     expect(status.isProtectedMinor).toBe(false);
+    expect(status.state).toBe('not_protected');
     expect(status.verifiedMinorAt).toBeNull();
   });
 
@@ -80,22 +85,26 @@ describe('fetchProtectedMinorStatus', () => {
     expect(status.verifiedMinorAt).toBeNull();
   });
 
-  it('fails to not-protected on a non-ok response', async () => {
+  it('is unknown on a non-ok response', async () => {
     const status = await fetchProtectedMinorStatus(
       't',
       fetchReturning({}, false),
     );
 
+    expect(status.state).toBe('unknown');
     expect(status.isProtectedMinor).toBe(false);
+    expect(status.isKnown).toBe(false);
   });
 
-  it('fails to not-protected when fetch throws', async () => {
+  it('is unknown when fetch throws', async () => {
     const fetchImpl = vi
       .fn()
       .mockRejectedValue(new Error('network')) as unknown as typeof fetch;
 
     const status = await fetchProtectedMinorStatus('t', fetchImpl);
 
+    expect(status.state).toBe('unknown');
     expect(status.isProtectedMinor).toBe(false);
+    expect(status.isKnown).toBe(false);
   });
 });

--- a/src/lib/protectedMinor.test.ts
+++ b/src/lib/protectedMinor.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DIVINE_LOGIN_ORIGIN } from './divineLoginOrigin';
+import { fetchProtectedMinorStatus } from './protectedMinor';
+
+const ACCOUNT_URL = `${DIVINE_LOGIN_ORIGIN}/api/user/account`;
+
+function fetchReturning(body: unknown, ok = true): typeof fetch {
+  return vi.fn().mockResolvedValue({
+    ok,
+    status: ok ? 200 : 500,
+    json: async () => body,
+  }) as unknown as typeof fetch;
+}
+
+describe('fetchProtectedMinorStatus', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('is protected with a timestamp when verified_minor is true', async () => {
+    const fetchImpl = fetchReturning({
+      verified_minor: true,
+      verified_minor_at: '2026-06-30T12:00:00Z',
+    });
+
+    const status = await fetchProtectedMinorStatus('tok123', fetchImpl);
+
+    expect(status.isProtectedMinor).toBe(true);
+    expect(status.verifiedMinorAt).toEqual(new Date('2026-06-30T12:00:00Z'));
+    expect(fetchImpl).toHaveBeenCalledWith(
+      ACCOUNT_URL,
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer tok123' }),
+      }),
+    );
+  });
+
+  it('is not protected when verified_minor is false', async () => {
+    const status = await fetchProtectedMinorStatus(
+      't',
+      fetchReturning({ verified_minor: false }),
+    );
+
+    expect(status.isProtectedMinor).toBe(false);
+    expect(status.verifiedMinorAt).toBeNull();
+  });
+
+  it('is not protected when the flag is absent', async () => {
+    const status = await fetchProtectedMinorStatus(
+      't',
+      fetchReturning({ email: 'a@b.com' }),
+    );
+
+    expect(status.isProtectedMinor).toBe(false);
+  });
+
+  it('stays protected with a null timestamp on a bad date', async () => {
+    const status = await fetchProtectedMinorStatus(
+      't',
+      fetchReturning({ verified_minor: true, verified_minor_at: 'not-a-date' }),
+    );
+
+    expect(status.isProtectedMinor).toBe(true);
+    expect(status.verifiedMinorAt).toBeNull();
+  });
+
+  it('fails to not-protected on a non-ok response', async () => {
+    const status = await fetchProtectedMinorStatus(
+      't',
+      fetchReturning({}, false),
+    );
+
+    expect(status.isProtectedMinor).toBe(false);
+  });
+
+  it('fails to not-protected when fetch throws', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockRejectedValue(new Error('network')) as unknown as typeof fetch;
+
+    const status = await fetchProtectedMinorStatus('t', fetchImpl);
+
+    expect(status.isProtectedMinor).toBe(false);
+  });
+});

--- a/src/lib/protectedMinor.test.ts
+++ b/src/lib/protectedMinor.test.ts
@@ -33,6 +33,24 @@ describe('fetchProtectedMinorStatus', () => {
     );
   });
 
+  it('does not call fetch and is not protected for an empty token', async () => {
+    const fetchSpy = vi.fn() as unknown as typeof fetch;
+
+    const status = await fetchProtectedMinorStatus('', fetchSpy);
+
+    expect(status.isProtectedMinor).toBe(false);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('is not protected when verified_minor is truthy but not strictly true', async () => {
+    const status = await fetchProtectedMinorStatus(
+      't',
+      fetchReturning({ verified_minor: 'true' }),
+    );
+
+    expect(status.isProtectedMinor).toBe(false);
+  });
+
   it('is not protected when verified_minor is false', async () => {
     const status = await fetchProtectedMinorStatus(
       't',

--- a/src/lib/protectedMinor.ts
+++ b/src/lib/protectedMinor.ts
@@ -4,14 +4,25 @@
 import { DIVINE_LOGIN_ORIGIN } from './divineLoginOrigin';
 
 export interface ProtectedMinorStatus {
+  state: 'protected' | 'not_protected' | 'unknown';
   isProtectedMinor: boolean;
+  isKnown: boolean;
   verifiedMinorAt: Date | null;
 }
 
 // Frozen so this shared sentinel can't be mutated by a consumer and poisoned
 // for every other caller (it's returned by reference from the lib and hook).
 export const NOT_PROTECTED: ProtectedMinorStatus = Object.freeze({
+  state: 'not_protected',
   isProtectedMinor: false,
+  isKnown: true,
+  verifiedMinorAt: null,
+});
+
+export const UNKNOWN_PROTECTED_MINOR_STATUS: ProtectedMinorStatus = Object.freeze({
+  state: 'unknown',
+  isProtectedMinor: false,
+  isKnown: false,
   verifiedMinorAt: null,
 });
 
@@ -24,9 +35,10 @@ function parseVerifiedMinorAt(raw: unknown): Date | null {
 /**
  * Fetches the protected-minor state from keycast for the given session token.
  *
- * Reads `verified_minor` from `GET /api/user/account` (keycast#263). Any failure —
- * non-ok response, network error, or an empty (signed-out) token — resolves to
- * {@link NOT_PROTECTED}: #452 is detection-only, so it fails to not-protected.
+ * Reads `verified_minor` from `GET /api/user/account` (keycast#263). Empty
+ * tokens are confirmed signed-out/not-protected; network/API failures resolve
+ * to {@link UNKNOWN_PROTECTED_MINOR_STATUS} so safety gates can choose their own
+ * fail-safe posture.
  */
 export async function fetchProtectedMinorStatus(
   token: string,
@@ -39,7 +51,7 @@ export async function fetchProtectedMinorStatus(
       headers: { Authorization: `Bearer ${token}` },
       signal,
     });
-    if (!response.ok) return NOT_PROTECTED;
+    if (!response.ok) return UNKNOWN_PROTECTED_MINOR_STATUS;
 
     const body = (await response.json()) as {
       verified_minor?: unknown;
@@ -48,10 +60,12 @@ export async function fetchProtectedMinorStatus(
     if (body.verified_minor !== true) return NOT_PROTECTED;
 
     return {
+      state: 'protected',
       isProtectedMinor: true,
+      isKnown: true,
       verifiedMinorAt: parseVerifiedMinorAt(body.verified_minor_at),
     };
   } catch {
-    return NOT_PROTECTED;
+    return UNKNOWN_PROTECTED_MINOR_STATUS;
   }
 }

--- a/src/lib/protectedMinor.ts
+++ b/src/lib/protectedMinor.ts
@@ -8,10 +8,12 @@ export interface ProtectedMinorStatus {
   verifiedMinorAt: Date | null;
 }
 
-export const NOT_PROTECTED: ProtectedMinorStatus = {
+// Frozen so this shared sentinel can't be mutated by a consumer and poisoned
+// for every other caller (it's returned by reference from the lib and hook).
+export const NOT_PROTECTED: ProtectedMinorStatus = Object.freeze({
   isProtectedMinor: false,
   verifiedMinorAt: null,
-};
+});
 
 function parseVerifiedMinorAt(raw: unknown): Date | null {
   if (typeof raw !== 'string') return null;

--- a/src/lib/protectedMinor.ts
+++ b/src/lib/protectedMinor.ts
@@ -31,11 +31,13 @@ function parseVerifiedMinorAt(raw: unknown): Date | null {
 export async function fetchProtectedMinorStatus(
   token: string,
   fetchImpl: typeof fetch = fetch,
+  signal?: AbortSignal,
 ): Promise<ProtectedMinorStatus> {
   if (!token) return NOT_PROTECTED;
   try {
     const response = await fetchImpl(`${DIVINE_LOGIN_ORIGIN}/api/user/account`, {
       headers: { Authorization: `Bearer ${token}` },
+      signal,
     });
     if (!response.ok) return NOT_PROTECTED;
 

--- a/src/lib/protectedMinor.ts
+++ b/src/lib/protectedMinor.ts
@@ -1,5 +1,5 @@
-// ABOUTME: Reads the keycast verified_minor flag (GET /user/account) and maps it
-// ABOUTME: to a non-blocking protected-minor (13-15) state for web (#452 / #174).
+// ABOUTME: Reads the keycast verified_minor flag (GET /api/user/account) and maps
+// ABOUTME: it to a non-blocking protected-minor (13-15) state for web (#452 / #174).
 
 import { DIVINE_LOGIN_ORIGIN } from './divineLoginOrigin';
 
@@ -24,7 +24,7 @@ function parseVerifiedMinorAt(raw: unknown): Date | null {
 /**
  * Fetches the protected-minor state from keycast for the given session token.
  *
- * Reads `verified_minor` from `GET /user/account` (keycast#263). Any failure —
+ * Reads `verified_minor` from `GET /api/user/account` (keycast#263). Any failure —
  * non-ok response, network error, or an empty (signed-out) token — resolves to
  * {@link NOT_PROTECTED}: #452 is detection-only, so it fails to not-protected.
  */

--- a/src/lib/protectedMinor.ts
+++ b/src/lib/protectedMinor.ts
@@ -1,0 +1,53 @@
+// ABOUTME: Reads the keycast verified_minor flag (GET /user/account) and maps it
+// ABOUTME: to a non-blocking protected-minor (13-15) state for web (#452 / #174).
+
+import { DIVINE_LOGIN_ORIGIN } from './divineLoginOrigin';
+
+export interface ProtectedMinorStatus {
+  isProtectedMinor: boolean;
+  verifiedMinorAt: Date | null;
+}
+
+export const NOT_PROTECTED: ProtectedMinorStatus = {
+  isProtectedMinor: false,
+  verifiedMinorAt: null,
+};
+
+function parseVerifiedMinorAt(raw: unknown): Date | null {
+  if (typeof raw !== 'string') return null;
+  const date = new Date(raw);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+/**
+ * Fetches the protected-minor state from keycast for the given session token.
+ *
+ * Reads `verified_minor` from `GET /user/account` (keycast#263). Any failure —
+ * non-ok response, network error, or an empty (signed-out) token — resolves to
+ * {@link NOT_PROTECTED}: #452 is detection-only, so it fails to not-protected.
+ */
+export async function fetchProtectedMinorStatus(
+  token: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<ProtectedMinorStatus> {
+  if (!token) return NOT_PROTECTED;
+  try {
+    const response = await fetchImpl(`${DIVINE_LOGIN_ORIGIN}/api/user/account`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!response.ok) return NOT_PROTECTED;
+
+    const body = (await response.json()) as {
+      verified_minor?: unknown;
+      verified_minor_at?: unknown;
+    };
+    if (body.verified_minor !== true) return NOT_PROTECTED;
+
+    return {
+      isProtectedMinor: true,
+      verifiedMinorAt: parseVerifiedMinorAt(body.verified_minor_at),
+    };
+  } catch {
+    return NOT_PROTECTED;
+  }
+}


### PR DESCRIPTION
## What

Web parity for #174: detect an approved minor (13-15) via Keycast's `verified_minor` flag and expose a **non-blocking** protected-minor state for the web content-lock / DM protections (#175/#176 web parity) to consume.

Part of the protected-minor safeguards epic (raised by Liz; tracked privately in the T&S repo). Consumes the `divinevideo/keycast#263` `GET /user/account` contract. Closes #452.

**Scope is detection + state only** — no protections, no UI/gating changes.

## Design

- `src/lib/protectedMinor.ts` — `fetchProtectedMinorStatus(token)` reads `verified_minor` **directly from Keycast** (`GET /api/user/account`, `Authorization: Bearer <session JWT>`) and maps it to `ProtectedMinorStatus`.
- `ProtectedMinorStatus` now has an explicit `state: 'protected' | 'not_protected' | 'unknown'` plus `isKnown`, so upcoming safety gates can distinguish confirmed adult/signed-out state from loading or failed checks.
- Empty/signed-out tokens resolve to `NOT_PROTECTED` without fetching. Non-ok responses and network/parse failures resolve to `UNKNOWN_PROTECTED_MINOR_STATUS`, not a false adult signal.
- `src/hooks/useProtectedMinorStatus.ts` — React Query hook keyed on the **reactive session token** (`useDivineSession().session?.token`); authenticated initial load/failure returns `unknown`, account switches refetch by token, and signed-out remains `not_protected` with no fetch.
- `useIsProtectedMinor()` remains as a convenience boolean for display-only/simple callers. Safety gates should inspect `useProtectedMinorStatus().state` / `isKnown` and choose their own fail-safe posture.

Reads straight from Keycast per the epic decision (web has no kind-1985 subscription and gates adult content via Blossom auth-challenge — that's #175, untouched here).

### CORS

Keycast's `/user/account` runs under `auth_cors`, which allows `GET` + the `Authorization` header from allow-listed first-party origins. divine.video already does OAuth against Keycast, so a plain Bearer `fetch` works — no Keycast change, and no `credentials: 'include'`.

## Tests

14 focused tests (vitest), all green; full suite green locally:
- lib: `verified_minor` true / false / missing / bad-timestamp / truthy-but-not-`true`; non-ok and thrown fetch → `unknown`; empty token → `not_protected` **without** fetching; asserts URL + Bearer header.
- hook: signed-out → `not_protected` without fetching; authenticated initial failure → `unknown`; authenticated + flag → `protected`; account switch refetches by token; remount and window-focus self-heal from `unknown` to `protected`.

Local verification after the latest revision:
- `npx vitest run src/lib/protectedMinor.test.ts src/hooks/useProtectedMinorStatus.test.ts`
- `npx eslint src/lib/protectedMinor.ts src/hooks/useProtectedMinorStatus.ts src/lib/protectedMinor.test.ts src/hooks/useProtectedMinorStatus.test.ts`

## Reviewed

Ran a code-review pass and addressed the safety-seam finding: the hook no longer collapses loading/failure/unknown into a confirmed not-protected state. Tests now pin the tri-state contract and the existing self-heal behavior.

## Follow-ups

The web protections themselves (#175 / #176 web parity) consume `useProtectedMinorStatus()` and choose fail-closed behavior for `unknown` where appropriate.
