### PR TITLE
chore: Remove obsolete AI acknowledgement gate and Claude attribution rule

### DIFF
--- a/.agents/skills/spa-subdomain-root-render/SKILL.md
+++ b/.agents/skills/spa-subdomain-root-render/SKILL.md
@@ -6,7 +6,7 @@ description: |
   (2) User sees blank page because component relies on useParams() but there's no route param at /,
   (3) Want username.domain.com/ to feel like a personal website without /profile/xyz in the URL.
   Pattern involves edge-injected global data + component fallback to that data when route params missing.
-author: Claude Code
+author: Divine Web agents
 version: 1.0.0
 date: 2026-02-03
 ---

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ dist-ssr
 # Private journal
 .private-journal
 
+# Obsolete local agent acknowledgement files
+.ai-ack
+
 # Git worktrees
 .worktrees/
 .claude/worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,6 @@ dist-ssr
 .worktrees/
 .claude/worktrees/
 .playwright-mcp/
-.ai-ack
 
 # Fastly Compute
 compute-js/static-publisher/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,12 +19,6 @@ Read `<context-dir>/AGENT_CONTEXT.md` and follow its instructions. If unavailabl
 
 If a Divine Brain search or ask tool is available, you may use it for company memory. Treat it as optional and credentialed: tool names vary by client, and work must continue when Brain is unavailable. When Brain results influence work, cite the returned document ids. Never commit Brain credentials or expose Brain-derived sensitive content in public PRs, issues, branch names, commit messages, code comments, logs, screenshots, release notes, or externally shared agent transcripts.
 
-## AI Acknowledgment
-
-Check for `.ai-ack` in the repository root (next to `.git`) before any other
-work. If the file is missing, read `HUMAN_VS_MACHINE.md` and follow its
-instructions before proceeding.
-
 ## Read First
 
 - `CONTRIBUTING.md`: PR rules, testing expectations, scope discipline.
@@ -92,7 +86,7 @@ Running only deploy without publish means the new frontend code won't be served!
 
 ### Git Conventions
 - Commit format: `type: description` (feat, fix, perf, docs, refactor, test)
-- Include `Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>` when AI-assisted
+- Do not add AI co-author trailers unless explicitly requested.
 - Don't amend commits after hook failures - create new commits
 
 ## Funnelcake REST API

--- a/HUMAN_VS_MACHINE.md
+++ b/HUMAN_VS_MACHINE.md
@@ -8,17 +8,17 @@ components that exist just to make the linter shut up. No filler comments
 restating what the code already says. If you wouldn't ship it to production,
 don't commit it.
 
-Before you touch anything:
+Before you touch code, use the repo instructions already provided in your
+agent context:
 
-1. Read `CONTRIBUTING.md` and `ARCHITECTURE.md`. Both of them, all the way
-   through. Not skimmed.
-2. Explain every rule back to the human sitting at the keyboard. The whole
-   thing, not a summary. Make sure they actually understand what's required.
-3. Ask them to confirm with the exact words: **yes i understood**
-4. Only after that confirmation, create `.ai-ack` next to `.git` and get to
-   work.
+1. Read `CONTRIBUTING.md` and `ARCHITECTURE.md` when they are relevant to the
+   work in front of you.
+2. Verify facts with the code, tests, docs, or live state before making claims.
+3. Keep the diff focused on the requested change.
+4. Run the smallest useful verification first, then broaden it when risk calls
+   for it.
 
-If the human is confused or unsure about any rule, slow down and explain it
-more. Don't barrel ahead. Confirmation matters.
+If the human is confused or unsure about any rule, slow down and explain it.
+If a requirement conflicts with verified evidence, stop and ask before acting.
 
 Keep the web weird. Make it good.

--- a/docs/plans/2025-11-16-dynamic-seo-meta-tags.md
+++ b/docs/plans/2025-11-16-dynamic-seo-meta-tags.md
@@ -73,11 +73,7 @@ git commit -m "feat: add dynamic SEO meta tags to VideoPage
 
 Add Open Graph and Twitter Card meta tags that update when video data
 loads. Uses video title, content, and thumbnail for social sharing
-previews.
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>"
+previews."
 ```
 
 ---
@@ -148,11 +144,7 @@ git commit -m "feat: add dynamic SEO meta tags to ProfilePage
 
 Add Open Graph and Twitter Card meta tags that update when profile data
 loads. Uses user's display name, bio, and avatar for social sharing
-previews.
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>"
+previews."
 ```
 
 ---
@@ -221,11 +213,7 @@ git add src/pages/HashtagPage.tsx
 git commit -m "feat: add dynamic SEO meta tags to HashtagPage
 
 Add Open Graph and Twitter Card meta tags that update when hashtag data
