### PR TITLE
feat(minor-safety): restrict protected-minor DMs to HQ/Support on web (#454)

### DIFF
--- a/docs/superpowers/specs/2026-07-07-protected-minor-dm-restriction-web-design.md
+++ b/docs/superpowers/specs/2026-07-07-protected-minor-dm-restriction-web-design.md
@@ -21,7 +21,10 @@ dcadenas on the PR before merge.
   mass-revoke support access); network failure keeps last-known state
   (pin-trusted on cold start). 1h TTL for the background/inbound cache, plus
   **send-time freshness**: the async send path awaits a fresh resolution when
-  the cache is stale. Per-entry canonical identifier. The mobile spec's
+  the cache is stale; and **receive-time revalidation**: inbound from a
+  stale-cached tier-2 counterparty triggers background re-resolution with the
+  filter re-applied on result, so the TTL is a backstop in both directions.
+  Per-entry canonical identifier. The mobile spec's
   "Threat model and accepted risks" section (reachability-bounded revocation,
   storage-clear un-revocation, client-side-only inbound enforcement) and its
   pre-merge ops launch checklist (revocation runbook, tier-2 name monitoring,

--- a/docs/superpowers/specs/2026-07-07-protected-minor-dm-restriction-web-design.md
+++ b/docs/superpowers/specs/2026-07-07-protected-minor-dm-restriction-web-design.md
@@ -1,164 +1,104 @@
-# Restrict protected-minor DMs to official Divine accounts on web (divine-web#454)
+# Protected-minor DM restriction (web) — design
 
 **Issue:** divine-web#454, web half of support-trust-safety#176 (epic #173).
-**Date:** 2026-07-07, following the divine-mobile#4948 trust-model decision.
-**Status:** Design complete, pending Matt's approval; implementation follows on
-this branch. Mirrors the mobile design
-(`divine-mobile/docs/superpowers/specs/2026-07-02-protected-minor-dm-restriction-design.md`);
-this doc records the web-specific seams and deltas. Security posture review by
-dcadenas on the PR before merge.
+**Authoritative design + full rationale:** the mobile spec,
+`divine-mobile/docs/superpowers/specs/2026-07-02-protected-minor-dm-restriction-design.md`.
+This doc is the clean web mirror: it inherits every decision there and records
+only the web-specific seams and deltas. Two adversarial reviews (2026-07-07)
+folded in.
+**Status:** Design complete; implementation held pending @dcadenas design-level review.
 
-## Shared decisions (see the mobile spec for full rationale)
+## Inherited from the mobile spec (unchanged on web)
 
-- **Approved set = pinned ∩ live NIP-05 (Tier 2, #4948):**
-  - Divine HQ `c4a39f1291291d452405cd8ddd798c4a29a3858c52cd0d843f1f6852cf17682e`
-    / `_@divinehq.divine.video`, minorContactable
-  - Divine Moderation `8fd5eb6d8f362163bc00a5ab6b4a3167dbf32d00ec4efdbcf43b3c9514433b7e`
-    / `moderation@divine.video`, minorContactable
-- **NIP-05 leg (amended 2026-07-07 after pressure-testing):** graded drop
-  signals — different-key resolution drops immediately; affirmative absence
-  requires a confirming ~5-minute recheck (a name-server hiccup must not
-  mass-revoke support access); network failure keeps last-known state
-  (pin-trusted on cold start). 1h TTL for the background/inbound cache, plus
-  **send-time freshness**: the async send path awaits a fresh resolution when
-  the cache is stale; and **receive-time revalidation**: inbound from a
-  stale-cached tier-2 counterparty triggers background re-resolution with the
-  filter re-applied on result, so the TTL is a backstop in both directions.
-  Per-entry canonical identifier. The mobile spec's
-  "Threat model and accepted risks" section (reachability-bounded revocation,
-  storage-clear un-revocation, client-side-only inbound enforcement) and its
-  pre-merge ops launch checklist (revocation runbook, tier-2 name monitoring,
-  two-person-rule decision) apply to web identically — web persists last-known
-  leg state in localStorage.
-- **Activation:** enforce when `useProtectedMinorStatus` resolves `protected`;
-  never-resolved unknown does not enforce; sticky through transient unknowns
-  (persist last-known protected, lift only on positive not-protected — web adds
-  the localStorage persistence the mobile provider gets from Riverpod `.value`).
+- **Approved set = pinned ∩ live NIP-05 (Tier 2):** Divine HQ
+  `c4a39f1291291d452405cd8ddd798c4a29a3858c52cd0d843f1f6852cf17682e` /
+  `_@divinehq.divine.video`; Divine Moderation
+  `8fd5eb6d8f362163bc00a5ab6b4a3167dbf32d00ec4efdbcf43b3c9514433b7e` /
+  `moderation@divine.video`; both `minorContactable`, each pins its own canonical form.
+- **Fail-safe: FAIL CLOSED and PERSISTENT.** Enforce on `unknown`/cold-start when
+  ever-seen-protected; the restricted party can suppress the check, so it must
+  fail closed on suppression; a persistent last-known store relaxes only for
+  accounts positively seen `not_protected`.
+- **Graded NIP-05 leg:** different-key drops immediately; absence needs a
+  confirming ~5-min recheck; network failure keeps last-known (pin-trusted cold
+  start); 1h TTL with send-time freshness + receive-time revalidation as the
+  real propagation, TTL a backstop.
+- **Threat model & accepted risks** and the **ops launch checklist**
+  (repoint-not-removal runbook, tier-2 monitoring incl. the divinehq origin,
+  two-person-rule decision) apply identically.
 
-## Web-specific findings and deltas
+## Web-specific facts
 
-1. **Web DMs are fully implemented** (NIP-17 send + inbox, `src/lib/dm.ts`,
-   `useDirectMessages.ts`, `MessagesPage`/`ConversationPage`), so this is a
-   full send-block + inbound filter, not a future-surface guard.
-2. **`DIVINE_SUPPORT_PUBKEY` (`dm.ts:17`) is the personal key
-   `78a5c21b5166dc1474b64ddf7454bf79e6b5d6b4a77148593bf1e866b73c2738`,**
-   used by `MessagesPage` for the pinned support conversation. Per #4948
-   ("deliberate, role-tagged accounts, not personal keys") this migrates to the
-   HQ account as part of this PR: the support-conversation affordance points at
-   HQ, and the personal key is not an approved minor-DM recipient.
+1. Web has a **full** NIP-17 DM implementation (`src/lib/dm.ts`,
+   `useDirectMessages.ts`, `MessagesPage`/`ConversationPage`), so this is a real
+   send-block + inbound filter, not a future-surface guard.
+2. `DIVINE_SUPPORT_PUBKEY` (`dm.ts:17`) is the **personal key**
+   `78a5c21b5166dc1474b64ddf7454bf79e6b5d6b4a77148593bf1e866b73c2738`, referenced
+   in `dm.ts`, `MessagesPage.tsx`, `Support.tsx`, and `ConversationPage.tsx`
+   (four sites). Per #4948 it migrates to HQ across **all four**.
 
 ## Architecture
 
 - **New `src/lib/officialAccounts.ts`:** `OfficialAccount` model +
   `PINNED_OFFICIAL_ACCOUNTS`; `isPinnedMinorContactable(hex)`;
-  `resolveNip05(identifier)` against the canonical form;
-  `isApprovedMinorDmRecipient(hex)` implementing pin ∩ NIP-05 with the leg
-  semantics + localStorage last-known store (1h TTL).
+  `resolveNip05(identifier)` returning the discriminated
+  `{ matched | differentKey | absent | networkError }` with fetch timeout,
+  redirect cap, size cap, and lowercase+trim normalization; `isApprovedMinorDmRecipient(hex)`
+  (pin ∩ NIP-05, graded rules, **localStorage** last-known store, 1h TTL,
+  send-time freshness that awaits any in-flight resolution rather than treating
+  concurrency as failure).
 - **New `src/hooks/useApprovedMinorDmRecipients.ts`:** React Query wrapper
-  exposing the resolved approved set + a sync predicate for list filtering.
+  exposing the resolved approved set + a sync predicate.
+- **Protected-state persistence:** `useProtectedMinorStatus` today is
+  `staleTime:0` + `refetchOnWindowFocus:true` and `fetchProtectedMinorStatus`
+  RETURNS `UNKNOWN` on failure, so React Query overwrites a prior `protected` on
+  any focus-refetch failure (fails open every refocus). Add a localStorage
+  last-known-protected store; on `unknown` fall back to it and never overwrite a
+  `protected` entry with `unknown`. Safety wins over the hook's current
+  "self-healing not sticky" intent for this tier.
 
 ### Enforcement points (seams verified 2026-07-07)
 
-1. **Send gate:** `useDmSend` mutation (`src/hooks/useDirectMessages.ts`
-   ~:427-460): when protected, reject recipients failing the predicate with a
-   typed error BEFORE `createRecipientGiftWraps` (~:453) — surfaced as inline
-   copy in `ConversationPage.handleSend` (~:220). Defense-in-depth: the same
-   predicate guard inside `createRecipientGiftWraps` (`src/lib/dm.ts` ~:384)
-   behind an options flag.
-2. **Inbound filter:** `useDmConversations` (~:316,
-   `groupDmConversations(...)`): when protected, drop conversations whose
-   counterparty fails the predicate. Sender identity comes from the
-   seal-validated `senderPubkey` (`dm.ts` unwrap ~:501, mismatch already
-   rejected; message built ~:525).
-3. **Affordances:** any profile/message entry points and the `MessagesPage`
-   support row (post-migration, points at HQ) — hide compose paths to
-   non-approved accounts when protected.
+1. **Send gate:** in `useDmSend` (`useDirectMessages.ts:427-460`), reject
+   recipients failing the predicate with a typed error BEFORE
+   `createRecipientGiftWraps` (`:453`); surfaced inline in
+   `ConversationPage.handleSend` (`:220`). Defense-in-depth guard inside
+   `createRecipientGiftWraps` (`dm.ts:384`) behind an options flag. Group send
+   requires all recipients approved. (Web has no durable outgoing queue, so no
+   drain re-check needed — the mobile enqueue-before-gate hazard does not apply.)
+2. **Inbound filter — list AND thread.** `useDmConversations`
+   (`:316`, `groupDmConversations`) drops non-approved counterparties when
+   protected; sender identity is the seal-validated `senderPubkey`
+   (`dm.ts:501` rejects seal≠rumor, built `:525`). **The thread view is a
+   separate seam:** `useDmConversation` (`:363`) → `useDmMessages` raw cache is
+   NOT filtered by the list, so a deep link to `/messages/<non-approved-peer>`
+   would show full history. Add a **thread-route guard** (redirect to inbox when
+   protected + counterparty non-approved) AND re-apply the predicate inside
+   `useDmConversation`'s result so a revoked-mid-session thread clears on
+   revalidation. Group inbound requires ALL non-self participants approved.
+   Unread count already inherits the filter (`useUnreadDmCount` derives from
+   `groupDmConversations`), provided the filter is applied inside/after it.
+3. **Support-key migration (bridge, do not orphan):** migrating
+   `78a5c21b…` → HQ orphans any existing minor↔`78a5c21b` support thread — for a
+   protected minor it is filtered out AND the synthetic support row now points at
+   HQ, so the minor loses the thread and replies. Grandfather `78a5c21b` as
+   read-allowed for existing threads (or migrate conversation ids), sweep all
+   four sites, and confirm HQ's DM inbox is staffed before pointing minors there.
+4. **Affordances:** hide compose paths to non-approved accounts when protected;
+   the `MessagesPage` support row points at HQ post-migration.
 
 ## Tests
 
 Mirror the mobile matrix: officialAccounts unit tests (pin-miss, match,
-affirmative-mismatch drop + persistence, network-failure retention, TTL);
-useDmSend gate (typed rejection, nothing published); conversation filtering
-(inbox + any request-like surface); non-minor unaffected; support-row
-migration renders HQ. Follow the existing `dm.ts`/hooks test harnesses.
+different-key drop+persist, absence-recheck, network retention, TTL, case
+normalization); useDmSend gate (typed rejection, nothing published); list +
+**thread-view** filtering; group requires all participants; unread inherits;
+protected-state persistence (fails closed on unknown, never overwrites protected,
+localStorage survives reload); support-row migration renders HQ without orphaning.
+Follow the existing `dm.ts`/hooks harnesses.
 
 ## Scope
 
-Web this branch/PR. Depends on nothing new — protected-minor state (#456) is
-merged and currently unconsumed on this surface. The #453 adult-content lock
-lands separately (PR #473). Parent-approved allowlist is #455 [later].
-
-## Corrections after adversarial review (2026-07-07)
-
-Independent adversarial review (verified against code) found web-specific holes;
-these supersede conflicting text above.
-
-### C-H3 — thread view needs its own guard (was: only conversation-list filtered)
-
-Enforcement point #2 filtered `useDmConversations` (:310), but the thread renders
-through the separate `useDmConversation` (:363) → `useDmMessages` raw cache, which
-is unfiltered. `ConversationPage` decodes the peer from the URL, so a protected
-minor deep-linking to `/messages/<non-approved-peer>` sees full history. Add a
-**thread-route guard** mirroring mobile: when protected and the conversation
-counterparty is non-approved, block the thread render (redirect to inbox with a
-notice) — not merely hide compose. Also re-apply the approved predicate inside
-`useDmConversation`'s result so a revoked counterparty's already-open thread
-clears on revalidation.
-
-### C-H2/M2 — `resolveNip05` gets the same discriminated result + limits
-
-`src/lib/officialAccounts.ts` `resolveNip05` returns
-`{ matched | differentKey | absent | networkError }` with fetch timeout,
-redirect cap, size cap, and lowercase+trim hex normalization (mirrors the mobile
-resolver corrections C-H2/M1/M3). The graded drop / fail-open rules attach to
-this, and send-time freshness awaits any in-flight resolution rather than
-treating concurrency as failure.
-
-### C-L2 — the personal-key migration must sweep ALL sites
-
-`78a5c21b…2738` is referenced in `src/lib/dm.ts`, `src/pages/MessagesPage.tsx`,
-`src/pages/Support.tsx`, and `src/pages/ConversationPage.tsx` — not just
-MessagesPage. Migrating only one leaves the personal key a reachable compose
-target that is not an approved recipient. Sweep all four; the constant should
-resolve to the HQ account (or be removed in favor of `PINNED_OFFICIAL_ACCOUNTS`).
-
-### C-M4 — HQ's subdomain is a distinct failure domain the migration depends on
-
-`_@divinehq.divine.video` resolves against the `divinehq.divine.video` origin,
-separate from `divine.video`. Since the migration makes HQ the primary support
-channel, an unprovisioned/404 `divinehq` well-known reads as affirmative-absence
-and (after the 5-min recheck) revokes the primary support channel for every
-protected minor. The launch-checklist monitor must probe the `divinehq`
-subdomain origin specifically, as its own dependency, before this ships.
-
-## Corrections round 2 — second adversarial review + fail-safe decision (2026-07-07)
-
-### C-B3 — web protected-state fails CLOSED and PERSISTENT (reverses fail-open)
-
-`useProtectedMinorStatus` is `staleTime: 0` + `refetchOnWindowFocus: true` and
-its own comment says "self-healing rather than sticky"; `fetchProtectedMinorStatus`
-RETURNS `UNKNOWN` on failure (not throws), so React Query stores it as success
-and OVERWRITES a prior `protected` on any focus-refetch failure — web fails open
-on every window refocus. No localStorage store exists. Required (mirrors mobile
-C-B2): persist last-known `protected` to localStorage; on `unknown`, fall back to
-the persisted value and never overwrite a `protected` entry with `unknown`; the
-safety requirement wins over the hook's "self-healing not sticky" intent for
-this tier. Same suppression logic as mobile: the restricted party can force the
-failed refetch, so it must fail closed.
-
-### C-S4 — bridge the support-key migration so minors don't lose in-flight threads
-
-Migrating `DIVINE_SUPPORT_PUBKEY` (`78a5c21b…`) to HQ orphans any existing
-minor↔`78a5c21b` support conversation: for a protected minor it is filtered out
-(not in the approved set) AND the synthetic support row now points at HQ, so the
-minor loses the thread and can't receive replies on it. Grandfather `78a5c21b`
-as read-allowed for existing threads (or migrate conversation ids), and confirm
-HQ's DM inbox is actually staffed before pointing minors at it. Sweep all four
-sites (`dm.ts`, `MessagesPage.tsx`, `Support.tsx`, `ConversationPage.tsx`).
-
-### Web metadata leak: none new — unread inherits the filter
-
-`useUnreadDmCount` derives from `useDmConversations`→`groupDmConversations`, the
-same seam the filter lands on, so it inherits filtering (unlike mobile's
-independent cubit) provided the filter is applied inside/after
-`groupDmConversations`.
+Web this branch/PR. Protected-minor state (#456) is merged and currently
+unconsumed here. The #453 adult-content lock is separate (PR #473).
+Parent-approved allowlist is #455 [later].

--- a/docs/superpowers/specs/2026-07-07-protected-minor-dm-restriction-web-design.md
+++ b/docs/superpowers/specs/2026-07-07-protected-minor-dm-restriction-web-design.md
@@ -130,3 +130,35 @@ channel, an unprovisioned/404 `divinehq` well-known reads as affirmative-absence
 and (after the 5-min recheck) revokes the primary support channel for every
 protected minor. The launch-checklist monitor must probe the `divinehq`
 subdomain origin specifically, as its own dependency, before this ships.
+
+## Corrections round 2 — second adversarial review + fail-safe decision (2026-07-07)
+
+### C-B3 — web protected-state fails CLOSED and PERSISTENT (reverses fail-open)
+
+`useProtectedMinorStatus` is `staleTime: 0` + `refetchOnWindowFocus: true` and
+its own comment says "self-healing rather than sticky"; `fetchProtectedMinorStatus`
+RETURNS `UNKNOWN` on failure (not throws), so React Query stores it as success
+and OVERWRITES a prior `protected` on any focus-refetch failure — web fails open
+on every window refocus. No localStorage store exists. Required (mirrors mobile
+C-B2): persist last-known `protected` to localStorage; on `unknown`, fall back to
+the persisted value and never overwrite a `protected` entry with `unknown`; the
+safety requirement wins over the hook's "self-healing not sticky" intent for
+this tier. Same suppression logic as mobile: the restricted party can force the
+failed refetch, so it must fail closed.
+
+### C-S4 — bridge the support-key migration so minors don't lose in-flight threads
+
+Migrating `DIVINE_SUPPORT_PUBKEY` (`78a5c21b…`) to HQ orphans any existing
+minor↔`78a5c21b` support conversation: for a protected minor it is filtered out
+(not in the approved set) AND the synthetic support row now points at HQ, so the
+minor loses the thread and can't receive replies on it. Grandfather `78a5c21b`
+as read-allowed for existing threads (or migrate conversation ids), and confirm
+HQ's DM inbox is actually staffed before pointing minors at it. Sweep all four
+sites (`dm.ts`, `MessagesPage.tsx`, `Support.tsx`, `ConversationPage.tsx`).
+
+### Web metadata leak: none new — unread inherits the filter
+
+`useUnreadDmCount` derives from `useDmConversations`→`groupDmConversations`, the
+same seam the filter lands on, so it inherits filtering (unlike mobile's
+independent cubit) provided the filter is applied inside/after
+`groupDmConversations`.

--- a/docs/superpowers/specs/2026-07-07-protected-minor-dm-restriction-web-design.md
+++ b/docs/superpowers/specs/2026-07-07-protected-minor-dm-restriction-web-design.md
@@ -15,8 +15,18 @@ dcadenas on the PR before merge.
     / `_@divinehq.divine.video`, minorContactable
   - Divine Moderation `8fd5eb6d8f362163bc00a5ab6b4a3167dbf32d00ec4efdbcf43b3c9514433b7e`
     / `moderation@divine.video`, minorContactable
-- **NIP-05 leg:** fail open on network failure, fail closed on affirmative
-  mismatch; 1h TTL; per-entry canonical identifier.
+- **NIP-05 leg (amended 2026-07-07 after pressure-testing):** graded drop
+  signals — different-key resolution drops immediately; affirmative absence
+  requires a confirming ~5-minute recheck (a name-server hiccup must not
+  mass-revoke support access); network failure keeps last-known state
+  (pin-trusted on cold start). 1h TTL for the background/inbound cache, plus
+  **send-time freshness**: the async send path awaits a fresh resolution when
+  the cache is stale. Per-entry canonical identifier. The mobile spec's
+  "Threat model and accepted risks" section (reachability-bounded revocation,
+  storage-clear un-revocation, client-side-only inbound enforcement) and its
+  pre-merge ops launch checklist (revocation runbook, tier-2 name monitoring,
+  two-person-rule decision) apply to web identically — web persists last-known
+  leg state in localStorage.
 - **Activation:** enforce when `useProtectedMinorStatus` resolves `protected`;
   never-resolved unknown does not enforce; sticky through transient unknowns
   (persist last-known protected, lift only on positive not-protected — web adds

--- a/docs/superpowers/specs/2026-07-07-protected-minor-dm-restriction-web-design.md
+++ b/docs/superpowers/specs/2026-07-07-protected-minor-dm-restriction-web-design.md
@@ -1,0 +1,20 @@
+# Restrict protected-minor DMs to HQ/Support on web (divine-web#454)
+
+**Status:** WIP stub — design pending the official-identity trust-model
+decision (divine-mobile#4948). Web sibling of divine-mobile#5754; the resolved
+design will land here mirroring the mobile spec.
+
+**Part of:** support-trust-safety#176 / epic support-trust-safety#173.
+
+## Blocked on
+
+- divine-mobile#4948: how clients pin the authoritative Divine HQ/Support
+  identity set (pin vs NIP-05 vs hybrid). support-trust-safety#176 is
+  blocked-by that decision; this branch stakes the web implementation slot.
+
+## Shape (to be confirmed by the decision)
+
+- Send-block: a protected minor cannot compose DMs to non-official npubs.
+- Inbound filter: DMs from non-official senders are not surfaced.
+- Client-side by necessity (NIP-17 gift-wraps hide sender from the relay).
+- Official set consumed via whatever mechanism #4948 lands.

--- a/docs/superpowers/specs/2026-07-07-protected-minor-dm-restriction-web-design.md
+++ b/docs/superpowers/specs/2026-07-07-protected-minor-dm-restriction-web-design.md
@@ -87,3 +87,46 @@ migration renders HQ. Follow the existing `dm.ts`/hooks test harnesses.
 Web this branch/PR. Depends on nothing new — protected-minor state (#456) is
 merged and currently unconsumed on this surface. The #453 adult-content lock
 lands separately (PR #473). Parent-approved allowlist is #455 [later].
+
+## Corrections after adversarial review (2026-07-07)
+
+Independent adversarial review (verified against code) found web-specific holes;
+these supersede conflicting text above.
+
+### C-H3 — thread view needs its own guard (was: only conversation-list filtered)
+
+Enforcement point #2 filtered `useDmConversations` (:310), but the thread renders
+through the separate `useDmConversation` (:363) → `useDmMessages` raw cache, which
+is unfiltered. `ConversationPage` decodes the peer from the URL, so a protected
+minor deep-linking to `/messages/<non-approved-peer>` sees full history. Add a
+**thread-route guard** mirroring mobile: when protected and the conversation
+counterparty is non-approved, block the thread render (redirect to inbox with a
+notice) — not merely hide compose. Also re-apply the approved predicate inside
+`useDmConversation`'s result so a revoked counterparty's already-open thread
+clears on revalidation.
+
+### C-H2/M2 — `resolveNip05` gets the same discriminated result + limits
+
+`src/lib/officialAccounts.ts` `resolveNip05` returns
+`{ matched | differentKey | absent | networkError }` with fetch timeout,
+redirect cap, size cap, and lowercase+trim hex normalization (mirrors the mobile
+resolver corrections C-H2/M1/M3). The graded drop / fail-open rules attach to
+this, and send-time freshness awaits any in-flight resolution rather than
+treating concurrency as failure.
+
+### C-L2 — the personal-key migration must sweep ALL sites
+
+`78a5c21b…2738` is referenced in `src/lib/dm.ts`, `src/pages/MessagesPage.tsx`,
+`src/pages/Support.tsx`, and `src/pages/ConversationPage.tsx` — not just
+MessagesPage. Migrating only one leaves the personal key a reachable compose
+target that is not an approved recipient. Sweep all four; the constant should
+resolve to the HQ account (or be removed in favor of `PINNED_OFFICIAL_ACCOUNTS`).
+
+### C-M4 — HQ's subdomain is a distinct failure domain the migration depends on
+
+`_@divinehq.divine.video` resolves against the `divinehq.divine.video` origin,
+separate from `divine.video`. Since the migration makes HQ the primary support
+channel, an unprovisioned/404 `divinehq` well-known reads as affirmative-absence
+and (after the 5-min recheck) revokes the primary support channel for every
+protected minor. The launch-checklist monitor must probe the `divinehq`
+subdomain origin specifically, as its own dependency, before this ships.

--- a/docs/superpowers/specs/2026-07-07-protected-minor-dm-restriction-web-design.md
+++ b/docs/superpowers/specs/2026-07-07-protected-minor-dm-restriction-web-design.md
@@ -71,14 +71,15 @@ folded in.
    `protected` block throws `DmSendBlockedError` (official-accounts-only copy);
    an `unknown`-status block throws `DmSendUnverifiedError` (retriable
    "couldn't verify" copy — the definitive copy would be wrong for an adult
-   whose status check merely failed). Defense-in-depth guard inside
-   `createRecipientGiftWraps` (`dm.ts:384`) behind an options flag. Group send
-   requires all recipients approved. (Web has no durable outgoing queue, so no
+   whose status check merely failed). `createRecipientGiftWraps` (`dm.ts`) has
+   NO runtime backstop; it carries a documented INVARIANT instead: its only
+   caller is `useDmSend`, which gates first, and any new caller must gate
+   before building wraps. Group send requires all recipients approved. (Web has no durable outgoing queue, so no
    drain re-check needed — the mobile enqueue-before-gate hazard does not apply.)
 2. **Inbound filter — list AND thread.** `useDmConversations`
    (`groupDmConversations`) drops non-approved counterparties when
    protected; sender identity is the seal-validated `senderPubkey`
-   (`dm.ts:501` rejects seal≠rumor, built `:525`). **The thread view is a
+   (`dm.ts` rejects seal≠rumor at parse time). **The thread view is a
    separate seam:** `useDmConversation` → `useDmMessages` raw cache is
    NOT filtered by the list, so a deep link to `/messages/<non-approved-peer>`
    would show full history. Add a **thread-route guard** (redirect to inbox when

--- a/docs/superpowers/specs/2026-07-07-protected-minor-dm-restriction-web-design.md
+++ b/docs/superpowers/specs/2026-07-07-protected-minor-dm-restriction-web-design.md
@@ -32,7 +32,7 @@ folded in.
 1. Web has a **full** NIP-17 DM implementation (`src/lib/dm.ts`,
    `useDirectMessages.ts`, `MessagesPage`/`ConversationPage`), so this is a real
    send-block + inbound filter, not a future-surface guard.
-2. `DIVINE_SUPPORT_PUBKEY` (`dm.ts:17`) is the **personal key**
+2. `DIVINE_SUPPORT_PUBKEY` (`dm.ts`) was the **personal key**
    `78a5c21b5166dc1474b64ddf7454bf79e6b5d6b4a77148593bf1e866b73c2738`, referenced
    in `dm.ts`, `MessagesPage.tsx`, `Support.tsx`, and `ConversationPage.tsx`
    (four sites). Per #4948 it migrates to the pinned **Moderation** account

--- a/docs/superpowers/specs/2026-07-07-protected-minor-dm-restriction-web-design.md
+++ b/docs/superpowers/specs/2026-07-07-protected-minor-dm-restriction-web-design.md
@@ -35,7 +35,11 @@ folded in.
 2. `DIVINE_SUPPORT_PUBKEY` (`dm.ts:17`) is the **personal key**
    `78a5c21b5166dc1474b64ddf7454bf79e6b5d6b4a77148593bf1e866b73c2738`, referenced
    in `dm.ts`, `MessagesPage.tsx`, `Support.tsx`, and `ConversationPage.tsx`
-   (four sites). Per #4948 it migrates to HQ across **all four**.
+   (four sites). Per #4948 it migrates to the pinned **Moderation** account
+   (`8fd5eb6d…` / `moderation@divine.video`) across **all four** — single-sourced
+   via `DIVINE_SUPPORT_PUBKEY = DIVINE_MODERATION_PUBKEY` (`dm.ts`), so the three
+   consumer sites pick it up transitively. (Decision: Moderation, not HQ, because
+   its DM inbox is staffed for support and it is already in the approved set.)
 
 ## Architecture
 
@@ -78,14 +82,22 @@ folded in.
    revalidation. Group inbound requires ALL non-self participants approved.
    Unread count already inherits the filter (`useUnreadDmCount` derives from
    `groupDmConversations`), provided the filter is applied inside/after it.
-3. **Support-key migration (bridge, do not orphan):** migrating
-   `78a5c21b…` → HQ orphans any existing minor↔`78a5c21b` support thread — for a
-   protected minor it is filtered out AND the synthetic support row now points at
-   HQ, so the minor loses the thread and replies. Grandfather `78a5c21b` as
-   read-allowed for existing threads (or migrate conversation ids), sweep all
-   four sites, and confirm HQ's DM inbox is staffed before pointing minors there.
+3. **Support-key migration (orphan risk accepted, no bridge built — decided):**
+   repointing `78a5c21b…` → Moderation means any pre-existing minor↔`78a5c21b`
+   support thread is filtered out for a protected minor (the peer `78a5c21b` is
+   not in the approved set), so the minor would lose visibility of that thread.
+   **We accept this and do NOT build a grandfather bridge**, because: (a) the
+   protected-minor feature is unshipped, so no protected minor has an existing
+   `78a5c21b` thread today; the repoint lands before any protected minor exists,
+   so new support threads go to Moderation (approved) from the start; (b) the
+   failure is fail-**closed** — an orphaned old thread is hidden, never leaked;
+   (c) the only residual case is a user who messaged web "Message Support"
+   (→`78a5c21b`) before ship AND later becomes a protected minor, losing an old
+   support thread's history — negligible and non-safety. If that case ever
+   matters, grandfather `78a5c21b` as read-allowed for inbound display only
+   (never send-approved) as a follow-up.
 4. **Affordances:** hide compose paths to non-approved accounts when protected;
-   the `MessagesPage` support row points at HQ post-migration.
+   the `MessagesPage` support row points at Moderation post-repoint.
 
 ## Tests
 
@@ -94,7 +106,8 @@ different-key drop+persist, absence-recheck, network retention, TTL, case
 normalization); useDmSend gate (typed rejection, nothing published); list +
 **thread-view** filtering; group requires all participants; unread inherits;
 protected-state persistence (fails closed on unknown, never overwrites protected,
-localStorage survives reload); support-row migration renders HQ without orphaning.
+localStorage survives reload); support-row repoint renders the Moderation account
+(orphan of old-key threads accepted per §3, no bridge).
 Follow the existing `dm.ts`/hooks harnesses.
 
 ## Scope

--- a/docs/superpowers/specs/2026-07-07-protected-minor-dm-restriction-web-design.md
+++ b/docs/superpowers/specs/2026-07-07-protected-minor-dm-restriction-web-design.md
@@ -6,7 +6,7 @@
 This doc is the clean web mirror: it inherits every decision there and records
 only the web-specific seams and deltas. Two adversarial reviews (2026-07-07)
 folded in.
-**Status:** Design complete; implementation held pending @dcadenas design-level review.
+**Status:** Implemented in this branch (PR #474).
 
 ## Inherited from the mobile spec (unchanged on web)
 
@@ -18,7 +18,9 @@ folded in.
 - **Fail-safe: FAIL CLOSED and PERSISTENT.** Enforce on `unknown`/cold-start when
   ever-seen-protected; the restricted party can suppress the check, so it must
   fail closed on suppression; a persistent last-known store relaxes only for
-  accounts positively seen `not_protected`.
+  accounts positively seen `not_protected`. On web every gate consumes the
+  tri-state `state` via `isMinorDmRestricted` (`unknown` restricts like
+  `protected`); there is no boolean convenience hook for gates to misuse.
 - **Graded NIP-05 leg:** different-key drops immediately; absence needs a
   confirming ~5-min recheck; network failure keeps last-known (pin-trusted cold
   start); 1h TTL with send-time freshness + receive-time revalidation as the
@@ -63,18 +65,21 @@ folded in.
 
 ### Enforcement points (seams verified 2026-07-07)
 
-1. **Send gate:** in `useDmSend` (`useDirectMessages.ts:427-460`), reject
-   recipients failing the predicate with a typed error BEFORE
-   `createRecipientGiftWraps` (`:453`); surfaced inline in
-   `ConversationPage.handleSend` (`:220`). Defense-in-depth guard inside
+1. **Send gate:** in `useDmSend` (`useDirectMessages.ts`), reject recipients
+   failing the predicate with a typed error BEFORE `createRecipientGiftWraps`;
+   surfaced inline in `ConversationPage.handleSend`. Two typed errors: a definitive
+   `protected` block throws `DmSendBlockedError` (official-accounts-only copy);
+   an `unknown`-status block throws `DmSendUnverifiedError` (retriable
+   "couldn't verify" copy — the definitive copy would be wrong for an adult
+   whose status check merely failed). Defense-in-depth guard inside
    `createRecipientGiftWraps` (`dm.ts:384`) behind an options flag. Group send
    requires all recipients approved. (Web has no durable outgoing queue, so no
    drain re-check needed — the mobile enqueue-before-gate hazard does not apply.)
 2. **Inbound filter — list AND thread.** `useDmConversations`
-   (`:316`, `groupDmConversations`) drops non-approved counterparties when
+   (`groupDmConversations`) drops non-approved counterparties when
    protected; sender identity is the seal-validated `senderPubkey`
    (`dm.ts:501` rejects seal≠rumor, built `:525`). **The thread view is a
-   separate seam:** `useDmConversation` (`:363`) → `useDmMessages` raw cache is
+   separate seam:** `useDmConversation` → `useDmMessages` raw cache is
    NOT filtered by the list, so a deep link to `/messages/<non-approved-peer>`
    would show full history. Add a **thread-route guard** (redirect to inbox when
    protected + counterparty non-approved) AND re-apply the predicate inside

--- a/docs/superpowers/specs/2026-07-07-protected-minor-dm-restriction-web-design.md
+++ b/docs/superpowers/specs/2026-07-07-protected-minor-dm-restriction-web-design.md
@@ -1,20 +1,76 @@
-# Restrict protected-minor DMs to HQ/Support on web (divine-web#454)
+# Restrict protected-minor DMs to official Divine accounts on web (divine-web#454)
 
-**Status:** WIP stub — design pending the official-identity trust-model
-decision (divine-mobile#4948). Web sibling of divine-mobile#5754; the resolved
-design will land here mirroring the mobile spec.
+**Issue:** divine-web#454, web half of support-trust-safety#176 (epic #173).
+**Date:** 2026-07-07, following the divine-mobile#4948 trust-model decision.
+**Status:** Design complete, pending Matt's approval; implementation follows on
+this branch. Mirrors the mobile design
+(`divine-mobile/docs/superpowers/specs/2026-07-02-protected-minor-dm-restriction-design.md`);
+this doc records the web-specific seams and deltas. Security posture review by
+dcadenas on the PR before merge.
 
-**Part of:** support-trust-safety#176 / epic support-trust-safety#173.
+## Shared decisions (see the mobile spec for full rationale)
 
-## Blocked on
+- **Approved set = pinned ∩ live NIP-05 (Tier 2, #4948):**
+  - Divine HQ `c4a39f1291291d452405cd8ddd798c4a29a3858c52cd0d843f1f6852cf17682e`
+    / `_@divinehq.divine.video`, minorContactable
+  - Divine Moderation `8fd5eb6d8f362163bc00a5ab6b4a3167dbf32d00ec4efdbcf43b3c9514433b7e`
+    / `moderation@divine.video`, minorContactable
+- **NIP-05 leg:** fail open on network failure, fail closed on affirmative
+  mismatch; 1h TTL; per-entry canonical identifier.
+- **Activation:** enforce when `useProtectedMinorStatus` resolves `protected`;
+  never-resolved unknown does not enforce; sticky through transient unknowns
+  (persist last-known protected, lift only on positive not-protected — web adds
+  the localStorage persistence the mobile provider gets from Riverpod `.value`).
 
-- divine-mobile#4948: how clients pin the authoritative Divine HQ/Support
-  identity set (pin vs NIP-05 vs hybrid). support-trust-safety#176 is
-  blocked-by that decision; this branch stakes the web implementation slot.
+## Web-specific findings and deltas
 
-## Shape (to be confirmed by the decision)
+1. **Web DMs are fully implemented** (NIP-17 send + inbox, `src/lib/dm.ts`,
+   `useDirectMessages.ts`, `MessagesPage`/`ConversationPage`), so this is a
+   full send-block + inbound filter, not a future-surface guard.
+2. **`DIVINE_SUPPORT_PUBKEY` (`dm.ts:17`) is the personal key
+   `78a5c21b5166dc1474b64ddf7454bf79e6b5d6b4a77148593bf1e866b73c2738`,**
+   used by `MessagesPage` for the pinned support conversation. Per #4948
+   ("deliberate, role-tagged accounts, not personal keys") this migrates to the
+   HQ account as part of this PR: the support-conversation affordance points at
+   HQ, and the personal key is not an approved minor-DM recipient.
 
-- Send-block: a protected minor cannot compose DMs to non-official npubs.
-- Inbound filter: DMs from non-official senders are not surfaced.
-- Client-side by necessity (NIP-17 gift-wraps hide sender from the relay).
-- Official set consumed via whatever mechanism #4948 lands.
+## Architecture
+
+- **New `src/lib/officialAccounts.ts`:** `OfficialAccount` model +
+  `PINNED_OFFICIAL_ACCOUNTS`; `isPinnedMinorContactable(hex)`;
+  `resolveNip05(identifier)` against the canonical form;
+  `isApprovedMinorDmRecipient(hex)` implementing pin ∩ NIP-05 with the leg
+  semantics + localStorage last-known store (1h TTL).
+- **New `src/hooks/useApprovedMinorDmRecipients.ts`:** React Query wrapper
+  exposing the resolved approved set + a sync predicate for list filtering.
+
+### Enforcement points (seams verified 2026-07-07)
+
+1. **Send gate:** `useDmSend` mutation (`src/hooks/useDirectMessages.ts`
+   ~:427-460): when protected, reject recipients failing the predicate with a
+   typed error BEFORE `createRecipientGiftWraps` (~:453) — surfaced as inline
+   copy in `ConversationPage.handleSend` (~:220). Defense-in-depth: the same
+   predicate guard inside `createRecipientGiftWraps` (`src/lib/dm.ts` ~:384)
+   behind an options flag.
+2. **Inbound filter:** `useDmConversations` (~:316,
+   `groupDmConversations(...)`): when protected, drop conversations whose
+   counterparty fails the predicate. Sender identity comes from the
+   seal-validated `senderPubkey` (`dm.ts` unwrap ~:501, mismatch already
+   rejected; message built ~:525).
+3. **Affordances:** any profile/message entry points and the `MessagesPage`
+   support row (post-migration, points at HQ) — hide compose paths to
+   non-approved accounts when protected.
+
+## Tests
+
+Mirror the mobile matrix: officialAccounts unit tests (pin-miss, match,
+affirmative-mismatch drop + persistence, network-failure retention, TTL);
+useDmSend gate (typed rejection, nothing published); conversation filtering
+(inbox + any request-like surface); non-minor unaffected; support-row
+migration renders HQ. Follow the existing `dm.ts`/hooks test harnesses.
+
+## Scope
+
+Web this branch/PR. Depends on nothing new — protected-minor state (#456) is
+merged and currently unconsumed on this surface. The #453 adult-content lock
+lands separately (PR #473). Parent-approved allowlist is #455 [later].

--- a/src/components/ProfileHeader.test.tsx
+++ b/src/components/ProfileHeader.test.tsx
@@ -26,18 +26,35 @@ vi.mock('@/hooks/useRssFeedAvailable', () => ({
   useRssFeedAvailable: () => false,
 }));
 
+// Mutable so protected-minor tests can flip the state (#176). Defaults preserve
+// the prior behavior (non-protected, DMs off).
+const pm = vi.hoisted(() => ({
+  isProtectedMinor: false,
+  canUseDirectMessages: false,
+  approved: new Set<string>(),
+}));
+
 vi.mock('@/hooks/useProtectedMinorStatus', () => ({
-  useIsProtectedMinor: () => false,
+  useIsProtectedMinor: () => pm.isProtectedMinor,
   useProtectedMinorStatus: () => ({
-    state: 'not_protected',
-    isProtectedMinor: false,
+    state: pm.isProtectedMinor ? 'protected' : 'not_protected',
+    isProtectedMinor: pm.isProtectedMinor,
     isKnown: true,
     verifiedMinorAt: null,
   }),
 }));
 
 vi.mock('@/hooks/useDirectMessages', () => ({
-  useDmCapability: () => ({ canUseDirectMessages: false }),
+  useDmCapability: () => ({ canUseDirectMessages: pm.canUseDirectMessages }),
+}));
+
+vi.mock('@/lib/officialAccounts', async (orig) => ({
+  ...(await orig<typeof import('@/lib/officialAccounts')>()),
+  officialAccountsService: {
+    isApprovedMinorDmRecipientSync: (pk: string) => pm.approved.has(pk),
+    isApprovedMinorDmRecipient: async (pk: string) => pm.approved.has(pk),
+    onVerdictChanged: () => () => {},
+  },
 }));
 
 vi.mock('@/hooks/useFollowers', () => ({
@@ -89,6 +106,9 @@ const baseStats: ProfileStats = {
 
 describe('ProfileHeader', () => {
   beforeEach(async () => {
+    pm.isProtectedMinor = false;
+    pm.canUseDirectMessages = false;
+    pm.approved.clear();
     const storage = new Map<string, string>();
     Object.defineProperty(window, 'localStorage', {
       configurable: true,
@@ -100,6 +120,52 @@ describe('ProfileHeader', () => {
       } satisfies Pick<Storage, 'getItem' | 'setItem' | 'removeItem' | 'clear'>,
     });
     await initializeI18n({ force: true, languages: ['en-US'] });
+  });
+
+  describe('protected-minor Message affordance (#176)', () => {
+    const HQ =
+      'c4a39f1291291d452405cd8ddd798c4a29a3858c52cd0d843f1f6852cf17682e';
+    const renderFor = (pubkey: string) =>
+      render(
+        <MemoryRouter>
+          <ProfileHeader
+            pubkey={pubkey}
+            metadata={{ display_name: 'Someone' }}
+            stats={baseStats}
+            legacySocials={[]}
+            isOwnProfile={false}
+            isFollowing={false}
+            onFollowToggle={vi.fn()}
+          />
+        </MemoryRouter>,
+      );
+
+    it('shows the Message button for a non-protected user', () => {
+      pm.canUseDirectMessages = true;
+      renderFor('a'.repeat(64));
+      expect(
+        screen.getByRole('button', { name: /message/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('hides the Message button when a protected minor views a non-approved profile', () => {
+      pm.canUseDirectMessages = true;
+      pm.isProtectedMinor = true; // 'a'*64 is not in the approved set
+      renderFor('a'.repeat(64));
+      expect(
+        screen.queryByRole('button', { name: /message/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('shows the Message button when a protected minor views an approved official profile', () => {
+      pm.canUseDirectMessages = true;
+      pm.isProtectedMinor = true;
+      pm.approved.add(HQ);
+      renderFor(HQ);
+      expect(
+        screen.getByRole('button', { name: /message/i }),
+      ).toBeInTheDocument();
+    });
   });
 
   it('shows clickable legacy socials for classic viners only', () => {

--- a/src/components/ProfileHeader.test.tsx
+++ b/src/components/ProfileHeader.test.tsx
@@ -29,17 +29,16 @@ vi.mock('@/hooks/useRssFeedAvailable', () => ({
 // Mutable so protected-minor tests can flip the state (#176). Defaults preserve
 // the prior behavior (non-protected, DMs off).
 const pm = vi.hoisted(() => ({
-  isProtectedMinor: false,
+  state: 'not_protected' as 'protected' | 'not_protected' | 'unknown',
   canUseDirectMessages: false,
   approved: new Set<string>(),
 }));
 
 vi.mock('@/hooks/useProtectedMinorStatus', () => ({
-  useIsProtectedMinor: () => pm.isProtectedMinor,
   useProtectedMinorStatus: () => ({
-    state: pm.isProtectedMinor ? 'protected' : 'not_protected',
-    isProtectedMinor: pm.isProtectedMinor,
-    isKnown: true,
+    state: pm.state,
+    isProtectedMinor: pm.state === 'protected',
+    isKnown: pm.state !== 'unknown',
     verifiedMinorAt: null,
   }),
 }));
@@ -106,7 +105,7 @@ const baseStats: ProfileStats = {
 
 describe('ProfileHeader', () => {
   beforeEach(async () => {
-    pm.isProtectedMinor = false;
+    pm.state = 'not_protected';
     pm.canUseDirectMessages = false;
     pm.approved.clear();
     const storage = new Map<string, string>();
@@ -150,7 +149,7 @@ describe('ProfileHeader', () => {
 
     it('hides the Message button when a protected minor views a non-approved profile', () => {
       pm.canUseDirectMessages = true;
-      pm.isProtectedMinor = true; // 'a'*64 is not in the approved set
+      pm.state = 'protected'; // 'a'*64 is not in the approved set
       renderFor('a'.repeat(64));
       expect(
         screen.queryByRole('button', { name: /message/i }),
@@ -159,7 +158,26 @@ describe('ProfileHeader', () => {
 
     it('shows the Message button when a protected minor views an approved official profile', () => {
       pm.canUseDirectMessages = true;
-      pm.isProtectedMinor = true;
+      pm.state = 'protected';
+      pm.approved.add(HQ);
+      renderFor(HQ);
+      expect(
+        screen.getByRole('button', { name: /message/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('fails closed on unknown: hides the Message button for a non-approved profile', () => {
+      pm.canUseDirectMessages = true;
+      pm.state = 'unknown'; // 'a'*64 is not in the approved set
+      renderFor('a'.repeat(64));
+      expect(
+        screen.queryByRole('button', { name: /message/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('keeps the Message button for an approved official while unknown', () => {
+      pm.canUseDirectMessages = true;
+      pm.state = 'unknown';
       pm.approved.add(HQ);
       renderFor(HQ);
       expect(

--- a/src/components/ProfileHeader.test.tsx
+++ b/src/components/ProfileHeader.test.tsx
@@ -37,7 +37,6 @@ const pm = vi.hoisted(() => ({
 vi.mock('@/hooks/useProtectedMinorStatus', () => ({
   useProtectedMinorStatus: () => ({
     state: pm.state,
-    isProtectedMinor: pm.state === 'protected',
     isKnown: pm.state !== 'unknown',
     verifiedMinorAt: null,
   }),

--- a/src/components/ProfileHeader.test.tsx
+++ b/src/components/ProfileHeader.test.tsx
@@ -26,6 +26,16 @@ vi.mock('@/hooks/useRssFeedAvailable', () => ({
   useRssFeedAvailable: () => false,
 }));
 
+vi.mock('@/hooks/useProtectedMinorStatus', () => ({
+  useIsProtectedMinor: () => false,
+  useProtectedMinorStatus: () => ({
+    state: 'not_protected',
+    isProtectedMinor: false,
+    isKnown: true,
+    verifiedMinorAt: null,
+  }),
+}));
+
 vi.mock('@/hooks/useDirectMessages', () => ({
   useDmCapability: () => ({ canUseDirectMessages: false }),
 }));

--- a/src/components/ProfileHeader.tsx
+++ b/src/components/ProfileHeader.tsx
@@ -20,6 +20,7 @@ import { UserPlus, UserCheck, CheckCircle, PencilSimple as Pencil, Copy, DotsThr
 import { useNavigate } from 'react-router-dom';
 import { feedUrls } from '@/lib/feedUrls';
 import { useRssFeedAvailable } from '@/hooks/useRssFeedAvailable';
+import { useDmComposeGuard } from '@/hooks/useDmComposeGuard';
 import { ReportContentDialog } from '@/components/ReportContentDialog';
 import { UserListDialog } from '@/components/UserListDialog';
 import { LinkedAccounts } from '@/components/LinkedAccounts';
@@ -105,6 +106,10 @@ export function ProfileHeader({
   const [showReportDialog, setShowReportDialog] = useState(false);
   const [userListDialog, setUserListDialog] = useState<'followers' | 'following' | null>(null);
   const { canUseDirectMessages } = useDmCapability();
+  // Protected-minor DM restriction (#176): hide the Message affordance when a
+  // protected minor views a non-approved profile (the send gate + route guard
+  // would block it anyway; this avoids the dead end).
+  const { isComposeBlocked } = useDmComposeGuard();
 
   // Fetch followers/following when dialog is open
   const followersQuery = useFollowers(userListDialog === 'followers' ? pubkey : '');
@@ -352,7 +357,7 @@ export function ProfileHeader({
                 </>
               )}
             </Button>
-            {canUseDirectMessages && (
+            {canUseDirectMessages && !isComposeBlocked(pubkey) && (
               <Button
                 variant="outline"
                 size="sm"

--- a/src/hooks/useAdultVerification.test.ts
+++ b/src/hooks/useAdultVerification.test.ts
@@ -18,7 +18,7 @@ vi.mock('@/lib/mediaViewerAuth', () => ({
 // Protected-minor lock (#453): default to a known not-protected session so the
 // pre-existing behavior tests run unlocked; lock tests override per-case.
 const PROTECTED: ProtectedMinorStatus = Object.freeze({
-  state: 'protected' as const, isProtectedMinor: true, isKnown: true, verifiedMinorAt: new Date('2026-05-01T00:00:00Z'),
+  state: 'protected' as const, isKnown: true, verifiedMinorAt: new Date('2026-05-01T00:00:00Z'),
 });
 let minorStatus: ProtectedMinorStatus = NOT_PROTECTED;
 vi.mock('@/hooks/useProtectedMinorStatus', () => ({

--- a/src/hooks/useAdultVerification.ts
+++ b/src/hooks/useAdultVerification.ts
@@ -59,7 +59,7 @@ export function useAdultVerification(): AdultVerificationState {
   // adult gate. Gating here, at the single seam every adult-content consumer
   // reads, locks them all at once.
   const minorStatus = useProtectedMinorStatus();
-  const minorLocked = minorStatus.isProtectedMinor;
+  const minorLocked = minorStatus.state === 'protected';
   // Unknown only occurs for authenticated sessions (signed-out resolves to
   // not-protected), and the check was designed for #175 to fail closed on it.
   // Unknown is also exposed through isLoading for consumers that can surface

--- a/src/hooks/useDirectMessages.test.ts
+++ b/src/hooks/useDirectMessages.test.ts
@@ -73,16 +73,15 @@ vi.mock('@/hooks/useToast', () => ({
 // and the approved set. Defaults preserve every existing test's non-protected
 // behavior. The real dmSendGuard / dmInboundFilter run against this stub service.
 const pm = vi.hoisted(() => ({
-  isProtectedMinor: false,
+  state: 'not_protected' as 'protected' | 'not_protected' | 'unknown',
   approved: new Set<string>(),
 }));
 
 vi.mock('@/hooks/useProtectedMinorStatus', () => ({
-  useIsProtectedMinor: () => pm.isProtectedMinor,
   useProtectedMinorStatus: () => ({
-    state: pm.isProtectedMinor ? 'protected' : 'not_protected',
-    isProtectedMinor: pm.isProtectedMinor,
-    isKnown: true,
+    state: pm.state,
+    isProtectedMinor: pm.state === 'protected',
+    isKnown: pm.state !== 'unknown',
     verifiedMinorAt: null,
   }),
 }));
@@ -113,7 +112,7 @@ vi.mock('@/lib/dm', async () => {
 import { encodeConversationId } from '@/lib/dm';
 import { DmSendBlockedError } from '@/lib/dmSendGuard';
 import { readDmOutbox, writeDmOutbox } from '@/lib/dmOutbox';
-import { useDmCapability, useDmConversation, useDmInboxStatus, useDmSend } from './useDirectMessages';
+import { useDmCapability, useDmConversation, useDmConversations, useDmInboxStatus, useDmSend } from './useDirectMessages';
 
 function createWrapper(queryClient: QueryClient) {
   return function Wrapper({ children }: { children: React.ReactNode }) {
@@ -125,7 +124,7 @@ describe('useDirectMessages', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     vi.clearAllMocks();
-    pm.isProtectedMinor = false;
+    pm.state = 'not_protected';
     pm.approved.clear();
     localStorageMock.clear();
     mockResolveDmReadRelays.mockResolvedValue(['wss://relay.example']);
@@ -631,7 +630,7 @@ describe('useDirectMessages', () => {
 
   describe('protected-minor enforcement wiring (#176)', () => {
     it('blocks a protected minor from sending to a non-approved recipient and publishes nothing', async () => {
-      pm.isProtectedMinor = true; // RECIPIENT_PUBKEY is NOT in pm.approved
+      pm.state = 'protected'; // RECIPIENT_PUBKEY is NOT in pm.approved
 
       const queryClient = new QueryClient({
         defaultOptions: {
@@ -657,7 +656,7 @@ describe('useDirectMessages', () => {
     });
 
     it('allows a protected minor to send to an approved official recipient', async () => {
-      pm.isProtectedMinor = true;
+      pm.state = 'protected';
       pm.approved.add(RECIPIENT_PUBKEY);
 
       const queryClient = new QueryClient({
@@ -683,7 +682,7 @@ describe('useDirectMessages', () => {
 
     it('blocks a group send when any recipient is non-approved (all-or-nothing), publishing nothing', async () => {
       const APPROVED = 'c'.repeat(64);
-      pm.isProtectedMinor = true;
+      pm.state = 'protected';
       pm.approved.add(APPROVED); // RECIPIENT_PUBKEY stays non-approved
 
       const queryClient = new QueryClient({
@@ -709,12 +708,135 @@ describe('useDirectMessages', () => {
 
     it('clears a thread with a non-approved peer for a protected minor', async () => {
       vi.spyOn(Date, 'now').mockReturnValue(1_234_567_890_000);
-      pm.isProtectedMinor = true; // RECIPIENT_PUBKEY not approved
+      pm.state = 'protected'; // RECIPIENT_PUBKEY not approved
 
       // A persisted outbox message to the non-approved peer would otherwise
       // surface in the thread; the inbound filter must clear it.
       writeDmOutbox(TEST_PUBKEY, [{
         clientId: 'local-1',
+        ownerPubkey: TEST_PUBKEY,
+        participantPubkeys: [RECIPIENT_PUBKEY],
+        content: 'history that must not show',
+        createdAt: 1_234_567_890,
+        lastAttemptAt: 1_234_567_890,
+        deliveryState: 'sending',
+        retryCount: 0,
+      }]);
+
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: { retry: false },
+          mutations: { retry: false },
+        },
+      });
+
+      const { result } = renderHook(
+        () => useDmConversation(encodeConversationId([RECIPIENT_PUBKEY])),
+        { wrapper: createWrapper(queryClient) },
+      );
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(result.current.data).toEqual([]);
+    });
+
+    it('fails closed on unknown: blocks a send to a non-approved recipient with retriable copy', async () => {
+      pm.state = 'unknown'; // RECIPIENT_PUBKEY not approved
+
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: { retry: false },
+          mutations: { retry: false },
+        },
+      });
+
+      const { result } = renderHook(() => useDmSend(), {
+        wrapper: createWrapper(queryClient),
+      });
+
+      await expect(
+        result.current.mutateAsync({
+          participantPubkeys: [RECIPIENT_PUBKEY],
+          content: 'sent before the status check resolved',
+        }),
+      ).rejects.toThrow();
+
+      // Nothing is built or published, exactly like the protected block.
+      expect(mockCreateRecipientGiftWraps).not.toHaveBeenCalled();
+      expect(mockPublishDmMessages).not.toHaveBeenCalled();
+
+      // The user-facing copy is the retriable "couldn't verify" framing, NOT
+      // the definitive official-accounts-only copy (wrong for an adult whose
+      // status check merely failed).
+      await waitFor(() =>
+        expect(mockToast).toHaveBeenCalledWith(
+          expect.objectContaining({
+            description: expect.stringContaining("couldn't verify your account"),
+          }),
+        ),
+      );
+    });
+
+    it('still allows a send to an approved official while unknown', async () => {
+      pm.state = 'unknown';
+      pm.approved.add(RECIPIENT_PUBKEY);
+
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: { retry: false },
+          mutations: { retry: false },
+        },
+      });
+
+      const { result } = renderHook(() => useDmSend(), {
+        wrapper: createWrapper(queryClient),
+      });
+
+      await act(async () => {
+        await result.current.mutateAsync({
+          participantPubkeys: [RECIPIENT_PUBKEY],
+          content: 'hi support, before my status resolved',
+        });
+      });
+
+      expect(mockPublishDmMessages).toHaveBeenCalled();
+    });
+
+    it('fails closed on unknown: filters a non-approved conversation from the list', async () => {
+      vi.spyOn(Date, 'now').mockReturnValue(1_234_567_890_000);
+      pm.state = 'unknown'; // RECIPIENT_PUBKEY not approved
+
+      writeDmOutbox(TEST_PUBKEY, [{
+        clientId: 'local-unknown-list',
+        ownerPubkey: TEST_PUBKEY,
+        participantPubkeys: [RECIPIENT_PUBKEY],
+        content: 'conversation that must not list',
+        createdAt: 1_234_567_890,
+        lastAttemptAt: 1_234_567_890,
+        deliveryState: 'sending',
+        retryCount: 0,
+      }]);
+
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: { retry: false },
+          mutations: { retry: false },
+        },
+      });
+
+      const { result } = renderHook(() => useDmConversations(), {
+        wrapper: createWrapper(queryClient),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(result.current.data).toEqual([]);
+    });
+
+    it('fails closed on unknown: clears a thread with a non-approved peer', async () => {
+      vi.spyOn(Date, 'now').mockReturnValue(1_234_567_890_000);
+      pm.state = 'unknown'; // RECIPIENT_PUBKEY not approved
+
+      writeDmOutbox(TEST_PUBKEY, [{
+        clientId: 'local-unknown-thread',
         ownerPubkey: TEST_PUBKEY,
         participantPubkeys: [RECIPIENT_PUBKEY],
         content: 'history that must not show',

--- a/src/hooks/useDirectMessages.test.ts
+++ b/src/hooks/useDirectMessages.test.ts
@@ -69,6 +69,33 @@ vi.mock('@/hooks/useToast', () => ({
   toast: (...args: unknown[]) => mockToast(...args),
 }));
 
+// Mutable protected-minor state (#176) so enforcement tests can flip protection
+// and the approved set. Defaults preserve every existing test's non-protected
+// behavior. The real dmSendGuard / dmInboundFilter run against this stub service.
+const pm = vi.hoisted(() => ({
+  isProtectedMinor: false,
+  approved: new Set<string>(),
+}));
+
+vi.mock('@/hooks/useProtectedMinorStatus', () => ({
+  useIsProtectedMinor: () => pm.isProtectedMinor,
+  useProtectedMinorStatus: () => ({
+    state: pm.isProtectedMinor ? 'protected' : 'not_protected',
+    isProtectedMinor: pm.isProtectedMinor,
+    isKnown: true,
+    verifiedMinorAt: null,
+  }),
+}));
+
+vi.mock('@/lib/officialAccounts', async (orig) => ({
+  ...(await orig<typeof import('@/lib/officialAccounts')>()),
+  officialAccountsService: {
+    isApprovedMinorDmRecipientSync: (pk: string) => pm.approved.has(pk),
+    isApprovedMinorDmRecipient: async (pk: string) => pm.approved.has(pk),
+    onVerdictChanged: () => () => {},
+  },
+}));
+
 vi.mock('@/lib/dm', async () => {
   const actual = await vi.importActual<typeof import('@/lib/dm')>('@/lib/dm');
   return {
@@ -84,6 +111,7 @@ vi.mock('@/lib/dm', async () => {
 });
 
 import { encodeConversationId } from '@/lib/dm';
+import { DmSendBlockedError } from '@/lib/dmSendGuard';
 import { readDmOutbox, writeDmOutbox } from '@/lib/dmOutbox';
 import { useDmCapability, useDmConversation, useDmInboxStatus, useDmSend } from './useDirectMessages';
 
@@ -97,6 +125,8 @@ describe('useDirectMessages', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     vi.clearAllMocks();
+    pm.isProtectedMinor = false;
+    pm.approved.clear();
     localStorageMock.clear();
     mockResolveDmReadRelays.mockResolvedValue(['wss://relay.example']);
     mockResolveDmWriteRelays.mockResolvedValue(['wss://relay.example']);
@@ -597,6 +627,118 @@ describe('useDirectMessages', () => {
         variant: 'destructive',
       }),
     );
+  });
+
+  describe('protected-minor enforcement wiring (#176)', () => {
+    it('blocks a protected minor from sending to a non-approved recipient and publishes nothing', async () => {
+      pm.isProtectedMinor = true; // RECIPIENT_PUBKEY is NOT in pm.approved
+
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: { retry: false },
+          mutations: { retry: false },
+        },
+      });
+
+      const { result } = renderHook(() => useDmSend(), {
+        wrapper: createWrapper(queryClient),
+      });
+
+      await expect(
+        result.current.mutateAsync({
+          participantPubkeys: [RECIPIENT_PUBKEY],
+          content: 'trying to reach a stranger',
+        }),
+      ).rejects.toThrow(DmSendBlockedError);
+
+      // The gate runs before any wrap build or publish — nothing leaks.
+      expect(mockCreateRecipientGiftWraps).not.toHaveBeenCalled();
+      expect(mockPublishDmMessages).not.toHaveBeenCalled();
+    });
+
+    it('allows a protected minor to send to an approved official recipient', async () => {
+      pm.isProtectedMinor = true;
+      pm.approved.add(RECIPIENT_PUBKEY);
+
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: { retry: false },
+          mutations: { retry: false },
+        },
+      });
+
+      const { result } = renderHook(() => useDmSend(), {
+        wrapper: createWrapper(queryClient),
+      });
+
+      await act(async () => {
+        await result.current.mutateAsync({
+          participantPubkeys: [RECIPIENT_PUBKEY],
+          content: 'hi support',
+        });
+      });
+
+      expect(mockPublishDmMessages).toHaveBeenCalled();
+    });
+
+    it('blocks a group send when any recipient is non-approved (all-or-nothing), publishing nothing', async () => {
+      const APPROVED = 'c'.repeat(64);
+      pm.isProtectedMinor = true;
+      pm.approved.add(APPROVED); // RECIPIENT_PUBKEY stays non-approved
+
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: { retry: false },
+          mutations: { retry: false },
+        },
+      });
+
+      const { result } = renderHook(() => useDmSend(), {
+        wrapper: createWrapper(queryClient),
+      });
+
+      await expect(
+        result.current.mutateAsync({
+          participantPubkeys: [APPROVED, RECIPIENT_PUBKEY],
+          content: 'group with one stranger',
+        }),
+      ).rejects.toThrow(DmSendBlockedError);
+
+      expect(mockPublishDmMessages).not.toHaveBeenCalled();
+    });
+
+    it('clears a thread with a non-approved peer for a protected minor', async () => {
+      vi.spyOn(Date, 'now').mockReturnValue(1_234_567_890_000);
+      pm.isProtectedMinor = true; // RECIPIENT_PUBKEY not approved
+
+      // A persisted outbox message to the non-approved peer would otherwise
+      // surface in the thread; the inbound filter must clear it.
+      writeDmOutbox(TEST_PUBKEY, [{
+        clientId: 'local-1',
+        ownerPubkey: TEST_PUBKEY,
+        participantPubkeys: [RECIPIENT_PUBKEY],
+        content: 'history that must not show',
+        createdAt: 1_234_567_890,
+        lastAttemptAt: 1_234_567_890,
+        deliveryState: 'sending',
+        retryCount: 0,
+      }]);
+
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: { retry: false },
+          mutations: { retry: false },
+        },
+      });
+
+      const { result } = renderHook(
+        () => useDmConversation(encodeConversationId([RECIPIENT_PUBKEY])),
+        { wrapper: createWrapper(queryClient) },
+      );
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(result.current.data).toEqual([]);
+    });
   });
 });
 

--- a/src/hooks/useDirectMessages.test.ts
+++ b/src/hooks/useDirectMessages.test.ts
@@ -80,7 +80,6 @@ const pm = vi.hoisted(() => ({
 vi.mock('@/hooks/useProtectedMinorStatus', () => ({
   useProtectedMinorStatus: () => ({
     state: pm.state,
-    isProtectedMinor: pm.state === 'protected',
     isKnown: pm.state !== 'unknown',
     verifiedMinorAt: null,
   }),

--- a/src/hooks/useDirectMessages.ts
+++ b/src/hooks/useDirectMessages.ts
@@ -10,7 +10,10 @@ import {
   assertMinorDmRecipientsAllowed,
   DmSendBlockedError,
 } from '@/lib/dmSendGuard';
-import { filterProtectedMinorConversations } from '@/lib/dmInboundFilter';
+import {
+  filterProtectedMinorConversations,
+  isThreadAllowedForProtectedMinor,
+} from '@/lib/dmInboundFilter';
 import { officialAccountsService } from '@/lib/officialAccounts';
 import {
   buildDmShareTags,
@@ -397,11 +400,32 @@ export function useDmConversation(conversationId: string | undefined, limit = 30
   const { user } = useCurrentUser();
   const messagesQuery = useDmMessages(limit);
   const { readState, markConversationRead } = useDmReadState(user?.pubkey);
+  const isProtectedMinor = useIsProtectedMinor();
+  const [, bumpVerdicts] = useReducer((x: number) => x + 1, 0);
+  useEffect(() => officialAccountsService.onVerdictChanged(bumpVerdicts), []);
 
-  const messages = useMemo<DmMessage[]>(
+  const threadMessages = useMemo<DmMessage[]>(
     () => (messagesQuery.data?.messages || []).filter((message) => message.conversationId === conversationId),
     [conversationId, messagesQuery.data],
   );
+
+  // Thread filter (#176): clear the thread when a protected minor's counterparty
+  // is not approved — defense-in-depth alongside ConversationPage's route guard
+  // (which redirects asynchronously, so history could otherwise flash). Checked
+  // each render so a verdict flip re-applies; peers are revalidated.
+  const peerPubkeys = threadMessages[0]?.peerPubkeys ?? [];
+  if (isProtectedMinor) {
+    for (const pubkey of peerPubkeys) {
+      void officialAccountsService.isApprovedMinorDmRecipient(pubkey);
+    }
+  }
+  const messages = isThreadAllowedForProtectedMinor(peerPubkeys, {
+    isProtectedMinor,
+    isApproved: (pubkey) =>
+      officialAccountsService.isApprovedMinorDmRecipientSync(pubkey),
+  })
+    ? threadMessages
+    : [];
 
   const latestMessageAt = messages[messages.length - 1]?.createdAt || 0;
   const lastReadAt = conversationId ? readState[conversationId] || 0 : 0;

--- a/src/hooks/useDirectMessages.ts
+++ b/src/hooks/useDirectMessages.ts
@@ -5,11 +5,13 @@ import { useNostrLogin } from '@nostrify/react/login';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { toast } from '@/hooks/useToast';
 import { useAppContext } from '@/hooks/useAppContext';
-import { useIsProtectedMinor } from '@/hooks/useProtectedMinorStatus';
+import { useProtectedMinorStatus } from '@/hooks/useProtectedMinorStatus';
 import {
   assertMinorDmRecipientsAllowed,
   DmSendBlockedError,
+  DmSendUnverifiedError,
 } from '@/lib/dmSendGuard';
+import { isMinorDmRestricted } from '@/lib/protectedMinor';
 import {
   filterProtectedMinorConversations,
   isThreadAllowedForProtectedMinor,
@@ -321,7 +323,7 @@ export function useDmConversations(limit = 200) {
   const { user } = useCurrentUser();
   const messagesQuery = useDmMessages(limit);
   const { readState } = useDmReadState(user?.pubkey);
-  const isProtectedMinor = useIsProtectedMinor();
+  const { state: minorState } = useProtectedMinorStatus();
 
   // Receive-time revalidation (#176): re-render when a persisted verdict flips
   // so the list re-filters and a just-revoked official drops.
@@ -336,7 +338,7 @@ export function useDmConversations(limit = 200) {
   // Receive-time revalidation kick (#176): refresh each counterparty's verdict
   // so a server-side revocation is pulled into the sync answer below; a flip
   // re-renders via `bumpVerdicts`.
-  if (isProtectedMinor) {
+  if (isMinorDmRestricted(minorState)) {
     for (const conversation of grouped) {
       for (const pubkey of conversation.participantPubkeys) {
         void officialAccountsService.isApprovedMinorDmRecipient(pubkey);
@@ -348,7 +350,7 @@ export function useDmConversations(limit = 200) {
   // sync verdict always applies. Non-restricted users get `grouped` back by
   // identity, so `useUnreadDmCount` (derived below) is unaffected for them.
   const conversations = filterProtectedMinorConversations(grouped, {
-    isProtectedMinor,
+    state: minorState,
     isApproved: (pubkey) =>
       officialAccountsService.isApprovedMinorDmRecipientSync(pubkey),
   });
@@ -400,7 +402,7 @@ export function useDmConversation(conversationId: string | undefined, limit = 30
   const { user } = useCurrentUser();
   const messagesQuery = useDmMessages(limit);
   const { readState, markConversationRead } = useDmReadState(user?.pubkey);
-  const isProtectedMinor = useIsProtectedMinor();
+  const { state: minorState } = useProtectedMinorStatus();
   const [, bumpVerdicts] = useReducer((x: number) => x + 1, 0);
   useEffect(() => officialAccountsService.onVerdictChanged(bumpVerdicts), []);
 
@@ -409,18 +411,18 @@ export function useDmConversation(conversationId: string | undefined, limit = 30
     [conversationId, messagesQuery.data],
   );
 
-  // Thread filter (#176): clear the thread when a protected minor's counterparty
+  // Thread filter (#176): clear the thread when a restricted user's counterparty
   // is not approved — defense-in-depth alongside ConversationPage's route guard
   // (which redirects asynchronously, so history could otherwise flash). Checked
   // each render so a verdict flip re-applies; peers are revalidated.
   const peerPubkeys = threadMessages[0]?.peerPubkeys ?? [];
-  if (isProtectedMinor) {
+  if (isMinorDmRestricted(minorState)) {
     for (const pubkey of peerPubkeys) {
       void officialAccountsService.isApprovedMinorDmRecipient(pubkey);
     }
   }
   const messages = isThreadAllowedForProtectedMinor(peerPubkeys, {
-    isProtectedMinor,
+    state: minorState,
     isApproved: (pubkey) =>
       officialAccountsService.isApprovedMinorDmRecipientSync(pubkey),
   })
@@ -447,8 +449,8 @@ export function useDmSend() {
   const { user, signer } = useCurrentUser();
   const { config } = useAppContext();
   // Protected-minor DM restriction (#176): captured per render so the send-time
-  // gate below sees the current status.
-  const isProtectedMinor = useIsProtectedMinor();
+  // gate below sees the current tri-state status (unknown fails closed).
+  const { state: minorState } = useProtectedMinorStatus();
 
   return useMutation<{ relayUrls: string[] }, Error, SendDmInput, SendDmMutationContext>({
     onMutate: ({ clientId, participantPubkeys, content, share }) => {
@@ -499,11 +501,12 @@ export function useDmSend() {
         throw new Error('Choose at least one person to message');
       }
 
-      // Send gate (#176): a protected minor may only DM approved official
-      // accounts; a group is all-or-nothing. Checked before any wrap build or
-      // publish, so a blocked send leaks no metadata. Throws DmSendBlockedError.
+      // Send gate (#176): a restricted user (protected minor, or unknown
+      // status — fail closed) may only DM approved official accounts; a group
+      // is all-or-nothing. Checked before any wrap build or publish, so a
+      // blocked send leaks no metadata.
       await assertMinorDmRecipientsAllowed(recipients, {
-        isProtectedMinor,
+        state: minorState,
         service: officialAccountsService,
       });
 
@@ -561,13 +564,18 @@ export function useDmSend() {
     },
     onError: (error, _variables, context) => {
       // Protected-minor block (#176): distinct, user-facing copy — not the raw
-      // internal error, and not a transient "try again" framing.
+      // internal error. A definitive block is non-retriable; an unverified
+      // block (status unknown) gets retriable framing, since "official accounts
+      // only" would be wrong for an adult whose status check merely failed.
       const isBlocked = error instanceof DmSendBlockedError;
+      const isUnverified = error instanceof DmSendUnverifiedError;
       const description = isBlocked
         ? 'You can only message official Divine accounts.'
-        : error instanceof Error
-          ? error.message
-          : 'Unable to send your message right now';
+        : isUnverified
+          ? "We couldn't verify your account just now. Try again in a minute."
+          : error instanceof Error
+            ? error.message
+            : 'Unable to send your message right now';
 
       if (user?.pubkey && context?.clientId) {
         markDmOutboxRecordFailed(user.pubkey, context.clientId, description);
@@ -578,7 +586,7 @@ export function useDmSend() {
       }
 
       toast({
-        title: isBlocked ? 'Message not sent' : 'Message failed',
+        title: isBlocked || isUnverified ? 'Message not sent' : 'Message failed',
         description,
         variant: 'destructive',
       });

--- a/src/hooks/useDirectMessages.ts
+++ b/src/hooks/useDirectMessages.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useReducer, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useNostrLogin } from '@nostrify/react/login';
 
@@ -10,6 +10,7 @@ import {
   assertMinorDmRecipientsAllowed,
   DmSendBlockedError,
 } from '@/lib/dmSendGuard';
+import { filterProtectedMinorConversations } from '@/lib/dmInboundFilter';
 import { officialAccountsService } from '@/lib/officialAccounts';
 import {
   buildDmShareTags,
@@ -317,11 +318,37 @@ export function useDmConversations(limit = 200) {
   const { user } = useCurrentUser();
   const messagesQuery = useDmMessages(limit);
   const { readState } = useDmReadState(user?.pubkey);
+  const isProtectedMinor = useIsProtectedMinor();
 
-  const conversations = useMemo<DmConversation[]>(
+  // Receive-time revalidation (#176): re-render when a persisted verdict flips
+  // so the list re-filters and a just-revoked official drops.
+  const [, bumpVerdicts] = useReducer((x: number) => x + 1, 0);
+  useEffect(() => officialAccountsService.onVerdictChanged(bumpVerdicts), []);
+
+  const grouped = useMemo<DmConversation[]>(
     () => groupDmConversations(messagesQuery.data?.messages || [], readState),
     [messagesQuery.data, readState],
   );
+
+  // Receive-time revalidation kick (#176): refresh each counterparty's verdict
+  // so a server-side revocation is pulled into the sync answer below; a flip
+  // re-renders via `bumpVerdicts`.
+  if (isProtectedMinor) {
+    for (const conversation of grouped) {
+      for (const pubkey of conversation.participantPubkeys) {
+        void officialAccountsService.isApprovedMinorDmRecipient(pubkey);
+      }
+    }
+  }
+
+  // Inbound filter (#176). Filtered each render — not memoized — so the fresh
+  // sync verdict always applies. Non-restricted users get `grouped` back by
+  // identity, so `useUnreadDmCount` (derived below) is unaffected for them.
+  const conversations = filterProtectedMinorConversations(grouped, {
+    isProtectedMinor,
+    isApproved: (pubkey) =>
+      officialAccountsService.isApprovedMinorDmRecipientSync(pubkey),
+  });
 
   return {
     ...messagesQuery,

--- a/src/hooks/useDirectMessages.ts
+++ b/src/hooks/useDirectMessages.ts
@@ -5,6 +5,12 @@ import { useNostrLogin } from '@nostrify/react/login';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { toast } from '@/hooks/useToast';
 import { useAppContext } from '@/hooks/useAppContext';
+import { useIsProtectedMinor } from '@/hooks/useProtectedMinorStatus';
+import {
+  assertMinorDmRecipientsAllowed,
+  DmSendBlockedError,
+} from '@/lib/dmSendGuard';
+import { officialAccountsService } from '@/lib/officialAccounts';
 import {
   buildDmShareTags,
   createRecipientGiftWraps,
@@ -389,6 +395,9 @@ export function useDmSend() {
   const queryClient = useQueryClient();
   const { user, signer } = useCurrentUser();
   const { config } = useAppContext();
+  // Protected-minor DM restriction (#176): captured per render so the send-time
+  // gate below sees the current status.
+  const isProtectedMinor = useIsProtectedMinor();
 
   return useMutation<{ relayUrls: string[] }, Error, SendDmInput, SendDmMutationContext>({
     onMutate: ({ clientId, participantPubkeys, content, share }) => {
@@ -438,6 +447,14 @@ export function useDmSend() {
       if (!recipients.length) {
         throw new Error('Choose at least one person to message');
       }
+
+      // Send gate (#176): a protected minor may only DM approved official
+      // accounts; a group is all-or-nothing. Checked before any wrap build or
+      // publish, so a blocked send leaks no metadata. Throws DmSendBlockedError.
+      await assertMinorDmRecipientsAllowed(recipients, {
+        isProtectedMinor,
+        service: officialAccountsService,
+      });
 
       const relayUrls = await resolveDmWriteRelays({
         appRelayUrls: config.relayUrls || [config.relayUrl],
@@ -492,17 +509,26 @@ export function useDmSend() {
       });
     },
     onError: (error, _variables, context) => {
+      // Protected-minor block (#176): distinct, user-facing copy — not the raw
+      // internal error, and not a transient "try again" framing.
+      const isBlocked = error instanceof DmSendBlockedError;
+      const description = isBlocked
+        ? 'You can only message official Divine accounts.'
+        : error instanceof Error
+          ? error.message
+          : 'Unable to send your message right now';
+
       if (user?.pubkey && context?.clientId) {
-        markDmOutboxRecordFailed(user.pubkey, context.clientId, error.message);
+        markDmOutboxRecordFailed(user.pubkey, context.clientId, description);
         updateOptimisticDmInAllCaches(queryClient, user.pubkey, context.clientId, {
           deliveryState: 'failed',
-          errorMessage: error.message,
+          errorMessage: description,
         });
       }
 
       toast({
-        title: 'Message failed',
-        description: error instanceof Error ? error.message : 'Unable to send your message right now',
+        title: isBlocked ? 'Message not sent' : 'Message failed',
+        description,
         variant: 'destructive',
       });
     },

--- a/src/hooks/useDmComposeGuard.ts
+++ b/src/hooks/useDmComposeGuard.ts
@@ -1,0 +1,37 @@
+// ABOUTME: Reusable compose-affordance guard for the protected-minor DM
+// ABOUTME: restriction (#176): hide "Message"/compose paths to non-approved
+// ABOUTME: accounts. Defense-in-depth over the send gate + route guard.
+
+import { useEffect, useReducer } from 'react';
+import { useIsProtectedMinor } from '@/hooks/useProtectedMinorStatus';
+import { isDmComposeBlockedForMinor } from '@/lib/dmSendGuard';
+import { officialAccountsService } from '@/lib/officialAccounts';
+
+/**
+ * Returns `isComposeBlocked(pubkey)`: whether the compose affordance to a given
+ * account should be hidden for the current user. `false` for a non-restricted
+ * user. For a protected minor it kicks a receive-time revalidation and returns
+ * the sync verdict; a persisted flip re-renders the consumer (via
+ * `onVerdictChanged`) so the affordance updates.
+ */
+export function useDmComposeGuard(): {
+  isProtectedMinor: boolean;
+  isComposeBlocked: (pubkey: string) => boolean;
+} {
+  const isProtectedMinor = useIsProtectedMinor();
+  const [, bumpVerdicts] = useReducer((x: number) => x + 1, 0);
+  useEffect(() => officialAccountsService.onVerdictChanged(bumpVerdicts), []);
+
+  const isComposeBlocked = (pubkey: string): boolean => {
+    if (isProtectedMinor) {
+      void officialAccountsService.isApprovedMinorDmRecipient(pubkey);
+    }
+    return isDmComposeBlockedForMinor(pubkey, {
+      isProtectedMinor,
+      isApproved: (candidate) =>
+        officialAccountsService.isApprovedMinorDmRecipientSync(candidate),
+    });
+  };
+
+  return { isProtectedMinor, isComposeBlocked };
+}

--- a/src/hooks/useDmComposeGuard.ts
+++ b/src/hooks/useDmComposeGuard.ts
@@ -3,35 +3,36 @@
 // ABOUTME: accounts. Defense-in-depth over the send gate + route guard.
 
 import { useEffect, useReducer } from 'react';
-import { useIsProtectedMinor } from '@/hooks/useProtectedMinorStatus';
+import { useProtectedMinorStatus } from '@/hooks/useProtectedMinorStatus';
 import { isDmComposeBlockedForMinor } from '@/lib/dmSendGuard';
 import { officialAccountsService } from '@/lib/officialAccounts';
+import { isMinorDmRestricted } from '@/lib/protectedMinor';
 
 /**
  * Returns `isComposeBlocked(pubkey)`: whether the compose affordance to a given
- * account should be hidden for the current user. `false` for a non-restricted
- * user. For a protected minor it kicks a receive-time revalidation and returns
- * the sync verdict; a persisted flip re-renders the consumer (via
+ * account should be hidden for the current user. `false` for a positively
+ * not-protected user. For a DM-restricted user (protected minor, or unknown
+ * status — fail closed) it kicks a receive-time revalidation and returns the
+ * sync verdict; a persisted flip re-renders the consumer (via
  * `onVerdictChanged`) so the affordance updates.
  */
 export function useDmComposeGuard(): {
-  isProtectedMinor: boolean;
   isComposeBlocked: (pubkey: string) => boolean;
 } {
-  const isProtectedMinor = useIsProtectedMinor();
+  const { state } = useProtectedMinorStatus();
   const [, bumpVerdicts] = useReducer((x: number) => x + 1, 0);
   useEffect(() => officialAccountsService.onVerdictChanged(bumpVerdicts), []);
 
   const isComposeBlocked = (pubkey: string): boolean => {
-    if (isProtectedMinor) {
+    if (isMinorDmRestricted(state)) {
       void officialAccountsService.isApprovedMinorDmRecipient(pubkey);
     }
     return isDmComposeBlockedForMinor(pubkey, {
-      isProtectedMinor,
+      state,
       isApproved: (candidate) =>
         officialAccountsService.isApprovedMinorDmRecipientSync(candidate),
     });
   };
 
-  return { isProtectedMinor, isComposeBlocked };
+  return { isComposeBlocked };
 }

--- a/src/hooks/useProtectedMinorStatus.test.ts
+++ b/src/hooks/useProtectedMinorStatus.test.ts
@@ -6,10 +6,7 @@ import {
 } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import {
-  useIsProtectedMinor,
-  useProtectedMinorStatus,
-} from './useProtectedMinorStatus';
+import { useProtectedMinorStatus } from './useProtectedMinorStatus';
 
 const mockUseDivineSession = vi.fn();
 vi.mock('@/hooks/useDivineSession', () => ({
@@ -102,11 +99,12 @@ describe('useProtectedMinorStatus', () => {
       }),
     );
 
-    const { result } = renderHook(() => useIsProtectedMinor(), {
+    const { result } = renderHook(() => useProtectedMinorStatus(), {
       wrapper: makeWrapper(),
     });
 
-    await waitFor(() => expect(result.current).toBe(true));
+    await waitFor(() => expect(result.current.state).toBe('protected'));
+    expect(result.current.isProtectedMinor).toBe(true);
   });
 
   it('refetches with the new token on account switch (no cross-user leak)', async () => {
@@ -122,11 +120,11 @@ describe('useProtectedMinorStatus', () => {
     vi.stubGlobal('fetch', fetchMock);
 
     mockUseDivineSession.mockReturnValue({ session: { token: 'minor' } });
-    const { result, rerender } = renderHook(() => useIsProtectedMinor(), {
+    const { result, rerender } = renderHook(() => useProtectedMinorStatus(), {
       wrapper: makeWrapper(),
     });
-    // Only true once the 'minor' fetch actually resolves (not a default).
-    await waitFor(() => expect(result.current).toBe(true));
+    // Only protected once the 'minor' fetch actually resolves (not a default).
+    await waitFor(() => expect(result.current.state).toBe('protected'));
 
     mockUseDivineSession.mockReturnValue({ session: { token: 'adult' } });
     rerender();
@@ -140,7 +138,7 @@ describe('useProtectedMinorStatus', () => {
         }),
       ),
     );
-    await waitFor(() => expect(result.current).toBe(false));
+    await waitFor(() => expect(result.current.state).toBe('not_protected'));
   });
 
   it('self-heals: a transient failure recovers on remount', async () => {

--- a/src/hooks/useProtectedMinorStatus.test.ts
+++ b/src/hooks/useProtectedMinorStatus.test.ts
@@ -80,7 +80,6 @@ describe('useProtectedMinorStatus', () => {
     });
 
     expect(result.current.state).toBe('not_protected');
-    expect(result.current.isProtectedMinor).toBe(false);
     expect(result.current.isKnown).toBe(true);
     expect(fetchSpy).not.toHaveBeenCalled();
   });
@@ -104,7 +103,6 @@ describe('useProtectedMinorStatus', () => {
     });
 
     await waitFor(() => expect(result.current.state).toBe('protected'));
-    expect(result.current.isProtectedMinor).toBe(true);
   });
 
   it('refetches with the new token on account switch (no cross-user leak)', async () => {
@@ -155,7 +153,6 @@ describe('useProtectedMinorStatus', () => {
     const first = renderHook(() => useProtectedMinorStatus(), { wrapper });
     await waitFor(() => expect(failing).toHaveBeenCalled());
     expect(first.result.current.state).toBe('unknown');
-    expect(first.result.current.isProtectedMinor).toBe(false);
     expect(first.result.current.isKnown).toBe(false);
     first.unmount();
 
@@ -171,7 +168,6 @@ describe('useProtectedMinorStatus', () => {
     );
     const second = renderHook(() => useProtectedMinorStatus(), { wrapper });
     await waitFor(() => expect(second.result.current.state).toBe('protected'));
-    expect(second.result.current.isProtectedMinor).toBe(true);
   });
 
   it('is unknown when the fetch fails for an authenticated session', async () => {
@@ -184,7 +180,6 @@ describe('useProtectedMinorStatus', () => {
     });
 
     expect(result.current.state).toBe('unknown');
-    expect(result.current.isProtectedMinor).toBe(false);
     expect(result.current.isKnown).toBe(false);
     await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
     expect(result.current.state).toBe('unknown');
@@ -222,7 +217,6 @@ describe('useProtectedMinorStatus', () => {
     // The refetch runs; the effective status must remain protected.
     await new Promise((r) => setTimeout(r, 30));
     expect(result.current.state).toBe('protected');
-    expect(result.current.isProtectedMinor).toBe(true);
   });
 
   it('#180: an unknown check with no prior verdict fails closed (stays unknown)', async () => {
@@ -237,7 +231,6 @@ describe('useProtectedMinorStatus', () => {
       expect((globalThis.fetch as ReturnType<typeof vi.fn>)).toHaveBeenCalled(),
     );
     expect(result.current.state).toBe('unknown');
-    expect(result.current.isProtectedMinor).toBe(false);
   });
 
   it('self-heals on window focus (refetchOnWindowFocus override)', async () => {
@@ -268,6 +261,5 @@ describe('useProtectedMinorStatus', () => {
     focusManager.setFocused(true);
 
     await waitFor(() => expect(result.current.state).toBe('protected'));
-    expect(result.current.isProtectedMinor).toBe(true);
   });
 });

--- a/src/hooks/useProtectedMinorStatus.test.ts
+++ b/src/hooks/useProtectedMinorStatus.test.ts
@@ -5,7 +5,7 @@ import {
   QueryClientProvider,
 } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   useIsProtectedMinor,
   useProtectedMinorStatus,
@@ -34,7 +34,39 @@ function makeWrapper() {
     createElement(QueryClientProvider, { client: queryClient }, children);
 }
 
+// A decodable JWT with a `sub` claim, so the sticky store (#180) keys on a
+// stable account id. The existing tests use non-JWT tokens on purpose — their
+// sub can't be decoded, so persistence is off and they test the live path only.
+function makeJwt(sub: string): string {
+  const b64url = (o: object) =>
+    btoa(JSON.stringify(o))
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '');
+  return `${b64url({ alg: 'none' })}.${b64url({ sub })}.sig`;
+}
+
+function fakeStorage(): Storage {
+  const m = new Map<string, string>();
+  return {
+    getItem: (k: string) => m.get(k) ?? null,
+    setItem: (k: string, v: string) => void m.set(k, v),
+    removeItem: (k: string) => void m.delete(k),
+    clear: () => m.clear(),
+    key: (i: number) => [...m.keys()][i] ?? null,
+    get length() {
+      return m.size;
+    },
+  } as Storage;
+}
+
 describe('useProtectedMinorStatus', () => {
+  beforeEach(() => {
+    // This env doesn't provide localStorage; the #180 sticky store keys on it.
+    // A fresh fake per test isolates the persisted verdict.
+    vi.stubGlobal('localStorage', fakeStorage());
+  });
+
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
@@ -158,6 +190,56 @@ describe('useProtectedMinorStatus', () => {
     expect(result.current.isKnown).toBe(false);
     await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
     expect(result.current.state).toBe('unknown');
+  });
+
+  it('#180: a stored protected verdict survives a later refetch that resolves to unknown', async () => {
+    focusManager.setFocused(true);
+    const token = makeJwt('minorpubkeyhex');
+    mockUseDivineSession.mockReturnValue({ session: { token } });
+
+    // First load succeeds -> protected -> persisted to the sticky store.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ verified_minor: true }),
+      }),
+    );
+    const { result } = renderHook(() => useProtectedMinorStatus(), {
+      wrapper: makeWrapper(),
+    });
+    await waitFor(() => expect(result.current.state).toBe('protected'));
+
+    // A focus refetch now fails; queryFn resolves to `unknown` and React Query
+    // writes it over the prior protected. WITHOUT the sticky store this fails
+    // open; WITH it, the hook falls back to the stored protected.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: false, status: 500 }),
+    );
+    focusManager.setFocused(false);
+    focusManager.setFocused(true);
+
+    // The refetch runs; the effective status must remain protected.
+    await new Promise((r) => setTimeout(r, 30));
+    expect(result.current.state).toBe('protected');
+    expect(result.current.isProtectedMinor).toBe(true);
+  });
+
+  it('#180: an unknown check with no prior verdict fails closed (stays unknown)', async () => {
+    const token = makeJwt('freshpubkeyhex');
+    mockUseDivineSession.mockReturnValue({ session: { token } });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+
+    const { result } = renderHook(() => useProtectedMinorStatus(), {
+      wrapper: makeWrapper(),
+    });
+    await waitFor(() =>
+      expect((globalThis.fetch as ReturnType<typeof vi.fn>)).toHaveBeenCalled(),
+    );
+    expect(result.current.state).toBe('unknown');
+    expect(result.current.isProtectedMinor).toBe(false);
   });
 
   it('self-heals on window focus (refetchOnWindowFocus override)', async () => {

--- a/src/hooks/useProtectedMinorStatus.ts
+++ b/src/hooks/useProtectedMinorStatus.ts
@@ -22,7 +22,6 @@ import {
 // `unknown`).
 const PROTECTED_STICKY: ProtectedMinorStatus = Object.freeze({
   state: 'protected',
-  isProtectedMinor: true,
   isKnown: true,
   verifiedMinorAt: null,
 });

--- a/src/hooks/useProtectedMinorStatus.ts
+++ b/src/hooks/useProtectedMinorStatus.ts
@@ -18,7 +18,8 @@ import {
 
 // Fail-safe fallback returned when the live check is `unknown` but this account
 // was last seen `protected` (#180). verifiedMinorAt is not persisted; safety
-// gates only read `isProtectedMinor`/`state`.
+// gates only read `state` (via isMinorDmRestricted, which fails closed on
+// `unknown`).
 const PROTECTED_STICKY: ProtectedMinorStatus = Object.freeze({
   state: 'protected',
   isProtectedMinor: true,
@@ -92,9 +93,4 @@ export function useProtectedMinorStatus(): ProtectedMinorStatus {
     if (lastKnown === 'not_protected') return NOT_PROTECTED;
   }
   return UNKNOWN_PROTECTED_MINOR_STATUS;
-}
-
-/** Convenience boolean for display-only callers; safety gates should inspect state. */
-export function useIsProtectedMinor(): boolean {
-  return useProtectedMinorStatus().isProtectedMinor;
 }

--- a/src/hooks/useProtectedMinorStatus.ts
+++ b/src/hooks/useProtectedMinorStatus.ts
@@ -1,14 +1,41 @@
 // ABOUTME: React Query hook exposing the non-blocking protected-minor (13-15)
 // ABOUTME: state from keycast's verified_minor flag, for #175/#176 web parity.
 
+import { useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useDivineSession } from '@/hooks/useDivineSession';
+import { decodeJWT } from '@/lib/jwtDecode';
 import {
   fetchProtectedMinorStatus,
   NOT_PROTECTED,
   type ProtectedMinorStatus,
   UNKNOWN_PROTECTED_MINOR_STATUS,
 } from '@/lib/protectedMinor';
+import {
+  readLastKnownProtected,
+  writeLastKnownProtected,
+} from '@/lib/protectedMinorStickyStore';
+
+// Fail-safe fallback returned when the live check is `unknown` but this account
+// was last seen `protected` (#180). verifiedMinorAt is not persisted; safety
+// gates only read `isProtectedMinor`/`state`.
+const PROTECTED_STICKY: ProtectedMinorStatus = Object.freeze({
+  state: 'protected',
+  isProtectedMinor: true,
+  isKnown: true,
+  verifiedMinorAt: null,
+});
+
+/** Stable per-account id (JWT `sub`) for keying the sticky store; null when the
+ *  token isn't a decodable JWT. */
+function accountIdFromToken(token: string | null): string | null {
+  if (!token) return null;
+  try {
+    return decodeJWT(token).sub ?? null;
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Non-blocking protected-minor state for the current session.
@@ -22,12 +49,11 @@ import {
 export function useProtectedMinorStatus(): ProtectedMinorStatus {
   const { session } = useDivineSession();
   const token = session?.token ?? null;
+  const accountId = accountIdFromToken(token);
 
   // queryFn never throws, so a transient failure resolves to an explicit unknown
-  // state. Keep that self-healing rather than sticky: set staleTime 0 +
-  // refetch-on-focus explicitly here, overriding the app-global defaults
-  // (staleTime 60s, refetchOnWindowFocus false) which would otherwise pin a
-  // failed check for the mounted lifetime.
+  // state. staleTime 0 + refetch-on-focus keep the LIVE value fresh; the sticky
+  // store below (not React Query) provides the fail-safe persistence.
   const { data } = useQuery({
     queryKey: ['protected-minor', token],
     enabled: !!token,
@@ -37,8 +63,35 @@ export function useProtectedMinorStatus(): ProtectedMinorStatus {
       fetchProtectedMinorStatus(token ?? '', fetch, signal),
   });
 
+  const live: ProtectedMinorStatus = !token
+    ? NOT_PROTECTED
+    : (data ?? UNKNOWN_PROTECTED_MINOR_STATUS);
+
+  // #180: persist a definitive verdict so a later `unknown` can fall back to it
+  // instead of failing open. A focus-refetch that resolves to `unknown` is
+  // written over the prior `protected` by React Query (queryFn never throws);
+  // without this, protection lifts on every failed refocus. `unknown` never
+  // writes, so a stored `protected` is never overwritten.
+  useEffect(() => {
+    if (!accountId) return;
+    if (live.state === 'protected') {
+      writeLastKnownProtected(accountId, 'protected');
+    } else if (live.state === 'not_protected') {
+      writeLastKnownProtected(accountId, 'not_protected');
+    }
+  }, [accountId, live.state]);
+
   if (!token) return NOT_PROTECTED;
-  return data ?? UNKNOWN_PROTECTED_MINOR_STATUS;
+  if (live.state !== 'unknown') return live;
+
+  // Unknown: fall back to the last-known verdict; fail CLOSED (stay unknown)
+  // when this account was never positively seen.
+  if (accountId) {
+    const lastKnown = readLastKnownProtected(accountId);
+    if (lastKnown === 'protected') return PROTECTED_STICKY;
+    if (lastKnown === 'not_protected') return NOT_PROTECTED;
+  }
+  return UNKNOWN_PROTECTED_MINOR_STATUS;
 }
 
 /** Convenience boolean for display-only callers; safety gates should inspect state. */

--- a/src/lib/dm.ts
+++ b/src/lib/dm.ts
@@ -386,6 +386,11 @@ function createWrapEvent(seal: NostrEvent, targetPubkey: string): NostrEvent {
  * use this function for the self copy — a self-wrap failure must not
  * abort delivery to the actual recipients (mirrors the pattern in
  * mobile/packages/dm_repository/lib/src/nip17_message_service.dart).
+ *
+ * INVARIANT (#176): the only caller is `useDmSend`, which runs the
+ * protected-minor send gate (`assertMinorDmRecipientsAllowed`) BEFORE this. Any
+ * new caller MUST gate first — this builder does not, so a bypass here would
+ * let a protected minor DM a non-approved account.
  */
 export async function createRecipientGiftWraps(input: CreateDmGiftWrapsInput): Promise<NostrEvent[]> {
   const { signer, senderPubkey, recipientPubkeys, content, additionalTags = [] } = input;

--- a/src/lib/dm.ts
+++ b/src/lib/dm.ts
@@ -4,6 +4,7 @@ import { sha256 } from '@noble/hashes/sha256';
 import { finalizeEvent, generateSecretKey, nip44, verifyEvent } from 'nostr-tools';
 
 import { PRESET_RELAYS, PROFILE_RELAYS, getRelayUrls } from '@/config/relays';
+import { DIVINE_MODERATION_PUBKEY } from '@/lib/officialAccounts';
 import { getVideoShareUrl } from '@/lib/shareUtils';
 import { getApexShareUrl } from '@/lib/subdomainLinks';
 import type { ParsedVideoData } from '@/types/video';
@@ -14,7 +15,12 @@ export const DM_SEAL_KIND = 13;
 export const DM_RUMOR_KIND = 14;
 export const DM_RELAY_LIST_KIND = 10050;
 
-export const DIVINE_SUPPORT_PUBKEY = '78a5c21b5166dc1474b64ddf7454bf79e6b5d6b4a77148593bf1e866b73c2738';
+// The "Message Support" destination. Points at the pinned Divine Moderation
+// account (moderation@divine.video) — a NIP-05-verified, minorContactable
+// official identity — NOT an unverifiable personal key. This is what lets a
+// protected minor's support message through the #176 send gate + inbound filter.
+// Single-sourced from officialAccounts so the two can't drift.
+export const DIVINE_SUPPORT_PUBKEY = DIVINE_MODERATION_PUBKEY;
 
 const TWO_DAYS_IN_SECONDS = 2 * 24 * 60 * 60;
 const PUBKEY_PATTERN = /^[a-f0-9]{64}$/;

--- a/src/lib/dmInboundFilter.test.ts
+++ b/src/lib/dmInboundFilter.test.ts
@@ -21,11 +21,11 @@ function convo(id: string, participants: string[]): DmConversation {
 const isApproved = (pubkey: string) => pubkey === HQ;
 
 describe('filterProtectedMinorConversations', () => {
-  it('is a pass-through for a non-restricted user', () => {
+  it('is a pass-through for a positively not-protected user', () => {
     const list = [convo('a', [HQ]), convo('b', [STRANGER])];
     expect(
       filterProtectedMinorConversations(list, {
-        isProtectedMinor: false,
+        state: 'not_protected',
         isApproved,
       }),
     ).toBe(list);
@@ -34,7 +34,7 @@ describe('filterProtectedMinorConversations', () => {
   it('keeps only conversations with an approved counterparty', () => {
     const list = [convo('a', [HQ]), convo('b', [STRANGER])];
     const out = filterProtectedMinorConversations(list, {
-      isProtectedMinor: true,
+      state: 'protected',
       isApproved,
     });
     expect(out.map((c) => c.id)).toEqual(['a']);
@@ -43,18 +43,27 @@ describe('filterProtectedMinorConversations', () => {
   it('drops a group unless every participant is approved', () => {
     const list = [convo('g', [HQ, OTHER])];
     const out = filterProtectedMinorConversations(list, {
-      isProtectedMinor: true,
+      state: 'protected',
       isApproved,
     });
     expect(out).toEqual([]);
   });
+
+  it('fails closed on unknown: filters like protected', () => {
+    const list = [convo('a', [HQ]), convo('b', [STRANGER])];
+    const out = filterProtectedMinorConversations(list, {
+      state: 'unknown',
+      isApproved,
+    });
+    expect(out.map((c) => c.id)).toEqual(['a']);
+  });
 });
 
 describe('isThreadAllowedForProtectedMinor', () => {
-  it('allows any thread for a non-restricted user', () => {
+  it('allows any thread for a positively not-protected user', () => {
     expect(
       isThreadAllowedForProtectedMinor([STRANGER], {
-        isProtectedMinor: false,
+        state: 'not_protected',
         isApproved,
       }),
     ).toBe(true);
@@ -63,7 +72,7 @@ describe('isThreadAllowedForProtectedMinor', () => {
   it('allows a thread whose peers are all approved', () => {
     expect(
       isThreadAllowedForProtectedMinor([HQ], {
-        isProtectedMinor: true,
+        state: 'protected',
         isApproved,
       }),
     ).toBe(true);
@@ -72,7 +81,7 @@ describe('isThreadAllowedForProtectedMinor', () => {
   it('blocks a thread with any non-approved peer', () => {
     expect(
       isThreadAllowedForProtectedMinor([HQ, STRANGER], {
-        isProtectedMinor: true,
+        state: 'protected',
         isApproved,
       }),
     ).toBe(false);
@@ -81,7 +90,25 @@ describe('isThreadAllowedForProtectedMinor', () => {
   it('allows an empty peer set (nothing to reveal)', () => {
     expect(
       isThreadAllowedForProtectedMinor([], {
-        isProtectedMinor: true,
+        state: 'protected',
+        isApproved,
+      }),
+    ).toBe(true);
+  });
+
+  it('fails closed on unknown: blocks a thread with a non-approved peer', () => {
+    expect(
+      isThreadAllowedForProtectedMinor([STRANGER], {
+        state: 'unknown',
+        isApproved,
+      }),
+    ).toBe(false);
+  });
+
+  it('still allows an all-approved thread while unknown', () => {
+    expect(
+      isThreadAllowedForProtectedMinor([HQ], {
+        state: 'unknown',
         isApproved,
       }),
     ).toBe(true);

--- a/src/lib/dmInboundFilter.test.ts
+++ b/src/lib/dmInboundFilter.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import type { DmConversation } from './dm';
-import { filterProtectedMinorConversations } from './dmInboundFilter';
+import {
+  filterProtectedMinorConversations,
+  isThreadAllowedForProtectedMinor,
+} from './dmInboundFilter';
 
 const HQ = 'c4a39f1291291d452405cd8ddd798c4a29a3858c52cd0d843f1f6852cf17682e';
 const STRANGER = 'de'.repeat(32);
@@ -44,5 +47,43 @@ describe('filterProtectedMinorConversations', () => {
       isApproved,
     });
     expect(out).toEqual([]);
+  });
+});
+
+describe('isThreadAllowedForProtectedMinor', () => {
+  it('allows any thread for a non-restricted user', () => {
+    expect(
+      isThreadAllowedForProtectedMinor([STRANGER], {
+        isProtectedMinor: false,
+        isApproved,
+      }),
+    ).toBe(true);
+  });
+
+  it('allows a thread whose peers are all approved', () => {
+    expect(
+      isThreadAllowedForProtectedMinor([HQ], {
+        isProtectedMinor: true,
+        isApproved,
+      }),
+    ).toBe(true);
+  });
+
+  it('blocks a thread with any non-approved peer', () => {
+    expect(
+      isThreadAllowedForProtectedMinor([HQ, STRANGER], {
+        isProtectedMinor: true,
+        isApproved,
+      }),
+    ).toBe(false);
+  });
+
+  it('allows an empty peer set (nothing to reveal)', () => {
+    expect(
+      isThreadAllowedForProtectedMinor([], {
+        isProtectedMinor: true,
+        isApproved,
+      }),
+    ).toBe(true);
   });
 });

--- a/src/lib/dmInboundFilter.test.ts
+++ b/src/lib/dmInboundFilter.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import type { DmConversation } from './dm';
+import { filterProtectedMinorConversations } from './dmInboundFilter';
+
+const HQ = 'c4a39f1291291d452405cd8ddd798c4a29a3858c52cd0d843f1f6852cf17682e';
+const STRANGER = 'de'.repeat(32);
+const OTHER = '11'.repeat(32);
+
+function convo(id: string, participants: string[]): DmConversation {
+  return {
+    id,
+    participantPubkeys: participants,
+    lastMessage: {} as DmConversation['lastMessage'],
+    unreadCount: 0,
+  };
+}
+
+const isApproved = (pubkey: string) => pubkey === HQ;
+
+describe('filterProtectedMinorConversations', () => {
+  it('is a pass-through for a non-restricted user', () => {
+    const list = [convo('a', [HQ]), convo('b', [STRANGER])];
+    expect(
+      filterProtectedMinorConversations(list, {
+        isProtectedMinor: false,
+        isApproved,
+      }),
+    ).toBe(list);
+  });
+
+  it('keeps only conversations with an approved counterparty', () => {
+    const list = [convo('a', [HQ]), convo('b', [STRANGER])];
+    const out = filterProtectedMinorConversations(list, {
+      isProtectedMinor: true,
+      isApproved,
+    });
+    expect(out.map((c) => c.id)).toEqual(['a']);
+  });
+
+  it('drops a group unless every participant is approved', () => {
+    const list = [convo('g', [HQ, OTHER])];
+    const out = filterProtectedMinorConversations(list, {
+      isProtectedMinor: true,
+      isApproved,
+    });
+    expect(out).toEqual([]);
+  });
+});

--- a/src/lib/dmInboundFilter.ts
+++ b/src/lib/dmInboundFilter.ts
@@ -1,0 +1,24 @@
+// ABOUTME: Pure inbound-DM filter for the protected-minor restriction (#176 web):
+// ABOUTME: a protected minor sees only conversations whose EVERY participant is
+// ABOUTME: an approved official account. Injectable predicate so it's testable.
+
+import type { DmConversation } from './dm';
+
+/**
+ * Filters [conversations] to those a protected minor may see. Pass-through when
+ * not restricted. A group needs ALL participants approved (participantPubkeys
+ * excludes self), else an attacker could p-tag the minor with a pinned decoy to
+ * slip content through.
+ */
+export function filterProtectedMinorConversations(
+  conversations: DmConversation[],
+  opts: {
+    isProtectedMinor: boolean;
+    isApproved: (pubkey: string) => boolean;
+  },
+): DmConversation[] {
+  if (!opts.isProtectedMinor) return conversations;
+  return conversations.filter((conversation) =>
+    conversation.participantPubkeys.every(opts.isApproved),
+  );
+}

--- a/src/lib/dmInboundFilter.ts
+++ b/src/lib/dmInboundFilter.ts
@@ -22,3 +22,22 @@ export function filterProtectedMinorConversations(
     conversation.participantPubkeys.every(opts.isApproved),
   );
 }
+
+/**
+ * Whether a protected minor may view a single thread (all peers approved).
+ * Applied INSIDE the thread hook to clear the messages — defense-in-depth
+ * alongside the route guard, which redirects asynchronously and could otherwise
+ * flash history first. Empty peers (nothing loaded yet) is allowed — there's
+ * nothing to evaluate or reveal.
+ */
+export function isThreadAllowedForProtectedMinor(
+  peerPubkeys: string[],
+  opts: {
+    isProtectedMinor: boolean;
+    isApproved: (pubkey: string) => boolean;
+  },
+): boolean {
+  if (!opts.isProtectedMinor) return true;
+  if (peerPubkeys.length === 0) return true;
+  return peerPubkeys.every(opts.isApproved);
+}

--- a/src/lib/dmInboundFilter.ts
+++ b/src/lib/dmInboundFilter.ts
@@ -1,30 +1,32 @@
 // ABOUTME: Pure inbound-DM filter for the protected-minor restriction (#176 web):
-// ABOUTME: a protected minor sees only conversations whose EVERY participant is
-// ABOUTME: an approved official account. Injectable predicate so it's testable.
+// ABOUTME: a DM-restricted user (protected minor, or unknown status — fail closed)
+// ABOUTME: sees only conversations whose EVERY participant is an approved official.
 
 import type { DmConversation } from './dm';
+import { isMinorDmRestricted, type ProtectedMinorState } from './protectedMinor';
 
 /**
- * Filters [conversations] to those a protected minor may see. Pass-through when
- * not restricted. A group needs ALL participants approved (participantPubkeys
- * excludes self), else an attacker could p-tag the minor with a pinned decoy to
- * slip content through.
+ * Filters [conversations] to those a DM-restricted user may see. Pass-through
+ * for a positive `not_protected` verdict; `unknown` restricts like `protected`.
+ * A group needs ALL participants approved (participantPubkeys excludes self),
+ * else an attacker could p-tag the minor with a pinned decoy to slip content
+ * through.
  */
 export function filterProtectedMinorConversations(
   conversations: DmConversation[],
   opts: {
-    isProtectedMinor: boolean;
+    state: ProtectedMinorState;
     isApproved: (pubkey: string) => boolean;
   },
 ): DmConversation[] {
-  if (!opts.isProtectedMinor) return conversations;
+  if (!isMinorDmRestricted(opts.state)) return conversations;
   return conversations.filter((conversation) =>
     conversation.participantPubkeys.every(opts.isApproved),
   );
 }
 
 /**
- * Whether a protected minor may view a single thread (all peers approved).
+ * Whether a DM-restricted user may view a single thread (all peers approved).
  * Applied INSIDE the thread hook to clear the messages — defense-in-depth
  * alongside the route guard, which redirects asynchronously and could otherwise
  * flash history first. Empty peers (nothing loaded yet) is allowed — there's
@@ -33,11 +35,11 @@ export function filterProtectedMinorConversations(
 export function isThreadAllowedForProtectedMinor(
   peerPubkeys: string[],
   opts: {
-    isProtectedMinor: boolean;
+    state: ProtectedMinorState;
     isApproved: (pubkey: string) => boolean;
   },
 ): boolean {
-  if (!opts.isProtectedMinor) return true;
+  if (!isMinorDmRestricted(opts.state)) return true;
   if (peerPubkeys.length === 0) return true;
   return peerPubkeys.every(opts.isApproved);
 }

--- a/src/lib/dmSendGuard.test.ts
+++ b/src/lib/dmSendGuard.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest';
+import { assertMinorDmRecipientsAllowed, DmSendBlockedError } from './dmSendGuard';
+
+const HQ = 'c4a39f1291291d452405cd8ddd798c4a29a3858c52cd0d843f1f6852cf17682e';
+const STRANGER = 'de'.repeat(32);
+
+function serviceApproving(approved: Set<string>) {
+  return {
+    isApprovedMinorDmRecipient: vi.fn(async (hex: string) => approved.has(hex)),
+  };
+}
+
+describe('assertMinorDmRecipientsAllowed', () => {
+  it('is a no-op for a non-protected user (never consults the service)', async () => {
+    const service = serviceApproving(new Set());
+    await assertMinorDmRecipientsAllowed([STRANGER], {
+      isProtectedMinor: false,
+      service,
+    });
+    expect(service.isApprovedMinorDmRecipient).not.toHaveBeenCalled();
+  });
+
+  it('resolves when a protected minor sends to all-approved recipients', async () => {
+    const service = serviceApproving(new Set([HQ]));
+    await expect(
+      assertMinorDmRecipientsAllowed([HQ], { isProtectedMinor: true, service }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('throws DmSendBlockedError when any recipient is not approved (group all-or-nothing)', async () => {
+    const service = serviceApproving(new Set([HQ]));
+    await expect(
+      assertMinorDmRecipientsAllowed([HQ, STRANGER], {
+        isProtectedMinor: true,
+        service,
+      }),
+    ).rejects.toBeInstanceOf(DmSendBlockedError);
+  });
+});

--- a/src/lib/dmSendGuard.test.ts
+++ b/src/lib/dmSendGuard.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
-import { assertMinorDmRecipientsAllowed, DmSendBlockedError } from './dmSendGuard';
+import {
+  assertMinorDmRecipientsAllowed,
+  DmSendBlockedError,
+  isDmComposeBlockedForMinor,
+} from './dmSendGuard';
 
 const HQ = 'c4a39f1291291d452405cd8ddd798c4a29a3858c52cd0d843f1f6852cf17682e';
 const STRANGER = 'de'.repeat(32);
@@ -35,5 +39,27 @@ describe('assertMinorDmRecipientsAllowed', () => {
         service,
       }),
     ).rejects.toBeInstanceOf(DmSendBlockedError);
+  });
+});
+
+describe('isDmComposeBlockedForMinor', () => {
+  const isApproved = (pubkey: string) => pubkey === HQ;
+
+  it('never blocks a non-restricted user', () => {
+    expect(
+      isDmComposeBlockedForMinor(STRANGER, { isProtectedMinor: false, isApproved }),
+    ).toBe(false);
+  });
+
+  it('allows a protected minor to compose to an approved account', () => {
+    expect(
+      isDmComposeBlockedForMinor(HQ, { isProtectedMinor: true, isApproved }),
+    ).toBe(false);
+  });
+
+  it('blocks a protected minor composing to a non-approved account', () => {
+    expect(
+      isDmComposeBlockedForMinor(STRANGER, { isProtectedMinor: true, isApproved }),
+    ).toBe(true);
   });
 });

--- a/src/lib/dmSendGuard.test.ts
+++ b/src/lib/dmSendGuard.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   assertMinorDmRecipientsAllowed,
   DmSendBlockedError,
+  DmSendUnverifiedError,
   isDmComposeBlockedForMinor,
 } from './dmSendGuard';
 
@@ -15,10 +16,10 @@ function serviceApproving(approved: Set<string>) {
 }
 
 describe('assertMinorDmRecipientsAllowed', () => {
-  it('is a no-op for a non-protected user (never consults the service)', async () => {
+  it('is a no-op for a positively not-protected user (never consults the service)', async () => {
     const service = serviceApproving(new Set());
     await assertMinorDmRecipientsAllowed([STRANGER], {
-      isProtectedMinor: false,
+      state: 'not_protected',
       service,
     });
     expect(service.isApprovedMinorDmRecipient).not.toHaveBeenCalled();
@@ -27,7 +28,7 @@ describe('assertMinorDmRecipientsAllowed', () => {
   it('resolves when a protected minor sends to all-approved recipients', async () => {
     const service = serviceApproving(new Set([HQ]));
     await expect(
-      assertMinorDmRecipientsAllowed([HQ], { isProtectedMinor: true, service }),
+      assertMinorDmRecipientsAllowed([HQ], { state: 'protected', service }),
     ).resolves.toBeUndefined();
   });
 
@@ -35,31 +36,57 @@ describe('assertMinorDmRecipientsAllowed', () => {
     const service = serviceApproving(new Set([HQ]));
     await expect(
       assertMinorDmRecipientsAllowed([HQ, STRANGER], {
-        isProtectedMinor: true,
+        state: 'protected',
         service,
       }),
     ).rejects.toBeInstanceOf(DmSendBlockedError);
+  });
+
+  it('fails closed on unknown: throws DmSendUnverifiedError for a non-approved recipient', async () => {
+    const service = serviceApproving(new Set([HQ]));
+    await expect(
+      assertMinorDmRecipientsAllowed([STRANGER], { state: 'unknown', service }),
+    ).rejects.toBeInstanceOf(DmSendUnverifiedError);
+  });
+
+  it('still allows an approved official recipient while unknown', async () => {
+    const service = serviceApproving(new Set([HQ]));
+    await expect(
+      assertMinorDmRecipientsAllowed([HQ], { state: 'unknown', service }),
+    ).resolves.toBeUndefined();
   });
 });
 
 describe('isDmComposeBlockedForMinor', () => {
   const isApproved = (pubkey: string) => pubkey === HQ;
 
-  it('never blocks a non-restricted user', () => {
+  it('never blocks a positively not-protected user', () => {
     expect(
-      isDmComposeBlockedForMinor(STRANGER, { isProtectedMinor: false, isApproved }),
+      isDmComposeBlockedForMinor(STRANGER, { state: 'not_protected', isApproved }),
     ).toBe(false);
   });
 
   it('allows a protected minor to compose to an approved account', () => {
     expect(
-      isDmComposeBlockedForMinor(HQ, { isProtectedMinor: true, isApproved }),
+      isDmComposeBlockedForMinor(HQ, { state: 'protected', isApproved }),
     ).toBe(false);
   });
 
   it('blocks a protected minor composing to a non-approved account', () => {
     expect(
-      isDmComposeBlockedForMinor(STRANGER, { isProtectedMinor: true, isApproved }),
+      isDmComposeBlockedForMinor(STRANGER, { state: 'protected', isApproved }),
     ).toBe(true);
+  });
+
+  it('fails closed on unknown: blocks compose to a non-approved account', () => {
+    expect(
+      isDmComposeBlockedForMinor(STRANGER, { state: 'unknown', isApproved }),
+    ).toBe(true);
+  });
+
+  it('keeps an approved official composable while unknown', () => {
+    expect(
+      isDmComposeBlockedForMinor(HQ, { state: 'unknown', isApproved }),
+    ).toBe(false);
   });
 });

--- a/src/lib/dmSendGuard.ts
+++ b/src/lib/dmSendGuard.ts
@@ -34,3 +34,17 @@ export async function assertMinorDmRecipientsAllowed(
     }
   }
 }
+
+/**
+ * Whether the compose affordance to [recipientPubkey] should be HIDDEN — a
+ * protected minor composing to a non-approved account. Sync (for rendering);
+ * backed by the same approval the send gate enforces, so hiding it just avoids
+ * a dead-end that the gate would block anyway. Never blocks a non-restricted
+ * user.
+ */
+export function isDmComposeBlockedForMinor(
+  recipientPubkey: string,
+  opts: { isProtectedMinor: boolean; isApproved: (pubkey: string) => boolean },
+): boolean {
+  return opts.isProtectedMinor && !opts.isApproved(recipientPubkey);
+}

--- a/src/lib/dmSendGuard.ts
+++ b/src/lib/dmSendGuard.ts
@@ -1,0 +1,36 @@
+// ABOUTME: Send-side gate for the protected-minor DM restriction (#176 web). A
+// ABOUTME: protected minor may only DM approved official accounts; a group send
+// ABOUTME: is all-or-nothing. Pure + injectable so useDmSend stays thin.
+
+import { OfficialAccountsService } from './officialAccounts';
+
+/** Thrown when a protected minor tries to DM a non-approved recipient. Typed so
+ *  the UI can show distinct, non-retriable copy. */
+export class DmSendBlockedError extends Error {
+  constructor(public readonly recipientPubkey: string) {
+    super('blocked: recipient not permitted for protected minor');
+    this.name = 'DmSendBlockedError';
+  }
+}
+
+/**
+ * Rejects the send if the current user is a protected minor and ANY recipient
+ * is not an approved official account (group all-or-nothing — per-recipient
+ * gating alone would still deliver to the approved participants). No-op for a
+ * non-restricted user. Uses the async recipient check so the verdict is fresh
+ * at send time.
+ */
+export async function assertMinorDmRecipientsAllowed(
+  recipients: string[],
+  opts: {
+    isProtectedMinor: boolean;
+    service: Pick<OfficialAccountsService, 'isApprovedMinorDmRecipient'>;
+  },
+): Promise<void> {
+  if (!opts.isProtectedMinor) return;
+  for (const recipient of recipients) {
+    if (!(await opts.service.isApprovedMinorDmRecipient(recipient))) {
+      throw new DmSendBlockedError(recipient);
+    }
+  }
+}

--- a/src/lib/dmSendGuard.ts
+++ b/src/lib/dmSendGuard.ts
@@ -1,8 +1,9 @@
 // ABOUTME: Send-side gate for the protected-minor DM restriction (#176 web). A
-// ABOUTME: protected minor may only DM approved official accounts; a group send
-// ABOUTME: is all-or-nothing. Pure + injectable so useDmSend stays thin.
+// ABOUTME: DM-restricted user (protected minor, or unknown status — fail closed)
+// ABOUTME: may only DM approved official accounts; a group send is all-or-nothing.
 
-import { OfficialAccountsService } from './officialAccounts';
+import type { OfficialAccountsService } from './officialAccounts';
+import { isMinorDmRestricted, type ProtectedMinorState } from './protectedMinor';
 
 /** Thrown when a protected minor tries to DM a non-approved recipient. Typed so
  *  the UI can show distinct, non-retriable copy. */
@@ -13,38 +14,54 @@ export class DmSendBlockedError extends Error {
   }
 }
 
+/** Thrown when a send is blocked because the protected-minor status is
+ *  `unknown` (fail closed). Typed so the UI can show retriable copy instead of
+ *  the definitive official-accounts-only message. */
+export class DmSendUnverifiedError extends Error {
+  constructor(public readonly recipientPubkey: string) {
+    super('blocked: protected-minor status unverified');
+    this.name = 'DmSendUnverifiedError';
+  }
+}
+
 /**
- * Rejects the send if the current user is a protected minor and ANY recipient
- * is not an approved official account (group all-or-nothing — per-recipient
- * gating alone would still deliver to the approved participants). No-op for a
- * non-restricted user. Uses the async recipient check so the verdict is fresh
- * at send time.
+ * Rejects the send unless the sender's tri-state protected-minor `state` is a
+ * positive `not_protected` OR every recipient is an approved official account
+ * (group all-or-nothing — per-recipient gating alone would still deliver to the
+ * approved participants). `unknown` restricts like `protected` but throws
+ * {@link DmSendUnverifiedError} so the UI can frame it as retriable. Uses the
+ * async recipient check so the verdict is fresh at send time.
  */
 export async function assertMinorDmRecipientsAllowed(
   recipients: string[],
   opts: {
-    isProtectedMinor: boolean;
+    state: ProtectedMinorState;
     service: Pick<OfficialAccountsService, 'isApprovedMinorDmRecipient'>;
   },
 ): Promise<void> {
-  if (!opts.isProtectedMinor) return;
+  if (!isMinorDmRestricted(opts.state)) return;
   for (const recipient of recipients) {
     if (!(await opts.service.isApprovedMinorDmRecipient(recipient))) {
-      throw new DmSendBlockedError(recipient);
+      throw opts.state === 'unknown'
+        ? new DmSendUnverifiedError(recipient)
+        : new DmSendBlockedError(recipient);
     }
   }
 }
 
 /**
  * Whether the compose affordance to [recipientPubkey] should be HIDDEN — a
- * protected minor composing to a non-approved account. Sync (for rendering);
+ * DM-restricted user composing to a non-approved account. Sync (for rendering);
  * backed by the same approval the send gate enforces, so hiding it just avoids
- * a dead-end that the gate would block anyway. Never blocks a non-restricted
- * user.
+ * a dead-end that the gate would block anyway. Never blocks a positively
+ * not-protected user.
  */
 export function isDmComposeBlockedForMinor(
   recipientPubkey: string,
-  opts: { isProtectedMinor: boolean; isApproved: (pubkey: string) => boolean },
+  opts: {
+    state: ProtectedMinorState;
+    isApproved: (pubkey: string) => boolean;
+  },
 ): boolean {
-  return opts.isProtectedMinor && !opts.isApproved(recipientPubkey);
+  return isMinorDmRestricted(opts.state) && !opts.isApproved(recipientPubkey);
 }

--- a/src/lib/officialAccounts.test.ts
+++ b/src/lib/officialAccounts.test.ts
@@ -86,6 +86,25 @@ describe('resolveOfficialNip05', () => {
     expect(res).toEqual({ kind: 'networkError' });
   });
 
+  it('does not follow redirects (NIP-05: fetchers MUST ignore redirects)', async () => {
+    // Following a 30x lets a MITM/misconfigured origin bounce the well-known
+    // lookup to an attacker host whose 200 body returns the expected key for a
+    // burner — a spurious APPROVE. `redirect: 'error'` makes fetch reject on any
+    // redirect, which the catch maps to networkError (no signal).
+    const fetchImpl = fetchReturning({ names: { _: HQ } });
+    await resolveOfficialNip05(HQ_NIP05, HQ, { fetchImpl });
+    const init = (fetchImpl as unknown as { mock: { calls: unknown[][] } }).mock
+      .calls[0][1] as RequestInit;
+    expect(init.redirect).toBe('error');
+  });
+
+  it('a redirect (fetch rejects under redirect:error) is networkError, never matched', async () => {
+    const res = await resolveOfficialNip05(HQ_NIP05, HQ, {
+      fetchImpl: vi.fn().mockRejectedValue(new TypeError('redirect not allowed')) as unknown as typeof fetch,
+    });
+    expect(res).toEqual({ kind: 'networkError' });
+  });
+
   it('case+whitespace-normalized compare: padded/uppercase still matches', async () => {
     const res = await resolveOfficialNip05(HQ_NIP05, HQ, {
       fetchImpl: fetchReturning({ names: { _: `  ${HQ.toUpperCase()}\n` } }),

--- a/src/lib/officialAccounts.test.ts
+++ b/src/lib/officialAccounts.test.ts
@@ -78,6 +78,14 @@ describe('resolveOfficialNip05', () => {
     expect(res).toEqual({ kind: 'networkError' });
   });
 
+  it('networkError: a non-hex value for the name does not revoke (malformed entry)', async () => {
+    const res = await resolveOfficialNip05(HQ_NIP05, HQ, {
+      fetchImpl: fetchReturning({ names: { _: 'not-a-valid-hex-pubkey' } }),
+    });
+    // Must NOT be differentKey — garbage should keep last-known, not drop.
+    expect(res).toEqual({ kind: 'networkError' });
+  });
+
   it('case+whitespace-normalized compare: padded/uppercase still matches', async () => {
     const res = await resolveOfficialNip05(HQ_NIP05, HQ, {
       fetchImpl: fetchReturning({ names: { _: `  ${HQ.toUpperCase()}\n` } }),

--- a/src/lib/officialAccounts.test.ts
+++ b/src/lib/officialAccounts.test.ts
@@ -1,0 +1,237 @@
+// ABOUTME: Tests the pinned official-accounts set + discriminated NIP-05
+// ABOUTME: resolver + graded pin ∩ NIP-05 gate for the protected-minor DM
+// ABOUTME: restriction (#176 web).
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  isPinnedMinorContactable,
+  OfficialAccountsService,
+  resolveOfficialNip05,
+  type OfficialAccount,
+} from './officialAccounts';
+
+const HQ = 'c4a39f1291291d452405cd8ddd798c4a29a3858c52cd0d843f1f6852cf17682e';
+const OTHER = '0'.repeat(64);
+const HQ_NIP05 = '_@divinehq.divine.video';
+
+function fetchReturning(
+  body: unknown,
+  { ok = true, status = 200 }: { ok?: boolean; status?: number } = {},
+) {
+  return vi.fn().mockResolvedValue({
+    ok,
+    status,
+    headers: { get: () => null },
+    json: async () => body,
+  }) as unknown as typeof fetch;
+}
+
+describe('resolveOfficialNip05', () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it('matched: the name maps to the expected pubkey', async () => {
+    const res = await resolveOfficialNip05(HQ_NIP05, HQ, {
+      fetchImpl: fetchReturning({ names: { _: HQ } }),
+    });
+    expect(res).toEqual({ kind: 'matched', resolvedPubkey: HQ });
+  });
+
+  it('differentKey: the name maps to a different pubkey', async () => {
+    const res = await resolveOfficialNip05(HQ_NIP05, HQ, {
+      fetchImpl: fetchReturning({ names: { _: OTHER } }),
+    });
+    expect(res).toEqual({ kind: 'differentKey', resolvedPubkey: OTHER });
+  });
+
+  it('absent: well-formed names map that lacks the name', async () => {
+    const res = await resolveOfficialNip05(HQ_NIP05, HQ, {
+      fetchImpl: fetchReturning({ names: { someoneelse: OTHER } }),
+    });
+    expect(res).toEqual({ kind: 'absent' });
+  });
+
+  it('absent: 404 from the name server', async () => {
+    const res = await resolveOfficialNip05(HQ_NIP05, HQ, {
+      fetchImpl: fetchReturning(null, { ok: false, status: 404 }),
+    });
+    expect(res).toEqual({ kind: 'absent' });
+  });
+
+  it('networkError: 5xx from the name server', async () => {
+    const res = await resolveOfficialNip05(HQ_NIP05, HQ, {
+      fetchImpl: fetchReturning(null, { ok: false, status: 503 }),
+    });
+    expect(res).toEqual({ kind: 'networkError' });
+  });
+
+  it('networkError: fetch throws (timeout/offline)', async () => {
+    const res = await resolveOfficialNip05(HQ_NIP05, HQ, {
+      fetchImpl: vi.fn().mockRejectedValue(new Error('offline')) as unknown as typeof fetch,
+    });
+    expect(res).toEqual({ kind: 'networkError' });
+  });
+
+  it('networkError: malformed body without a names map', async () => {
+    const res = await resolveOfficialNip05(HQ_NIP05, HQ, {
+      fetchImpl: fetchReturning({ relays: {} }),
+    });
+    expect(res).toEqual({ kind: 'networkError' });
+  });
+
+  it('case+whitespace-normalized compare: padded/uppercase still matches', async () => {
+    const res = await resolveOfficialNip05(HQ_NIP05, HQ, {
+      fetchImpl: fetchReturning({ names: { _: `  ${HQ.toUpperCase()}\n` } }),
+    });
+    expect(res.kind).toBe('matched');
+  });
+});
+
+const MOD = '8fd5eb6d8f362163bc00a5ab6b4a3167dbf32d00ec4efdbcf43b3c9514433b7e';
+const STRANGER = 'de'.repeat(32);
+
+function fakeStorage(): Storage {
+  const m = new Map<string, string>();
+  return {
+    getItem: (k: string) => m.get(k) ?? null,
+    setItem: (k: string, v: string) => void m.set(k, v),
+    removeItem: (k: string) => void m.delete(k),
+    clear: () => m.clear(),
+    key: (i: number) => [...m.keys()][i] ?? null,
+    get length() {
+      return m.size;
+    },
+  } as Storage;
+}
+
+describe('isPinnedMinorContactable', () => {
+  it('accepts a pinned minor-contactable account, rejects a stranger', () => {
+    expect(isPinnedMinorContactable(HQ)).toBe(true);
+    expect(isPinnedMinorContactable(MOD)).toBe(true);
+    expect(isPinnedMinorContactable(STRANGER)).toBe(false);
+  });
+  it('normalizes the caller hex (mixed-case + whitespace)', () => {
+    expect(isPinnedMinorContactable(`  ${HQ.toUpperCase()}\n`)).toBe(true);
+  });
+});
+
+describe('OfficialAccountsService', () => {
+  let clock: number;
+  const build = (opts: {
+    resolve?: typeof resolveOfficialNip05 extends never ? never : (nip05: string, hex: string) => Promise<import('./officialAccounts').Nip05Resolution>;
+    accounts?: OfficialAccount[];
+    storage?: Storage;
+  } = {}) =>
+    new OfficialAccountsService({
+      now: () => clock,
+      storage: opts.storage ?? fakeStorage(),
+      resolve: opts.resolve,
+      accounts: opts.accounts,
+    });
+
+  beforeEach(() => {
+    clock = 1_000_000_000;
+  });
+
+  it('unpinned pubkey is never approved and never resolved', async () => {
+    const resolve = vi.fn();
+    const svc = build({ resolve: resolve as never });
+    expect(svc.isApprovedMinorDmRecipientSync(STRANGER)).toBe(false);
+    expect(await svc.isApprovedMinorDmRecipient(STRANGER)).toBe(false);
+    expect(resolve).not.toHaveBeenCalled();
+  });
+
+  it('pinned but not minorContactable is rejected without resolving', async () => {
+    const resolve = vi.fn();
+    const svc = build({
+      resolve: resolve as never,
+      accounts: [{ pubkeyHex: HQ, nip05: HQ_NIP05, role: 'hq', minorContactable: false }],
+    });
+    expect(await svc.isApprovedMinorDmRecipient(HQ)).toBe(false);
+    expect(resolve).not.toHaveBeenCalled();
+  });
+
+  it('pinned + matched -> approved', async () => {
+    const svc = build({ resolve: async () => ({ kind: 'matched', resolvedPubkey: HQ }) });
+    expect(await svc.isApprovedMinorDmRecipient(HQ)).toBe(true);
+  });
+
+  it('pinned + differentKey -> dropped immediately and persisted', async () => {
+    const svc = build({ resolve: async () => ({ kind: 'differentKey', resolvedPubkey: STRANGER }) });
+    expect(await svc.isApprovedMinorDmRecipient(HQ)).toBe(false);
+    expect(svc.isApprovedMinorDmRecipientSync(HQ)).toBe(false);
+  });
+
+  it('a single absence never drops', async () => {
+    const svc = build({ resolve: async () => ({ kind: 'absent' }) });
+    expect(await svc.isApprovedMinorDmRecipient(HQ)).toBe(true);
+    expect(svc.isApprovedMinorDmRecipientSync(HQ)).toBe(true);
+  });
+
+  it('a confirming absence after the recheck window drops', async () => {
+    const svc = build({ resolve: async () => ({ kind: 'absent' }) });
+    expect(await svc.isApprovedMinorDmRecipient(HQ)).toBe(true);
+    clock += 6 * 60 * 1000;
+    expect(await svc.isApprovedMinorDmRecipient(HQ)).toBe(false);
+  });
+
+  it('networkError keeps a previously revoked verdict', async () => {
+    const answers: Array<import('./officialAccounts').Nip05Resolution> = [
+      { kind: 'differentKey', resolvedPubkey: STRANGER },
+      { kind: 'networkError' },
+    ];
+    let i = 0;
+    const svc = build({ resolve: async () => answers[i++] });
+    expect(await svc.isApprovedMinorDmRecipient(HQ)).toBe(false);
+    clock += 2 * 60 * 60 * 1000;
+    expect(await svc.isApprovedMinorDmRecipient(HQ)).toBe(false);
+  });
+
+  it('networkError with no record defaults to pin-trusted', async () => {
+    const svc = build({ resolve: async () => ({ kind: 'networkError' }) });
+    expect(await svc.isApprovedMinorDmRecipient(HQ)).toBe(true);
+  });
+
+  it('a fresh verdict is reused without re-resolving (TTL)', async () => {
+    const resolve = vi.fn(async () => ({ kind: 'matched', resolvedPubkey: HQ }) as const);
+    const svc = build({ resolve: resolve as never });
+    expect(await svc.isApprovedMinorDmRecipient(HQ)).toBe(true);
+    clock += 30 * 60 * 1000;
+    expect(await svc.isApprovedMinorDmRecipient(HQ)).toBe(true);
+    expect(resolve).toHaveBeenCalledTimes(1);
+  });
+
+  it('a stale verdict re-resolves (send-time freshness)', async () => {
+    const resolve = vi.fn(async () => ({ kind: 'matched', resolvedPubkey: HQ }) as const);
+    const svc = build({ resolve: resolve as never });
+    expect(await svc.isApprovedMinorDmRecipient(HQ)).toBe(true);
+    clock += 2 * 60 * 60 * 1000;
+    expect(await svc.isApprovedMinorDmRecipient(HQ)).toBe(true);
+    expect(resolve).toHaveBeenCalledTimes(2);
+  });
+
+  it('persists across a reload (a new service over the same storage sees revoked)', async () => {
+    const storage = fakeStorage();
+    const svc = build({ resolve: async () => ({ kind: 'differentKey', resolvedPubkey: STRANGER }), storage });
+    await svc.isApprovedMinorDmRecipient(HQ);
+    const reloaded = build({ storage });
+    expect(reloaded.isApprovedMinorDmRecipientSync(HQ)).toBe(false);
+  });
+
+  it('concurrent calls for the same account resolve once', async () => {
+    let calls = 0;
+    let release!: (r: import('./officialAccounts').Nip05Resolution) => void;
+    const pending = new Promise<import('./officialAccounts').Nip05Resolution>((r) => (release = r));
+    const svc = build({
+      resolve: (() => {
+        calls++;
+        return pending;
+      }) as never,
+    });
+    const a = svc.isApprovedMinorDmRecipient(HQ);
+    const b = svc.isApprovedMinorDmRecipient(HQ);
+    release({ kind: 'matched', resolvedPubkey: HQ });
+    expect(await a).toBe(true);
+    expect(await b).toBe(true);
+    expect(calls).toBe(1);
+  });
+});

--- a/src/lib/officialAccounts.ts
+++ b/src/lib/officialAccounts.ts
@@ -100,6 +100,19 @@ export interface OfficialAccount {
   minorContactable: boolean;
 }
 
+/** Divine HQ pinned pubkey (`_@divinehq.divine.video`). */
+export const DIVINE_HQ_PUBKEY =
+  'c4a39f1291291d452405cd8ddd798c4a29a3858c52cd0d843f1f6852cf17682e';
+
+/**
+ * Divine Moderation pinned pubkey (`moderation@divine.video`) — the official,
+ * NIP-05-verified support/contact identity. Re-exported as `DIVINE_SUPPORT_PUBKEY`
+ * (dm.ts) so the "Message Support" surfaces point at a pinned, minorContactable
+ * account rather than an unverifiable personal key.
+ */
+export const DIVINE_MODERATION_PUBKEY =
+  '8fd5eb6d8f362163bc00a5ab6b4a3167dbf32d00ec4efdbcf43b3c9514433b7e';
+
 /**
  * The pinned child-contactable set (verified live 2026-07-07). Additions are
  * release-gated by design — this is a child-contact list, so requiring a deploy
@@ -108,15 +121,13 @@ export interface OfficialAccount {
  */
 export const PINNED_OFFICIAL_ACCOUNTS: OfficialAccount[] = [
   {
-    pubkeyHex:
-      'c4a39f1291291d452405cd8ddd798c4a29a3858c52cd0d843f1f6852cf17682e',
+    pubkeyHex: DIVINE_HQ_PUBKEY,
     nip05: '_@divinehq.divine.video',
     role: 'hq',
     minorContactable: true,
   },
   {
-    pubkeyHex:
-      '8fd5eb6d8f362163bc00a5ab6b4a3167dbf32d00ec4efdbcf43b3c9514433b7e',
+    pubkeyHex: DIVINE_MODERATION_PUBKEY,
     nip05: 'moderation@divine.video',
     role: 'moderation',
     minorContactable: true,

--- a/src/lib/officialAccounts.ts
+++ b/src/lib/officialAccounts.ts
@@ -86,6 +86,12 @@ export async function resolveOfficialNip05(
   // Normalize BOTH sides identically: the pin is the trust anchor, and a
   // checksummed/padded nostr.json must not read as a different key.
   const norm = resolved.trim().toLowerCase();
+  if (!/^[0-9a-f]{64}$/.test(norm)) {
+    // A non-hex value isn't a usable pubkey — a malformed directory entry
+    // carries no trustworthy signal. Treat as networkError (keep last-known),
+    // NOT differentKey, so garbage from the name server can't spuriously revoke.
+    return { kind: 'networkError' };
+  }
   if (norm === expectedPubkey.trim().toLowerCase()) {
     return { kind: 'matched', resolvedPubkey: norm };
   }

--- a/src/lib/officialAccounts.ts
+++ b/src/lib/officialAccounts.ts
@@ -1,0 +1,295 @@
+// ABOUTME: Pinned official-accounts set + discriminated NIP-05 resolver + graded
+// ABOUTME: pin ∩ NIP-05 gate for the protected-minor DM restriction (#176 web).
+// ABOUTME: Mirrors the mobile OfficialAccountsService; localStorage last-known store.
+
+import { parseNip05 } from './nip05Resolve';
+
+/**
+ * How a NIP-05 resolution landed, graded by ambiguity so the caller can react
+ * differently: a different key is an unambiguous revoke/compromise (drop now),
+ * an affirmative absence is softer (confirm before dropping), and a network
+ * failure carries no signal at all (keep last-known). Unlike
+ * {@link resolveNip05ToPubkey} which collapses all three into `null`.
+ */
+export type Nip05Resolution =
+  | { kind: 'matched'; resolvedPubkey: string }
+  | { kind: 'differentKey'; resolvedPubkey: string }
+  | { kind: 'absent' }
+  | { kind: 'networkError' };
+
+const RESOLVE_TIMEOUT_MS = 5000;
+// A legitimate nostr.json for a handful of names is well under a kilobyte;
+// reject anything advertising far more before parsing it.
+const MAX_CONTENT_LENGTH = 256 * 1024;
+
+export async function resolveOfficialNip05(
+  nip05: string,
+  expectedPubkey: string,
+  opts: { fetchImpl?: typeof fetch; timeoutMs?: number } = {},
+): Promise<Nip05Resolution> {
+  const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+  const parts = parseNip05(nip05);
+  // A malformed identifier is not a trustworthy "absent" — treat as no signal.
+  if (!parts) return { kind: 'networkError' };
+
+  const url = `https://${parts.domain}/.well-known/nostr.json?name=${encodeURIComponent(parts.name)}`;
+  const controller = new AbortController();
+  const timer = setTimeout(
+    () => controller.abort(),
+    opts.timeoutMs ?? RESOLVE_TIMEOUT_MS,
+  );
+
+  let response: Response;
+  try {
+    response = await fetchImpl(url, {
+      signal: controller.signal,
+      headers: { Accept: 'application/json' },
+      redirect: 'follow',
+    });
+  } catch {
+    // Offline, timeout (abort), DNS, connection reset — no signal.
+    return { kind: 'networkError' };
+  } finally {
+    clearTimeout(timer);
+  }
+
+  // A 404 is an affirmative "this name is not here"; other non-2xx carry no
+  // trustworthy signal.
+  if (response.status === 404) return { kind: 'absent' };
+  if (!response.ok) return { kind: 'networkError' };
+
+  const advertised = Number(response.headers?.get?.('content-length') ?? '');
+  if (Number.isFinite(advertised) && advertised > MAX_CONTENT_LENGTH) {
+    return { kind: 'networkError' };
+  }
+
+  let data: unknown;
+  try {
+    data = await response.json();
+  } catch {
+    return { kind: 'networkError' };
+  }
+
+  // A well-formed nostr.json MUST carry a `names` object; its absence means the
+  // response isn't a usable directory (malformed), not an affirmative absence.
+  const names = (data as { names?: unknown } | null)?.names;
+  if (typeof names !== 'object' || names === null) {
+    return { kind: 'networkError' };
+  }
+
+  const resolved = (names as Record<string, unknown>)[parts.name];
+  if (typeof resolved !== 'string') {
+    // Well-formed directory that simply does not list this name.
+    return { kind: 'absent' };
+  }
+
+  // Normalize BOTH sides identically: the pin is the trust anchor, and a
+  // checksummed/padded nostr.json must not read as a different key.
+  const norm = resolved.trim().toLowerCase();
+  if (norm === expectedPubkey.trim().toLowerCase()) {
+    return { kind: 'matched', resolvedPubkey: norm };
+  }
+  return { kind: 'differentKey', resolvedPubkey: norm };
+}
+
+export interface OfficialAccount {
+  pubkeyHex: string;
+  nip05: string;
+  role: string;
+  /** Whether a protected minor may exchange DMs with this account. */
+  minorContactable: boolean;
+}
+
+/**
+ * The pinned child-contactable set (verified live 2026-07-07). Additions are
+ * release-gated by design — this is a child-contact list, so requiring a deploy
+ * to add a key is the accepted friction that makes the pin an attacker-addition
+ * barrier. Each entry pins its OWN canonical identifier form.
+ */
+export const PINNED_OFFICIAL_ACCOUNTS: OfficialAccount[] = [
+  {
+    pubkeyHex:
+      'c4a39f1291291d452405cd8ddd798c4a29a3858c52cd0d843f1f6852cf17682e',
+    nip05: '_@divinehq.divine.video',
+    role: 'hq',
+    minorContactable: true,
+  },
+  {
+    pubkeyHex:
+      '8fd5eb6d8f362163bc00a5ab6b4a3167dbf32d00ec4efdbcf43b3c9514433b7e',
+    nip05: 'moderation@divine.video',
+    role: 'moderation',
+    minorContactable: true,
+  },
+];
+
+const normHex = (hex: string): string => hex.trim().toLowerCase();
+
+function pinnedFor(
+  hex: string,
+  accounts: OfficialAccount[],
+): OfficialAccount | undefined {
+  const h = normHex(hex);
+  return accounts.find((a) => normHex(a.pubkeyHex) === h);
+}
+
+/** Pin-only, synchronous: the attacker-addition barrier. */
+export function isPinnedMinorContactable(
+  hex: string,
+  accounts: OfficialAccount[] = PINNED_OFFICIAL_ACCOUNTS,
+): boolean {
+  const a = pinnedFor(hex, accounts);
+  return !!a && a.minorContactable;
+}
+
+const TTL_MS = 60 * 60 * 1000;
+const ABSENCE_RECHECK_MS = 5 * 60 * 1000;
+
+interface StoredVerdict {
+  approved: boolean;
+  checkedAt: number;
+  firstAbsentAt?: number;
+}
+
+type ResolveFn = (nip05: string, expectedHex: string) => Promise<Nip05Resolution>;
+
+/**
+ * Decides whether a protected minor may DM a given pubkey (#176): pin ∩ live
+ * NIP-05, graded revocation, a 1h freshness TTL, a 5-min confirming recheck for
+ * absence, and a persistent (localStorage) last-known verdict. Mirrors the
+ * mobile OfficialAccountsService.
+ */
+export class OfficialAccountsService {
+  private readonly resolve: ResolveFn;
+  private readonly now: () => number;
+  private readonly storage: Storage | undefined;
+  private readonly accounts: OfficialAccount[];
+  private readonly inFlight = new Map<string, Promise<boolean>>();
+  private readonly listeners = new Set<() => void>();
+
+  constructor(
+    opts: {
+      resolve?: ResolveFn;
+      now?: () => number;
+      storage?: Storage;
+      accounts?: OfficialAccount[];
+      fetchImpl?: typeof fetch;
+    } = {},
+  ) {
+    this.now = opts.now ?? Date.now;
+    this.storage =
+      opts.storage ??
+      (typeof localStorage !== 'undefined' ? localStorage : undefined);
+    this.accounts = opts.accounts ?? PINNED_OFFICIAL_ACCOUNTS;
+    this.resolve =
+      opts.resolve ??
+      ((nip05, hex) =>
+        resolveOfficialNip05(nip05, hex, { fetchImpl: opts.fetchImpl }));
+  }
+
+  isPinnedMinorContactable(hex: string): boolean {
+    return isPinnedMinorContactable(hex, this.accounts);
+  }
+
+  /** Pin ∩ last-known, synchronous, no network. For hot list/render paths. */
+  isApprovedMinorDmRecipientSync(hex: string): boolean {
+    if (!this.isPinnedMinorContactable(hex)) return false;
+    return this.load(hex)?.approved ?? true;
+  }
+
+  /** Pin ∩ live NIP-05, graded. Awaits any in-flight resolution for the same
+   *  account rather than treating concurrency as failure. */
+  async isApprovedMinorDmRecipient(hex: string): Promise<boolean> {
+    const account = pinnedFor(hex, this.accounts);
+    if (!account || !account.minorContactable) return false;
+
+    const key = normHex(hex);
+    const existing = this.inFlight.get(key);
+    if (existing) return existing;
+    const p = this.resolveAndDecide(account, hex).finally(() =>
+      this.inFlight.delete(key),
+    );
+    this.inFlight.set(key, p);
+    return p;
+  }
+
+  /** Subscribe to persisted verdict flips (for receive-time revalidation). */
+  onVerdictChanged(fn: () => void): () => void {
+    this.listeners.add(fn);
+    return () => void this.listeners.delete(fn);
+  }
+
+  private async resolveAndDecide(
+    account: OfficialAccount,
+    hex: string,
+  ): Promise<boolean> {
+    const record = this.load(hex);
+    if (record && !this.isStale(record)) return record.approved;
+
+    const priorApproved = record?.approved ?? true;
+    const res = await this.resolve(account.nip05, account.pubkeyHex);
+    const now = this.now();
+    switch (res.kind) {
+      case 'matched':
+        this.persist(hex, { approved: true, checkedAt: now }, priorApproved);
+        return true;
+      case 'differentKey':
+        this.persist(hex, { approved: false, checkedAt: now }, priorApproved);
+        return false;
+      case 'absent': {
+        if (record && !record.approved) return false; // stays revoked
+        const firstAbsent = record?.firstAbsentAt;
+        if (firstAbsent !== undefined && now - firstAbsent >= ABSENCE_RECHECK_MS) {
+          this.persist(hex, { approved: false, checkedAt: now }, priorApproved);
+          return false; // confirming recheck: drop
+        }
+        this.persist(
+          hex,
+          { approved: true, checkedAt: now, firstAbsentAt: firstAbsent ?? now },
+          priorApproved,
+        );
+        return true;
+      }
+      case 'networkError':
+        // No trustworthy signal: keep last-known; pinned default is trusted.
+        return record?.approved ?? true;
+    }
+  }
+
+  private isStale(r: StoredVerdict): boolean {
+    const age = this.now() - r.checkedAt;
+    const limit = r.firstAbsentAt !== undefined ? ABSENCE_RECHECK_MS : TTL_MS;
+    return age >= limit;
+  }
+
+  private keyFor(hex: string): string {
+    return `official_recipient_${normHex(hex)}`;
+  }
+
+  private load(hex: string): StoredVerdict | null {
+    const raw = this.storage?.getItem(this.keyFor(hex));
+    if (!raw) return null;
+    try {
+      const d = JSON.parse(raw) as StoredVerdict;
+      if (typeof d.checkedAt === 'number' && typeof d.approved === 'boolean') {
+        return d;
+      }
+    } catch {
+      // Intentional no-op: a corrupt entry is treated as no record — the caller
+      // falls back to the pin-trusted default and the async path re-resolves.
+    }
+    return null;
+  }
+
+  private persist(hex: string, record: StoredVerdict, priorApproved: boolean) {
+    try {
+      this.storage?.setItem(this.keyFor(hex), JSON.stringify(record));
+    } catch {
+      // Storage full/unavailable: skip persistence. Safety is unaffected — the
+      // sync default stays pin-trusted and every send re-resolves.
+    }
+    if (record.approved !== priorApproved) {
+      for (const fn of this.listeners) fn();
+    }
+  }
+}

--- a/src/lib/officialAccounts.ts
+++ b/src/lib/officialAccounts.ts
@@ -293,3 +293,10 @@ export class OfficialAccountsService {
     }
   }
 }
+
+/**
+ * App-wide singleton (browser default: real fetch + localStorage). Shared by the
+ * send gate and the inbound filter so the last-known cache + onVerdictChanged
+ * stream are consistent across both.
+ */
+export const officialAccountsService = new OfficialAccountsService();

--- a/src/lib/officialAccounts.ts
+++ b/src/lib/officialAccounts.ts
@@ -44,7 +44,13 @@ export async function resolveOfficialNip05(
     response = await fetchImpl(url, {
       signal: controller.signal,
       headers: { Accept: 'application/json' },
-      redirect: 'follow',
+      // NIP-05 (§05): the .well-known/nostr.json endpoint MUST NOT redirect and
+      // fetchers MUST ignore redirects. Following a 30x is a spurious-APPROVE
+      // vector (a MITM/misconfigured origin could bounce the lookup to an
+      // attacker host that returns the expected key for a burner). `error`
+      // makes fetch reject on any redirect, which the catch maps to
+      // networkError (no signal) rather than trusting a redirect target's body.
+      redirect: 'error',
     });
   } catch {
     // Offline, timeout (abort), DNS, connection reset — no signal.

--- a/src/lib/protectedMinor.test.ts
+++ b/src/lib/protectedMinor.test.ts
@@ -44,13 +44,18 @@ describe('fetchProtectedMinorStatus', () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it('is not protected when verified_minor is truthy but not strictly true', async () => {
-    const status = await fetchProtectedMinorStatus(
-      't',
-      fetchReturning({ verified_minor: 'true' }),
-    );
-
-    expect(status.state).toBe('not_protected');
+  it('fails closed on a truthy non-boolean verified_minor (schema drift)', async () => {
+    // A stringly "true" (or any truthy non-boolean) is not a trustworthy
+    // NEGATIVE: mapping it to not_protected would lift protection for an
+    // actual minor if keycast's schema ever drifts. Only explicit booleans
+    // are authoritative; anything else truthy stays unknown.
+    for (const drifted of ['true', 1, {}] as const) {
+      const status = await fetchProtectedMinorStatus(
+        't',
+        fetchReturning({ verified_minor: drifted }),
+      );
+      expect(status.state).toBe('unknown');
+    }
   });
 
   it('is not protected when verified_minor is false', async () => {

--- a/src/lib/protectedMinor.test.ts
+++ b/src/lib/protectedMinor.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { DIVINE_LOGIN_ORIGIN } from './divineLoginOrigin';
-import { fetchProtectedMinorStatus } from './protectedMinor';
+import { fetchProtectedMinorStatus, isMinorDmRestricted } from './protectedMinor';
 
 const ACCOUNT_URL = `${DIVINE_LOGIN_ORIGIN}/api/user/account`;
 
@@ -118,5 +118,19 @@ describe('fetchProtectedMinorStatus', () => {
     expect(status.state).toBe('unknown');
     expect(status.isProtectedMinor).toBe(false);
     expect(status.isKnown).toBe(false);
+  });
+});
+
+describe('isMinorDmRestricted', () => {
+  it('restricts a protected account', () => {
+    expect(isMinorDmRestricted('protected')).toBe(true);
+  });
+
+  it('fails closed: restricts while the status is unknown', () => {
+    expect(isMinorDmRestricted('unknown')).toBe(true);
+  });
+
+  it('lifts the restriction only on a positive not_protected verdict', () => {
+    expect(isMinorDmRestricted('not_protected')).toBe(false);
   });
 });

--- a/src/lib/protectedMinor.test.ts
+++ b/src/lib/protectedMinor.test.ts
@@ -24,7 +24,6 @@ describe('fetchProtectedMinorStatus', () => {
     const status = await fetchProtectedMinorStatus('tok123', fetchImpl);
 
     expect(status.state).toBe('protected');
-    expect(status.isProtectedMinor).toBe(true);
     expect(status.isKnown).toBe(true);
     expect(status.verifiedMinorAt).toEqual(new Date('2026-06-30T12:00:00Z'));
     expect(fetchImpl).toHaveBeenCalledWith(
@@ -41,7 +40,6 @@ describe('fetchProtectedMinorStatus', () => {
     const status = await fetchProtectedMinorStatus('', fetchSpy);
 
     expect(status.state).toBe('not_protected');
-    expect(status.isProtectedMinor).toBe(false);
     expect(status.isKnown).toBe(true);
     expect(fetchSpy).not.toHaveBeenCalled();
   });
@@ -52,7 +50,7 @@ describe('fetchProtectedMinorStatus', () => {
       fetchReturning({ verified_minor: 'true' }),
     );
 
-    expect(status.isProtectedMinor).toBe(false);
+    expect(status.state).toBe('not_protected');
   });
 
   it('is not protected when verified_minor is false', async () => {
@@ -61,7 +59,6 @@ describe('fetchProtectedMinorStatus', () => {
       fetchReturning({ verified_minor: false }),
     );
 
-    expect(status.isProtectedMinor).toBe(false);
     expect(status.state).toBe('not_protected');
     expect(status.verifiedMinorAt).toBeNull();
   });
@@ -72,7 +69,7 @@ describe('fetchProtectedMinorStatus', () => {
       fetchReturning({ email: 'a@b.com' }),
     );
 
-    expect(status.isProtectedMinor).toBe(false);
+    expect(status.state).toBe('not_protected');
   });
 
   it('stays protected with a null timestamp on a bad date', async () => {
@@ -81,7 +78,7 @@ describe('fetchProtectedMinorStatus', () => {
       fetchReturning({ verified_minor: true, verified_minor_at: 'not-a-date' }),
     );
 
-    expect(status.isProtectedMinor).toBe(true);
+    expect(status.state).toBe('protected');
     expect(status.verifiedMinorAt).toBeNull();
   });
 
@@ -92,7 +89,6 @@ describe('fetchProtectedMinorStatus', () => {
     );
 
     expect(status.state).toBe('unknown');
-    expect(status.isProtectedMinor).toBe(false);
     expect(status.isKnown).toBe(false);
   });
 
@@ -116,7 +112,6 @@ describe('fetchProtectedMinorStatus', () => {
     const status = await fetchProtectedMinorStatus('t', fetchImpl);
 
     expect(status.state).toBe('unknown');
-    expect(status.isProtectedMinor).toBe(false);
     expect(status.isKnown).toBe(false);
   });
 });

--- a/src/lib/protectedMinor.test.ts
+++ b/src/lib/protectedMinor.test.ts
@@ -96,6 +96,18 @@ describe('fetchProtectedMinorStatus', () => {
     expect(status.isKnown).toBe(false);
   });
 
+  it('is unknown (not not_protected) on a malformed non-object 200 body', async () => {
+    // A malformed 200 (an error page or truncated body deserialized to a
+    // non-object) must NOT read as a positive not_protected: through the sticky
+    // store that would overwrite a confirmed `protected`. Only a well-formed
+    // object with an explicit verified_minor is authoritative; anything else
+    // carries no trustworthy signal.
+    for (const body of ['unexpected', 42, ['x'], true] as const) {
+      const status = await fetchProtectedMinorStatus('t', fetchReturning(body));
+      expect(status.state).toBe('unknown');
+    }
+  });
+
   it('is unknown when fetch throws', async () => {
     const fetchImpl = vi
       .fn()

--- a/src/lib/protectedMinor.ts
+++ b/src/lib/protectedMinor.ts
@@ -74,13 +74,21 @@ export async function fetchProtectedMinorStatus(
       verified_minor?: unknown;
       verified_minor_at?: unknown;
     };
-    if (account.verified_minor !== true) return NOT_PROTECTED;
-
-    return {
-      state: 'protected',
-      isKnown: true,
-      verifiedMinorAt: parseVerifiedMinorAt(account.verified_minor_at),
-    };
+    if (account.verified_minor === true) {
+      return {
+        state: 'protected',
+        isKnown: true,
+        verifiedMinorAt: parseVerifiedMinorAt(account.verified_minor_at),
+      };
+    }
+    // Fail closed on schema drift: a truthy non-boolean verified_minor (e.g.
+    // the string "true") is not a trustworthy negative, so it must not lift
+    // protection. Absent or false stays a positive not_protected — keycast
+    // omits the flag for ordinary accounts, so treating absence as unknown
+    // would restrict every adult.
+    return account.verified_minor
+      ? UNKNOWN_PROTECTED_MINOR_STATUS
+      : NOT_PROTECTED;
   } catch {
     return UNKNOWN_PROTECTED_MINOR_STATUS;
   }

--- a/src/lib/protectedMinor.ts
+++ b/src/lib/protectedMinor.ts
@@ -5,7 +5,6 @@ import { DIVINE_LOGIN_ORIGIN } from './divineLoginOrigin';
 
 export interface ProtectedMinorStatus {
   state: 'protected' | 'not_protected' | 'unknown';
-  isProtectedMinor: boolean;
   isKnown: boolean;
   verifiedMinorAt: Date | null;
 }
@@ -26,14 +25,12 @@ export function isMinorDmRestricted(state: ProtectedMinorState): boolean {
 // for every other caller (it's returned by reference from the lib and hook).
 export const NOT_PROTECTED: ProtectedMinorStatus = Object.freeze({
   state: 'not_protected',
-  isProtectedMinor: false,
   isKnown: true,
   verifiedMinorAt: null,
 });
 
 export const UNKNOWN_PROTECTED_MINOR_STATUS: ProtectedMinorStatus = Object.freeze({
   state: 'unknown',
-  isProtectedMinor: false,
   isKnown: false,
   verifiedMinorAt: null,
 });
@@ -81,7 +78,6 @@ export async function fetchProtectedMinorStatus(
 
     return {
       state: 'protected',
-      isProtectedMinor: true,
       isKnown: true,
       verifiedMinorAt: parseVerifiedMinorAt(account.verified_minor_at),
     };

--- a/src/lib/protectedMinor.ts
+++ b/src/lib/protectedMinor.ts
@@ -53,17 +53,25 @@ export async function fetchProtectedMinorStatus(
     });
     if (!response.ok) return UNKNOWN_PROTECTED_MINOR_STATUS;
 
-    const body = (await response.json()) as {
+    const body = (await response.json()) as unknown;
+    // A malformed 200 (non-object body — an error page, truncated response, or
+    // a bare primitive) carries no trustworthy signal. Only a well-formed object
+    // with an explicit verified_minor is authoritative; otherwise stay unknown
+    // so the sticky store's last-known `protected` is never overwritten by junk.
+    if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+      return UNKNOWN_PROTECTED_MINOR_STATUS;
+    }
+    const account = body as {
       verified_minor?: unknown;
       verified_minor_at?: unknown;
     };
-    if (body.verified_minor !== true) return NOT_PROTECTED;
+    if (account.verified_minor !== true) return NOT_PROTECTED;
 
     return {
       state: 'protected',
       isProtectedMinor: true,
       isKnown: true,
-      verifiedMinorAt: parseVerifiedMinorAt(body.verified_minor_at),
+      verifiedMinorAt: parseVerifiedMinorAt(account.verified_minor_at),
     };
   } catch {
     return UNKNOWN_PROTECTED_MINOR_STATUS;

--- a/src/lib/protectedMinor.ts
+++ b/src/lib/protectedMinor.ts
@@ -10,6 +10,18 @@ export interface ProtectedMinorStatus {
   verifiedMinorAt: Date | null;
 }
 
+export type ProtectedMinorState = ProtectedMinorStatus['state'];
+
+/**
+ * DM-restriction verdict for the safety gates (#176). Fails CLOSED: only a
+ * positive `not_protected` verdict lifts the restriction, so `unknown`
+ * (cold start, keycast failure) restricts exactly like `protected`. Signed-out
+ * sessions resolve to {@link NOT_PROTECTED} upstream and are never restricted.
+ */
+export function isMinorDmRestricted(state: ProtectedMinorState): boolean {
+  return state !== 'not_protected';
+}
+
 // Frozen so this shared sentinel can't be mutated by a consumer and poisoned
 // for every other caller (it's returned by reference from the lib and hook).
 export const NOT_PROTECTED: ProtectedMinorStatus = Object.freeze({

--- a/src/lib/protectedMinorStickyStore.test.ts
+++ b/src/lib/protectedMinorStickyStore.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import {
+  readLastKnownProtected,
+  writeLastKnownProtected,
+} from './protectedMinorStickyStore';
+
+function fakeStorage(): Storage {
+  const m = new Map<string, string>();
+  return {
+    getItem: (k: string) => m.get(k) ?? null,
+    setItem: (k: string, v: string) => void m.set(k, v),
+    removeItem: (k: string) => void m.delete(k),
+    clear: () => m.clear(),
+    key: (i: number) => [...m.keys()][i] ?? null,
+    get length() {
+      return m.size;
+    },
+  } as Storage;
+}
+
+describe('protectedMinorStickyStore', () => {
+  it('returns null when nothing is stored', () => {
+    expect(readLastKnownProtected('acct', fakeStorage())).toBeNull();
+  });
+
+  it('round-trips a definitive verdict', () => {
+    const s = fakeStorage();
+    writeLastKnownProtected('acct', 'protected', s);
+    expect(readLastKnownProtected('acct', s)).toBe('protected');
+    writeLastKnownProtected('acct', 'not_protected', s);
+    expect(readLastKnownProtected('acct', s)).toBe('not_protected');
+  });
+
+  it('is keyed per account', () => {
+    const s = fakeStorage();
+    writeLastKnownProtected('minor', 'protected', s);
+    expect(readLastKnownProtected('adult', s)).toBeNull();
+  });
+
+  it('ignores a garbage stored value', () => {
+    const s = fakeStorage();
+    s.setItem('protected_minor_sticky_acct', 'nonsense');
+    expect(readLastKnownProtected('acct', s)).toBeNull();
+  });
+});

--- a/src/lib/protectedMinorStickyStore.ts
+++ b/src/lib/protectedMinorStickyStore.ts
@@ -1,0 +1,42 @@
+// ABOUTME: Persistent last-known protected-minor status (#176/#180 web). Fail-safe
+// ABOUTME: backing for useProtectedMinorStatus: remembers a definitive verdict per
+// ABOUTME: account so an `unknown` (refetch failure) never lifts a prior `protected`.
+
+/** Only definitive verdicts are stored; `unknown` never writes. */
+export type LastKnownProtected = 'protected' | 'not_protected';
+
+const KEY_PREFIX = 'protected_minor_sticky_';
+
+function defaultStorage(): Storage | undefined {
+  return typeof localStorage !== 'undefined' ? localStorage : undefined;
+}
+
+/**
+ * Last-known definitive verdict for [accountId] (the JWT `sub`, stable across
+ * token refresh), or `null` when never seen. Keyed per account so a stale
+ * verdict from a previous account is never consulted.
+ */
+export function readLastKnownProtected(
+  accountId: string,
+  storage: Storage | undefined = defaultStorage(),
+): LastKnownProtected | null {
+  const raw = storage?.getItem(KEY_PREFIX + accountId);
+  return raw === 'protected' || raw === 'not_protected' ? raw : null;
+}
+
+/**
+ * Persist a definitive verdict. Callers must NOT pass `unknown` — the whole
+ * point is that an unknown never overwrites a stored `protected`.
+ */
+export function writeLastKnownProtected(
+  accountId: string,
+  state: LastKnownProtected,
+  storage: Storage | undefined = defaultStorage(),
+): void {
+  try {
+    storage?.setItem(KEY_PREFIX + accountId, state);
+  } catch {
+    // Storage full/unavailable: skip persistence. Safety is unaffected — the
+    // hook falls back to the fail-closed `unknown` default.
+  }
+}

--- a/src/pages/ConversationPage.test.tsx
+++ b/src/pages/ConversationPage.test.tsx
@@ -52,7 +52,6 @@ const pm = vi.hoisted(() => ({
 vi.mock('@/hooks/useProtectedMinorStatus', () => ({
   useProtectedMinorStatus: () => ({
     state: pm.state,
-    isProtectedMinor: pm.state === 'protected',
     isKnown: pm.state !== 'unknown',
     verifiedMinorAt: null,
   }),

--- a/src/pages/ConversationPage.test.tsx
+++ b/src/pages/ConversationPage.test.tsx
@@ -44,6 +44,16 @@ const {
   } as Record<string, { metadata: { display_name?: string; name?: string; picture?: string; nip05?: string } }>,
 }));
 
+vi.mock('@/hooks/useProtectedMinorStatus', () => ({
+  useIsProtectedMinor: () => false,
+  useProtectedMinorStatus: () => ({
+    state: 'not_protected',
+    isProtectedMinor: false,
+    isKnown: true,
+    verifiedMinorAt: null,
+  }),
+}));
+
 vi.mock('@/hooks/useDirectMessages', () => ({
   useDmCapability: () => ({ canUseDirectMessages: true, isCheckingDmCapability: false }),
   useDmConversation: () => ({

--- a/src/pages/ConversationPage.test.tsx
+++ b/src/pages/ConversationPage.test.tsx
@@ -45,16 +45,15 @@ const {
 }));
 
 const pm = vi.hoisted(() => ({
-  isProtectedMinor: false,
+  state: 'not_protected' as 'protected' | 'not_protected' | 'unknown',
   approved: new Set<string>(),
 }));
 
 vi.mock('@/hooks/useProtectedMinorStatus', () => ({
-  useIsProtectedMinor: () => pm.isProtectedMinor,
   useProtectedMinorStatus: () => ({
-    state: pm.isProtectedMinor ? 'protected' : 'not_protected',
-    isProtectedMinor: pm.isProtectedMinor,
-    isKnown: true,
+    state: pm.state,
+    isProtectedMinor: pm.state === 'protected',
+    isKnown: pm.state !== 'unknown',
     verifiedMinorAt: null,
   }),
 }));
@@ -129,7 +128,7 @@ function renderPage() {
 describe('ConversationPage', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
-    pm.isProtectedMinor = false;
+    pm.state = 'not_protected';
     pm.approved.clear();
     const storage = new Map<string, string>();
     Object.defineProperty(window, 'localStorage', {
@@ -161,7 +160,7 @@ describe('ConversationPage', () => {
 
   describe('protected-minor thread route guard (#176)', () => {
     it('redirects a protected minor away from a non-approved thread', async () => {
-      pm.isProtectedMinor = true; // RECIPIENT_PUBKEY not approved
+      pm.state = 'protected'; // RECIPIENT_PUBKEY not approved
       renderPage();
       await waitFor(() =>
         expect(mockNavigate).toHaveBeenCalledWith('/messages', {
@@ -171,7 +170,7 @@ describe('ConversationPage', () => {
     });
 
     it('does NOT redirect when the thread peer is an approved official', async () => {
-      pm.isProtectedMinor = true;
+      pm.state = 'protected';
       pm.approved.add(RECIPIENT_PUBKEY);
       renderPage();
       // let the guard effect run
@@ -182,6 +181,26 @@ describe('ConversationPage', () => {
     });
 
     it('does NOT redirect a non-protected user', async () => {
+      renderPage();
+      await new Promise((r) => setTimeout(r, 20));
+      expect(mockNavigate).not.toHaveBeenCalledWith('/messages', {
+        replace: true,
+      });
+    });
+
+    it('fails closed on unknown: redirects away from a non-approved thread', async () => {
+      pm.state = 'unknown'; // RECIPIENT_PUBKEY not approved
+      renderPage();
+      await waitFor(() =>
+        expect(mockNavigate).toHaveBeenCalledWith('/messages', {
+          replace: true,
+        }),
+      );
+    });
+
+    it('does NOT redirect from an approved-official thread while unknown', async () => {
+      pm.state = 'unknown';
+      pm.approved.add(RECIPIENT_PUBKEY);
       renderPage();
       await new Promise((r) => setTimeout(r, 20));
       expect(mockNavigate).not.toHaveBeenCalledWith('/messages', {

--- a/src/pages/ConversationPage.test.tsx
+++ b/src/pages/ConversationPage.test.tsx
@@ -44,14 +44,28 @@ const {
   } as Record<string, { metadata: { display_name?: string; name?: string; picture?: string; nip05?: string } }>,
 }));
 
+const pm = vi.hoisted(() => ({
+  isProtectedMinor: false,
+  approved: new Set<string>(),
+}));
+
 vi.mock('@/hooks/useProtectedMinorStatus', () => ({
-  useIsProtectedMinor: () => false,
+  useIsProtectedMinor: () => pm.isProtectedMinor,
   useProtectedMinorStatus: () => ({
-    state: 'not_protected',
-    isProtectedMinor: false,
+    state: pm.isProtectedMinor ? 'protected' : 'not_protected',
+    isProtectedMinor: pm.isProtectedMinor,
     isKnown: true,
     verifiedMinorAt: null,
   }),
+}));
+
+vi.mock('@/lib/officialAccounts', async (orig) => ({
+  ...(await orig<typeof import('@/lib/officialAccounts')>()),
+  officialAccountsService: {
+    isApprovedMinorDmRecipientSync: (pk: string) => pm.approved.has(pk),
+    isApprovedMinorDmRecipient: async (pk: string) => pm.approved.has(pk),
+    onVerdictChanged: () => () => {},
+  },
 }));
 
 vi.mock('@/hooks/useDirectMessages', () => ({
@@ -115,6 +129,8 @@ function renderPage() {
 describe('ConversationPage', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
+    pm.isProtectedMinor = false;
+    pm.approved.clear();
     const storage = new Map<string, string>();
     Object.defineProperty(window, 'localStorage', {
       configurable: true,
@@ -141,6 +157,37 @@ describe('ConversationPage', () => {
     directMessageState.share = null;
     mockSendMutate.mockImplementation(() => undefined);
     mockSendMutateAsync.mockImplementation(() => new Promise<void>(() => undefined));
+  });
+
+  describe('protected-minor thread route guard (#176)', () => {
+    it('redirects a protected minor away from a non-approved thread', async () => {
+      pm.isProtectedMinor = true; // RECIPIENT_PUBKEY not approved
+      renderPage();
+      await waitFor(() =>
+        expect(mockNavigate).toHaveBeenCalledWith('/messages', {
+          replace: true,
+        }),
+      );
+    });
+
+    it('does NOT redirect when the thread peer is an approved official', async () => {
+      pm.isProtectedMinor = true;
+      pm.approved.add(RECIPIENT_PUBKEY);
+      renderPage();
+      // let the guard effect run
+      await new Promise((r) => setTimeout(r, 20));
+      expect(mockNavigate).not.toHaveBeenCalledWith('/messages', {
+        replace: true,
+      });
+    });
+
+    it('does NOT redirect a non-protected user', async () => {
+      renderPage();
+      await new Promise((r) => setTimeout(r, 20));
+      expect(mockNavigate).not.toHaveBeenCalledWith('/messages', {
+        replace: true,
+      });
+    });
   });
 
   it('renders the composer with a two-line baseline', () => {

--- a/src/pages/ConversationPage.tsx
+++ b/src/pages/ConversationPage.tsx
@@ -15,7 +15,8 @@ import {
   useParsedDmShare,
 } from '@/hooks/useDirectMessages';
 import { useSubdomainNavigate } from '@/hooks/useSubdomainNavigate';
-import { useIsProtectedMinor } from '@/hooks/useProtectedMinorStatus';
+import { useProtectedMinorStatus } from '@/hooks/useProtectedMinorStatus';
+import { isMinorDmRestricted } from '@/lib/protectedMinor';
 import { officialAccountsService } from '@/lib/officialAccounts';
 import {
   DIVINE_SUPPORT_PUBKEY,
@@ -209,23 +210,24 @@ export function ConversationPage() {
     }
   }, [lastReadAt, latestMessageAt, markConversationRead]);
 
-  // Thread route guard (#176): a protected minor must not open a thread with a
-  // non-approved counterparty via deep-link or a stale route (send + list
-  // already block those paths). Computed each render so a verdict flip
-  // re-evaluates; the counterparties are revalidated so a revoked official is
-  // caught after mount.
-  const isProtectedMinor = useIsProtectedMinor();
+  // Thread route guard (#176): a restricted user (protected minor, or unknown
+  // status — fail closed) must not open a thread with a non-approved
+  // counterparty via deep-link or a stale route (send + list already block
+  // those paths). Computed each render so a verdict flip re-evaluates; the
+  // counterparties are revalidated so a revoked official is caught after mount.
+  const { state: minorState } = useProtectedMinorStatus();
+  const isDmRestricted = isMinorDmRestricted(minorState);
   const [, bumpVerdicts] = useReducer((x: number) => x + 1, 0);
   useEffect(() => officialAccountsService.onVerdictChanged(bumpVerdicts), []);
   useEffect(() => {
-    if (isProtectedMinor) {
+    if (isDmRestricted) {
       for (const pubkey of peerPubkeys) {
         void officialAccountsService.isApprovedMinorDmRecipient(pubkey);
       }
     }
-  }, [isProtectedMinor, peerPubkeys]);
+  }, [isDmRestricted, peerPubkeys]);
   const threadBlocked =
-    isProtectedMinor &&
+    isDmRestricted &&
     peerPubkeys.length > 0 &&
     !peerPubkeys.every((pubkey) =>
       officialAccountsService.isApprovedMinorDmRecipientSync(pubkey),

--- a/src/pages/ConversationPage.tsx
+++ b/src/pages/ConversationPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useReducer, useState } from 'react';
 import { ArrowLeft, ArrowUp, LinkSimple as Link2, X } from '@phosphor-icons/react';
 import { Link, useLocation, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
@@ -15,6 +15,8 @@ import {
   useParsedDmShare,
 } from '@/hooks/useDirectMessages';
 import { useSubdomainNavigate } from '@/hooks/useSubdomainNavigate';
+import { useIsProtectedMinor } from '@/hooks/useProtectedMinorStatus';
+import { officialAccountsService } from '@/lib/officialAccounts';
 import {
   DIVINE_SUPPORT_PUBKEY,
   decodeConversationId,
@@ -206,6 +208,31 @@ export function ConversationPage() {
       markConversationRead();
     }
   }, [lastReadAt, latestMessageAt, markConversationRead]);
+
+  // Thread route guard (#176): a protected minor must not open a thread with a
+  // non-approved counterparty via deep-link or a stale route (send + list
+  // already block those paths). Computed each render so a verdict flip
+  // re-evaluates; the counterparties are revalidated so a revoked official is
+  // caught after mount.
+  const isProtectedMinor = useIsProtectedMinor();
+  const [, bumpVerdicts] = useReducer((x: number) => x + 1, 0);
+  useEffect(() => officialAccountsService.onVerdictChanged(bumpVerdicts), []);
+  useEffect(() => {
+    if (isProtectedMinor) {
+      for (const pubkey of peerPubkeys) {
+        void officialAccountsService.isApprovedMinorDmRecipient(pubkey);
+      }
+    }
+  }, [isProtectedMinor, peerPubkeys]);
+  const threadBlocked =
+    isProtectedMinor &&
+    peerPubkeys.length > 0 &&
+    !peerPubkeys.every((pubkey) =>
+      officialAccountsService.isApprovedMinorDmRecipientSync(pubkey),
+    );
+  useEffect(() => {
+    if (threadBlocked) navigate('/messages', { replace: true });
+  }, [threadBlocked, navigate]);
 
   const peerNames = peerPubkeys.map((pubkey) => getDisplayName(pubkey, authorMap[pubkey]?.metadata, t));
   const title = peerNames.length === 1

--- a/src/pages/MessagesPage.test.tsx
+++ b/src/pages/MessagesPage.test.tsx
@@ -41,7 +41,10 @@ const {
     },
   ] as DmConversation[],
   mockAuthorMap: {
-    ['78a5c21b5166dc1474b64ddf7454bf79e6b5d6b4a77148593bf1e866b73c2738']: {
+    // DIVINE_SUPPORT_PUBKEY now resolves to the Moderation pinned key (#176);
+    // key the support metadata under it so this exercises real metadata
+    // resolution rather than only the hard-coded display-name fallback.
+    ['8fd5eb6d8f362163bc00a5ab6b4a3167dbf32d00ec4efdbcf43b3c9514433b7e']: {
       metadata: {
         display_name: 'Divine Support',
         picture: 'https://example.com/support.png',
@@ -78,14 +81,28 @@ const {
   }>,
 }));
 
+const pm = vi.hoisted(() => ({
+  isProtectedMinor: false,
+  approved: new Set<string>(),
+}));
+
 vi.mock('@/hooks/useProtectedMinorStatus', () => ({
-  useIsProtectedMinor: () => false,
+  useIsProtectedMinor: () => pm.isProtectedMinor,
   useProtectedMinorStatus: () => ({
-    state: 'not_protected',
-    isProtectedMinor: false,
+    state: pm.isProtectedMinor ? 'protected' : 'not_protected',
+    isProtectedMinor: pm.isProtectedMinor,
     isKnown: true,
     verifiedMinorAt: null,
   }),
+}));
+
+vi.mock('@/lib/officialAccounts', async (orig) => ({
+  ...(await orig<typeof import('@/lib/officialAccounts')>()),
+  officialAccountsService: {
+    isApprovedMinorDmRecipientSync: (pk: string) => pm.approved.has(pk),
+    isApprovedMinorDmRecipient: async (pk: string) => pm.approved.has(pk),
+    onVerdictChanged: () => () => {},
+  },
 }));
 
 vi.mock('@/hooks/useDirectMessages', () => ({
@@ -121,6 +138,8 @@ function renderPage() {
 
 describe('MessagesPage', () => {
   beforeEach(async () => {
+    pm.isProtectedMinor = false;
+    pm.approved.clear();
     mockSearchResults.length = 0;
     mockInboxStatus.value = 'ok';
     mockConversations.length = 0;
@@ -250,5 +269,24 @@ describe('MessagesPage', () => {
 
     expect(screen.getByText('Alice')).toBeInTheDocument();
     expect(screen.queryByText('Rabble')).not.toBeInTheDocument();
+  });
+
+  it('filters compose search results to approved accounts for a protected minor (#176)', async () => {
+    const user = userEvent.setup();
+    const HQ = 'c4a39f1291291d452405cd8ddd798c4a29a3858c52cd0d843f1f6852cf17682e';
+    pm.isProtectedMinor = true;
+    pm.approved.add(HQ);
+
+    mockSearchResults.push(
+      { pubkey: HQ, metadata: { display_name: 'Divine HQ' } },
+      { pubkey: otherUserPubkey, metadata: { display_name: 'Alice' } },
+    );
+
+    renderPage();
+    await user.type(screen.getByRole('textbox'), 'a');
+
+    // Only the approved official is offered as a compose target.
+    expect(screen.getByText('Divine HQ')).toBeInTheDocument();
+    expect(screen.queryByText('Alice')).not.toBeInTheDocument();
   });
 });

--- a/src/pages/MessagesPage.test.tsx
+++ b/src/pages/MessagesPage.test.tsx
@@ -89,7 +89,6 @@ const pm = vi.hoisted(() => ({
 vi.mock('@/hooks/useProtectedMinorStatus', () => ({
   useProtectedMinorStatus: () => ({
     state: pm.state,
-    isProtectedMinor: pm.state === 'protected',
     isKnown: pm.state !== 'unknown',
     verifiedMinorAt: null,
   }),

--- a/src/pages/MessagesPage.test.tsx
+++ b/src/pages/MessagesPage.test.tsx
@@ -78,6 +78,16 @@ const {
   }>,
 }));
 
+vi.mock('@/hooks/useProtectedMinorStatus', () => ({
+  useIsProtectedMinor: () => false,
+  useProtectedMinorStatus: () => ({
+    state: 'not_protected',
+    isProtectedMinor: false,
+    isKnown: true,
+    verifiedMinorAt: null,
+  }),
+}));
+
 vi.mock('@/hooks/useDirectMessages', () => ({
   useDmCapability: () => ({ canUseDirectMessages: true, isCheckingDmCapability: false }),
   useDmConversations: () => ({ data: mockConversations, isLoading: false }),

--- a/src/pages/MessagesPage.test.tsx
+++ b/src/pages/MessagesPage.test.tsx
@@ -82,16 +82,15 @@ const {
 }));
 
 const pm = vi.hoisted(() => ({
-  isProtectedMinor: false,
+  state: 'not_protected' as 'protected' | 'not_protected' | 'unknown',
   approved: new Set<string>(),
 }));
 
 vi.mock('@/hooks/useProtectedMinorStatus', () => ({
-  useIsProtectedMinor: () => pm.isProtectedMinor,
   useProtectedMinorStatus: () => ({
-    state: pm.isProtectedMinor ? 'protected' : 'not_protected',
-    isProtectedMinor: pm.isProtectedMinor,
-    isKnown: true,
+    state: pm.state,
+    isProtectedMinor: pm.state === 'protected',
+    isKnown: pm.state !== 'unknown',
     verifiedMinorAt: null,
   }),
 }));
@@ -138,7 +137,7 @@ function renderPage() {
 
 describe('MessagesPage', () => {
   beforeEach(async () => {
-    pm.isProtectedMinor = false;
+    pm.state = 'not_protected';
     pm.approved.clear();
     mockSearchResults.length = 0;
     mockInboxStatus.value = 'ok';
@@ -274,7 +273,7 @@ describe('MessagesPage', () => {
   it('filters compose search results to approved accounts for a protected minor (#176)', async () => {
     const user = userEvent.setup();
     const HQ = 'c4a39f1291291d452405cd8ddd798c4a29a3858c52cd0d843f1f6852cf17682e';
-    pm.isProtectedMinor = true;
+    pm.state = 'protected';
     pm.approved.add(HQ);
 
     mockSearchResults.push(
@@ -286,6 +285,24 @@ describe('MessagesPage', () => {
     await user.type(screen.getByRole('textbox'), 'a');
 
     // Only the approved official is offered as a compose target.
+    expect(screen.getByText('Divine HQ')).toBeInTheDocument();
+    expect(screen.queryByText('Alice')).not.toBeInTheDocument();
+  });
+
+  it('fails closed on unknown: compose search offers only approved accounts', async () => {
+    const user = userEvent.setup();
+    const HQ = 'c4a39f1291291d452405cd8ddd798c4a29a3858c52cd0d843f1f6852cf17682e';
+    pm.state = 'unknown';
+    pm.approved.add(HQ);
+
+    mockSearchResults.push(
+      { pubkey: HQ, metadata: { display_name: 'Divine HQ' } },
+      { pubkey: otherUserPubkey, metadata: { display_name: 'Alice' } },
+    );
+
+    renderPage();
+    await user.type(screen.getByRole('textbox'), 'a');
+
     expect(screen.getByText('Divine HQ')).toBeInTheDocument();
     expect(screen.queryByText('Alice')).not.toBeInTheDocument();
   });

--- a/src/pages/MessagesPage.tsx
+++ b/src/pages/MessagesPage.tsx
@@ -15,6 +15,7 @@ import {
   useParsedDmShare,
 } from '@/hooks/useDirectMessages';
 import { useSearchUsers } from '@/hooks/useSearchUsers';
+import { useDmComposeGuard } from '@/hooks/useDmComposeGuard';
 import { useSubdomainNavigate } from '@/hooks/useSubdomainNavigate';
 import {
   DIVINE_SUPPORT_PUBKEY,
@@ -203,6 +204,10 @@ export function MessagesPage() {
   const { t } = useTranslation();
   const { user } = useCurrentUser();
   const { canUseDirectMessages, isCheckingDmCapability } = useDmCapability();
+  // Protected-minor DM restriction (#176): a protected minor's user search may
+  // only surface approved accounts to compose to (the send gate blocks the rest
+  // anyway; this keeps the compose list from dead-ending).
+  const { isComposeBlocked } = useDmComposeGuard();
   const conversationsQuery = useDmConversations();
   const inboxStatus = useDmInboxStatus();
   const share = useParsedDmShare(location.search);
@@ -233,7 +238,9 @@ export function MessagesPage() {
   const supportDisplayName = getDisplayName(DIVINE_SUPPORT_PUBKEY, supportMetadata);
   const supportPicture = getSafeProfileImage(supportMetadata?.picture) || '/user-avatar.png';
 
-  const searchResults = (searchUsersQuery.data || []).filter((result) => result.pubkey !== user?.pubkey);
+  const searchResults = (searchUsersQuery.data || [])
+    .filter((result) => result.pubkey !== user?.pubkey)
+    .filter((result) => !isComposeBlocked(result.pubkey));
 
   return (
     <div className="min-h-full bg-brand-off-white dark:bg-brand-dark-green">


### PR DESCRIPTION
Web half of the protected-minor DM restriction (support-trust-safety#176, epic #173; issue #454). Mirrors the mobile implementation (divinevideo/divine-mobile#5754). A protected minor (13-15) may only DM the pinned official Divine accounts (HQ + Moderation); everything else is blocked on send and hidden on receive. Client-side by necessity — NIP-17 gift-wraps hide the recipient, so relays can't enforce it.

## Trust model (#4948)

Approved set = **pinned ∩ live NIP-05** (Tier 2): Divine HQ (`_@divinehq.divine.video`) + Divine Moderation (`moderation@divine.video`), both minorContactable. `officialAccounts.ts` — discriminated NIP-05 resolver + graded revocation (different-key drops immediately, a single absence needs a confirming recheck, a network blip keeps last-known), 1h TTL, localStorage last-known store, in-flight dedup.

## What's enforced

- **#180 protected-state persistence:** `useProtectedMinorStatus` was self-healing-not-sticky — a failed focus-refetch resolves to `unknown`, which React Query wrote over the prior `protected` (lifting protection on every failed refocus). Now persists the last-known verdict (keyed on JWT `sub`) and falls back to it on `unknown`; never overwrites `protected`; fail-closed when never seen.
- **Send gate:** `useDmSend` blocks a non-approved recipient before building/publishing any wrap; group all-or-nothing; typed `DmSendBlockedError` → distinct non-retriable toast.
- **Inbound filter:** `useDmConversations` hides non-approved conversations (unread inherits). The thread seam gets **both** a route guard (`ConversationPage` redirects to inbox) and result-clearing (`useDmConversation` returns no messages when blocked, so a deep-link can't flash history). Receive-time revalidation drops a revoked official live.
- **Affordances:** the profile Message button and the messages user-search hide non-approved compose targets.
- **Support-key fix:** `DIVINE_SUPPORT_PUBKEY` repointed from an unverifiable personal key (`78a5c21b` — "Rabble's personal Nostr key" per its own config comment; no kind-0, no NIP-05) to the pinned **Moderation** account, so support reaches an approved identity and a protected minor's support message passes the gate. Broader support-identity cleanup: support-trust-safety#184.

## Accepted ceiling

Same as mobile: for self-custody the control raises the bar to "sideload a modified app"; for custodial minors it's friction + defense-in-depth, not containment (Keycast's headless signer — support-trust-safety#183). Documented in the spec.

## Tests

Pure helpers + hooks throughout (resolver, graded service, send guard, inbound list/thread filters, compose guard, persistence). Full suite green (1253 tests), `tsc` + `eslint` + `vite build` clean.

Design spec on the branch: `docs/superpowers/specs/2026-07-07-protected-minor-dm-restriction-web-design.md`.
