### PR TITLE
fix(auth): wait for NIP-07 extension injection before skipping logins

### DIFF
--- a/src/hooks/useCurrentUser.test.ts
+++ b/src/hooks/useCurrentUser.test.ts
@@ -1,6 +1,8 @@
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { NLoginType } from '@nostrify/react/login';
+
+import { NIP07_GRACE_MS, NIP07_POLL_INTERVAL_MS } from './useNip07Availability';
 
 const {
   mockGetValidToken,
@@ -203,24 +205,71 @@ describe('useCurrentUser', () => {
     expect(result.current.isResolvingJwt).toBe(true);
   });
 
-  it('skips extension logins when no browser extension is available', () => {
+  it('recovers an extension login when the provider injects shortly after mount', () => {
+    vi.useFakeTimers();
+    try {
+      mockLogins.push({
+        id: 'extension:pub123',
+        type: 'extension',
+        pubkey: 'pub123',
+        createdAt: '2026-03-10T00:00:00.000Z',
+        data: null,
+      });
+
+      const { result } = renderHook(() => useCurrentUser());
+
+      // Extension content script hasn't injected window.nostr yet.
+      expect(result.current.user).toBeUndefined();
+
+      setNostrProvider();
+      act(() => {
+        vi.advanceTimersByTime(NIP07_POLL_INTERVAL_MS);
+      });
+
+      expect(result.current.user?.pubkey).toBe('pub123');
+      expect(result.current.signer).toBeDefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('skips extension logins without a Sentry-visible warning when no extension appears', () => {
+    vi.useFakeTimers();
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    try {
+      mockLogins.push({
+        id: 'extension:pub123',
+        type: 'extension',
+        pubkey: 'pub123',
+        createdAt: '2026-03-10T00:00:00.000Z',
+        data: null,
+      });
 
-    mockLogins.push({
-      id: 'extension:pub123',
-      type: 'extension',
-      pubkey: 'pub123',
-      createdAt: '2026-03-10T00:00:00.000Z',
-      data: null,
-    });
+      const { result } = renderHook(() => useCurrentUser());
 
-    const { result } = renderHook(() => useCurrentUser());
+      // While the grace period runs, nothing is logged at all.
+      expect(result.current.user).toBeUndefined();
+      expect(warnSpy).not.toHaveBeenCalled();
+      expect(infoSpy).not.toHaveBeenCalled();
 
-    expect(result.current.user).toBeUndefined();
-    expect(result.current.users).toEqual([]);
-    expect(result.current.signer).toBeUndefined();
-    expect(mockUseAuthor).toHaveBeenCalledWith(undefined);
-    expect(warnSpy).toHaveBeenCalledWith('Skipped invalid login', 'extension:pub123', expect.any(Error));
+      act(() => {
+        vi.advanceTimersByTime(NIP07_GRACE_MS + NIP07_POLL_INTERVAL_MS);
+      });
+
+      expect(result.current.user).toBeUndefined();
+      expect(result.current.users).toEqual([]);
+      expect(result.current.signer).toBeUndefined();
+      // Sentry captures console.warn/error; a missing extension is an expected
+      // state and must stay at info level.
+      expect(warnSpy).not.toHaveBeenCalled();
+      expect(infoSpy).toHaveBeenCalledWith(
+        'Skipped extension login; no NIP-07 provider found',
+        'extension:pub123',
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('returns an extension user and signer when a browser extension is available', () => {

--- a/src/hooks/useCurrentUser.ts
+++ b/src/hooks/useCurrentUser.ts
@@ -8,6 +8,7 @@ import { selectCurrentUsers, isJwtResolving } from '@/lib/selectCurrentUsers';
 
 import { useAuthor } from './useAuthor.ts';
 import { useDivineSession } from './useDivineSession';
+import { useNip07Availability } from './useNip07Availability';
 
 type CurrentUser = {
   pubkey: string;
@@ -70,20 +71,35 @@ export function useCurrentUser() {
   const jwtError =
     !!jwtResolution && jwtResolution.token === token && 'error' in jwtResolution;
 
+  const hasExtensionLogin = logins.some((login) => login.type === 'extension');
+  const nip07Status = useNip07Availability(hasExtensionLogin);
+
   const manualUsers = useMemo(() => {
     const users: CurrentUser[] = [];
 
     for (const login of logins) {
+      // Extension content scripts can inject window.nostr after first render;
+      // hold off on extension logins until the availability check settles.
+      if (login.type === 'extension' && nip07Status === 'checking') {
+        continue;
+      }
+
       try {
         const user = loginToUser(login);
         users.push(user);
       } catch (error) {
-        console.warn('Skipped invalid login', login.id, error);
+        if (login.type === 'extension' && nip07Status === 'unavailable') {
+          // Expected when the extension was removed or disabled. Sentry
+          // captures console.warn, so keep this at info to avoid alert noise.
+          console.info('Skipped extension login; no NIP-07 provider found', login.id);
+        } else {
+          console.warn('Skipped invalid login', login.id, error);
+        }
       }
     }
 
     return users;
-  }, [logins, loginToUser]);
+  }, [logins, loginToUser, nip07Status]);
 
   const jwtUser = useMemo<CurrentUser | undefined>(() => {
     if (!jwtSigner || !jwtPubkey) {

--- a/src/hooks/useLoggedInAccounts.test.ts
+++ b/src/hooks/useLoggedInAccounts.test.ts
@@ -1,5 +1,8 @@
-import { renderHook } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { NLoginType } from '@nostrify/react/login';
+
+import { NIP07_POLL_INTERVAL_MS } from './useNip07Availability';
 
 type MockCurrentUserResult = {
   metadata?: { name?: string };
@@ -8,11 +11,13 @@ type MockCurrentUserResult = {
 
 const {
   mockGetValidToken,
+  mockLogins,
   mockRemoveLogin,
   mockSetLogin,
   mockUseCurrentUser,
 } = vi.hoisted(() => ({
   mockGetValidToken: vi.fn<() => string | null>(() => null),
+  mockLogins: [] as NLoginType[],
   mockRemoveLogin: vi.fn(),
   mockSetLogin: vi.fn(),
   mockUseCurrentUser: vi.fn<() => MockCurrentUserResult>(() => ({ user: undefined, metadata: undefined })),
@@ -26,13 +31,17 @@ vi.mock('@nostrify/react', () => ({
   }),
 }));
 
-vi.mock('@nostrify/react/login', () => ({
-  useNostrLogin: () => ({
-    logins: [],
-    removeLogin: mockRemoveLogin,
-    setLogin: mockSetLogin,
-  }),
-}));
+vi.mock('@nostrify/react/login', async () => {
+  const actual = await vi.importActual<typeof import('@nostrify/react/login')>('@nostrify/react/login');
+  return {
+    ...actual,
+    useNostrLogin: () => ({
+      logins: mockLogins,
+      removeLogin: mockRemoveLogin,
+      setLogin: mockSetLogin,
+    }),
+  };
+});
 
 vi.mock('@tanstack/react-query', async () => {
   const actual = await vi.importActual<typeof import('@tanstack/react-query')>('@tanstack/react-query');
@@ -54,14 +63,40 @@ vi.mock('./useDivineSession', () => ({
 
 import { useLoggedInAccounts } from './useLoggedInAccounts';
 
+const originalNostrDescriptor = Object.getOwnPropertyDescriptor(window, 'nostr');
+
+function resetNostrProvider() {
+  if (originalNostrDescriptor) {
+    Object.defineProperty(window, 'nostr', originalNostrDescriptor);
+    return;
+  }
+
+  delete (window as Window & { nostr?: unknown }).nostr;
+}
+
+function setNostrProvider(value: unknown = { getPublicKey: vi.fn() }) {
+  Object.defineProperty(window, 'nostr', {
+    value,
+    writable: true,
+    configurable: true,
+  });
+}
+
 describe('useLoggedInAccounts', () => {
   beforeEach(() => {
     mockGetValidToken.mockReset();
     mockGetValidToken.mockReturnValue(null);
+    mockLogins.length = 0;
     mockRemoveLogin.mockClear();
     mockSetLogin.mockClear();
     mockUseCurrentUser.mockReset();
     mockUseCurrentUser.mockReturnValue({ user: undefined, metadata: undefined });
+    resetNostrProvider();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    resetNostrProvider();
   });
 
   it('treats a JWT-backed web session as the current account', () => {
@@ -90,5 +125,29 @@ describe('useLoggedInAccounts', () => {
     expect(result.current.otherUsers).toEqual([]);
     expect(result.current.setLogin).toBe(mockSetLogin);
     expect(result.current.removeLogin).toBe(mockRemoveLogin);
+  });
+
+  it('recovers an extension account when the provider injects shortly after mount', () => {
+    vi.useFakeTimers();
+
+    mockLogins.push({
+      id: 'extension:pub123',
+      type: 'extension',
+      pubkey: 'pub123',
+      createdAt: '2026-03-10T00:00:00.000Z',
+      data: null,
+    });
+
+    const { result } = renderHook(() => useLoggedInAccounts());
+
+    // Extension content script hasn't injected window.nostr yet.
+    expect(result.current.currentUser).toBeUndefined();
+
+    setNostrProvider();
+    act(() => {
+      vi.advanceTimersByTime(NIP07_POLL_INTERVAL_MS);
+    });
+
+    expect(result.current.currentUser?.pubkey).toBe('pub123');
   });
 });

--- a/src/hooks/useLoggedInAccounts.ts
+++ b/src/hooks/useLoggedInAccounts.ts
@@ -6,6 +6,7 @@ import { NSchema as n, NostrEvent, NostrMetadata } from '@nostrify/nostrify';
 import { createUserFromLogin } from '@/lib/nostrLogin';
 import { useCurrentUser } from './useCurrentUser';
 import { useDivineSession } from './useDivineSession';
+import { useNip07Availability } from './useNip07Availability';
 
 export interface Account {
   id: string;
@@ -20,8 +21,16 @@ export function useLoggedInAccounts() {
   const { getValidToken } = useDivineSession();
   const { metadata, user } = useCurrentUser();
   const token = getValidToken();
+  const hasExtensionLogin = logins.some((login) => login.type === 'extension');
+  const nip07Status = useNip07Availability(hasExtensionLogin);
   const activeLogins = useMemo(
     () => logins.filter((login) => {
+      // Extension content scripts can inject window.nostr after first render;
+      // hold off on extension logins until the availability check settles.
+      if (login.type === 'extension' && nip07Status === 'checking') {
+        return false;
+      }
+
       try {
         createUserFromLogin(login, nostr);
         return true;
@@ -29,7 +38,7 @@ export function useLoggedInAccounts() {
         return false;
       }
     }),
-    [logins, nostr],
+    [logins, nostr, nip07Status],
   );
 
   const jwtCurrentUser = useMemo<Account | undefined>(() => {

--- a/src/hooks/useNip07Availability.test.ts
+++ b/src/hooks/useNip07Availability.test.ts
@@ -1,0 +1,104 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  NIP07_GRACE_MS,
+  NIP07_POLL_INTERVAL_MS,
+  useNip07Availability,
+} from './useNip07Availability';
+
+const originalNostrDescriptor = Object.getOwnPropertyDescriptor(window, 'nostr');
+
+function resetNostrProvider() {
+  if (originalNostrDescriptor) {
+    Object.defineProperty(window, 'nostr', originalNostrDescriptor);
+    return;
+  }
+
+  delete (window as Window & { nostr?: unknown }).nostr;
+}
+
+function setNostrProvider(value: unknown = { getPublicKey: vi.fn() }) {
+  Object.defineProperty(window, 'nostr', {
+    value,
+    writable: true,
+    configurable: true,
+  });
+}
+
+describe('useNip07Availability', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    resetNostrProvider();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    resetNostrProvider();
+  });
+
+  it('reports available immediately when the provider is already injected', () => {
+    setNostrProvider();
+
+    const { result } = renderHook(() => useNip07Availability(true));
+
+    expect(result.current).toBe('available');
+  });
+
+  it('reports checking, then available once the provider injects within the grace period', () => {
+    const { result } = renderHook(() => useNip07Availability(true));
+
+    expect(result.current).toBe('checking');
+
+    act(() => {
+      vi.advanceTimersByTime(NIP07_POLL_INTERVAL_MS * 3);
+    });
+    expect(result.current).toBe('checking');
+
+    setNostrProvider();
+    act(() => {
+      vi.advanceTimersByTime(NIP07_POLL_INTERVAL_MS);
+    });
+
+    expect(result.current).toBe('available');
+  });
+
+  it('reports unavailable once the grace period elapses without a provider', () => {
+    const { result } = renderHook(() => useNip07Availability(true));
+
+    act(() => {
+      vi.advanceTimersByTime(NIP07_GRACE_MS + NIP07_POLL_INTERVAL_MS);
+    });
+
+    expect(result.current).toBe('unavailable');
+  });
+
+  it('does not poll when no extension login needs the provider', () => {
+    const { result } = renderHook(() => useNip07Availability(false));
+
+    act(() => {
+      vi.advanceTimersByTime(NIP07_GRACE_MS + NIP07_POLL_INTERVAL_MS);
+    });
+
+    // Without a consumer there is nothing to wait for; the status stays
+    // "checking" and no timer flips it to a misleading terminal state.
+    expect(result.current).toBe('checking');
+  });
+
+  it('recovers a provider that injects even when polling started before it was needed', () => {
+    const { result, rerender } = renderHook(
+      ({ needed }: { needed: boolean }) => useNip07Availability(needed),
+      { initialProps: { needed: false } },
+    );
+
+    expect(result.current).toBe('checking');
+
+    setNostrProvider();
+    rerender({ needed: true });
+    act(() => {
+      vi.advanceTimersByTime(NIP07_POLL_INTERVAL_MS);
+    });
+
+    expect(result.current).toBe('available');
+  });
+});

--- a/src/hooks/useNip07Availability.ts
+++ b/src/hooks/useNip07Availability.ts
@@ -1,0 +1,52 @@
+import { useEffect, useState } from 'react';
+
+import { hasNip07Provider } from '@/lib/nostrLogin';
+
+/** How long to wait for a NIP-07 extension to inject `window.nostr` after mount. */
+export const NIP07_GRACE_MS = 2000;
+export const NIP07_POLL_INTERVAL_MS = 100;
+
+export type Nip07Status = 'checking' | 'available' | 'unavailable';
+
+/**
+ * Tracks whether a NIP-07 browser extension is usable. Extension content
+ * scripts can inject `window.nostr` after the app's first render, so a stored
+ * extension login must not be declared broken at mount — poll briefly and only
+ * settle on 'unavailable' once the grace period has elapsed.
+ *
+ * @param needed - true when a stored extension login is waiting on the
+ * provider; polling only runs while this is set.
+ */
+export function useNip07Availability(needed: boolean): Nip07Status {
+  const [status, setStatus] = useState<Nip07Status>(() =>
+    hasNip07Provider() ? 'available' : 'checking',
+  );
+
+  useEffect(() => {
+    if (!needed || status !== 'checking') {
+      return;
+    }
+
+    if (hasNip07Provider()) {
+      setStatus('available');
+      return;
+    }
+
+    let elapsed = 0;
+    const timer = setInterval(() => {
+      elapsed += NIP07_POLL_INTERVAL_MS;
+
+      if (hasNip07Provider()) {
+        setStatus('available');
+        clearInterval(timer);
+      } else if (elapsed >= NIP07_GRACE_MS) {
+        setStatus('unavailable');
+        clearInterval(timer);
+      }
+    }, NIP07_POLL_INTERVAL_MS);
+
+    return () => clearInterval(timer);
+  }, [needed, status]);
+
+  return status;
+}


### PR DESCRIPTION
## Problem

Sentry production alert `JAVASCRIPT-REACT-39` ("Error: Browser extension not available", `/discovery/classics`): users with a stored NIP-07 extension login can land on a page before the extension's content script injects `window.nostr`. `useCurrentUser` ran `createUserFromLogin` synchronously in a memo, the extension login threw, the user rendered **logged out with no recovery**, and the caught error's `console.warn` was forwarded to Sentry by `captureConsoleIntegration({ levels: ['error','warn'] })` — paging on an expected condition.

`useLoggedInAccounts` had the same race in its `activeLogins` filter.

## Fix

- New `useNip07Availability(needed)` hook: `'checking' → 'available' | 'unavailable'`. Polls `window.nostr` every 100ms for a 2s grace period, only while a stored extension login actually needs it.
- `useCurrentUser` / `useLoggedInAccounts`: extension logins are **held** (not failed) while status is `checking`, recover as soon as the provider appears, and are only skipped once the grace period settles on `unavailable`.
- The settled no-extension case (extension removed/disabled) now logs at `console.info`, which Sentry's console capture ignores — no more high-priority alerts for an expected state.

## Testing

- TDD: each behavior red → green (`useNip07Availability.test.ts` 5 tests, `useCurrentUser.test.ts` +2, `useLoggedInAccounts.test.ts` +1, fake-timer based).
- Full gate: `npm test` — tsc clean, eslint 0 errors, 1207 vitest tests pass, build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
