### PR TITLE
fix(profiles): bound external-identities relay query with a timeout

### DIFF
--- a/src/hooks/useBadges.test.ts
+++ b/src/hooks/useBadges.test.ts
@@ -1,0 +1,69 @@
+// ABOUTME: Tests for profile badge hook relay timeout behavior
+// ABOUTME: Ensures badge lookups settle on abort instead of hiding profile surfaces behind errors
+
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useBadges } from './useBadges';
+
+const mockNostrQuery = vi.fn();
+
+vi.mock('@nostrify/react', () => ({
+  useNostr: () => ({
+    nostr: {
+      query: mockNostrQuery,
+    },
+  }),
+}));
+
+const TEST_PUBKEY = 'a'.repeat(64);
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+}
+
+describe('useBadges', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('settles with an empty list when the timed-out relay query throws on abort', async () => {
+    vi.useFakeTimers();
+
+    mockNostrQuery.mockImplementation(
+      (_filters: unknown, opts: { signal: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          opts.signal.addEventListener('abort', () => {
+            reject(new DOMException('The operation was aborted.', 'AbortError'));
+          });
+        }),
+    );
+
+    const { result } = renderHook(
+      () => useBadges(TEST_PUBKEY),
+      { wrapper: createWrapper() },
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(9000);
+    });
+    vi.useRealTimers();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([]);
+    expect(result.current.isError).toBe(false);
+  });
+});