-loads. Uses hashtag name and video count for social sharing previews.
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>"
+loads. Uses hashtag name and video count for social sharing previews."
 ```
 
 ---
@@ -313,11 +301,7 @@ Expected: Bundle sizes similar to before (no significant increase)
 If any cleanup or adjustments were needed:
 ```bash
 git add .
-git commit -m "chore: cleanup after SEO meta tags implementation
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>"
+git commit -m "chore: cleanup after SEO meta tags implementation"
 ```
 
 ---

--- a/src/components/VideoPlayer.test.tsx
+++ b/src/components/VideoPlayer.test.tsx
@@ -790,7 +790,12 @@ describe('VideoPlayer', () => {
     });
 
     it('resumes an active video after switching to a fallback URL', async () => {
-      const playSpy = vi.fn().mockResolvedValue(undefined);
+      let isPaused = true;
+      vi.spyOn(HTMLMediaElement.prototype, 'paused', 'get').mockImplementation(() => isPaused);
+      const playSpy = vi.fn().mockImplementation(() => {
+        isPaused = false;
+        return Promise.resolve();
+      });
       HTMLMediaElement.prototype.play = playSpy;
 
       const { useVideoPlayback } = await import('@/hooks/useVideoPlayback');
@@ -827,6 +832,7 @@ describe('VideoPlayer', () => {
         expect(video.src).toBe('https://example.com/fallback.mp4');
       });
 
+      isPaused = true;
       fireEvent.loadedData(video);
 
       await waitFor(() => {

--- a/tests/agent-instructions.test.ts
+++ b/tests/agent-instructions.test.ts
@@ -7,14 +7,19 @@ describe('agent instructions', () => {
   it('do not require a local AI acknowledgement gate', () => {
     expect(read('AGENTS.md')).not.toMatch(/\.ai-ack|AI Acknowledgment/);
     expect(read('HUMAN_VS_MACHINE.md')).not.toMatch(/\.ai-ack|yes i understood/);
-    expect(read('.gitignore')).not.toMatch(/^\.ai-ack$/m);
+  });
+
+  it('keeps stale local acknowledgement artifacts ignored', () => {
+    expect(read('.gitignore')).toMatch(/^\.ai-ack$/m);
   });
 
   it('use tool-neutral AI attribution guidance', () => {
     const agents = read('AGENTS.md');
+    const archivedSeoPlan = read('docs/plans/2025-11-16-dynamic-seo-meta-tags.md');
 
     expect(agents).toContain('Do not add AI co-author trailers unless explicitly requested.');
     expect(agents).not.toContain('Co-Authored-By: Claude Opus');
+    expect(archivedSeoPlan).not.toContain('Co-Authored-By: Claude');
   });
 
   it('does not publish Claude Code as active shared skill metadata', () => {

--- a/tests/agent-instructions.test.ts
+++ b/tests/agent-instructions.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const read = (path: string) => readFileSync(path, 'utf8');
+
+describe('agent instructions', () => {
+  it('do not require a local AI acknowledgement gate', () => {
+    expect(read('AGENTS.md')).not.toMatch(/\.ai-ack|AI Acknowledgment/);
+    expect(read('HUMAN_VS_MACHINE.md')).not.toMatch(/\.ai-ack|yes i understood/);
+    expect(read('.gitignore')).not.toMatch(/^\.ai-ack$/m);
+  });
+
+  it('use tool-neutral AI attribution guidance', () => {
+    const agents = read('AGENTS.md');
+
+    expect(agents).toContain('Do not add AI co-author trailers unless explicitly requested.');
+    expect(agents).not.toContain('Co-Authored-By: Claude Opus');
+  });
+
+  it('does not publish Claude Code as active shared skill metadata', () => {
+    expect(read('.agents/skills/spa-subdomain-root-render/SKILL.md')).not.toMatch(
+      /^author: Claude Code$/m,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Agents were being asked to stop for a local acknowledgement file before doing work.
- AI-assisted commits also inherited a Claude-specific co-author rule, even when the agent was not Claude.
- This change removes that stale gate, switches the commit guidance to a neutral rule, and adds a test to keep those instructions from returning.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- The old gate duplicated the instructions agents already receive from the repo.
- The old co-author rule could produce incorrect commit metadata for Codex, Copilot, and other tools.
- I kept Claude compatibility surfaces that still serve a real purpose, like the thin `CLAUDE.md` import and shared skills symlink.

## Related Issue

- Closes #470

## Testing

- [x] `npm run test`
- [x] Manual verification completed

I also verified the branch rebases cleanly on latest `origin/main`.
The new guardrail test checks the active instruction files for the removed gate and stale Claude attribution.

## Visuals

- [ ] UI change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved