### PR TITLE
feat(minor-safety): lock adult-content settings for protected minors (#453)

### DIFF
--- a/docs/superpowers/specs/2026-07-07-protected-minor-adult-lock-design.md
+++ b/docs/superpowers/specs/2026-07-07-protected-minor-adult-lock-design.md
@@ -1,0 +1,49 @@
+# Lock adult-content settings for protected minors on web (divine-web#453)
+
+**Status:** WIP design — implementation follows on this branch.
+**Part of:** support-trust-safety#175 / epic support-trust-safety#173. Web parity
+with the merged mobile lock (divine-mobile#5744). Builds on the merged
+protected-minor state (#452 / PR #456).
+
+## Problem
+
+A protected minor (13-15, `verified_minor` in keycast) can still pass the web
+adult-content gate: `useAdultVerification` is a 30-day localStorage
+self-attestation + signer check, with no awareness of protected-minor state.
+
+## Design — gate at the single seam
+
+All adult-gating consumers (`VideoCard`, `VideoGrid`, `ThumbnailPlayer`,
+`AgeVerificationOverlay`) read `useAdultVerification`. Lock inside that hook so
+every consumer inherits the lock with no per-component changes:
+
+1. Consume `useIsProtectedMinor()` (from `useProtectedMinorStatus`, #456)
+   inside `useAdultVerification`.
+2. When protected: `isVerified` is forced `false` (regardless of localStorage
+   or signer), `confirmAdult()` is a no-op, and `getAuthHeader` therefore keeps
+   returning `null` (existing `!isVerified` guard).
+3. **Self-healing:** when protected-minor state resolves true and a stored
+   verification exists (confirmed before protection landed, or a shared
+   browser), clear it (`revokeVerification` path) so the stale attestation
+   doesn't survive age-up/revocation boundaries incorrectly.
+4. Fail-safe follows #456 semantics: unknown/loading protected-minor state does
+   not lock (non-blocking state, per the #174 foundation's fail-open naming);
+   a resolved `true` locks.
+
+## Out of scope
+
+- DM restriction (#454 — parked on the identity-pinning decision).
+- Mobile (already merged, #5744).
+
+## Tests
+
+- protected minor: `isVerified===false` despite valid localStorage + signer;
+  `confirmAdult()` does not set storage; stored verification is cleared.
+- non-minor: behavior unchanged (30-day attestation honored).
+- state transition: protection resolving true after mount locks and clears.
+- follow existing hook/component test harnesses (`AgeVerificationOverlay.test.tsx` etc.).
+
+## Acceptance (from #453 / #175)
+
+A protected minor on web cannot enable or retain adult-content access; the
+setting is locked, not merely defaulted.

--- a/docs/superpowers/specs/2026-07-07-protected-minor-adult-lock-design.md
+++ b/docs/superpowers/specs/2026-07-07-protected-minor-adult-lock-design.md
@@ -1,6 +1,6 @@
 # Lock adult-content settings for protected minors on web (divine-web#453)
 
-**Status:** Implemented on this branch; PR stays draft until Matt green-lights review.
+**Status:** Implemented on this branch.
 **Part of:** support-trust-safety#175 / epic support-trust-safety#173. Web parity
 with the merged mobile lock (divine-mobile#5744). Builds on the merged
 protected-minor state (#452 / PR #456).
@@ -17,7 +17,7 @@ All adult-gating consumers (`VideoCard`, `VideoGrid`, `ThumbnailPlayer`,
 `AgeVerificationOverlay`) read `useAdultVerification`. Lock inside that hook so
 every consumer inherits the lock with no per-component changes:
 
-1. Consume `useIsProtectedMinor()` (from `useProtectedMinorStatus`, #456)
+1. Consume `useProtectedMinorStatus()` (#456)
    inside `useAdultVerification`.
 2. When protected: `isVerified` is forced `false` (regardless of localStorage
    or signer), `confirmAdult()` is a no-op, and `getAuthHeader` therefore keeps
@@ -27,12 +27,15 @@ every consumer inherits the lock with no per-component changes:
    browser), clear it (`revokeVerification` path) so the stale attestation
    doesn't survive age-up/revocation boundaries incorrectly.
 4. Fail-safe: unknown/loading protected-minor state **fails closed for
-   granting** — folded into the hook's `isLoading` (consumers keep their
-   loading treatment; no flicker-grant for a minor, no hard "not verified"
-   for an adult mid-refetch), `confirmAdult` no-ops, and the stored
-   attestation is NOT purged (purge only on known-true). This matches the
-   #452/#456 foundation's stated intent that #175 gates fail closed on
-   unknown, corrected from this spec's earlier fail-open draft.
+   granting**: `isVerified` is forced false, `confirmAdult` no-ops, and the
+   stored attestation is NOT purged (purge only on known-true). The hook also
+   exposes unknown through `isLoading` for consumers that can surface it, but
+   the current adult-content consumers key their gate decisions off
+   `isVerified`, `confirmAdult`, and `getAuthHeader`, so confirmed adults may
+   see a brief locked state while the protected-minor check resolves. Smoothing
+   that adult experience stays in the follow-up support-trust-safety#180. This
+   matches the #452/#456 foundation's stated intent that #175 gates fail closed
+   on unknown, corrected from this spec's earlier fail-open draft.
 
 ## Out of scope
 

--- a/docs/superpowers/specs/2026-07-07-protected-minor-adult-lock-design.md
+++ b/docs/superpowers/specs/2026-07-07-protected-minor-adult-lock-design.md
@@ -1,6 +1,6 @@
 # Lock adult-content settings for protected minors on web (divine-web#453)
 
-**Status:** WIP design — implementation follows on this branch.
+**Status:** Implemented on this branch; PR stays draft until Matt green-lights review.
 **Part of:** support-trust-safety#175 / epic support-trust-safety#173. Web parity
 with the merged mobile lock (divine-mobile#5744). Builds on the merged
 protected-minor state (#452 / PR #456).
@@ -26,9 +26,13 @@ every consumer inherits the lock with no per-component changes:
    verification exists (confirmed before protection landed, or a shared
    browser), clear it (`revokeVerification` path) so the stale attestation
    doesn't survive age-up/revocation boundaries incorrectly.
-4. Fail-safe follows #456 semantics: unknown/loading protected-minor state does
-   not lock (non-blocking state, per the #174 foundation's fail-open naming);
-   a resolved `true` locks.
+4. Fail-safe: unknown/loading protected-minor state **fails closed for
+   granting** — folded into the hook's `isLoading` (consumers keep their
+   loading treatment; no flicker-grant for a minor, no hard "not verified"
+   for an adult mid-refetch), `confirmAdult` no-ops, and the stored
+   attestation is NOT purged (purge only on known-true). This matches the
+   #452/#456 foundation's stated intent that #175 gates fail closed on
+   unknown, corrected from this spec's earlier fail-open draft.
 
 ## Out of scope
 

--- a/src/hooks/useAdultVerification.test.ts
+++ b/src/hooks/useAdultVerification.test.ts
@@ -137,7 +137,7 @@ describe('useAdultVerification', () => {
 
       const { result } = renderHook(() => useAdultVerification());
 
-      // Unknown folds into isLoading so consumers keep their loading treatment.
+      // Unknown is exposed through isLoading and still fails closed for granting.
       expect(result.current.isLoading).toBe(true);
       expect(result.current.isVerified).toBe(false);
 

--- a/src/hooks/useAdultVerification.test.ts
+++ b/src/hooks/useAdultVerification.test.ts
@@ -2,6 +2,7 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAdultVerification } from './useAdultVerification';
 import { createMediaViewerAuthHeader } from '@/lib/mediaViewerAuth';
+import { NOT_PROTECTED, UNKNOWN_PROTECTED_MINOR_STATUS, type ProtectedMinorStatus } from '@/lib/protectedMinor';
 
 const mockSigner = { signEvent: vi.fn(), getPublicKey: vi.fn() };
 let currentSigner: typeof mockSigner | null = mockSigner;
@@ -12,6 +13,16 @@ vi.mock('@/hooks/useCurrentUser', () => ({
 
 vi.mock('@/lib/mediaViewerAuth', () => ({
   createMediaViewerAuthHeader: vi.fn(),
+}));
+
+// Protected-minor lock (#453): default to a known not-protected session so the
+// pre-existing behavior tests run unlocked; lock tests override per-case.
+const PROTECTED: ProtectedMinorStatus = Object.freeze({
+  state: 'protected' as const, isProtectedMinor: true, isKnown: true, verifiedMinorAt: new Date('2026-05-01T00:00:00Z'),
+});
+let minorStatus: ProtectedMinorStatus = NOT_PROTECTED;
+vi.mock('@/hooks/useProtectedMinorStatus', () => ({
+  useProtectedMinorStatus: () => minorStatus,
 }));
 
 function installMemoryStorage(): void {
@@ -39,6 +50,7 @@ describe('useAdultVerification', () => {
   beforeEach(() => {
     installMemoryStorage();
     currentSigner = mockSigner;
+    minorStatus = NOT_PROTECTED;
   });
 
   it('synchronizes confirmation across mounted hook instances', async () => {
@@ -73,6 +85,101 @@ describe('useAdultVerification', () => {
 
     expect(result.current.isVerified).toBe(false);
     expect(result.current.hasSigner).toBe(false);
+  });
+
+  describe('protected-minor lock (#453)', () => {
+    const storeAttestation = () => {
+      window.localStorage.setItem('adult-verification-confirmed', 'true');
+      window.localStorage.setItem('adult-verification-expiry', String(Date.now() + 60_000));
+    };
+
+    it('is never verified for a protected minor, despite a valid stored attestation and signer', async () => {
+      minorStatus = PROTECTED;
+      storeAttestation();
+
+      const { result } = renderHook(() => useAdultVerification());
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(result.current.isVerified).toBe(false);
+    });
+
+    it('purges a stale stored attestation once protection is known (self-heal)', async () => {
+      minorStatus = PROTECTED;
+      storeAttestation();
+
+      const { result } = renderHook(() => useAdultVerification());
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      await waitFor(() => {
+        expect(window.localStorage.getItem('adult-verification-confirmed')).toBeNull();
+        expect(window.localStorage.getItem('adult-verification-expiry')).toBeNull();
+      });
+      expect(result.current.isVerified).toBe(false);
+    });
+
+    it('confirmAdult is a no-op for a protected minor', async () => {
+      minorStatus = PROTECTED;
+
+      const { result } = renderHook(() => useAdultVerification());
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      act(() => {
+        result.current.confirmAdult();
+      });
+
+      expect(result.current.isVerified).toBe(false);
+      expect(window.localStorage.getItem('adult-verification-confirmed')).toBeNull();
+    });
+
+    it('fails closed while the check is unknown: stays loading, no verification, no purge', async () => {
+      minorStatus = UNKNOWN_PROTECTED_MINOR_STATUS;
+      storeAttestation();
+
+      const { result } = renderHook(() => useAdultVerification());
+
+      // Unknown folds into isLoading so consumers keep their loading treatment.
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.isVerified).toBe(false);
+
+      act(() => {
+        result.current.confirmAdult();
+      });
+      expect(result.current.isVerified).toBe(false);
+
+      // The adult's stored attestation must survive a transient unknown.
+      expect(window.localStorage.getItem('adult-verification-confirmed')).toBe('true');
+    });
+
+    it('honors the stored attestation again once the check resolves not-protected', async () => {
+      minorStatus = UNKNOWN_PROTECTED_MINOR_STATUS;
+      storeAttestation();
+
+      const { result, rerender } = renderHook(() => useAdultVerification());
+      expect(result.current.isVerified).toBe(false);
+
+      minorStatus = NOT_PROTECTED;
+      rerender();
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+        expect(result.current.isVerified).toBe(true);
+      });
+    });
+
+    it('locks and purges when protection resolves true after mount', async () => {
+      storeAttestation();
+
+      const { result, rerender } = renderHook(() => useAdultVerification());
+      await waitFor(() => expect(result.current.isVerified).toBe(true));
+
+      minorStatus = PROTECTED;
+      rerender();
+
+      await waitFor(() => {
+        expect(result.current.isVerified).toBe(false);
+        expect(window.localStorage.getItem('adult-verification-confirmed')).toBeNull();
+      });
+    });
   });
 
   describe('getAuthHeader', () => {

--- a/src/hooks/useAdultVerification.ts
+++ b/src/hooks/useAdultVerification.ts
@@ -3,6 +3,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
+import { useProtectedMinorStatus } from '@/hooks/useProtectedMinorStatus';
 import { createMediaViewerAuthHeader } from '@/lib/mediaViewerAuth';
 
 const STORAGE_KEY = 'adult-verification-confirmed';
@@ -50,14 +51,29 @@ function notifyVerificationChange(): void {
 
 export function useAdultVerification(): AdultVerificationState {
   const [storedIsVerified, setStoredIsVerified] = useState(false);
-  const [isLoading, setIsLoading] = useState(true);
+  const [isStorageLoading, setIsStorageLoading] = useState(true);
   const { signer } = useCurrentUser();
-  const isVerified = storedIsVerified && !!signer;
+
+  // Protected-minor lock (#453 / support-trust-safety#175): a protected minor
+  // (13-15, keycast verified_minor) must not be able to pass or retain the
+  // adult gate. Gating here, at the single seam every adult-content consumer
+  // reads, locks them all at once.
+  const minorStatus = useProtectedMinorStatus();
+  const minorLocked = minorStatus.isProtectedMinor;
+  // Unknown only occurs for authenticated sessions (signed-out resolves to
+  // not-protected), and the check was designed for #175 to fail closed on it.
+  // Fold unknown into isLoading rather than isVerified so a transient check
+  // renders as "still loading" — it can neither flicker-grant a minor nor
+  // read as a hard "not verified" for an adult mid-refetch.
+  const minorUnknown = !minorStatus.isKnown;
+
+  const isVerified = !minorLocked && !minorUnknown && storedIsVerified && !!signer;
+  const isLoading = isStorageLoading || minorUnknown;
 
   useEffect(() => {
     const syncFromStorage = () => {
       setStoredIsVerified(getStoredVerificationState());
-      setIsLoading(false);
+      setIsStorageLoading(false);
     };
 
     const handleStorageChange = (event: Event) => {
@@ -78,13 +94,30 @@ export function useAdultVerification(): AdultVerificationState {
     };
   }, []);
 
+  // Self-heal: purge a stale stored attestation once protection is KNOWN true
+  // (attested before protection landed, or a shared browser). Known-true only —
+  // an adult's attestation must survive transient unknown states.
+  useEffect(() => {
+    if (minorLocked && getStoredVerificationState()) {
+      localStorage.removeItem(STORAGE_KEY);
+      localStorage.removeItem(STORAGE_EXPIRY_KEY);
+      setStoredIsVerified(false);
+      notifyVerificationChange();
+    }
+  }, [minorLocked, storedIsVerified]);
+
   const confirmAdult = useCallback(() => {
+    // Locked for protected minors; unknown fails closed (no new attestation
+    // until the check resolves).
+    if (minorLocked || minorUnknown) {
+      return;
+    }
     const expiryTime = Date.now() + VERIFICATION_DURATION_MS;
     localStorage.setItem(STORAGE_KEY, 'true');
     localStorage.setItem(STORAGE_EXPIRY_KEY, expiryTime.toString());
     setStoredIsVerified(true);
     notifyVerificationChange();
-  }, []);
+  }, [minorLocked, minorUnknown]);
 
   const revokeVerification = useCallback(() => {
     localStorage.removeItem(STORAGE_KEY);

--- a/src/hooks/useAdultVerification.ts
+++ b/src/hooks/useAdultVerification.ts
@@ -62,9 +62,8 @@ export function useAdultVerification(): AdultVerificationState {
   const minorLocked = minorStatus.isProtectedMinor;
   // Unknown only occurs for authenticated sessions (signed-out resolves to
   // not-protected), and the check was designed for #175 to fail closed on it.
-  // Fold unknown into isLoading rather than isVerified so a transient check
-  // renders as "still loading" — it can neither flicker-grant a minor nor
-  // read as a hard "not verified" for an adult mid-refetch.
+  // Unknown is also exposed through isLoading for consumers that can surface
+  // that state, but today's gate decisions still key off isVerified.
   const minorUnknown = !minorStatus.isKnown;
 
   const isVerified = !minorLocked && !minorUnknown && storedIsVerified && !!signer;
@@ -94,18 +93,6 @@ export function useAdultVerification(): AdultVerificationState {
     };
   }, []);
 
-  // Self-heal: purge a stale stored attestation once protection is KNOWN true
-  // (attested before protection landed, or a shared browser). Known-true only —
-  // an adult's attestation must survive transient unknown states.
-  useEffect(() => {
-    if (minorLocked && getStoredVerificationState()) {
-      localStorage.removeItem(STORAGE_KEY);
-      localStorage.removeItem(STORAGE_EXPIRY_KEY);
-      setStoredIsVerified(false);
-      notifyVerificationChange();
-    }
-  }, [minorLocked, storedIsVerified]);
-
   const confirmAdult = useCallback(() => {
     // Locked for protected minors; unknown fails closed (no new attestation
     // until the check resolves).
@@ -125,6 +112,15 @@ export function useAdultVerification(): AdultVerificationState {
     setStoredIsVerified(false);
     notifyVerificationChange();
   }, []);
+
+  // Self-heal: purge a stale stored attestation once protection is KNOWN true
+  // (attested before protection landed, or a shared browser). Known-true only —
+  // an adult's attestation must survive transient unknown states.
+  useEffect(() => {
+    if (minorLocked && getStoredVerificationState()) {
+      revokeVerification();
+    }
+  }, [minorLocked, revokeVerification, storedIsVerified]);
 
   // Generate viewer auth header for a given URL (Blossom or NIP-98 depending on inputs)
   const getAuthHeader = useCallback(


### PR DESCRIPTION
Closes #453. Web half of divinevideo/support-trust-safety#175 (epic divinevideo/support-trust-safety#173); parity with the merged mobile lock (divinevideo/divine-mobile#5744). Builds on the merged protected-minor state (#452/#456).

## What this does

Locks the adult-content gate at its single seam — `useAdultVerification`, which every adult-content consumer (VideoCard/VideoGrid/ThumbnailPlayer/AgeVerificationOverlay) reads — so all of them inherit the lock with no per-component changes:

- **Known protected minor:** `isVerified` forced `false` (regardless of the 30-day localStorage attestation or signer), `confirmAdult()` no-ops, `getAuthHeader` keeps returning `null` via the existing guard.
- **Self-heal:** a stale stored attestation (attested before protection landed, or a shared browser) is purged once protection is known-true — and only then.
- **Unknown check (authenticated, loading/failed): fails closed for granting.** `isVerified` is forced false, `confirmAdult` no-ops, and the adult's stored attestation survives untouched. The hook also exposes unknown through `isLoading` for consumers that can surface it, but current adult-content gates key their decisions off `isVerified`, `confirmAdult`, and `getAuthHeader`, so confirmed adults can see a brief locked state while the protected-minor check resolves. That adult smoothing work is intentionally split into divinevideo/support-trust-safety#180.

## Tests

- 6 new hook tests: minor never verified despite valid attestation+signer; self-heal purge; confirmAdult no-op; unknown stays loading/no-grant/no-purge; attestation honored again when resolving not-protected; lock+purge when protection resolves true after mount.
- Full suite 181 files / 1218 tests green; tsc + eslint clean (0 errors; 14 pre-existing warnings, none in touched files); vite build ok.

Design: `docs/superpowers/specs/2026-07-07-protected-minor-adult-lock-design.md`