--- a/src/hooks/useBadges.ts
+++ b/src/hooks/useBadges.ts
@@ -30,6 +30,13 @@ import {
  */
 const BADGES_QUERY_TIMEOUT_MS = 8000;
 
+function isAbortLikeError(error: unknown): boolean {
+  const name = typeof error === 'object' && error !== null && 'name' in error
+    ? String(error.name)
+    : '';
+  return name === 'AbortError' || name === 'TimeoutError';
+}
+
 export function useBadges(pubkey: string | undefined) {
   const { nostr } = useNostr();
 
@@ -48,10 +55,16 @@ export function useBadges(pubkey: string | undefined) {
         limit: 1,
       };
 
-      const profileBadgeEvents = await nostr.query(
-        [profileBadgeFilter],
-        { signal }
-      );
+      let profileBadgeEvents: NostrEvent[] = [];
+      try {
+        profileBadgeEvents = await nostr.query(
+          [profileBadgeFilter],
+          { signal }
+        );
+      } catch (error) {
+        if (!isAbortLikeError(error)) throw error;
+        return [];
+      }
 
       // Fallback: if no profile_badges event, show all awarded badges
       if (!profileBadgeEvents.length) {
@@ -61,7 +74,13 @@ export function useBadges(pubkey: string | undefined) {
           '#p': [pubkey],
           limit: 20,
         };
-        const awards = await nostr.query([awardFilter], { signal });
+        let awards: NostrEvent[] = [];
+        try {
+          awards = await nostr.query([awardFilter], { signal });
+        } catch (error) {
+          if (!isAbortLikeError(error)) throw error;
+          return [];
+        }
         if (!awards.length) return [];
 
         // For each award, extract the badge definition reference and fetch it

--- a/src/hooks/useBadges.ts
+++ b/src/hooks/useBadges.ts
@@ -23,13 +23,22 @@ import {
  * 3. Validate the chain: definition → award → user
  * 4. Return only validated badges in display order
  */
+/**
+ * Shared time budget for the whole badge fan-out (kinds 30008/30009 are
+ * addressable, so NPool waits for every relay to EOSE — one hung relay would
+ * otherwise block the query forever; same failure mode as issue #415).
+ */
+const BADGES_QUERY_TIMEOUT_MS = 8000;
+
 export function useBadges(pubkey: string | undefined) {
   const { nostr } = useNostr();
 
   return useQuery<ValidatedBadge[]>({
     queryKey: ['badges', pubkey ?? ''],
-    queryFn: async ({ signal }) => {
+    queryFn: async ({ signal: querySignal }) => {
       if (!pubkey || !nostr) return [];
+
+      const signal = AbortSignal.any([querySignal, AbortSignal.timeout(BADGES_QUERY_TIMEOUT_MS)]);
 
       // Step 1: Fetch profile badges (kind 30008)
       const profileBadgeFilter: NostrFilter = {

--- a/src/hooks/useExternalIdentities.test.ts
+++ b/src/hooks/useExternalIdentities.test.ts
@@ -1,8 +1,8 @@
 // ABOUTME: Tests for NIP-39 external identity parsing and verification
 // ABOUTME: Tests parseIdentityTag, verifyIdentityClaim, and useExternalIdentities hook
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 
@@ -515,6 +515,10 @@ describe('useExternalIdentities', () => {
     vi.resetAllMocks();
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('returns empty array when no events found', async () => {
     mockNostrQuery.mockResolvedValueOnce([]);
 
@@ -617,6 +621,72 @@ describe('useExternalIdentities', () => {
     );
 
     expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('is bounded: resolves with the events NPool returns on abort when a relay hangs forever (issue #415)', async () => {
+    vi.useFakeTimers();
+
+    // Simulate NPool.query against a fan-out where one relay never opens or
+    // closes: the promise only settles (with partial results) once the
+    // caller-provided signal aborts. Without a timeout signal, it hangs forever.
+    mockNostrQuery.mockImplementation(
+      (_filters: unknown, opts: { signal: AbortSignal }) =>
+        new Promise((resolve) => {
+          opts.signal.addEventListener('abort', () => {
+            resolve([{
+              kind: 10011,
+              pubkey: TEST_PUBKEY,
+              created_at: 1700000000,
+              tags: [['i', 'github:semisol', '9721ce4ee4fceb3c7b532b0c']],
+              content: '',
+              id: 'abc',
+              sig: 'def',
+            }]);
+          });
+        }),
+    );
+
+    const { result } = renderHook(
+      () => useExternalIdentities(TEST_PUBKEY),
+      { wrapper: createWrapper() },
+    );
+
+    // Advance well past any reasonable timeout; the query must settle.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+    vi.useRealTimers();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data![0].identity).toBe('semisol');
+  });
+
+  it('settles with an empty result (not an error) if the aborted query throws', async () => {
+    vi.useFakeTimers();
+
+    mockNostrQuery.mockImplementation(
+      (_filters: unknown, opts: { signal: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          opts.signal.addEventListener('abort', () => {
+            reject(new DOMException('The operation was aborted.', 'AbortError'));
+          });
+        }),
+    );
+
+    const { result } = renderHook(
+      () => useExternalIdentities(TEST_PUBKEY),
+      { wrapper: createWrapper() },
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+    vi.useRealTimers();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([]);
+    expect(result.current.isError).toBe(false);
   });
 
   it('queries kind 10011 with correct filters', async () => {

--- a/src/hooks/useExternalIdentities.test.ts
+++ b/src/hooks/useExternalIdentities.test.ts
@@ -689,6 +689,17 @@ describe('useExternalIdentities', () => {
     expect(result.current.isError).toBe(false);
   });
 
+  it('surfaces non-abort relay query failures', async () => {
+    mockNostrQuery.mockRejectedValueOnce(new Error('relay exploded'));
+
+    const { result } = renderHook(
+      () => useExternalIdentities(TEST_PUBKEY),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+
   it('queries kind 10011 with correct filters', async () => {
     mockNostrQuery.mockResolvedValueOnce([]);
 

--- a/src/hooks/useExternalIdentities.ts
+++ b/src/hooks/useExternalIdentities.ts
@@ -3,6 +3,7 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { useNostr } from '@nostrify/react';
+import type { NostrEvent } from '@nostrify/nostrify';
 import { nip19 } from 'nostr-tools';
 import { getCachedVerification, setCachedVerification } from '@/lib/verificationCache';
 import { API_CONFIG, getFeatureFlag } from '@/config/api';
@@ -167,6 +168,14 @@ export function parseIdentityTag(tag: string[]): ExternalIdentity | null {
   };
 }
 
+/**
+ * How long to wait for the kind:10011 relay fan-out before settling with
+ * whatever arrived. Kind 10011 is replaceable, so NPool.query waits for every
+ * routed relay to EOSE — a single unreachable relay (hung WebSocket that never
+ * opens or closes) would otherwise block the query forever. See issue #415.
+ */
+const IDENTITIES_QUERY_TIMEOUT_MS = 5000;
+
 export function useExternalIdentities(pubkey: string | undefined) {
   const { nostr } = useNostr();
 
@@ -175,10 +184,19 @@ export function useExternalIdentities(pubkey: string | undefined) {
     queryFn: async ({ signal }) => {
       if (!pubkey || !nostr) return [];
 
-      const events = await nostr.query(
-        [{ kinds: [10011], authors: [pubkey], limit: 1 }],
-        { signal },
-      );
+      let events: NostrEvent[] = [];
+      try {
+        events = await nostr.query(
+          [{ kinds: [10011], authors: [pubkey], limit: 1 }],
+          { signal: AbortSignal.any([signal, AbortSignal.timeout(IDENTITIES_QUERY_TIMEOUT_MS)]) },
+        );
+      } catch {
+        // NPool.query returns partial results when the signal aborts, but
+        // other NRelay implementations may throw. Settle with no identities
+        // rather than an error state that would retry-loop and suppress
+        // badges anyway.
+        events = [];
+      }
 
       if (events.length === 0) return [];
 

--- a/src/hooks/useExternalIdentities.ts
+++ b/src/hooks/useExternalIdentities.ts
@@ -176,6 +176,13 @@ export function parseIdentityTag(tag: string[]): ExternalIdentity | null {
  */
 const IDENTITIES_QUERY_TIMEOUT_MS = 5000;
 
+function isAbortLikeError(error: unknown): boolean {
+  const name = typeof error === 'object' && error !== null && 'name' in error
+    ? String(error.name)
+    : '';
+  return name === 'AbortError' || name === 'TimeoutError';
+}
+
 export function useExternalIdentities(pubkey: string | undefined) {
   const { nostr } = useNostr();
 
@@ -190,11 +197,11 @@ export function useExternalIdentities(pubkey: string | undefined) {
           [{ kinds: [10011], authors: [pubkey], limit: 1 }],
           { signal: AbortSignal.any([signal, AbortSignal.timeout(IDENTITIES_QUERY_TIMEOUT_MS)]) },
         );
-      } catch {
+      } catch (error) {
         // NPool.query returns partial results when the signal aborts, but
         // other NRelay implementations may throw. Settle with no identities
-        // rather than an error state that would retry-loop and suppress
-        // badges anyway.
+        // rather than an error state that would retry-loop.
+        if (!isAbortLikeError(error)) throw error;
         events = [];
       }
 


### PR DESCRIPTION
Fixes #415

## Problem

`useExternalIdentities` queried kind:10011 (NIP-39 external identities) across the PROFILE_RELAYS fan-out with only React Query's lifecycle signal. Kind 10011 is replaceable, so `NPool.query` waits for **every** routed relay to EOSE before resolving. One unreachable relay (a hung WebSocket that never opens or closes — e.g. `wss://relay.ditto.pub` in the report) left the query in `fetching` forever, so linked-account badges never rendered even though the reachable relays had the event.

## Fix

- `src/hooks/useExternalIdentities.ts`: combine the React Query signal with `AbortSignal.timeout(5000)` (`AbortSignal.any`), matching the pattern used by `useLoggedInAccounts`, `useAuthor`, etc. `NPool.query` returns partial results on abort, so the hook now resolves with whatever the reachable subset returned within 5s.
- A `try/catch` settles the query with an empty identity list if a non-NPool `NRelay` implementation throws on abort, so the query can't fall into an error/retry loop that suppresses badges anyway.
- `src/hooks/useBadges.ts`: applied the same bound (8s shared budget for its sequential fan-out) — it's the other always-on profile-surface hook (`ProfileHeader`) with the identical unbounded pattern on addressable kinds 30008/30009.

## Other unbounded queries noted (not fixed here)

These share the pattern but are not always-on profile surfaces, and bounding them is less trivial (multi-step flows / different UX expectations): `useBatchedVideoInteractions`, `useVideoEvents` (several sites), `useVideoLists`, `useInfiniteSearchVideos` (some sites), `useProfileStats` WebSocket fallbacks (lines 107–142). Happy to follow up separately.

## Testing

TDD — the two new tests in `src/hooks/useExternalIdentities.test.ts` failed against the old code (query never settles when the mocked `nostr.query` only resolves/rejects on abort), then passed after the fix:

- mocks an `nostr.query` that never settles until its signal aborts (NPool partial-result behavior), advances fake timers 10s, asserts the hook reaches `isSuccess` with the parsed identity
- mocks an abort that **throws** and asserts the hook settles `isSuccess` with `[]`, not `isError`

Verification: `npx tsc --noEmit` clean, `npx eslint` clean on changed files, full `npx vitest run` — 1209 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)