### PR TITLE
fix: start active videos before loadeddata

### DIFF
--- a/src/components/VideoPlayer.test.tsx
+++ b/src/components/VideoPlayer.test.tsx
@@ -680,6 +680,8 @@ describe('VideoPlayer', () => {
         throw new Error('expected rendered video element');
       }
 
+      playSpy.mockClear();
+
       let currentTimeValue = 6.4;
       Object.defineProperty(video, 'currentTime', {
         get: () => currentTimeValue,
@@ -758,6 +760,33 @@ describe('VideoPlayer', () => {
         'shared-video-id',
         expect.any(HTMLVideoElement)
       );
+    });
+  });
+
+  describe('active playback startup', () => {
+    it('starts an active video before loadeddata fires', async () => {
+      const playSpy = vi.fn().mockResolvedValue(undefined);
+      HTMLMediaElement.prototype.play = playSpy;
+
+      const { useVideoPlayback } = await import('@/hooks/useVideoPlayback');
+      (useVideoPlayback as ReturnType<typeof vi.fn>).mockImplementation(() => ({
+        activeVideoId: 'ios-metadata-only',
+        registerVideo: mockRegisterVideo,
+        unregisterVideo: mockUnregisterVideo,
+        updateVideoVisibility: mockUpdateVideoVisibility,
+        globalMuted: true,
+      }));
+
+      render(
+        <VideoPlayer
+          videoId="ios-metadata-only"
+          src="https://example.com/ios-metadata-only.mp4"
+        />
+      );
+
+      await waitFor(() => {
+        expect(playSpy).toHaveBeenCalledTimes(1);
+      });
     });
   });
 

--- a/src/components/VideoPlayer.test.tsx
+++ b/src/components/VideoPlayer.test.tsx
@@ -788,6 +788,51 @@ describe('VideoPlayer', () => {
         expect(playSpy).toHaveBeenCalledTimes(1);
       });
     });
+
+    it('resumes an active video after switching to a fallback URL', async () => {
+      const playSpy = vi.fn().mockResolvedValue(undefined);
+      HTMLMediaElement.prototype.play = playSpy;
+
+      const { useVideoPlayback } = await import('@/hooks/useVideoPlayback');
+      (useVideoPlayback as ReturnType<typeof vi.fn>).mockImplementation(() => ({
+        activeVideoId: 'fallback-resume',
+        registerVideo: mockRegisterVideo,
+        unregisterVideo: mockUnregisterVideo,
+        updateVideoVisibility: mockUpdateVideoVisibility,
+        globalMuted: true,
+      }));
+
+      const { container } = render(
+        <VideoPlayer
+          videoId="fallback-resume"
+          src="https://example.com/primary.mp4"
+          fallbackUrls={['https://example.com/fallback.mp4']}
+        />
+      );
+
+      const video = container.querySelector('video');
+      expect(video).not.toBeNull();
+      if (!video) {
+        throw new Error('expected rendered video element');
+      }
+
+      await waitFor(() => {
+        expect(playSpy).toHaveBeenCalledTimes(1);
+      });
+
+      playSpy.mockClear();
+      fireEvent.error(video);
+
+      await waitFor(() => {
+        expect(video.src).toBe('https://example.com/fallback.mp4');
+      });
+
+      fireEvent.loadedData(video);
+
+      await waitFor(() => {
+        expect(playSpy).toHaveBeenCalledTimes(1);
+      });
+    });
   });
 
   describe('playback is not blocked by auth', () => {

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -270,7 +270,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
 
       // Actually control the video element
       if (videoRef.current) {
-        if (isActive && !isLoading && !hasError) {
+        if (isActive && !hasError) {
           verboseLog(`[VideoPlayer ${videoId}] Starting playback`);
           // Ensure video is not already playing before calling play()
           if (videoRef.current.paused) {
@@ -289,13 +289,13 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
           videoRef.current.currentTime = 0;
         }
       }
-    }, [isActive, videoId, isLoading, hasError]);
+    }, [isActive, videoId, hasError]);
 
     // Sync video muted state with global muted state
     useEffect(() => {
       if (videoRef.current) {
         const video = videoRef.current;
-        const shouldBePlayingCheck = isActive && !isLoading && !hasError;
+        const shouldBePlayingCheck = isActive && !hasError;
 
         verboseLog(`[VideoPlayer ${videoId}] Syncing muted state to: ${globalMuted}, isActive: ${isActive}, shouldBePlaying: ${shouldBePlayingCheck}`);
 
@@ -331,7 +331,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
           }, 100);
         }
       }
-    }, [globalMuted, videoId, isActive, isLoading, hasError]);
+    }, [globalMuted, videoId, isActive, hasError]);
 
     // Handle play/pause
     const togglePlay = useCallback(() => {

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -562,6 +562,15 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
       setHasLoadedOnce(true);
       setAuthDeniedAfterVerification(false);
 
+      if (isActive && !hasError && videoRef.current?.paused) {
+        videoRef.current.play().catch((error) => {
+          debugError(`[VideoPlayer ${videoId}] Failed to resume after load:`, error);
+          if (error.name === 'NotSupportedError') {
+            handleError();
+          }
+        });
+      }
+
       // Emit first video load metric (only once)
       if (loadDuration > 0 && typeof window !== 'undefined') {
         trackFirstVideoPlayback();


### PR DESCRIPTION
## Summary

- Start active videos before `loadeddata` fires so iOS Safari can advance from metadata-only loading into playback.
- Add a regression test covering active playback startup before `loadeddata`.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- iOS Safari can hold an inline muted video at metadata-ready until `play()` is called.
- The previous player logic waited for loading to finish before calling `play()`, which could leave the video hidden behind the loading surface even though the media request succeeded.

## Related Issue

- N/A

## Testing

- [x] `npm run test`
- [x] Manual verification completed: loaded the local dev build on a connected iPhone and confirmed the affected video plays.

## Visuals

- [ ] UI change with screenshots/video attached
- [ ] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved

Manual visual verification was done on a connected iPhone. No screenshot is attached because the available device screenshot path can show a black hardware video layer even while Safari is visibly playing the video.
