### PR TITLE
fix(a11y): add missing dialog descriptions (#461)

### DIFF
--- a/src/components/BadgeDetailModal.tsx
+++ b/src/components/BadgeDetailModal.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
@@ -43,6 +44,9 @@ export function BadgeDetailModal({ badge, open, onOpenChange }: BadgeDetailModal
             <Award className="h-5 w-5" />
             {t('badgeDetailModal.title')}
           </DialogTitle>
+          <DialogDescription className="sr-only">
+            {t('badgeDetailModal.description')}
+          </DialogDescription>
         </DialogHeader>
 
         <div className="flex flex-col items-center gap-4 py-4">

--- a/src/components/VideoCommentsModal.tsx
+++ b/src/components/VideoCommentsModal.tsx
@@ -2,7 +2,7 @@
 // ABOUTME: Uses CommentsSection for NIP-22 comments
 
 import { useTranslation } from 'react-i18next';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { CommentsSection } from '@/components/comments/CommentsSection';
 import { cn } from '@/lib/utils';
 import type { ParsedVideoData } from '@/types/video';
@@ -61,6 +61,9 @@ export function VideoCommentsModal({
           <DialogTitle className="text-lg font-semibold">
             {video.title || t('videoCommentsModal.title')}
           </DialogTitle>
+          <DialogDescription className="sr-only">
+            {t('videoCommentsModal.description')}
+          </DialogDescription>
         </DialogHeader>
 
         {/* Just Comments - No Video */}

--- a/src/components/VideoReactionsModal.tsx
+++ b/src/components/VideoReactionsModal.tsx
@@ -1,4 +1,4 @@
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Heart, Repeat as Repeat2, CircleNotch as Loader2 } from '@phosphor-icons/react';
 import { useAuthor } from '@/hooks/useAuthor';
@@ -90,6 +90,9 @@ export function VideoReactionsModal({
             <Icon className={cn('h-5 w-5', type === 'likes' && 'fill-red-500 text-red-500')} />
             {title} ({count})
           </DialogTitle>
+          <DialogDescription className="sr-only">
+            Everyone who {type === 'likes' ? 'liked' : 'reposted'} this video.
+          </DialogDescription>
         </DialogHeader>
 
         <div className="overflow-y-auto max-h-[calc(80vh-80px)]">

--- a/src/components/dialog-descriptions.test.tsx
+++ b/src/components/dialog-descriptions.test.tsx
@@ -1,0 +1,176 @@
+// ABOUTME: Guards that every Radix dialog reachable from feed/category surfaces has an
+// ABOUTME: accessible description (no "Missing `Description`" console warning in prod)
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TestApp } from '@/test/TestApp';
+import { VideoCommentsModal } from '@/components/VideoCommentsModal';
+import { VideoReactionsModal } from '@/components/VideoReactionsModal';
+import { BadgeDetailModal } from '@/components/BadgeDetailModal';
+import { CommandDialog, CommandInput } from '@/components/ui/command';
+import { SidebarProvider, Sidebar, SidebarTrigger } from '@/components/ui/sidebar';
+import type { ParsedVideoData } from '@/types/video';
+import type { ValidatedBadge } from '@/lib/badges';
+import type { NostrEvent } from '@nostrify/nostrify';
+import { initializeI18n } from '@/lib/i18n';
+
+vi.mock('@/hooks/useIsMobile', () => ({
+  useIsMobile: () => true,
+}));
+
+const PUBKEY = 'a'.repeat(64);
+
+const video: ParsedVideoData = {
+  id: 'b'.repeat(64),
+  pubkey: PUBKEY,
+  kind: 34236,
+  createdAt: 1700000000,
+  content: 'A test video',
+  videoUrl: 'https://media.divine.video/test.mp4',
+  title: 'Test video',
+  hashtags: ['comedy'],
+  vineId: 'test-vine-id',
+  isVineMigrated: false,
+};
+
+const awardEvent: NostrEvent = {
+  id: 'c'.repeat(64),
+  pubkey: PUBKEY,
+  created_at: 1700000000,
+  kind: 8,
+  tags: [],
+  content: '',
+  sig: 'd'.repeat(128),
+};
+
+const badge: ValidatedBadge = {
+  definition: {
+    dTag: 'test-badge',
+    name: 'Test Badge',
+    description: 'A badge for testing',
+    image: 'https://media.divine.video/badge.png',
+    thumbs: {},
+    issuerPubkey: PUBKEY,
+    naddr: `30009:${PUBKEY}:test-badge`,
+    isOfficial: false,
+  },
+  awardEvent,
+  awardedAt: 1700000000,
+};
+
+let warnSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(async () => {
+  const storage = new Map<string, string>();
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => storage.set(key, value),
+      removeItem: (key: string) => storage.delete(key),
+      clear: () => storage.clear(),
+    } satisfies Pick<Storage, 'getItem' | 'setItem' | 'removeItem' | 'clear'>,
+  });
+  await initializeI18n({ force: true, languages: ['en-US'] });
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  warnSpy.mockRestore();
+  errorSpy.mockRestore();
+});
+
+function expectNoRadixDescriptionWarning() {
+  const allCalls = [...warnSpy.mock.calls, ...errorSpy.mock.calls];
+  const radixWarnings = allCalls.filter((args) =>
+    args.some(
+      (arg) => typeof arg === 'string' && arg.includes('Missing `Description`')
+    )
+  );
+  expect(radixWarnings).toEqual([]);
+}
+
+async function expectDescribedDialog() {
+  const dialog = await screen.findByRole('dialog');
+  const describedBy = dialog.getAttribute('aria-describedby');
+  expect(describedBy).toBeTruthy();
+  const description = document.getElementById(describedBy!);
+  expect(description).not.toBeNull();
+  expect(description!.textContent!.trim()).not.toBe('');
+  expectNoRadixDescriptionWarning();
+}
+
+describe('dialog descriptions (a11y)', () => {
+  it('VideoCommentsModal renders with an accessible description', async () => {
+    render(
+      <TestApp>
+        <VideoCommentsModal
+          video={video}
+          open={true}
+          onOpenChange={() => {}}
+          isLoadingComments={true}
+        />
+      </TestApp>
+    );
+    await expectDescribedDialog();
+  });
+
+  it('VideoReactionsModal renders with an accessible description', async () => {
+    render(
+      <TestApp>
+        <VideoReactionsModal
+          open={true}
+          onOpenChange={() => {}}
+          reactions={{ likes: [], reposts: [] }}
+          type="likes"
+        />
+      </TestApp>
+    );
+    await expectDescribedDialog();
+  });
+
+  it('BadgeDetailModal renders with an accessible description', async () => {
+    render(
+      <TestApp>
+        <BadgeDetailModal badge={badge} open={true} onOpenChange={() => {}} />
+      </TestApp>
+    );
+    await expectDescribedDialog();
+  });
+
+  it('CommandDialog renders with an accessible description', async () => {
+    render(
+      <TestApp>
+        <CommandDialog open={true}>
+          <CommandInput placeholder="Search..." />
+        </CommandDialog>
+      </TestApp>
+    );
+    await expectDescribedDialog();
+  });
+
+  it('mobile Sidebar sheet renders with an accessible description', async () => {
+    const user = userEvent.setup();
+    render(
+      <TestApp>
+        <SidebarProvider>
+          <Sidebar>
+            <div>Sidebar content</div>
+          </Sidebar>
+          <SidebarTrigger />
+        </SidebarProvider>
+      </TestApp>
+    );
+
+    await user.click(screen.getByRole('button', { name: /sidebar/i }));
+
+    await waitFor(async () => {
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toBeInTheDocument();
+    });
+    await expectDescribedDialog();
+  });
+});

--- a/src/components/dialog-descriptions.test.tsx
+++ b/src/components/dialog-descriptions.test.tsx
@@ -4,7 +4,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { TestApp } from '@/test/TestApp';
 import { VideoCommentsModal } from '@/components/VideoCommentsModal';
 import { VideoReactionsModal } from '@/components/VideoReactionsModal';
 import { BadgeDetailModal } from '@/components/BadgeDetailModal';
@@ -17,6 +16,21 @@ import { initializeI18n } from '@/lib/i18n';
 
 vi.mock('@/hooks/useIsMobile', () => ({
   useIsMobile: () => true,
+}));
+
+vi.mock('@/hooks/useAuthor', () => ({
+  useAuthor: () => ({
+    data: {
+      metadata: {
+        name: 'Badge Issuer',
+        picture: 'https://media.divine.video/issuer.png',
+      },
+    },
+  }),
+}));
+
+vi.mock('@/hooks/useBatchedAuthors', () => ({
+  useBatchedAuthors: () => undefined,
 }));
 
 const PUBKEY = 'a'.repeat(64);
@@ -73,6 +87,7 @@ const badge: ValidatedBadge = {
 
 let warnSpy: ReturnType<typeof vi.spyOn>;
 let errorSpy: ReturnType<typeof vi.spyOn>;
+let fetchSpy: ReturnType<typeof vi.spyOn>;
 
 beforeEach(async () => {
   const storage = new Map<string, string>();
@@ -86,11 +101,16 @@ beforeEach(async () => {
     } satisfies Pick<Storage, 'getItem' | 'setItem' | 'removeItem' | 'clear'>,
   });
   await initializeI18n({ force: true, languages: ['en-US'] });
+  fetchSpy = vi
+    .spyOn(globalThis, 'fetch')
+    .mockRejectedValue(new Error('Unexpected network call'));
   warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
   errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 });
 
 afterEach(() => {
+  expect(fetchSpy).not.toHaveBeenCalled();
+  fetchSpy.mockRestore();
   warnSpy.mockRestore();
   errorSpy.mockRestore();
 });
@@ -118,48 +138,40 @@ async function expectDescribedDialog() {
 describe('dialog descriptions (a11y)', () => {
   it('VideoCommentsModal renders with an accessible description', async () => {
     render(
-      <TestApp>
-        <VideoCommentsModal
-          video={video}
-          open={true}
-          onOpenChange={() => {}}
-          isLoadingComments={true}
-        />
-      </TestApp>
+      <VideoCommentsModal
+        video={video}
+        open={true}
+        onOpenChange={() => {}}
+        isLoadingComments={true}
+      />
     );
     await expectDescribedDialog();
   });
 
   it('VideoReactionsModal renders with an accessible description', async () => {
     render(
-      <TestApp>
-        <VideoReactionsModal
-          open={true}
-          onOpenChange={() => {}}
-          reactions={{ likes: [], reposts: [] }}
-          type="likes"
-        />
-      </TestApp>
+      <VideoReactionsModal
+        open={true}
+        onOpenChange={() => {}}
+        reactions={{ likes: [], reposts: [] }}
+        type="likes"
+      />
     );
     await expectDescribedDialog();
   });
 
   it('BadgeDetailModal renders with an accessible description', async () => {
     render(
-      <TestApp>
-        <BadgeDetailModal badge={badge} open={true} onOpenChange={() => {}} />
-      </TestApp>
+      <BadgeDetailModal badge={badge} open={true} onOpenChange={() => {}} />
     );
     await expectDescribedDialog();
   });
 
   it('CommandDialog renders with an accessible description', async () => {
     render(
-      <TestApp>
-        <CommandDialog open={true}>
-          <CommandInput placeholder="Search..." />
-        </CommandDialog>
-      </TestApp>
+      <CommandDialog open={true}>
+        <CommandInput placeholder="Search..." />
+      </CommandDialog>
     );
     await expectDescribedDialog();
   });
@@ -167,14 +179,12 @@ describe('dialog descriptions (a11y)', () => {
   it('mobile Sidebar sheet renders with an accessible description', async () => {
     const user = userEvent.setup();
     render(
-      <TestApp>
-        <SidebarProvider>
-          <Sidebar>
-            <div>Sidebar content</div>
-          </Sidebar>
-          <SidebarTrigger />
-        </SidebarProvider>
-      </TestApp>
+      <SidebarProvider>
+        <Sidebar>
+          <div>Sidebar content</div>
+        </Sidebar>
+        <SidebarTrigger />
+      </SidebarProvider>
     );
 
     await user.click(screen.getByRole('button', { name: /sidebar/i }));

--- a/src/components/dialog-descriptions.test.tsx
+++ b/src/components/dialog-descriptions.test.tsx
@@ -32,6 +32,7 @@ const video: ParsedVideoData = {
   hashtags: ['comedy'],
   vineId: 'test-vine-id',
   isVineMigrated: false,
+  reposts: [],
 };
 
 const awardEvent: NostrEvent = {
@@ -44,6 +45,16 @@ const awardEvent: NostrEvent = {
   sig: 'd'.repeat(128),
 };
 
+const definitionEvent: NostrEvent = {
+  id: 'e'.repeat(64),
+  pubkey: PUBKEY,
+  created_at: 1700000000,
+  kind: 30009,
+  tags: [['d', 'test-badge']],
+  content: '',
+  sig: 'f'.repeat(128),
+};
+
 const badge: ValidatedBadge = {
   definition: {
     dTag: 'test-badge',
@@ -54,6 +65,7 @@ const badge: ValidatedBadge = {
     issuerPubkey: PUBKEY,
     naddr: `30009:${PUBKEY}:test-badge`,
     isOfficial: false,
+    event: definitionEvent,
   },
   awardEvent,
   awardedAt: 1700000000,

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import { type DialogProps } from "@radix-ui/react-dialog"
 import { Command as CommandPrimitive } from "cmdk"
 import { MagnifyingGlass as Search } from '@phosphor-icons/react';import { cn } from "@/lib/utils"
-import { Dialog, DialogContent } from "@/components/ui/dialog"
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 
 const Command = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive>,
@@ -25,6 +25,10 @@ const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (
     <Dialog {...props}>
       <DialogContent className="overflow-hidden p-0 shadow-lg">
+        <DialogHeader className="sr-only">
+          <DialogTitle>Command menu</DialogTitle>
+          <DialogDescription>Type a command or search.</DialogDescription>
+        </DialogHeader>
         <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -7,7 +7,7 @@ import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Separator } from "@/components/ui/separator"
-import { Sheet, SheetContent } from "@/components/ui/sheet"
+import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet"
 import { Skeleton } from "@/components/ui/skeleton"
 import {
   Tooltip,
@@ -187,6 +187,10 @@ const Sidebar = React.forwardRef<
             }
             side={side}
           >
+            <SheetHeader className="sr-only">
+              <SheetTitle>Sidebar</SheetTitle>
+              <SheetDescription>Displays the mobile sidebar.</SheetDescription>
+            </SheetHeader>
             <div className="flex h-full w-full flex-col">{children}</div>
           </SheetContent>
         </Sheet>

--- a/src/lib/i18n/locales/ar/common.json
+++ b/src/lib/i18n/locales/ar/common.json
@@ -520,6 +520,7 @@
     "signInButton": "تسجيل الدخول"
   },
   "badgeDetailModal": {
+    "description": "القصة الكاملة لهذه الشارة — من أصدرها ومتى.",
     "title": "تفاصيل الشارة",
     "officialBadge": "✦ شارة Divine الرسمية",
     "issuedBy": "صادرة من",
@@ -947,6 +948,7 @@
     "placeholderMessage": "اكتب رسالة..."
   },
   "videoCommentsModal": {
+    "description": "شاهد ما يقوله الناس وأضف تعليقك.",
     "title": "التعليقات",
     "loading": "جارٍ تحميل التعليقات...",
     "emptyMessage": "لا توجد تعليقات بعد",

--- a/src/lib/i18n/locales/de/common.json
+++ b/src/lib/i18n/locales/de/common.json
@@ -516,6 +516,7 @@
     "signInButton": "Anmelden"
   },
   "badgeDetailModal": {
+    "description": "Alles zu diesem Abzeichen — wer es vergeben hat und wann.",
     "title": "Badge-Details",
     "officialBadge": "✦ Offizielles Divine-Badge",
     "issuedBy": "Ausgestellt von",
@@ -943,6 +944,7 @@
     "placeholderMessage": "Schreib eine Nachricht..."
   },
   "videoCommentsModal": {
+    "description": "Sieh, was andere sagen, und schreib deinen eigenen Kommentar.",
     "title": "Kommentare",
     "loading": "Kommentare werden geladen...",
     "emptyMessage": "Noch keine Kommentare",

--- a/src/lib/i18n/locales/en/common.json
+++ b/src/lib/i18n/locales/en/common.json
@@ -516,6 +516,7 @@
     "signInButton": "Sign in"
   },
   "badgeDetailModal": {
+    "description": "The full story on this badge — who issued it and when.",
     "title": "Badge Details",
     "officialBadge": "✦ Official Divine Badge",
     "issuedBy": "Issued by",
@@ -943,6 +944,7 @@
     "placeholderMessage": "Write a message..."
   },
   "videoCommentsModal": {
+    "description": "See what people are saying and drop your own comment.",
     "title": "Comments",
     "loading": "Loading comments...",
     "emptyMessage": "No comments yet",

--- a/src/lib/i18n/locales/es/common.json
+++ b/src/lib/i18n/locales/es/common.json
@@ -516,6 +516,7 @@
     "signInButton": "Iniciar sesión"
   },
   "badgeDetailModal": {
+    "description": "Toda la historia de esta insignia: quién la emitió y cuándo.",
     "title": "Detalles de la insignia",
     "officialBadge": "✦ Insignia oficial de Divine",
     "issuedBy": "Emitida por",
@@ -943,6 +944,7 @@
     "placeholderMessage": "Escribe un mensaje..."
   },
   "videoCommentsModal": {
+    "description": "Mira lo que dice la gente y deja tu propio comentario.",
     "title": "Comentarios",
     "loading": "Cargando comentarios...",
     "emptyMessage": "Aún no hay comentarios",

--- a/src/lib/i18n/locales/fil/common.json
+++ b/src/lib/i18n/locales/fil/common.json
@@ -516,6 +516,7 @@
     "signInButton": "Mag-log in"
   },
   "badgeDetailModal": {
+    "description": "Ang buong kuwento ng badge na ito — kung sino ang nagbigay at kailan.",
     "title": "Mga Detalye ng Badge",
     "officialBadge": "✦ Opisyal na Divine Badge",
     "issuedBy": "Ibinigay ni",
@@ -943,6 +944,7 @@
     "placeholderMessage": "Ipasok ang mensahe..."
   },
   "videoCommentsModal": {
+    "description": "Tingnan ang sinasabi ng iba at mag-iwan ng sarili mong komento.",
     "title": "Mga komento",
     "loading": "Naglo-load ng mga komento...",
     "emptyMessage": "Wala pang komento.",

--- a/src/lib/i18n/locales/fr/common.json
+++ b/src/lib/i18n/locales/fr/common.json
@@ -516,6 +516,7 @@
     "signInButton": "Se connecter"
   },
   "badgeDetailModal": {
+    "description": "Toute l'histoire de ce badge — qui l'a décerné et quand.",
     "title": "Détails du badge",
     "officialBadge": "✦ Badge Divine officiel",
     "issuedBy": "Émis par",
@@ -943,6 +944,7 @@
     "placeholderMessage": "Écris un message..."
   },
   "videoCommentsModal": {
+    "description": "Regarde ce que les gens disent et laisse ton propre commentaire.",
     "title": "Commentaires",
     "loading": "Chargement des commentaires...",
     "emptyMessage": "Aucun commentaire pour l'instant",

--- a/src/lib/i18n/locales/id/common.json
+++ b/src/lib/i18n/locales/id/common.json
@@ -516,6 +516,7 @@
     "signInButton": "Masuk"
   },
   "badgeDetailModal": {
+    "description": "Cerita lengkap lencana ini — siapa yang memberikannya dan kapan.",
     "title": "Detail Badge",
     "officialBadge": "✦ Badge Resmi Divine",
     "issuedBy": "Diterbitkan oleh",
@@ -943,6 +944,7 @@
     "placeholderMessage": "Tulis pesan..."
   },
   "videoCommentsModal": {
+    "description": "Lihat apa kata orang dan tinggalkan komentarmu sendiri.",
     "title": "Komentar",
     "loading": "Memuat komentar...",
     "emptyMessage": "Belum ada komentar",

--- a/src/lib/i18n/locales/it/common.json
+++ b/src/lib/i18n/locales/it/common.json
@@ -516,6 +516,7 @@
     "signInButton": "Accedi"
   },
   "badgeDetailModal": {
+    "description": "Tutta la storia di questo badge: chi l'ha assegnato e quando.",
     "title": "Dettagli badge",
     "officialBadge": "✦ Badge ufficiale Divine",
     "issuedBy": "Emesso da",
@@ -943,6 +944,7 @@
     "placeholderMessage": "Scrivi un messaggio..."
   },
   "videoCommentsModal": {
+    "description": "Guarda cosa dicono gli altri e lascia il tuo commento.",
     "title": "Commenti",
     "loading": "Caricamento commenti...",
     "emptyMessage": "Ancora nessun commento",

--- a/src/lib/i18n/locales/ja/common.json
+++ b/src/lib/i18n/locales/ja/common.json
@@ -516,6 +516,7 @@
     "signInButton": "サインイン"
   },
   "badgeDetailModal": {
+    "description": "このバッジの詳細 — 発行者と授与日。",
     "title": "バッジ詳細",
     "officialBadge": "✦ 公式Divineバッジ",
     "issuedBy": "発行者",
@@ -943,6 +944,7 @@
     "placeholderMessage": "メッセージを書く..."
   },
   "videoCommentsModal": {
+    "description": "みんなのコメントを見て、自分のコメントも残そう。",
     "title": "コメント",
     "loading": "コメントを読み込み中...",
     "emptyMessage": "まだコメントがありません",

--- a/src/lib/i18n/locales/ko/common.json
+++ b/src/lib/i18n/locales/ko/common.json
@@ -516,6 +516,7 @@
     "signInButton": "로그인"
   },
   "badgeDetailModal": {
+    "description": "이 배지의 전체 이야기 — 누가 언제 발급했는지.",
     "title": "배지 정보",
     "officialBadge": "✦ 공식 Divine 배지",
     "issuedBy": "발급자",
@@ -943,6 +944,7 @@
     "placeholderMessage": "메시지를 입력하세요..."
   },
   "videoCommentsModal": {
+    "description": "다른 사람들의 댓글을 보고 직접 댓글을 남겨보세요.",
     "title": "댓글",
     "loading": "댓글 불러오는 중...",
     "emptyMessage": "아직 댓글이 없어요",

--- a/src/lib/i18n/locales/nl/common.json
+++ b/src/lib/i18n/locales/nl/common.json
@@ -516,6 +516,7 @@
     "signInButton": "Inloggen"
   },
   "badgeDetailModal": {
+    "description": "Het hele verhaal achter deze badge — wie hem uitgaf en wanneer.",
     "title": "Badge-details",
     "officialBadge": "✦ Officiële Divine-badge",
     "issuedBy": "Uitgegeven door",
@@ -943,6 +944,7 @@
     "placeholderMessage": "Schrijf een bericht..."
   },
   "videoCommentsModal": {
+    "description": "Bekijk wat anderen zeggen en plaats je eigen reactie.",
     "title": "Reacties",
     "loading": "Reacties laden...",
     "emptyMessage": "Nog geen reacties",

--- a/src/lib/i18n/locales/pl/common.json
+++ b/src/lib/i18n/locales/pl/common.json
@@ -518,6 +518,7 @@
     "signInButton": "Zaloguj się"
   },
   "badgeDetailModal": {
+    "description": "Cała historia tej odznaki — kto ją przyznał i kiedy.",
     "title": "Szczegóły odznaki",
     "officialBadge": "✦ Oficjalna odznaka Divine",
     "issuedBy": "Wydane przez",
@@ -945,6 +946,7 @@
     "placeholderMessage": "Napisz wiadomość..."
   },
   "videoCommentsModal": {
+    "description": "Zobacz, co mówią inni, i dodaj własny komentarz.",
     "title": "Komentarze",
     "loading": "Ładowanie komentarzy...",
     "emptyMessage": "Jeszcze żadnych komentarzy",

--- a/src/lib/i18n/locales/pt/common.json
+++ b/src/lib/i18n/locales/pt/common.json
@@ -516,6 +516,7 @@
     "signInButton": "Entrar"
   },
   "badgeDetailModal": {
+    "description": "A história completa deste selo — quem o emitiu e quando.",
     "title": "Detalhes do badge",
     "officialBadge": "✦ Badge oficial Divine",
     "issuedBy": "Emitido por",
@@ -943,6 +944,7 @@
     "placeholderMessage": "Escreva uma mensagem..."
   },
   "videoCommentsModal": {
+    "description": "Veja o que as pessoas estão dizendo e deixe seu próprio comentário.",
     "title": "Comentários",
     "loading": "Carregando comentários...",
     "emptyMessage": "Nenhum comentário ainda",

--- a/src/lib/i18n/locales/ro/common.json
+++ b/src/lib/i18n/locales/ro/common.json
@@ -517,6 +517,7 @@
     "signInButton": "Conectează-te"
   },
   "badgeDetailModal": {
+    "description": "Povestea completă a acestei insigne — cine a acordat-o și când.",
     "title": "Detalii insignă",
     "officialBadge": "✦ Insignă oficială Divine",
     "issuedBy": "Emisă de",
@@ -944,6 +945,7 @@
     "placeholderMessage": "Scrie un mesaj..."
   },
   "videoCommentsModal": {
+    "description": "Vezi ce spun ceilalți și lasă propriul tău comentariu.",
     "title": "Comentarii",
     "loading": "Se încarcă comentariile...",
     "emptyMessage": "Niciun comentariu încă",

--- a/src/lib/i18n/locales/sv/common.json
+++ b/src/lib/i18n/locales/sv/common.json
@@ -516,6 +516,7 @@
     "signInButton": "Logga in"
   },
   "badgeDetailModal": {
+    "description": "Hela historien om det här märket — vem som delade ut det och när.",
     "title": "Märkesinformation",
     "officialBadge": "✦ Officiellt Divine-märke",
     "issuedBy": "Utfärdat av",
@@ -943,6 +944,7 @@
     "placeholderMessage": "Skriv ett meddelande..."
   },
   "videoCommentsModal": {
+    "description": "Se vad folk säger och lämna en egen kommentar.",
     "title": "Kommentarer",
     "loading": "Laddar kommentarer...",
     "emptyMessage": "Inga kommentarer ännu",

--- a/src/lib/i18n/locales/tr/common.json
+++ b/src/lib/i18n/locales/tr/common.json
@@ -516,6 +516,7 @@
     "signInButton": "Giriş yap"
   },
   "badgeDetailModal": {
+    "description": "Bu rozetin tüm hikâyesi — kim, ne zaman verdi.",
     "title": "Rozet Detayları",
     "officialBadge": "✦ Resmi Divine Rozeti",
     "issuedBy": "Veren",
@@ -943,6 +944,7 @@
     "placeholderMessage": "Bir mesaj yaz..."
   },
   "videoCommentsModal": {
+    "description": "İnsanların ne dediğine bak ve kendi yorumunu bırak.",
     "title": "Yorumlar",
     "loading": "Yorumlar yükleniyor...",
     "emptyMessage": "Henüz yorum yok",


### PR DESCRIPTION
## Summary

Part 1 of #461: fixes every Radix dialog that opened without an accessible description, which fired the console warning behind Sentry **JAVASCRIPT-REACT-3H** (seen on `/category/comedy`):

```
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.
```

Part 2 of #461 (profile hydration mismatch, **JAVASCRIPT-REACT-31**) is investigation-only — findings below. Verdict: **benign, third-party (HubSpot), not a divine-web SSR/CSR divergence.** No code change needed.

## Dialogs fixed

Each gets a real `sr-only` `<DialogDescription>` (same pattern as `UserListDialog` / `VideoVerificationDetailsDialog`):

| Dialog | Where it's reachable | Description |
|---|---|---|
| `VideoCommentsModal` | video cards on category/feed pages | "See what people are saying and drop your own comment." (i18n, 16 locales) |
| `VideoReactionsModal` | likes/reposts counts on video cards | "Everyone who liked/reposted this video." |
| `BadgeDetailModal` | badge chips on profiles and feeds | "The full story on this badge — who issued it and when." (i18n, 16 locales) |
| `CommandDialog` (`ui/command.tsx`) | shared primitive | sr-only title + "Type a command or search." (was also missing its `DialogTitle`) |
| `Sidebar` mobile `SheetContent` (`ui/sidebar.tsx`) | shared primitive; Radix Sheet wraps the same dialog and emits the identical warning | sr-only "Sidebar" title + description |

New i18n keys (`videoCommentsModal.description`, `badgeDetailModal.description`) are translated in all 16 locales so `src/lib/i18n/locales.test.ts` (locale parity) stays green.

**TDD**: new `src/components/dialog-descriptions.test.tsx` renders each fixed dialog and asserts `aria-describedby` resolves to a non-empty element and that no Radix "Missing \`Description\`" warning hits `console.warn`/`console.error`.

## Part 2 findings: profile-page "Hydration Error" (JAVASCRIPT-REACT-31)

**Verdict: benign one-off from HubSpot's cookie-banner React bundle. Not our code. Recommend resolving the Sentry issue.**

Evidence (pulled via the Sentry API + the linked session replay `c1ca6a61284a4c79ad41cf0c09c1e397`):

1. **All 3 events are one burst**: firstSeen == lastSeen == `2026-06-26T23:27:58Z`, 1 user, Chrome Mobile 149 / Android 10. The issue is a Sentry **Replay-detected occurrence** (`occurrence.type = 5003`, "Hydration Error"), not a captured exception — hence no stack trace on the issue.
2. **The replay's console breadcrumbs name the culprit.** The three `replay.hydrate-error` breadcrumbs are each followed by React minified errors **#425, #418, #422** arriving via `window.error` with:
   ```
   filename: https://static.hsappstatic.net/cms-js-static/ex/js/react/v18/react-combined.mjs
   ```
   That is **HubSpot's own React 18 bundle** (their CMS embed modules, loaded by our HubSpot cookie banner — the `hubspotusercontent` embed script shows up in the replay's resource spans ~3s before the errors). HubSpot's widget hydrates its own server-rendered HTML; that hydration failed on this device, and Sentry's replay hydration detector attributed it to whatever URL was active — `/profile/npub1zmhp4kd…`.
3. **divine-web cannot produce React hydration errors.** `src/main.tsx` mounts with `createRoot` (no `hydrateRoot` anywhere in the tree — checked at HEAD and at the event's release commit). React #418/#422/#425 are hydration-only codes, so they provably came from a foreign React copy on the page.
4. **The edge-injected profile HTML is not involved.** The compute-js worker only rewrites `<head>` (og tags + `window.__DIVINE_USER__` for subdomain profiles); apex `/profile/*` browser requests get the plain SPA `index.html`, and crawler HTML ships no scripts at all. Nothing renders into `#root` for React to mismatch against.
5. Side observation: the event's release is `divine-web@2026-02-03` — this user's device was still running a **five-month-old bundle** on June 26, i.e. a stale service-worker-cached app shell from before the SW removal/cleanup. Unrelated to the hydration error, but worth knowing the SW-cleanup path hasn't reached all old PWA installs.

Optional follow-up (not done here, since it's beyond "small and certain"): add `denyUrls: [/hsappstatic\.net/, /hubspotusercontent/]` to `Sentry.init` to drop third-party HubSpot script errors at the source.

## Testing

- `npx vitest run src/components/dialog-descriptions.test.tsx` — 5/5 pass (failed before the fix, as expected)
- `npx vitest run` — full suite, **1212 passed / 0 failed**
- `npx tsc --noEmit` — clean
- `npx eslint <changed files>` — clean

Closes #461

🤖 Generated with [Claude Code](https://claude.com/claude-code)