### PR TITLE
fix(ui): make video thumbnails real links for native browser behavior

### DIFF
--- a/src/components/ThumbnailPlayer.test.tsx
+++ b/src/components/ThumbnailPlayer.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ThumbnailPlayer } from './ThumbnailPlayer';
 
@@ -119,5 +120,58 @@ describe('ThumbnailPlayer', () => {
       'src',
       'blob:protected-thumb'
     );
+  });
+
+  it('renders a real link to the video page when linkTo is provided', () => {
+    render(
+      <MemoryRouter>
+        <ThumbnailPlayer
+          videoId="video-123"
+          src="https://example.com/video.mp4"
+          thumbnailUrl="https://example.com/thumb.jpg"
+          linkTo="/video/video-123"
+        />
+      </MemoryRouter>
+    );
+
+    const link = screen.getByRole('link', { name: 'Open video' });
+    expect(link).toHaveAttribute('href', '/video/video-123');
+  });
+
+  it('keeps the play button outside the link so it does not navigate', () => {
+    const handlePlayButtonClick = vi.fn();
+
+    render(
+      <MemoryRouter>
+        <ThumbnailPlayer
+          videoId="video-123"
+          src="https://example.com/video.mp4"
+          thumbnailUrl="https://example.com/thumb.jpg"
+          linkTo="/video/video-123"
+          onPlayButtonClick={handlePlayButtonClick}
+        />
+      </MemoryRouter>
+    );
+
+    const playButton = screen.getByLabelText('Play video');
+    const link = screen.getByRole('link', { name: 'Open video' });
+    expect(link.contains(playButton)).toBe(false);
+
+    fireEvent.click(playButton);
+    expect(handlePlayButtonClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render a link when linkTo is omitted', () => {
+    render(
+      <MemoryRouter>
+        <ThumbnailPlayer
+          videoId="video-123"
+          src="https://example.com/video.mp4"
+          thumbnailUrl="https://example.com/thumb.jpg"
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
   });
 });

--- a/src/components/ThumbnailPlayer.test.tsx
+++ b/src/components/ThumbnailPlayer.test.tsx
@@ -138,6 +138,26 @@ describe('ThumbnailPlayer', () => {
     expect(link).toHaveAttribute('href', '/video/video-123');
   });
 
