### PR TITLE
fix(worker): escape user-controlled profile JSON on subdomain pages

### DIFF
--- a/compute-js/src/index.js
+++ b/compute-js/src/index.js
@@ -10,7 +10,7 @@ import rc from '../static-publish.rc.js';
 import { buildFunnelcakeUrl, getFunnelcakeOriginForApiHost } from './funnelcakeOrigin.js';
 import { handleAuthPersistCookie } from './authPersistCookie.js';
 import { isJsonWellKnownPath, shouldServeWellKnownBeforeWwwRedirect } from './wellKnownPaths.js';
-import { buildCrawlerHtml, escapeHtml, escapeFeedJson, cleanText, truncateText } from './ogTags.js';
+import { buildCrawlerHtml, buildUserScript, escapeHtml, escapeFeedJson, cleanText, truncateText } from './ogTags.js';
 import { hexToNpub, decodeNpubToHex } from './bech32.js';
 import { buildWwwRedirectResponse } from './hostRedirect.js';
 import { applyStaticResponseHeaders } from './staticResponseHeaders.js';
@@ -897,7 +897,7 @@ async function handleSubdomainProfile(subdomain, url, request, originalHostname)
   };
 
   // Inject the user data as a global variable before the main script
-  const userScript = `<script>window.__DIVINE_USER__ = ${JSON.stringify(divineUser)};</script>`;
+  const userScript = buildUserScript(divineUser);
 
   // Update OG tags for the profile
   const ogTitle = divineUser.displayName + ' on Divine';

--- a/compute-js/src/ogTags.js
+++ b/compute-js/src/ogTags.js
@@ -23,6 +23,13 @@ export function escapeFeedJson(value) {
     .replace(/\u2029/g, "\\u2029");
 }
 
+// The injected profile object carries user-controlled Nostr fields (displayName,
+// about, picture, ...), so it must go through escapeFeedJson, never raw
+// JSON.stringify.
+export function buildUserScript(divineUser) {
+  return `<script>window.__DIVINE_USER__ = ${escapeFeedJson(divineUser)};</script>`;
+}
+
 export function cleanText(value) {
   return (value || '').replace(/\s+/g, ' ').trim();
 }

--- a/compute-js/src/ogTags.test.ts
+++ b/compute-js/src/ogTags.test.ts
@@ -1,6 +1,6 @@
 // ABOUTME: Vitest unit tests for buildCrawlerHtml, escapeHtml, escapeFeedJson, and truncateText
 import { describe, expect, it } from 'vitest';
-import { buildCrawlerHtml, escapeHtml, escapeFeedJson, truncateText } from './ogTags.js';
+import { buildCrawlerHtml, buildUserScript, escapeHtml, escapeFeedJson, truncateText } from './ogTags.js';
 
 const baseArgs = {
   title: 'Hello',
@@ -181,5 +181,28 @@ describe('truncateText', () => {
   });
   it('collapses whitespace before truncating', () => {
     expect(truncateText('hi   there', 80)).toBe('hi there');
+  });
+});
+
+describe('buildUserScript', () => {
+  it('escapes user-controlled profile fields so they cannot break out of the script tag', () => {
+    const script = buildUserScript({
+      displayName: 'Mallory',
+      about: '</script><script>alert(1)</script>',
+    });
+
+    // The one legitimate opening tag plus its closer; no injected tags in between.
+    expect(script.startsWith('<script>window.__DIVINE_USER__ = ')).toBe(true);
+    expect(script.endsWith(';</script>')).toBe(true);
+    expect(script.slice('<script>'.length, -'</script>'.length)).not.toContain('<');
+    expect(script).toContain('\\u003c');
+  });
+
+  it('round-trips the profile data through JSON.parse', () => {
+    const divineUser = { displayName: 'A</script>B', about: 'hi', followersCount: 3 };
+    const script = buildUserScript(divineUser);
+    const json = script.replace('<script>window.__DIVINE_USER__ = ', '').replace(';</script>', '');
+
+    expect(JSON.parse(json)).toEqual(divineUser);
   });
 });


### PR DESCRIPTION
## Problem (security)

The edge worker injects `window.__DIVINE_USER__ = ${JSON.stringify(divineUser)}` into subdomain profile HTML (`compute-js/src/index.js:900`). `divineUser` carries **user-controlled Nostr profile fields** (`displayName`, `about`, `picture`, `nip05`) — a profile `about` containing `</script><script>…` breaks out of the inline script element: **stored XSS on every edge-rendered profile page**.

#447 fixed the identical pattern for `window.__DIVINE_FEED__` via `escapeFeedJson`, but the profile path was left raw. This was surfaced during the review of #407, which is the wider audit-batch PR; this PR extracts just the still-open XSS fix, rebased on current main and reusing the existing escaper (per that review's guidance — no second escape helper).

## Change

- New `buildUserScript(divineUser)` in `ogTags.js` routing the profile object through the existing `escapeFeedJson` (escapes `<`, U+2028, U+2029; payload stays inert, data round-trips via `JSON.parse`).
- `index.js` uses it instead of raw `JSON.stringify`.

## Testing

- TDD: new tests failed red (`buildUserScript is not a function`), then green — script-breakout payload assertion + JSON round-trip.
- `vitest run compute-js/` 100/100; `tsc --noEmit` clean; eslint 0 errors (the 1 warning at `index.js:44` is pre-existing on main).

Related: #407 (remaining scope there is dep bumps only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