+  it('does not also fire the thumbnail click action when the link is clicked', () => {
+    const handleThumbnailClick = vi.fn();
+
+    render(
+      <MemoryRouter>
+        <ThumbnailPlayer
+          videoId="video-123"
+          src="https://example.com/video.mp4"
+          thumbnailUrl="https://example.com/thumb.jpg"
+          linkTo="/video/video-123"
+          onClick={handleThumbnailClick}
+        />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: 'Open video' }));
+
+    expect(handleThumbnailClick).not.toHaveBeenCalled();
+  });
+
   it('keeps the play button outside the link so it does not navigate', () => {
     const handlePlayButtonClick = vi.fn();
 

--- a/src/components/ThumbnailPlayer.tsx
+++ b/src/components/ThumbnailPlayer.tsx
@@ -204,6 +204,9 @@ export function ThumbnailPlayer({
           className="absolute inset-0 z-10"
           aria-label={t('thumbnailPlayer.openVideo')}
           data-testid="thumbnail-link"
+          onClick={(event) => {
+            event.stopPropagation();
+          }}
         />
       )}
 

--- a/src/components/ThumbnailPlayer.tsx
+++ b/src/components/ThumbnailPlayer.tsx
@@ -5,6 +5,7 @@ import { useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Play } from '@phosphor-icons/react';
 import { Button } from '@/components/ui/button';
+import { SmartLink } from '@/components/SmartLink';
 import { cn } from '@/lib/utils';
 import { useAdultVerification, checkMediaAuth } from '@/hooks/useAdultVerification';
 import { AgeVerificationOverlay } from '@/components/AgeVerificationOverlay';
@@ -19,6 +20,14 @@ interface ThumbnailPlayerProps {
   className?: string;
   /** Whether the source video is age-restricted; gates whether to attach auth on the thumbnail fetch. */
   ageRestricted?: boolean;
+  /**
+   * When set, the thumbnail renders a real anchor (stretched over the media)
+   * pointing at this route so middle-click / right-click → open in new tab work.
+   * Plain left-clicks still use SPA navigation via SmartLink.
+   */
+  linkTo?: string;
+  /** Content owner pubkey passed to SmartLink for subdomain-aware routing. */
+  linkOwnerPubkey?: string | null;
   onClick?: () => void;
   onPlayButtonClick?: () => void;
   onError?: () => void;
@@ -32,6 +41,8 @@ export function ThumbnailPlayer({
   duration: _duration,
   className,
   ageRestricted,
+  linkTo,
+  linkOwnerPubkey,
   onClick,
   onPlayButtonClick,
   onError,
@@ -183,13 +194,26 @@ export function ThumbnailPlayer({
         </div>
       )}
 
+      {/* Stretched link — real anchor so middle-click / open-in-new-tab work.
+          Sits above the media but below the play button (which stays outside
+          the anchor to avoid nested-interactive markup). */}
+      {linkTo && !requiresAuth && (
+        <SmartLink
+          to={linkTo}
+          ownerPubkey={linkOwnerPubkey}
+          className="absolute inset-0 z-10"
+          aria-label={t('thumbnailPlayer.openVideo')}
+          data-testid="thumbnail-link"
+        />
+      )}
+
       {/* Play button overlay - only show when not showing auth overlay */}
       {!requiresAuth && (
-        <div className="absolute inset-0 flex items-center justify-center bg-black/20 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
+        <div className="absolute inset-0 z-20 flex items-center justify-center bg-black/20 opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none">
           <Button
             variant="ghost"
             size="icon"
-            className="w-16 h-16 rounded-full bg-black/50 hover:bg-black/70 text-white backdrop-blur-sm"
+            className="w-16 h-16 rounded-full bg-black/50 hover:bg-black/70 text-white backdrop-blur-sm pointer-events-auto"
             data-testid="thumbnail-play-button"
             aria-label={t('thumbnailPlayer.playVideo')}
             onClick={(event) => {

--- a/src/components/VideoCard.test.tsx
+++ b/src/components/VideoCard.test.tsx
@@ -108,11 +108,18 @@ vi.mock('@/components/ThumbnailPlayer', () => ({
   ThumbnailPlayer: ({
     onClick,
     onPlayButtonClick,
+    linkTo,
   }: {
     onClick?: () => void;
     onPlayButtonClick?: () => void;
+    linkTo?: string;
   }) => (
     <div data-testid="thumbnail-player">
+      {linkTo && (
+        <a href={linkTo} data-testid="thumbnail-link">
+          Open video
+        </a>
+      )}
       <button onClick={onClick} type="button">
         Thumbnail
       </button>
@@ -398,6 +405,37 @@ describe('VideoCard', () => {
       isLoading: false,
       hasSigner: false,
     });
+  });
+
+  it('renders the thumbnail as a real link to the video page in thumbnail mode', () => {
+    render(<VideoCard video={baseVideo} mode="thumbnail" />);
+
+    const link = screen.getByTestId('thumbnail-link');
+    expect(link).toHaveAttribute('href', `/video/${baseVideo.id}`);
+    expect(playbackMocks.navigate).not.toHaveBeenCalled();
+  });
+
+  it('builds the thumbnail link from the navigation context when provided', () => {
+    render(
+      <VideoCard
+        video={baseVideo}
+        mode="thumbnail"
+        navigationContext={{ source: 'search', query: 'cats' }}
+        videoIndex={2}
+      />
+    );
+
+    const href = screen.getByTestId('thumbnail-link').getAttribute('href') ?? '';
+    expect(href).toContain(`/video/${baseVideo.id}`);
+    expect(href).toContain('source=search');
+    expect(href).toContain('q=cats');
+    expect(href).toContain('index=2');
+  });
+
+  it('does not render a thumbnail link in auto-play mode', () => {
+    render(<VideoCard video={makeVideo({ id: 'video-1' })} mode="auto-play" />);
+
+    expect(screen.queryByTestId('thumbnail-link')).not.toBeInTheDocument();
   });
 
   it('marks a thumbnail-mode video active when inline playback starts', () => {

--- a/src/components/VideoCard.tsx
+++ b/src/components/VideoCard.tsx
@@ -352,18 +352,20 @@ export function VideoCard({
     }
   };
 
-  const handleThumbnailClick = () => {
-    // In thumbnail mode (grid view), navigate to video page instead of playing inline
-    if (mode === 'thumbnail') {
-      const targetUrl = navigationContext
+  // In thumbnail mode (grid view), the thumbnail is a real link to the video
+  // page so native browser behaviors (middle-click, open in new tab) work.
+  const thumbnailLinkTo = mode === 'thumbnail'
+    ? (navigationContext
         ? buildVideoNavigationUrl(video.id, navigationContext, videoIndex)
-        : `/video/${video.id}`;
-      navigate(targetUrl, { ownerPubkey: video.pubkey });
-    } else {
-      setActiveVideo(video.id);
-      setIsPlaying(true);
-      onPlay?.();
-    }
+        : `/video/${video.id}`)
+    : undefined;
+
+  const handleThumbnailClick = () => {
+    // Thumbnail mode: navigation is handled by the real link inside ThumbnailPlayer
+    if (mode === 'thumbnail') return;
+    setActiveVideo(video.id);
+    setIsPlaying(true);
+    onPlay?.();
   };
 
   const handleThumbnailPlayButtonClick = () => {
@@ -617,6 +619,8 @@ export function VideoCard({
                   duration={video.duration}
                   ageRestricted={video.ageRestricted}
                   className="w-full h-full"
+                  linkTo={thumbnailLinkTo}
+                  linkOwnerPubkey={video.pubkey}
                   onClick={handleThumbnailClick}
                   onPlayButtonClick={handleThumbnailPlayButtonClick}
                   onError={() => setVideoError(true)}

--- a/src/components/VideoGrid.test.tsx
+++ b/src/components/VideoGrid.test.tsx
@@ -1,7 +1,13 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import type { ReactElement } from 'react';
 import { VideoGrid } from './VideoGrid';
 import type { ParsedVideoData } from '@/types/video';
+
+function renderGrid(ui: ReactElement) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
 
 const mockNavigate = vi.fn();
 const mockOpenLoginDialog = vi.fn();
@@ -66,7 +72,7 @@ describe('VideoGrid age-restricted gating', () => {
   });
 
   it('renders a logged-out gated tile without mounting restricted media elements', () => {
-    render(
+    renderGrid(
       <VideoGrid
         videos={[
           makeVideo({
@@ -85,7 +91,7 @@ describe('VideoGrid age-restricted gating', () => {
   });
 
   it('opens the login dialog when the gated tile is clicked', () => {
-    render(
+    renderGrid(
       <VideoGrid
         videos={[
           makeVideo({
@@ -109,7 +115,7 @@ describe('VideoGrid age-restricted gating', () => {
       status: 401,
     });
 
-    render(
+    renderGrid(
       <VideoGrid
         videos={[
           makeVideo({
@@ -132,7 +138,7 @@ describe('VideoGrid age-restricted gating', () => {
   });
 
   it('renders unrestricted videos with their thumbnail media as before', () => {
-    render(
+    renderGrid(
       <VideoGrid
         videos={[
           makeVideo({
@@ -155,7 +161,7 @@ describe('VideoGrid age-restricted gating', () => {
       getAuthHeader: vi.fn().mockResolvedValue('Nostr grid-auth-header'),
     });
 
-    render(
+    renderGrid(
       <VideoGrid
         videos={[
           makeVideo({
@@ -179,5 +185,57 @@ describe('VideoGrid age-restricted gating', () => {
     });
 
     expect(screen.getByTestId('video-thumbnail-verified-restricted-video')).toHaveAttribute('src', 'blob:grid-thumb');
+  });
+});
+
+describe('VideoGrid native link navigation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseCurrentUser.mockReturnValue({ user: null });
+    mockUseAdultVerification.mockReturnValue({ isVerified: false, confirmAdult: vi.fn(), getAuthHeader: vi.fn() });
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      blob: async () => new Blob(['thumb'], { type: 'image/jpeg' }),
+    }) as typeof fetch;
+    global.URL.createObjectURL = vi.fn().mockReturnValue('blob:grid-thumb');
+    global.URL.revokeObjectURL = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders unrestricted tiles as real links to the video page', () => {
+    renderGrid(
+      <VideoGrid videos={[makeVideo({ id: 'public-video' })]} />
+    );
+
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', '/video/public-video');
+  });
+
+  it('builds the link href from the navigation context when provided', () => {
+    renderGrid(
+      <VideoGrid
+        videos={[makeVideo({ id: 'ctx-video' })]}
+        navigationContext={{ source: 'profile', pubkey: 'f'.repeat(64) }}
+      />
+    );
+
+    const href = screen.getByRole('link').getAttribute('href') ?? '';
+    expect(href).toContain('/video/ctx-video');
+    expect(href).toContain('source=profile');
+    expect(href).toContain('index=0');
+  });
+
+  it('does not render a link for age-gated tiles', () => {
+    renderGrid(
+      <VideoGrid
+        videos={[makeVideo({ id: 'restricted-video', ageRestricted: true })]}
+      />
+    );
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
   });
 });

--- a/src/components/VideoGrid.tsx
+++ b/src/components/VideoGrid.tsx
@@ -2,11 +2,11 @@
 // ABOUTME: Shows video thumbnails with play overlays and metadata on hover
 
 import { useState, useRef } from 'react';
-import { useSubdomainNavigate } from '@/hooks/useSubdomainNavigate';
 import { Play, Repeat } from '@phosphor-icons/react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { AgeRestrictedMediaPlaceholder } from '@/components/AgeRestrictedMediaPlaceholder';
+import { SmartLink } from '@/components/SmartLink';
 import { useLoginDialog } from '@/contexts/LoginDialogContext';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { checkMediaAuth, useAdultVerification } from '@/hooks/useAdultVerification';
@@ -137,7 +137,6 @@ function VideoGridMedia({
 }
 
 export function VideoGrid({ videos, loading = false, className, navigationContext }: VideoGridProps) {
-  const navigate = useSubdomainNavigate();
   const { user } = useCurrentUser();
   const { isVerified: isAdultVerified, confirmAdult } = useAdultVerification();
   const { openLoginDialog } = useLoginDialog();
@@ -146,22 +145,18 @@ export function VideoGrid({ videos, loading = false, className, navigationContex
   const [discoveredAgeRestrictedVideos, setDiscoveredAgeRestrictedVideos] = useState<Set<string>>(new Set());
   const videoRefs = useRef<Map<string, HTMLVideoElement>>(new Map());
 
-  const handleVideoClick = (videoId: string, index: number) => {
-    const url = navigationContext
+  const buildVideoUrl = (videoId: string, index: number) => {
+    return navigationContext
       ? buildVideoNavigationUrl(videoId, navigationContext, index)
       : `/video/${videoId}`;
-    navigate(url);
   };
 
-  const handleKeyDown = (event: React.KeyboardEvent, videoId: string, index: number, isAgeGated: boolean) => {
+  // Keyboard activation for age-gated tiles only — unrestricted tiles are
+  // real links, so Enter activation comes for free from the anchor element.
+  const handleGatedKeyDown = (event: React.KeyboardEvent) => {
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault();
-      if (isAgeGated) {
-        handleAgeGateAction();
-        return;
-      }
-
-      handleVideoClick(videoId, index);
+      handleAgeGateAction();
     }
   };
 
@@ -263,25 +258,7 @@ export function VideoGrid({ videos, loading = false, className, navigationContex
         const gridVideo = isKnownAgeRestricted ? { ...video, ageRestricted: true } : video;
         const isAgeGated = isKnownAgeRestricted && (!user || !isAdultVerified);
 
-        return (
-          <Card
-            key={video.id}
-            className="overflow-hidden cursor-pointer transition-transform hover:scale-105 group"
-            data-testid="video-grid-item"
-            onClick={() => {
-              if (isAgeGated) {
-                handleAgeGateAction();
-                return;
-              }
-
-              handleVideoClick(video.id, index);
-            }}
-            onKeyDown={(e) => handleKeyDown(e, video.id, index, isAgeGated)}
-            onMouseEnter={() => handleMouseEnter(video.id, isAgeGated)}
-            onMouseLeave={() => handleMouseLeave(video.id, isAgeGated)}
-            tabIndex={0}
-            data-video-id={video.id}
-          >
+        const tile = (
             <div className="aspect-square relative bg-muted" data-thumbnail-container="true">
               {/* Video Thumbnail or Actual Video */}
               {isAgeGated ? (
@@ -344,6 +321,38 @@ export function VideoGrid({ videos, loading = false, className, navigationContex
                 </div>
               )}
             </div>
+        );
+
+        return (
+          <Card
+            key={video.id}
+            className="overflow-hidden cursor-pointer transition-transform hover:scale-105 group"
+            data-testid="video-grid-item"
+            onMouseEnter={() => handleMouseEnter(video.id, isAgeGated)}
+            onMouseLeave={() => handleMouseLeave(video.id, isAgeGated)}
+            data-video-id={video.id}
+            {...(isAgeGated
+              ? {
+                  onClick: handleAgeGateAction,
+                  onKeyDown: handleGatedKeyDown,
+                  tabIndex: 0,
+                }
+              : {})}
+          >
+            {isAgeGated ? (
+              tile
+            ) : (
+              // Real link so middle-click / right-click → open in new tab work;
+              // plain left-click stays SPA navigation via SmartLink.
+              <SmartLink
+                to={buildVideoUrl(video.id, index)}
+                ownerPubkey={video.pubkey}
+                className="block"
+                aria-label={video.title || video.content || 'Open video'}
+              >
+                {tile}
+              </SmartLink>
+            )}
           </Card>
         );
       })}

--- a/src/lib/i18n/locales/ar/common.json
+++ b/src/lib/i18n/locales/ar/common.json
@@ -964,7 +964,8 @@
   "thumbnailPlayer": {
     "videoPreview": "معاينة الفيديو",
     "thumbnailAlt": "صورة الفيديو المصغرة",
-    "playVideo": "تشغيل الفيديو"
+    "playVideo": "تشغيل الفيديو",
+    "openVideo": "فتح الفيديو"
   },
   "hashtagExplorer": {
     "heading": "مستكشف الوسوم",

--- a/src/lib/i18n/locales/de/common.json
+++ b/src/lib/i18n/locales/de/common.json
@@ -960,7 +960,8 @@
   "thumbnailPlayer": {
     "videoPreview": "Videovorschau",
     "thumbnailAlt": "Video-Thumbnail",
-    "playVideo": "Video abspielen"
+    "playVideo": "Video abspielen",
+    "openVideo": "Video öffnen"
   },
   "hashtagExplorer": {
     "heading": "Hashtag-Explorer",

--- a/src/lib/i18n/locales/en/common.json
+++ b/src/lib/i18n/locales/en/common.json
@@ -960,7 +960,8 @@
   "thumbnailPlayer": {
     "videoPreview": "Video Preview",
     "thumbnailAlt": "Video thumbnail",
-    "playVideo": "Play video"
+    "playVideo": "Play video",
+    "openVideo": "Open video"
   },
   "hashtagExplorer": {
     "heading": "Hashtag Explorer",

--- a/src/lib/i18n/locales/es/common.json
+++ b/src/lib/i18n/locales/es/common.json
@@ -960,7 +960,8 @@
   "thumbnailPlayer": {
     "videoPreview": "Vista previa del video",
     "thumbnailAlt": "Miniatura del video",
-    "playVideo": "Reproducir video"
+    "playVideo": "Reproducir video",
+    "openVideo": "Abrir video"
   },
   "hashtagExplorer": {
     "heading": "Explorador de hashtags",

--- a/src/lib/i18n/locales/fil/common.json
+++ b/src/lib/i18n/locales/fil/common.json
@@ -960,7 +960,8 @@
   "thumbnailPlayer": {
     "videoPreview": "Preview ng video",
     "thumbnailAlt": "Thumbnail ng video",
-    "playVideo": "I-play ang video"
+    "playVideo": "I-play ang video",
+    "openVideo": "Buksan ang video"
   },
   "hashtagExplorer": {
     "heading": "Mga hashtag",

--- a/src/lib/i18n/locales/fr/common.json
+++ b/src/lib/i18n/locales/fr/common.json
@@ -960,7 +960,8 @@
   "thumbnailPlayer": {
     "videoPreview": "Aperçu de la vidéo",
     "thumbnailAlt": "Miniature de la vidéo",
-    "playVideo": "Lire la vidéo"
+    "playVideo": "Lire la vidéo",
+    "openVideo": "Ouvrir la vidéo"
   },
   "hashtagExplorer": {
     "heading": "Explorateur de hashtags",

--- a/src/lib/i18n/locales/id/common.json
+++ b/src/lib/i18n/locales/id/common.json
@@ -960,7 +960,8 @@
   "thumbnailPlayer": {
     "videoPreview": "Pratinjau Video",
     "thumbnailAlt": "Thumbnail video",
-    "playVideo": "Putar video"
+    "playVideo": "Putar video",
+    "openVideo": "Buka video"
   },
   "hashtagExplorer": {
     "heading": "Hashtag Explorer",

--- a/src/lib/i18n/locales/it/common.json
+++ b/src/lib/i18n/locales/it/common.json
@@ -960,7 +960,8 @@
   "thumbnailPlayer": {
     "videoPreview": "Anteprima video",
     "thumbnailAlt": "Miniatura video",
-    "playVideo": "Riproduci video"
+    "playVideo": "Riproduci video",
+    "openVideo": "Apri il video"
   },
   "hashtagExplorer": {
     "heading": "Esploratore hashtag",

--- a/src/lib/i18n/locales/ja/common.json
+++ b/src/lib/i18n/locales/ja/common.json
@@ -960,7 +960,8 @@
   "thumbnailPlayer": {
     "videoPreview": "動画プレビュー",
     "thumbnailAlt": "動画サムネイル",
-    "playVideo": "動画を再生"
+    "playVideo": "動画を再生",
+    "openVideo": "動画を開く"
   },
   "hashtagExplorer": {
     "heading": "ハッシュタグエクスプローラー",

--- a/src/lib/i18n/locales/ko/common.json
+++ b/src/lib/i18n/locales/ko/common.json
@@ -960,7 +960,8 @@
   "thumbnailPlayer": {
     "videoPreview": "비디오 미리보기",
     "thumbnailAlt": "비디오 썸네일",
-    "playVideo": "비디오 재생"
+    "playVideo": "비디오 재생",
+    "openVideo": "동영상 열기"
   },
   "hashtagExplorer": {
     "heading": "해시태그 탐색",

--- a/src/lib/i18n/locales/nl/common.json
+++ b/src/lib/i18n/locales/nl/common.json
@@ -960,7 +960,8 @@
   "thumbnailPlayer": {
     "videoPreview": "Videovoorbeeld",
     "thumbnailAlt": "Videothumbnail",
-    "playVideo": "Video afspelen"
+    "playVideo": "Video afspelen",
+    "openVideo": "Video openen"
   },
   "hashtagExplorer": {
     "heading": "Hashtag Explorer",

--- a/src/lib/i18n/locales/pl/common.json
+++ b/src/lib/i18n/locales/pl/common.json
@@ -962,7 +962,8 @@
   "thumbnailPlayer": {
     "videoPreview": "Podgląd wideo",
     "thumbnailAlt": "Miniatura wideo",
-    "playVideo": "Odtwórz wideo"
+    "playVideo": "Odtwórz wideo",
+    "openVideo": "Otwórz wideo"
   },
   "hashtagExplorer": {
     "heading": "Eksplorator hashtagów",

--- a/src/lib/i18n/locales/pt/common.json
+++ b/src/lib/i18n/locales/pt/common.json
@@ -960,7 +960,8 @@
   "thumbnailPlayer": {
     "videoPreview": "Pré-visualização do vídeo",
     "thumbnailAlt": "Thumbnail do vídeo",
-    "playVideo": "Reproduzir vídeo"
+    "playVideo": "Reproduzir vídeo",
+    "openVideo": "Abrir vídeo"
   },
   "hashtagExplorer": {
     "heading": "Explorador de hashtags",

--- a/src/lib/i18n/locales/ro/common.json
+++ b/src/lib/i18n/locales/ro/common.json
@@ -961,7 +961,8 @@
   "thumbnailPlayer": {
     "videoPreview": "Previzualizare videoclip",
     "thumbnailAlt": "Miniatură videoclip",
-    "playVideo": "Redă videoclipul"
+    "playVideo": "Redă videoclipul",
+    "openVideo": "Deschide videoclipul"
   },
   "hashtagExplorer": {
     "heading": "Explorator de hashtag-uri",

--- a/src/lib/i18n/locales/sv/common.json
+++ b/src/lib/i18n/locales/sv/common.json
@@ -960,7 +960,8 @@
   "thumbnailPlayer": {
     "videoPreview": "Förhandsvisning av video",
     "thumbnailAlt": "Videominiatyr",
-    "playVideo": "Spela video"
+    "playVideo": "Spela video",
+    "openVideo": "Öppna video"
   },
   "hashtagExplorer": {
     "heading": "Hashtaggsutforskaren",

--- a/src/lib/i18n/locales/tr/common.json
+++ b/src/lib/i18n/locales/tr/common.json
@@ -960,7 +960,8 @@
   "thumbnailPlayer": {
     "videoPreview": "Video Önizlemesi",
     "thumbnailAlt": "Video küçük resmi",
-    "playVideo": "Videoyu oynat"
+    "playVideo": "Videoyu oynat",
+    "openVideo": "Videoyu aç"
   },
   "hashtagExplorer": {
     "heading": "Hashtag Kâşifi",


### PR DESCRIPTION
Fixes #381 — video thumbnails couldn't be middle-clicked or right-click → "Open in new tab" because they navigated via `onClick` on `<div>`s instead of real `<a href>` elements.

## What changed

Thumbnail click-to-video-page paths are now real anchors (via the existing subdomain-aware `SmartLink`, which renders react-router `<Link>` locally), so all native browser link behaviors work. Plain left-click keeps SPA navigation.

### Surfaces converted

- **Profile video grid** (`VideoGrid`, the issue's primary case — also used by pinned videos, list detail pages, and feed grid mode): each unrestricted tile's content is wrapped in a `SmartLink` to `/video/{id}` (with navigation context preserved in the query string). The redundant `tabIndex`/`onKeyDown` are gone for these tiles — the anchor gives keyboard activation for free.
- **Search result cards** (`VideoCard` in `mode="thumbnail"` via `VideoCardWithMetrics`): `ThumbnailPlayer` gained optional `linkTo`/`linkOwnerPubkey` props that render a stretched anchor over the media. `VideoCard` passes the video-page URL instead of calling `navigate()` from `onClick`.

### Nested-interactive handling

The play button inside `ThumbnailPlayer` stays **outside** the anchor (the stretched-link pattern): its overlay is `pointer-events-none` with `pointer-events-auto` on the button, so no `<button>`-inside-`<a>` markup, and clicking play still starts inline playback without navigating.

### Surfaces intentionally left alone

- **Age-gated tiles** (grid + card): clicking opens login / age verification — a state action, not navigation, and their placeholder contains an action button, so no anchor.
- **Home/trending/discovery feed cards** (`VideoCard` in auto-play mode): thumbnail click toggles inline playback (state), not navigation. The timestamp / title / view-count elements on those cards were already `SmartLink` anchors to the video page.
- **Toggle/action buttons** (like, repost, share, mute, CC, fullscreen, play/pause): state changes, not navigation.
- Out-of-scope click-rows that navigate to non-video or non-thumbnail targets (notification rows, search user results, compilation banner cards) — same issue class but different surfaces; can be follow-ups.

### Misc

- New i18n key `thumbnailPlayer.openVideo` added to all 16 locales (locale-parity test enforces this) for the stretched link's accessible name.

## Testing

- New tests assert the thumbnail renders an `<a>` with the expected href (`getByRole('link')`) on `VideoGrid`, `ThumbnailPlayer`, and `VideoCard` thumbnail mode, that the play button is not nested inside the anchor, and that age-gated tiles render no link.
- `npx vitest run` — 1216 passed, 0 failed
- `npx tsc --noEmit` — clean
- `npx eslint` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)