### PR TITLE
feat(minor-safety): gate raw-key handover affordances for protected minors on web

### DIFF
--- a/src/components/auth/AccountSwitcher.test.tsx
+++ b/src/components/auth/AccountSwitcher.test.tsx
@@ -13,6 +13,8 @@ const {
   mockRelaySelector,
   mockSetLogin,
   mockUseLoggedInAccounts,
+  mockUseNostrLogin,
+  mockUseProtectedMinorStatus,
 } = vi.hoisted(() => ({
   mockClearJwtCookie: vi.fn(),
   mockClearLoginCookie: vi.fn(),
@@ -22,6 +24,8 @@ const {
   mockRelaySelector: vi.fn(),
   mockSetLogin: vi.fn(),
   mockUseLoggedInAccounts: vi.fn(),
+  mockUseNostrLogin: vi.fn(),
+  mockUseProtectedMinorStatus: vi.fn(),
 }));
 
 vi.mock('react-router-dom', () => ({
@@ -29,9 +33,11 @@ vi.mock('react-router-dom', () => ({
 }));
 
 vi.mock('@nostrify/react/login', () => ({
-  useNostrLogin: () => ({
-    logins: [],
-  }),
+  useNostrLogin: () => mockUseNostrLogin(),
+}));
+
+vi.mock('@/hooks/useProtectedMinorStatus', () => ({
+  useProtectedMinorStatus: () => mockUseProtectedMinorStatus(),
 }));
 
 vi.mock('@/hooks/useLoggedInAccounts', () => ({
@@ -80,11 +86,28 @@ vi.mock('@/components/RelaySelector', () => ({
 }));
 
 vi.mock('./LocalNsecBanner', () => ({
-  LocalNsecBanner: () => null,
+  LocalNsecBanner: () => <div data-testid="local-nsec-banner" />,
 }));
 
 import { AccountSwitcher } from './AccountSwitcher';
 import { OVERLAY_LAYERS } from '@/lib/overlayLayers';
+import {
+  NOT_PROTECTED,
+  UNKNOWN_PROTECTED_MINOR_STATUS,
+  type ProtectedMinorStatus,
+} from '@/lib/protectedMinor';
+
+const PROTECTED_STATUS: ProtectedMinorStatus = Object.freeze({
+  state: 'protected',
+  isKnown: true,
+  verifiedMinorAt: null,
+});
+
+const LOCAL_NSEC_LOGIN = {
+  id: 'nsec-login',
+  type: 'nsec',
+  data: { nsec: 'nsec1localsecret' },
+};
 
 describe('AccountSwitcher', () => {
   beforeEach(async () => {
@@ -107,6 +130,10 @@ describe('AccountSwitcher', () => {
     mockRemoveLogin.mockClear();
     mockRelaySelector.mockClear();
     mockSetLogin.mockClear();
+    mockUseNostrLogin.mockReset();
+    mockUseNostrLogin.mockReturnValue({ logins: [] });
+    mockUseProtectedMinorStatus.mockReset();
+    mockUseProtectedMinorStatus.mockReturnValue(NOT_PROTECTED);
     mockUseLoggedInAccounts.mockReturnValue({
       currentUser: {
         id: `jwt:${'a'.repeat(64)}`,
@@ -141,5 +168,33 @@ describe('AccountSwitcher', () => {
         contentClassName: OVERLAY_LAYERS.nestedOverlayFloating,
       }),
     );
+  });
+
+  describe('nsec backup banner gating (#182)', () => {
+    beforeEach(() => {
+      mockUseNostrLogin.mockReturnValue({ logins: [LOCAL_NSEC_LOGIN] });
+    });
+
+    it('shows the backup banner for a positively not-protected user with a local nsec login', () => {
+      render(<AccountSwitcher onAddAccountClick={vi.fn()} />);
+
+      expect(screen.getByTestId('local-nsec-banner')).toBeInTheDocument();
+    });
+
+    it('hides the backup banner for a protected minor', () => {
+      mockUseProtectedMinorStatus.mockReturnValue(PROTECTED_STATUS);
+
+      render(<AccountSwitcher onAddAccountClick={vi.fn()} />);
+
+      expect(screen.queryByTestId('local-nsec-banner')).not.toBeInTheDocument();
+    });
+
+    it('fails closed: hides the backup banner while the status is unknown', () => {
+      mockUseProtectedMinorStatus.mockReturnValue(UNKNOWN_PROTECTED_MINOR_STATUS);
+
+      render(<AccountSwitcher onAddAccountClick={vi.fn()} />);
+
+      expect(screen.queryByTestId('local-nsec-banner')).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/components/auth/AccountSwitcher.test.tsx
+++ b/src/components/auth/AccountSwitcher.test.tsx
@@ -93,7 +93,6 @@ import { AccountSwitcher } from './AccountSwitcher';
 import { OVERLAY_LAYERS } from '@/lib/overlayLayers';
 import {
   NOT_PROTECTED,
-  UNKNOWN_PROTECTED_MINOR_STATUS,
   type ProtectedMinorStatus,
 } from '@/lib/protectedMinor';
 
@@ -170,27 +169,32 @@ describe('AccountSwitcher', () => {
     );
   });
 
-  describe('nsec backup banner gating (#182)', () => {
+  describe('nsec backup banner mounting (#182)', () => {
     beforeEach(() => {
       mockUseNostrLogin.mockReturnValue({ logins: [LOCAL_NSEC_LOGIN] });
     });
 
-    it('shows the backup banner for a positively not-protected user with a local nsec login', () => {
+    it('renders the backup banner whenever a local nsec login exists', () => {
       render(<AccountSwitcher onAddAccountClick={vi.fn()} />);
 
       expect(screen.getByTestId('local-nsec-banner')).toBeInTheDocument();
     });
 
-    it('hides the backup banner for a protected minor', () => {
+    // The banner gates itself for protected minors (LocalNsecBanner.test.tsx;
+    // real-parent flip coverage in LoginDialog.test.tsx). This parent must NOT
+    // gate it: unmounting on a restricted flip would freeze the banner's
+    // command-boundary re-checks at their pre-flip verdict (dcadenas review on
+    // #476), so the banner stays mounted here even while restricted.
+    it('keeps the banner mounted while restricted so its own gate stays live', () => {
       mockUseProtectedMinorStatus.mockReturnValue(PROTECTED_STATUS);
 
       render(<AccountSwitcher onAddAccountClick={vi.fn()} />);
 
-      expect(screen.queryByTestId('local-nsec-banner')).not.toBeInTheDocument();
+      expect(screen.getByTestId('local-nsec-banner')).toBeInTheDocument();
     });
 
-    it('fails closed: hides the backup banner while the status is unknown', () => {
-      mockUseProtectedMinorStatus.mockReturnValue(UNKNOWN_PROTECTED_MINOR_STATUS);
+    it('renders no banner without a local nsec login', () => {
+      mockUseNostrLogin.mockReturnValue({ logins: [] });
 
       render(<AccountSwitcher onAddAccountClick={vi.fn()} />);
 

--- a/src/components/auth/AccountSwitcher.tsx
+++ b/src/components/auth/AccountSwitcher.tsx
@@ -18,10 +18,12 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar.tsx'
 import { useNostrLogin } from '@nostrify/react/login';
 import { useLoggedInAccounts, type Account } from '@/hooks/useLoggedInAccounts';
 import { useDivineSession } from '@/hooks/useDivineSession';
+import { useProtectedMinorStatus } from '@/hooks/useProtectedMinorStatus';
 import { clearLoginCookie, clearJwtCookie } from '@/lib/crossSubdomainAuth';
 import { genUserName } from '@/lib/genUserName';
 import { getSafeProfileImage } from '@/lib/imageUtils';
 import { getActiveLocalNsecLogin } from '@/lib/localNsecAccount';
+import { isMinorKeyHandoverRestricted } from '@/lib/protectedMinor';
 import { OVERLAY_LAYERS } from '@/lib/overlayLayers';
 import { RelaySelector } from '@/components/RelaySelector';
 import { LocalNsecBanner } from './LocalNsecBanner';
@@ -35,8 +37,12 @@ export function AccountSwitcher({ onAddAccountClick }: AccountSwitcherProps) {
   const { logins } = useNostrLogin();
   const { currentUser, otherUsers, setLogin, removeLogin } = useLoggedInAccounts();
   const { clearSession } = useDivineSession();
+  const { state: protectedMinorState } = useProtectedMinorStatus();
   const navigate = useNavigate();
   const localNsecLogin = getActiveLocalNsecLogin(logins);
+  // #182: a protected-minor session (or one whose status is still unknown —
+  // fail closed) must not be offered the raw-key backup/copy affordance.
+  const keyHandoverRestricted = isMinorKeyHandoverRestricted(protectedMinorState);
 
   if (!currentUser) return null;
 
@@ -64,7 +70,7 @@ export function AccountSwitcher({ onAddAccountClick }: AccountSwitcherProps) {
 
   return (
     <div className='account-switcher w-full min-w-0 max-w-full space-y-3'>
-      {localNsecLogin ? <LocalNsecBanner nsec={localNsecLogin.data.nsec} /> : null}
+      {localNsecLogin && !keyHandoverRestricted ? <LocalNsecBanner nsec={localNsecLogin.data.nsec} /> : null}
       <DropdownMenu modal={false}>
         <DropdownMenuTrigger asChild>
           <button className='flex w-full min-w-0 items-center gap-3 rounded-full p-3 text-foreground transition-all hover:bg-accent'>

--- a/src/components/auth/AccountSwitcher.tsx
+++ b/src/components/auth/AccountSwitcher.tsx
@@ -18,12 +18,10 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar.tsx'
 import { useNostrLogin } from '@nostrify/react/login';
 import { useLoggedInAccounts, type Account } from '@/hooks/useLoggedInAccounts';
 import { useDivineSession } from '@/hooks/useDivineSession';
-import { useProtectedMinorStatus } from '@/hooks/useProtectedMinorStatus';
 import { clearLoginCookie, clearJwtCookie } from '@/lib/crossSubdomainAuth';
 import { genUserName } from '@/lib/genUserName';
 import { getSafeProfileImage } from '@/lib/imageUtils';
 import { getActiveLocalNsecLogin } from '@/lib/localNsecAccount';
-import { isMinorKeyHandoverRestricted } from '@/lib/protectedMinor';
 import { OVERLAY_LAYERS } from '@/lib/overlayLayers';
 import { RelaySelector } from '@/components/RelaySelector';
 import { LocalNsecBanner } from './LocalNsecBanner';
@@ -37,12 +35,8 @@ export function AccountSwitcher({ onAddAccountClick }: AccountSwitcherProps) {
   const { logins } = useNostrLogin();
   const { currentUser, otherUsers, setLogin, removeLogin } = useLoggedInAccounts();
   const { clearSession } = useDivineSession();
-  const { state: protectedMinorState } = useProtectedMinorStatus();
   const navigate = useNavigate();
   const localNsecLogin = getActiveLocalNsecLogin(logins);
-  // #182: a protected-minor session (or one whose status is still unknown —
-  // fail closed) must not be offered the raw-key backup/copy affordance.
-  const keyHandoverRestricted = isMinorKeyHandoverRestricted(protectedMinorState);
 
   if (!currentUser) return null;
 
@@ -70,7 +64,11 @@ export function AccountSwitcher({ onAddAccountClick }: AccountSwitcherProps) {
 
   return (
     <div className='account-switcher w-full min-w-0 max-w-full space-y-3'>
-      {localNsecLogin && !keyHandoverRestricted ? <LocalNsecBanner nsec={localNsecLogin.data.nsec} /> : null}
+      {/* #182: the banner gates itself for protected minors. It must render
+          unconditionally here so a restricted flip keeps it mounted (rendering
+          null) and its command-boundary re-checks stay live; a gate at this
+          level would unmount it mid-flight (dcadenas review on #476). */}
+      {localNsecLogin ? <LocalNsecBanner nsec={localNsecLogin.data.nsec} /> : null}
       <DropdownMenu modal={false}>
         <DropdownMenuTrigger asChild>
           <button className='flex w-full min-w-0 items-center gap-3 rounded-full p-3 text-foreground transition-all hover:bg-accent'>

--- a/src/components/auth/LocalNsecBanner.test.tsx
+++ b/src/components/auth/LocalNsecBanner.test.tsx
@@ -25,8 +25,22 @@ const PROTECTED_STATUS: ProtectedMinorStatus = Object.freeze({
 });
 
 const originalLocation = window.location;
+const originalCreateObjectURL = Object.getOwnPropertyDescriptor(URL, 'createObjectURL');
+const originalRevokeObjectURL = Object.getOwnPropertyDescriptor(URL, 'revokeObjectURL');
 const locationAssign = vi.fn();
 const clipboardWriteText = vi.fn();
+
+/** Install a controllable download rig (jsdom lacks both URL blob helpers). */
+function stubObjectUrl(): ReturnType<typeof vi.fn> {
+  const createObjectURL = vi.fn(() => 'blob:stub');
+  Object.defineProperty(URL, 'createObjectURL', {
+    value: createObjectURL, writable: true, configurable: true,
+  });
+  Object.defineProperty(URL, 'revokeObjectURL', {
+    value: vi.fn(), writable: true, configurable: true,
+  });
+  return createObjectURL;
+}
 
 vi.mock('@/lib/divineLogin', async () => {
   const actual = await vi.importActual<typeof import('@/lib/divineLogin')>('@/lib/divineLogin');
@@ -66,6 +80,18 @@ describe('LocalNsecBanner', () => {
       writable: true,
       configurable: true,
     });
+    // Restore the URL blob helpers so a test that stubs them can't order-couple
+    // the next one (jsdom's default is that both are absent).
+    if (originalCreateObjectURL) {
+      Object.defineProperty(URL, 'createObjectURL', originalCreateObjectURL);
+    } else {
+      delete (URL as { createObjectURL?: unknown }).createObjectURL;
+    }
+    if (originalRevokeObjectURL) {
+      Object.defineProperty(URL, 'revokeObjectURL', originalRevokeObjectURL);
+    } else {
+      delete (URL as { revokeObjectURL?: unknown }).revokeObjectURL;
+    }
   });
 
   it('renders the secure-account and backup call to action set', () => {
@@ -137,12 +163,7 @@ describe('LocalNsecBanner', () => {
       clipboardWriteText.mockImplementation(
         () => new Promise((_resolve, reject) => { rejectWrite = reject; }),
       );
-      const createObjectURL = vi.fn(() => 'blob:stub');
-      Object.defineProperty(URL, 'createObjectURL', {
-        value: createObjectURL,
-        writable: true,
-        configurable: true,
-      });
+      const createObjectURL = stubObjectUrl();
 
       const { rerender } = render(<LocalNsecBanner nsec="nsec1example" />);
 
@@ -161,13 +182,26 @@ describe('LocalNsecBanner', () => {
       expect(screen.queryByText(/somewhere safe/i)).not.toBeInTheDocument();
     });
 
+    it('falls through to a file download when the clipboard rejects and the user is not restricted (positive control)', async () => {
+      let rejectWrite!: (error: Error) => void;
+      clipboardWriteText.mockImplementation(
+        () => new Promise((_resolve, reject) => { rejectWrite = reject; }),
+      );
+      const createObjectURL = stubObjectUrl();
+
+      render(<LocalNsecBanner nsec="nsec1example" />);
+
+      fireEvent.click(screen.getByRole('button', { name: /Back up nsec/i }));
+      rejectWrite(new Error('NotAllowedError'));
+      await screen.findByText(/somewhere safe/i);
+
+      // Guarantees the guard the negative tests rely on isn't just always-on:
+      // an unrestricted user still gets the download fall-through.
+      expect(createObjectURL).toHaveBeenCalled();
+    });
+
     it('refuses to copy or download the nsec when rendered by an ungated parent while restricted', async () => {
-      const createObjectURL = vi.fn(() => 'blob:stub');
-      Object.defineProperty(URL, 'createObjectURL', {
-        value: createObjectURL,
-        writable: true,
-        configurable: true,
-      });
+      const createObjectURL = stubObjectUrl();
       mockUseProtectedMinorStatus.mockReturnValue(PROTECTED_STATUS);
 
       render(<LocalNsecBanner nsec="nsec1example" />);

--- a/src/components/auth/LocalNsecBanner.test.tsx
+++ b/src/components/auth/LocalNsecBanner.test.tsx
@@ -188,16 +188,25 @@ describe('LocalNsecBanner', () => {
         () => new Promise((_resolve, reject) => { rejectWrite = reject; }),
       );
       const createObjectURL = stubObjectUrl();
+      // downloadBackup reaches anchor.click(); jsdom logs an unimplemented-
+      // navigation stack for that, so stub it to keep the run output clean.
+      const anchorClick = vi
+        .spyOn(HTMLAnchorElement.prototype, 'click')
+        .mockImplementation(() => {});
 
-      render(<LocalNsecBanner nsec="nsec1example" />);
+      try {
+        render(<LocalNsecBanner nsec="nsec1example" />);
 
-      fireEvent.click(screen.getByRole('button', { name: /Back up nsec/i }));
-      rejectWrite(new Error('NotAllowedError'));
-      await screen.findByText(/somewhere safe/i);
+        fireEvent.click(screen.getByRole('button', { name: /Back up nsec/i }));
+        rejectWrite(new Error('NotAllowedError'));
+        await screen.findByText(/somewhere safe/i);
 
-      // Guarantees the guard the negative tests rely on isn't just always-on:
-      // an unrestricted user still gets the download fall-through.
-      expect(createObjectURL).toHaveBeenCalled();
+        // Guarantees the guard the negative tests rely on isn't just always-on:
+        // an unrestricted user still gets the download fall-through.
+        expect(createObjectURL).toHaveBeenCalled();
+      } finally {
+        anchorClick.mockRestore();
+      }
     });
 
     it('refuses to copy or download the nsec when rendered by an ungated parent while restricted', async () => {

--- a/src/components/auth/LocalNsecBanner.test.tsx
+++ b/src/components/auth/LocalNsecBanner.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -122,22 +122,61 @@ describe('LocalNsecBanner', () => {
         url: 'https://login.divine.video/api/oauth/authorize?client_id=divine-web',
       });
       // Let the pending handleSecure continuation run to completion. The
-      // happy-path test above proves this rig reaches location.assign when
-      // unrestricted, so not-called here is a real verdict, not a vacuous one.
+      // happy-path test above proves this code path reaches location.assign
+      // when unrestricted, so not-called here is a real verdict.
       await new Promise((resolve) => setTimeout(resolve, 10));
 
       expect(locationAssign).not.toHaveBeenCalled();
     });
 
+    // fireEvent (not userEvent) for the clipboard paths: userEvent.setup()
+    // installs its own navigator.clipboard stub, which would detach the
+    // clipboardWriteText spy these two tests assert on.
+    it('aborts the download fall-through when the restriction engages while the clipboard write is pending', async () => {
+      let rejectWrite!: (error: Error) => void;
+      clipboardWriteText.mockImplementation(
+        () => new Promise((_resolve, reject) => { rejectWrite = reject; }),
+      );
+      const createObjectURL = vi.fn(() => 'blob:stub');
+      Object.defineProperty(URL, 'createObjectURL', {
+        value: createObjectURL,
+        writable: true,
+        configurable: true,
+      });
+
+      const { rerender } = render(<LocalNsecBanner nsec="nsec1example" />);
+
+      fireEvent.click(screen.getByRole('button', { name: /Back up nsec/i }));
+      expect(clipboardWriteText).toHaveBeenCalled();
+
+      mockUseProtectedMinorStatus.mockReturnValue(PROTECTED_STATUS);
+      rerender(<LocalNsecBanner nsec="nsec1example" />);
+
+      // A clipboard write can reject late (permission prompt, focus loss); the
+      // catch fall-through must not hand the key over via a file download.
+      rejectWrite(new Error('NotAllowedError'));
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(createObjectURL).not.toHaveBeenCalled();
+      expect(screen.queryByText(/somewhere safe/i)).not.toBeInTheDocument();
+    });
+
     it('refuses to copy or download the nsec when rendered by an ungated parent while restricted', async () => {
-      const user = userEvent.setup();
+      const createObjectURL = vi.fn(() => 'blob:stub');
+      Object.defineProperty(URL, 'createObjectURL', {
+        value: createObjectURL,
+        writable: true,
+        configurable: true,
+      });
       mockUseProtectedMinorStatus.mockReturnValue(PROTECTED_STATUS);
 
       render(<LocalNsecBanner nsec="nsec1example" />);
 
-      await user.click(screen.getByRole('button', { name: /Back up nsec/i }));
+      fireEvent.click(screen.getByRole('button', { name: /Back up nsec/i }));
+      await new Promise((resolve) => setTimeout(resolve, 10));
 
       expect(clipboardWriteText).not.toHaveBeenCalled();
+      expect(createObjectURL).not.toHaveBeenCalled();
       expect(screen.queryByText(/somewhere safe/i)).not.toBeInTheDocument();
     });
 

--- a/src/components/auth/LocalNsecBanner.test.tsx
+++ b/src/components/auth/LocalNsecBanner.test.tsx
@@ -3,10 +3,26 @@ import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { LocalNsecBanner } from './LocalNsecBanner';
+import {
+  NOT_PROTECTED,
+  UNKNOWN_PROTECTED_MINOR_STATUS,
+  type ProtectedMinorStatus,
+} from '@/lib/protectedMinor';
 
-const { mockBuildSecureAccountRedirect } = vi.hoisted(() => ({
+const { mockBuildSecureAccountRedirect, mockUseProtectedMinorStatus } = vi.hoisted(() => ({
   mockBuildSecureAccountRedirect: vi.fn(),
+  mockUseProtectedMinorStatus: vi.fn(),
 }));
+
+vi.mock('@/hooks/useProtectedMinorStatus', () => ({
+  useProtectedMinorStatus: () => mockUseProtectedMinorStatus(),
+}));
+
+const PROTECTED_STATUS: ProtectedMinorStatus = Object.freeze({
+  state: 'protected',
+  isKnown: true,
+  verifiedMinorAt: null,
+});
 
 const originalLocation = window.location;
 const locationAssign = vi.fn();
@@ -23,6 +39,7 @@ vi.mock('@/lib/divineLogin', async () => {
 
 describe('LocalNsecBanner', () => {
   beforeEach(() => {
+    mockUseProtectedMinorStatus.mockReturnValue(NOT_PROTECTED);
     mockBuildSecureAccountRedirect.mockResolvedValue({
       state: 'secure-state',
       pubkey: 'pubkey-123',
@@ -80,6 +97,60 @@ describe('LocalNsecBanner', () => {
         returnPath: '/settings/linked-accounts',
       });
       expect(locationAssign).toHaveBeenCalledWith('https://login.divine.video/api/oauth/authorize?client_id=divine-web');
+    });
+  });
+
+  describe('command-boundary re-check (#182)', () => {
+    it('aborts a pending secure-account redirect when the restriction engages mid-flight', async () => {
+      const user = userEvent.setup();
+      let resolveRedirect!: (value: { state: string; pubkey: string; url: string }) => void;
+      mockBuildSecureAccountRedirect.mockImplementation(
+        () => new Promise((resolve) => { resolveRedirect = resolve; }),
+      );
+
+      const { rerender } = render(<LocalNsecBanner nsec="nsec1example" />);
+
+      await user.click(screen.getByRole('button', { name: /Secure with divine.video login/i }));
+      expect(mockBuildSecureAccountRedirect).toHaveBeenCalled();
+
+      mockUseProtectedMinorStatus.mockReturnValue(PROTECTED_STATUS);
+      rerender(<LocalNsecBanner nsec="nsec1example" />);
+
+      resolveRedirect({
+        state: 'secure-state',
+        pubkey: 'pubkey-123',
+        url: 'https://login.divine.video/api/oauth/authorize?client_id=divine-web',
+      });
+      // Let the pending handleSecure continuation run to completion. The
+      // happy-path test above proves this rig reaches location.assign when
+      // unrestricted, so not-called here is a real verdict, not a vacuous one.
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(locationAssign).not.toHaveBeenCalled();
+    });
+
+    it('refuses to copy or download the nsec when rendered by an ungated parent while restricted', async () => {
+      const user = userEvent.setup();
+      mockUseProtectedMinorStatus.mockReturnValue(PROTECTED_STATUS);
+
+      render(<LocalNsecBanner nsec="nsec1example" />);
+
+      await user.click(screen.getByRole('button', { name: /Back up nsec/i }));
+
+      expect(clipboardWriteText).not.toHaveBeenCalled();
+      expect(screen.queryByText(/somewhere safe/i)).not.toBeInTheDocument();
+    });
+
+    it('fails closed: refuses to start the secure-account redirect while the status is unknown', async () => {
+      const user = userEvent.setup();
+      mockUseProtectedMinorStatus.mockReturnValue(UNKNOWN_PROTECTED_MINOR_STATUS);
+
+      render(<LocalNsecBanner nsec="nsec1example" />);
+
+      await user.click(screen.getByRole('button', { name: /Secure with divine.video login/i }));
+
+      expect(mockBuildSecureAccountRedirect).not.toHaveBeenCalled();
+      expect(locationAssign).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/components/auth/LocalNsecBanner.test.tsx
+++ b/src/components/auth/LocalNsecBanner.test.tsx
@@ -209,30 +209,24 @@ describe('LocalNsecBanner', () => {
       }
     });
 
-    it('refuses to copy or download the nsec when rendered by an ungated parent while restricted', async () => {
-      const createObjectURL = stubObjectUrl();
+    // The banner is its own gate (dcadenas review on #476): parents render it
+    // unconditionally so a restricted flip keeps it mounted, and the banner
+    // renders null itself. These two pin the render-side of that gate; the
+    // flip tests above pin the command-boundary side.
+    it('renders nothing while the account is a protected minor', () => {
       mockUseProtectedMinorStatus.mockReturnValue(PROTECTED_STATUS);
 
-      render(<LocalNsecBanner nsec="nsec1example" />);
+      const { container } = render(<LocalNsecBanner nsec="nsec1example" />);
 
-      fireEvent.click(screen.getByRole('button', { name: /Back up nsec/i }));
-      await new Promise((resolve) => setTimeout(resolve, 10));
-
-      expect(clipboardWriteText).not.toHaveBeenCalled();
-      expect(createObjectURL).not.toHaveBeenCalled();
-      expect(screen.queryByText(/somewhere safe/i)).not.toBeInTheDocument();
+      expect(container).toBeEmptyDOMElement();
     });
 
-    it('fails closed: refuses to start the secure-account redirect while the status is unknown', async () => {
-      const user = userEvent.setup();
+    it('fails closed: renders nothing while the status is unknown', () => {
       mockUseProtectedMinorStatus.mockReturnValue(UNKNOWN_PROTECTED_MINOR_STATUS);
 
-      render(<LocalNsecBanner nsec="nsec1example" />);
+      const { container } = render(<LocalNsecBanner nsec="nsec1example" />);
 
-      await user.click(screen.getByRole('button', { name: /Secure with divine.video login/i }));
-
-      expect(mockBuildSecureAccountRedirect).not.toHaveBeenCalled();
-      expect(locationAssign).not.toHaveBeenCalled();
+      expect(container).toBeEmptyDOMElement();
     });
   });
 });

--- a/src/components/auth/LocalNsecBanner.tsx
+++ b/src/components/auth/LocalNsecBanner.tsx
@@ -32,14 +32,13 @@ export function LocalNsecBanner(props: LocalNsecBannerProps) {
   const [status, setStatus] = useState<string | null>(null);
   const { state: protectedMinorState } = useProtectedMinorStatus();
   // #182 command-boundary re-check (mirrors the divine-mobile #5991 review
-  // finding): render-time gating in the parents decides whether this banner
-  // shows, but a pending continuation (the secure-redirect await below)
-  // captures its closure before a live status check can resolve `protected`
-  // mid-interaction. A ref always holds the latest verdict, so each raw-key
-  // handover re-checks at the moment it happens, and a stale-rendered banner
-  // under a future ungated parent cannot hand the key over either.
+  // finding): a pending continuation (the clipboard-reject fall-through, the
+  // secure-redirect await) captures its closure before a live status check can
+  // resolve `protected` mid-interaction. A ref always holds the latest verdict,
+  // so each raw-key handover re-checks at the moment it happens.
+  const keyHandoverRestricted = isMinorKeyHandoverRestricted(protectedMinorState);
   const keyHandoverRestrictedRef = useRef(false);
-  keyHandoverRestrictedRef.current = isMinorKeyHandoverRestricted(protectedMinorState);
+  keyHandoverRestrictedRef.current = keyHandoverRestricted;
 
   const handleBackUp = async () => {
     if (keyHandoverRestrictedRef.current) return;
@@ -70,6 +69,15 @@ export function LocalNsecBanner(props: LocalNsecBannerProps) {
     if (keyHandoverRestrictedRef.current) return;
     window.location.assign(redirect.url);
   };
+
+  // The banner gates itself (dcadenas review on #476): parents must render it
+  // unconditionally so a restricted flip keeps this component MOUNTED rendering
+  // null instead of unmounting it. An unmounting component never re-renders, so
+  // a parent-side gate would freeze the ref above at its pre-flip value and the
+  // re-checks in the handlers would never see the restriction engage.
+  if (keyHandoverRestricted) {
+    return null;
+  }
 
   return (
     <Alert className="border-brand-green/30 bg-brand-light-green/40 dark:bg-brand-dark-green/20">

--- a/src/components/auth/LocalNsecBanner.tsx
+++ b/src/components/auth/LocalNsecBanner.tsx
@@ -1,9 +1,11 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
+import { useProtectedMinorStatus } from '@/hooks/useProtectedMinorStatus';
 import { buildSecureAccountRedirect } from '@/lib/divineLogin';
 import { buildNsecDownload } from '@/lib/localNsecAccount';
+import { isMinorKeyHandoverRestricted } from '@/lib/protectedMinor';
 
 interface LocalNsecBannerProps {
   nsec: string;
@@ -28,8 +30,19 @@ function downloadBackup(nsec: string): boolean {
 export function LocalNsecBanner(props: LocalNsecBannerProps) {
   const { nsec } = props;
   const [status, setStatus] = useState<string | null>(null);
+  const { state: protectedMinorState } = useProtectedMinorStatus();
+  // #182 command-boundary re-check (mirrors the divine-mobile #5991 review
+  // finding): render-time gating in the parents decides whether this banner
+  // shows, but a pending continuation (the secure-redirect await below)
+  // captures its closure before a live status check can resolve `protected`
+  // mid-interaction. A ref always holds the latest verdict, so each raw-key
+  // handover re-checks at the moment it happens, and a stale-rendered banner
+  // under a future ungated parent cannot hand the key over either.
+  const keyHandoverRestrictedRef = useRef(false);
+  keyHandoverRestrictedRef.current = isMinorKeyHandoverRestricted(protectedMinorState);
 
   const handleBackUp = async () => {
+    if (keyHandoverRestrictedRef.current) return;
     try {
       if (navigator.clipboard?.writeText) {
         await navigator.clipboard.writeText(nsec);
@@ -47,8 +60,11 @@ export function LocalNsecBanner(props: LocalNsecBannerProps) {
   };
 
   const handleSecure = async () => {
+    if (keyHandoverRestrictedRef.current) return;
     const returnPath = `${window.location.pathname}${window.location.search}`;
     const redirect = await buildSecureAccountRedirect(nsec, { returnPath });
+    // Re-check after the await: the nsec leaves the app in this URL.
+    if (keyHandoverRestrictedRef.current) return;
     window.location.assign(redirect.url);
   };
 

--- a/src/components/auth/LocalNsecBanner.tsx
+++ b/src/components/auth/LocalNsecBanner.tsx
@@ -53,6 +53,9 @@ export function LocalNsecBanner(props: LocalNsecBannerProps) {
       // Fall through to file download when clipboard access is unavailable.
     }
 
+    // Re-check after the await: a clipboard write can reject late (permission
+    // prompt, focus loss) and the nsec would leave the app in the file below.
+    if (keyHandoverRestrictedRef.current) return;
     const didDownload = downloadBackup(nsec);
     setStatus(didDownload
       ? 'Backup file downloaded. Stash it somewhere safe.'

--- a/src/components/auth/LoginDialog.test.tsx
+++ b/src/components/auth/LoginDialog.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -243,6 +243,55 @@ describe('LoginDialog', () => {
 
       expect(await screen.findByRole('button', { name: /Use Nostr instead/i })).toBeInTheDocument();
       expect(screen.queryByRole('button', { name: /Login with Extension/i })).not.toBeInTheDocument();
+    });
+
+    it('logs in with a pasted nsec when positively not protected (positive control)', async () => {
+      const user = userEvent.setup();
+
+      render(<LoginDialog isOpen onClose={vi.fn()} onLogin={vi.fn()} />);
+
+      await user.click(await screen.findByRole('tab', { name: /^Sign in$/i }));
+      await user.click(screen.getByRole('button', { name: /Use Nostr instead/i }));
+      await user.click(await screen.findByRole('tab', { name: /^Key$/i }));
+      fireEvent.change(screen.getByLabelText(/Secret key/i), {
+        target: { value: 'nsec1czx9vnnpgx8dlf72xct3ntry2l2suss2kv4ll496geja4qjmwn9sh3qlyn' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: /^Log In$/i }));
+
+      await waitFor(() => {
+        expect(mockLoginActions.nsec).toHaveBeenCalledWith('nsec1czx9vnnpgx8dlf72xct3ntry2l2suss2kv4ll496geja4qjmwn9sh3qlyn');
+      });
+    });
+
+    it('blocks a pending nsec import when the restriction engages before the deferred login runs', async () => {
+      const user = userEvent.setup();
+
+      const { rerender } = render(<LoginDialog isOpen onClose={vi.fn()} onLogin={vi.fn()} />);
+
+      await user.click(await screen.findByRole('tab', { name: /^Sign in$/i }));
+      await user.click(screen.getByRole('button', { name: /Use Nostr instead/i }));
+      await user.click(await screen.findByRole('tab', { name: /^Key$/i }));
+      fireEvent.change(screen.getByLabelText(/Secret key/i), {
+        target: { value: 'nsec1czx9vnnpgx8dlf72xct3ntry2l2suss2kv4ll496geja4qjmwn9sh3qlyn' },
+      });
+
+      // Schedule the deferred login (50ms window), then flip the status to
+      // protected before the timer fires - the shape of the mobile #5991
+      // finding: a live check resolving mid-interaction must beat a pending
+      // continuation to the raw-key handover.
+      vi.useFakeTimers();
+      try {
+        fireEvent.click(screen.getByRole('button', { name: /^Log In$/i }));
+
+        mockUseProtectedMinorStatus.mockReturnValue(PROTECTED_STATUS);
+        rerender(<LoginDialog isOpen onClose={vi.fn()} onLogin={vi.fn()} />);
+
+        vi.advanceTimersByTime(100);
+      } finally {
+        vi.useRealTimers();
+      }
+
+      expect(mockLoginActions.nsec).not.toHaveBeenCalled();
     });
 
     it('fails closed: hides the banner and the Nostr disclosure while the status is unknown', async () => {

--- a/src/components/auth/LoginDialog.test.tsx
+++ b/src/components/auth/LoginDialog.test.tsx
@@ -225,6 +225,26 @@ describe('LoginDialog', () => {
       expect(screen.queryByRole('button', { name: /Login with Extension/i })).not.toBeInTheDocument();
     });
 
+    it('does not reopen the Nostr disclosure unprompted after a restriction interlude', async () => {
+      const user = userEvent.setup();
+
+      const { rerender } = render(<LoginDialog isOpen onClose={vi.fn()} onLogin={vi.fn()} />);
+
+      await user.click(await screen.findByRole('tab', { name: /^Sign in$/i }));
+      await user.click(screen.getByRole('button', { name: /Use Nostr instead/i }));
+      expect(await screen.findByRole('button', { name: /Login with Extension/i })).toBeInTheDocument();
+
+      mockUseProtectedMinorStatus.mockReturnValue(PROTECTED_STATUS);
+      rerender(<LoginDialog isOpen onClose={vi.fn()} onLogin={vi.fn()} />);
+      expect(screen.queryByRole('button', { name: /Login with Extension/i })).not.toBeInTheDocument();
+
+      mockUseProtectedMinorStatus.mockReturnValue(NOT_PROTECTED);
+      rerender(<LoginDialog isOpen onClose={vi.fn()} onLogin={vi.fn()} />);
+
+      expect(await screen.findByRole('button', { name: /Use Nostr instead/i })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /Login with Extension/i })).not.toBeInTheDocument();
+    });
+
     it('fails closed: hides the banner and the Nostr disclosure while the status is unknown', async () => {
       const user = userEvent.setup();
       mockUseProtectedMinorStatus.mockReturnValue(UNKNOWN_PROTECTED_MINOR_STATUS);

--- a/src/components/auth/LoginDialog.test.tsx
+++ b/src/components/auth/LoginDialog.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -286,7 +286,9 @@ describe('LoginDialog', () => {
         mockUseProtectedMinorStatus.mockReturnValue(PROTECTED_STATUS);
         rerender(<LoginDialog isOpen onClose={vi.fn()} onLogin={vi.fn()} />);
 
-        vi.advanceTimersByTime(100);
+        act(() => {
+          vi.advanceTimersByTime(100);
+        });
       } finally {
         vi.useRealTimers();
       }

--- a/src/components/auth/LoginDialog.test.tsx
+++ b/src/components/auth/LoginDialog.test.tsx
@@ -296,6 +296,105 @@ describe('LoginDialog', () => {
       expect(mockLoginActions.nsec).not.toHaveBeenCalled();
     });
 
+    it('logs in via extension when positively not protected (positive control)', async () => {
+      const user = userEvent.setup();
+      (window as unknown as { nostr?: object }).nostr = {};
+      mockLoginActions.extension.mockResolvedValue(true);
+      const onLogin = vi.fn();
+      const onClose = vi.fn();
+
+      try {
+        render(<LoginDialog isOpen onClose={onClose} onLogin={onLogin} />);
+
+        await user.click(await screen.findByRole('tab', { name: /^Sign in$/i }));
+        await user.click(screen.getByRole('button', { name: /Use Nostr instead/i }));
+        await user.click(await screen.findByRole('button', { name: /Login with Extension/i }));
+
+        await waitFor(() => {
+          expect(onLogin).toHaveBeenCalled();
+          expect(onClose).toHaveBeenCalled();
+        });
+      } finally {
+        delete (window as unknown as { nostr?: object }).nostr;
+      }
+    });
+
+    it('blocks a pending extension login when the restriction engages during the handshake', async () => {
+      const user = userEvent.setup();
+      (window as unknown as { nostr?: object }).nostr = {};
+      let resolveHandshake!: () => void;
+      const handshake = new Promise<void>((resolve) => { resolveHandshake = resolve; });
+      // Faithful to the real contract (pinned in useLoginActions.test.ts): the
+      // action runs the caller's guard at commit time and reports whether the
+      // signer was committed.
+      mockLoginActions.extension.mockImplementation(
+        async (options?: { beforeCommit?: () => boolean }) => {
+          await handshake;
+          return options?.beforeCommit?.() ?? true;
+        },
+      );
+      const onLogin = vi.fn();
+      const onClose = vi.fn();
+
+      try {
+        const { rerender } = render(<LoginDialog isOpen onClose={onClose} onLogin={onLogin} />);
+
+        await user.click(await screen.findByRole('tab', { name: /^Sign in$/i }));
+        await user.click(screen.getByRole('button', { name: /Use Nostr instead/i }));
+        await user.click(await screen.findByRole('button', { name: /Login with Extension/i }));
+        expect(mockLoginActions.extension).toHaveBeenCalled();
+
+        // The verdict flips to protected while the extension prompt is open.
+        mockUseProtectedMinorStatus.mockReturnValue(PROTECTED_STATUS);
+        rerender(<LoginDialog isOpen onClose={onClose} onLogin={onLogin} />);
+
+        resolveHandshake();
+        await new Promise((resolve) => setTimeout(resolve, 10));
+
+        expect(onLogin).not.toHaveBeenCalled();
+        expect(onClose).not.toHaveBeenCalled();
+      } finally {
+        delete (window as unknown as { nostr?: object }).nostr;
+      }
+    });
+
+    it('blocks a pending bunker login when the restriction engages during the connect', async () => {
+      const user = userEvent.setup();
+      let resolveConnect!: () => void;
+      const connect = new Promise<void>((resolve) => { resolveConnect = resolve; });
+      mockLoginActions.bunker.mockImplementation(
+        async (_uri: string, options?: { beforeCommit?: () => boolean }) => {
+          await connect;
+          return options?.beforeCommit?.() ?? true;
+        },
+      );
+      const onLogin = vi.fn();
+      const onClose = vi.fn();
+
+      const { rerender } = render(<LoginDialog isOpen onClose={onClose} onLogin={onLogin} />);
+
+      await user.click(await screen.findByRole('tab', { name: /^Sign in$/i }));
+      await user.click(screen.getByRole('button', { name: /Use Nostr instead/i }));
+      // The trigger renders both the full and sm:hidden short labels, so the
+      // accessible name is "Bunker Bnkr" - no exact match.
+      await user.click(await screen.findByRole('tab', { name: /Bunker/i }));
+      fireEvent.change(screen.getByLabelText(/Bunker URI/i), {
+        target: { value: 'bunker://remote-signer.example?relay=wss%3A%2F%2Frelay.example' },
+      });
+      await user.click(screen.getByRole('button', { name: /Login with Bunker/i }));
+      expect(mockLoginActions.bunker).toHaveBeenCalled();
+
+      // The verdict flips to protected while the bunker connect is pending.
+      mockUseProtectedMinorStatus.mockReturnValue(PROTECTED_STATUS);
+      rerender(<LoginDialog isOpen onClose={onClose} onLogin={onLogin} />);
+
+      resolveConnect();
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(onLogin).not.toHaveBeenCalled();
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
     // fireEvent (not userEvent) so the local clipboard spy stays attached;
     // userEvent.setup() installs its own navigator.clipboard stub.
     it('aborts an in-flight nsec backup when the restriction engages mid-flight (real parent path)', async () => {

--- a/src/components/auth/LoginDialog.test.tsx
+++ b/src/components/auth/LoginDialog.test.tsx
@@ -296,6 +296,70 @@ describe('LoginDialog', () => {
       expect(mockLoginActions.nsec).not.toHaveBeenCalled();
     });
 
+    // fireEvent (not userEvent) so the local clipboard spy stays attached;
+    // userEvent.setup() installs its own navigator.clipboard stub.
+    it('aborts an in-flight nsec backup when the restriction engages mid-flight (real parent path)', async () => {
+      mockGetStoredLocalNsecLogin.mockReturnValue({
+        type: 'nsec',
+        data: { nsec: 'nsec1example' },
+      });
+
+      let rejectWrite!: (error: Error) => void;
+      const clipboardWriteText = vi.fn(
+        () => new Promise<void>((_resolve, reject) => { rejectWrite = reject; }),
+      );
+      const originalClipboard = Object.getOwnPropertyDescriptor(window.navigator, 'clipboard');
+      const originalCreateObjectURL = Object.getOwnPropertyDescriptor(URL, 'createObjectURL');
+      const originalRevokeObjectURL = Object.getOwnPropertyDescriptor(URL, 'revokeObjectURL');
+      const createObjectURL = vi.fn(() => 'blob:stub');
+      Object.defineProperty(window.navigator, 'clipboard', {
+        value: { writeText: clipboardWriteText }, writable: true, configurable: true,
+      });
+      Object.defineProperty(URL, 'createObjectURL', {
+        value: createObjectURL, writable: true, configurable: true,
+      });
+      Object.defineProperty(URL, 'revokeObjectURL', {
+        value: vi.fn(), writable: true, configurable: true,
+      });
+
+      try {
+        const { rerender } = render(<LoginDialog isOpen onClose={vi.fn()} onLogin={vi.fn()} />);
+
+        fireEvent.click(await screen.findByRole('button', { name: /Back up nsec/i }));
+        expect(clipboardWriteText).toHaveBeenCalled();
+
+        mockUseProtectedMinorStatus.mockReturnValue(PROTECTED_STATUS);
+        rerender(<LoginDialog isOpen onClose={vi.fn()} onLogin={vi.fn()} />);
+        // The affordance disappears from the DOM...
+        expect(screen.queryByRole('button', { name: /Back up nsec/i })).not.toBeInTheDocument();
+
+        // ...and the flip must reach the in-flight continuation too: a late
+        // clipboard rejection must not fall through to a plaintext download.
+        // This goes through the real parent (not an in-place banner rerender)
+        // so the banner's mount lifecycle is the production one.
+        rejectWrite(new Error('NotAllowedError'));
+        await new Promise((resolve) => setTimeout(resolve, 10));
+
+        expect(createObjectURL).not.toHaveBeenCalled();
+      } finally {
+        if (originalClipboard) {
+          Object.defineProperty(window.navigator, 'clipboard', originalClipboard);
+        } else {
+          delete (window.navigator as { clipboard?: unknown }).clipboard;
+        }
+        if (originalCreateObjectURL) {
+          Object.defineProperty(URL, 'createObjectURL', originalCreateObjectURL);
+        } else {
+          delete (URL as { createObjectURL?: unknown }).createObjectURL;
+        }
+        if (originalRevokeObjectURL) {
+          Object.defineProperty(URL, 'revokeObjectURL', originalRevokeObjectURL);
+        } else {
+          delete (URL as { revokeObjectURL?: unknown }).revokeObjectURL;
+        }
+      }
+    });
+
     it('fails closed: hides the banner and the Nostr disclosure while the status is unknown', async () => {
       const user = userEvent.setup();
       mockUseProtectedMinorStatus.mockReturnValue(UNKNOWN_PROTECTED_MINOR_STATUS);

--- a/src/components/auth/LoginDialog.test.tsx
+++ b/src/components/auth/LoginDialog.test.tsx
@@ -3,7 +3,18 @@ import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { initializeI18n } from '@/lib/i18n';
+import {
+  NOT_PROTECTED,
+  UNKNOWN_PROTECTED_MINOR_STATUS,
+  type ProtectedMinorStatus,
+} from '@/lib/protectedMinor';
 import LoginDialog from './LoginDialog';
+
+const PROTECTED_STATUS: ProtectedMinorStatus = Object.freeze({
+  state: 'protected',
+  isKnown: true,
+  verifiedMinorAt: null,
+});
 
 const {
   mockBuildLoginRedirect,
@@ -13,6 +24,7 @@ const {
   mockJoinInviteWaitlist,
   mockLoginActions,
   mockSetInviteHandoff,
+  mockUseProtectedMinorStatus,
   mockValidateInviteCode,
 } = vi.hoisted(() => ({
   mockBuildLoginRedirect: vi.fn(),
@@ -26,6 +38,7 @@ const {
     nsec: vi.fn(),
   },
   mockSetInviteHandoff: vi.fn(),
+  mockUseProtectedMinorStatus: vi.fn(),
   mockValidateInviteCode: vi.fn(),
 }));
 
@@ -56,6 +69,10 @@ vi.mock('@/hooks/useLoginActions', () => ({
   useLoginActions: () => mockLoginActions,
 }));
 
+vi.mock('@/hooks/useProtectedMinorStatus', () => ({
+  useProtectedMinorStatus: () => mockUseProtectedMinorStatus(),
+}));
+
 vi.mock('@/lib/localNsecAccount', async () => {
   const actual = await vi.importActual<typeof import('@/lib/localNsecAccount')>('@/lib/localNsecAccount');
 
@@ -84,6 +101,7 @@ describe('LoginDialog', () => {
       waitlistEnabled: true,
     });
     mockGetStoredLocalNsecLogin.mockReturnValue(null);
+    mockUseProtectedMinorStatus.mockReturnValue(NOT_PROTECTED);
     mockBuildSignupRedirect.mockResolvedValue({
       state: 'signup-state',
       url: 'https://login.divine.video/api/oauth/authorize?client_id=divine-web',
@@ -177,6 +195,54 @@ describe('LoginDialog', () => {
 
     expect(await screen.findByRole('button', { name: /Secure with divine.video login/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Back up nsec/i })).toBeInTheDocument();
+  });
+
+  describe('key-handover gating for protected minors (#182)', () => {
+    it('hides the local nsec banner for a protected minor even when a browser-local key exists', async () => {
+      mockUseProtectedMinorStatus.mockReturnValue(PROTECTED_STATUS);
+      mockGetStoredLocalNsecLogin.mockReturnValue({
+        type: 'nsec',
+        data: { nsec: 'nsec1example' },
+      });
+
+      render(<LoginDialog isOpen onClose={vi.fn()} onLogin={vi.fn()} />);
+
+      expect(await screen.findByRole('tab', { name: /^Register$/i })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /Back up nsec/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /Secure with divine.video login/i })).not.toBeInTheDocument();
+    });
+
+    it('hides the Nostr key-import disclosure on the sign-in tab for a protected minor', async () => {
+      const user = userEvent.setup();
+      mockUseProtectedMinorStatus.mockReturnValue(PROTECTED_STATUS);
+
+      render(<LoginDialog isOpen onClose={vi.fn()} onLogin={vi.fn()} />);
+
+      await user.click(await screen.findByRole('tab', { name: /^Sign in$/i }));
+
+      expect(await screen.findByRole('button', { name: /^Sign in at login\.divine\.video$/i })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /Use Nostr instead/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /Login with Extension/i })).not.toBeInTheDocument();
+    });
+
+    it('fails closed: hides the banner and the Nostr disclosure while the status is unknown', async () => {
+      const user = userEvent.setup();
+      mockUseProtectedMinorStatus.mockReturnValue(UNKNOWN_PROTECTED_MINOR_STATUS);
+      mockGetStoredLocalNsecLogin.mockReturnValue({
+        type: 'nsec',
+        data: { nsec: 'nsec1example' },
+      });
+
+      render(<LoginDialog isOpen onClose={vi.fn()} onLogin={vi.fn()} />);
+
+      expect(await screen.findByRole('tab', { name: /^Register$/i })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /Back up nsec/i })).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole('tab', { name: /^Sign in$/i }));
+
+      expect(await screen.findByRole('button', { name: /^Sign in at login\.divine\.video$/i })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /Use Nostr instead/i })).not.toBeInTheDocument();
+    });
   });
 
   it('validates an invite, stores the handoff, and redirects to login.divine.video', async () => {

--- a/src/components/auth/LoginDialog.tsx
+++ b/src/components/auth/LoginDialog.tsx
@@ -68,6 +68,14 @@ const LoginDialog: React.FC<LoginDialogProps> = ({ isOpen, onClose, onLogin }) =
   // Signed-out visitors have no session token and resolve not_protected, so
   // the ordinary login paths are unaffected.
   const keyHandoverRestricted = isMinorKeyHandoverRestricted(protectedMinorState);
+  // #182 command-boundary re-check (mirrors the divine-mobile #5991 review
+  // finding): the render gates below hide the import affordances, but pending
+  // continuations (the deferred nsec login timer, a FileReader callback, an
+  // open native file picker) capture their closures before a live status
+  // check can resolve `protected` mid-interaction. The ref always holds the
+  // latest verdict so each signer-swap re-checks when it actually runs.
+  const keyHandoverRestrictedRef = useRef(false);
+  keyHandoverRestrictedRef.current = keyHandoverRestricted;
 
   // The render-side gates below stay closed synchronously; this only clears the
   // stale toggle state so the disclosure doesn't pop back open unprompted if
@@ -131,6 +139,7 @@ const LoginDialog: React.FC<LoginDialogProps> = ({ isOpen, onClose, onLogin }) =
   }, [isOpen]);
 
   const handleExtensionLogin = async () => {
+    if (keyHandoverRestrictedRef.current) return;
     setIsLoginLoading(true);
     setGeneralError(null);
 
@@ -154,6 +163,10 @@ const LoginDialog: React.FC<LoginDialogProps> = ({ isOpen, onClose, onLogin }) =
     setKeyError(null);
 
     window.setTimeout(() => {
+      if (keyHandoverRestrictedRef.current) {
+        setIsLoginLoading(false);
+        return;
+      }
       try {
         login.nsec(nextNsec);
         onLogin();
@@ -190,6 +203,7 @@ const LoginDialog: React.FC<LoginDialogProps> = ({ isOpen, onClose, onLogin }) =
       return;
     }
 
+    if (keyHandoverRestrictedRef.current) return;
     setIsLoginLoading(true);
     setBunkerError(null);
 

--- a/src/components/auth/LoginDialog.tsx
+++ b/src/components/auth/LoginDialog.tsx
@@ -148,7 +148,13 @@ const LoginDialog: React.FC<LoginDialogProps> = ({ isOpen, onClose, onLogin }) =
         throw new Error(t('loginDialog.errorExtensionNotFound'));
       }
 
-      await login.extension();
+      // The pre-click ref check above goes stale while the extension prompt is
+      // open; the beforeCommit guard re-checks at the moment the signer would
+      // be committed. Not committed → stop silently, like the nsec path.
+      const committed = await login.extension({
+        beforeCommit: () => !keyHandoverRestrictedRef.current,
+      });
+      if (!committed) return;
       onLogin();
       onClose();
     } catch (caughtError) {
@@ -208,7 +214,12 @@ const LoginDialog: React.FC<LoginDialogProps> = ({ isOpen, onClose, onLogin }) =
     setBunkerError(null);
 
     try {
-      await login.bunker(bunkerUri);
+      // Same commit-boundary re-check as the extension path: the pre-click
+      // check goes stale while the bunker connect is pending.
+      const committed = await login.bunker(bunkerUri, {
+        beforeCommit: () => !keyHandoverRestrictedRef.current,
+      });
+      if (!committed) return;
       onLogin();
       onClose();
       setBunkerUri('');

--- a/src/components/auth/LoginDialog.tsx
+++ b/src/components/auth/LoginDialog.tsx
@@ -69,6 +69,15 @@ const LoginDialog: React.FC<LoginDialogProps> = ({ isOpen, onClose, onLogin }) =
   // the ordinary login paths are unaffected.
   const keyHandoverRestricted = isMinorKeyHandoverRestricted(protectedMinorState);
 
+  // The render-side gates below stay closed synchronously; this only clears the
+  // stale toggle state so the disclosure doesn't pop back open unprompted if
+  // the restriction later lifts (e.g. a transient unknown that resolves).
+  useEffect(() => {
+    if (keyHandoverRestricted) {
+      setAdvancedOpen(false);
+    }
+  }, [keyHandoverRestricted]);
+
   useEffect(() => {
     if (!isOpen) {
       return;

--- a/src/components/auth/LoginDialog.tsx
+++ b/src/components/auth/LoginDialog.tsx
@@ -12,8 +12,10 @@ import { setInviteHandoff } from '@/lib/authHandoff';
 import { buildLoginRedirect, buildSignupRedirect } from '@/lib/divineLogin';
 import { getInviteClientConfig, joinInviteWaitlist, validateInviteCode } from '@/lib/inviteApi';
 import { getStoredLocalNsecLogin } from '@/lib/localNsecAccount';
+import { isMinorKeyHandoverRestricted } from '@/lib/protectedMinor';
 import { cn } from '@/lib/utils';
 import { useLoginActions } from '@/hooks/useLoginActions';
+import { useProtectedMinorStatus } from '@/hooks/useProtectedMinorStatus';
 
 import InviteCodeForm from './InviteCodeForm';
 import LocalNsecBanner from './LocalNsecBanner';
@@ -59,6 +61,13 @@ const LoginDialog: React.FC<LoginDialogProps> = ({ isOpen, onClose, onLogin }) =
   const [waitlistSuccess, setWaitlistSuccess] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const login = useLoginActions();
+  const { state: protectedMinorState } = useProtectedMinorStatus();
+  // #182: while a protected-minor session is active (or its status is still
+  // unknown — fail closed), this dialog must not surface raw-key affordances:
+  // no stored-nsec backup banner, no nsec/key-file/bunker/extension import.
+  // Signed-out visitors have no session token and resolve not_protected, so
+  // the ordinary login paths are unaffected.
+  const keyHandoverRestricted = isMinorKeyHandoverRestricted(protectedMinorState);
 
   useEffect(() => {
     if (!isOpen) {
@@ -300,7 +309,7 @@ const LoginDialog: React.FC<LoginDialogProps> = ({ isOpen, onClose, onLogin }) =
         </DialogHeader>
 
         <div className="space-y-4 px-6 pb-6 pt-2">
-          {storedLocalNsec ? <LocalNsecBanner nsec={storedLocalNsec} /> : null}
+          {storedLocalNsec && !keyHandoverRestricted ? <LocalNsecBanner nsec={storedLocalNsec} /> : null}
 
           {generalError ? (
             <Alert variant="destructive">
@@ -356,9 +365,10 @@ const LoginDialog: React.FC<LoginDialogProps> = ({ isOpen, onClose, onLogin }) =
                 isLoading={isLoginLoading}
                 onContinue={handleExistingAccountLogin}
                 onToggleAdvanced={() => setAdvancedOpen((current) => !current)}
+                showNostrOptions={!keyHandoverRestricted}
               />
 
-              <Collapsible open={advancedOpen}>
+              <Collapsible open={advancedOpen && !keyHandoverRestricted}>
                 <CollapsibleContent className="space-y-4 pt-2">
                   <Tabs className="w-full" defaultValue="extension">
                     <TabsList className="grid w-full grid-cols-3 rounded-lg bg-muted">

--- a/src/components/auth/LoginDialog.tsx
+++ b/src/components/auth/LoginDialog.tsx
@@ -64,9 +64,9 @@ const LoginDialog: React.FC<LoginDialogProps> = ({ isOpen, onClose, onLogin }) =
   const { state: protectedMinorState } = useProtectedMinorStatus();
   // #182: while a protected-minor session is active (or its status is still
   // unknown — fail closed), this dialog must not surface raw-key affordances:
-  // no stored-nsec backup banner, no nsec/key-file/bunker/extension import.
-  // Signed-out visitors have no session token and resolve not_protected, so
-  // the ordinary login paths are unaffected.
+  // no nsec/key-file/bunker/extension import (the stored-nsec backup banner
+  // gates itself). Signed-out visitors have no session token and resolve
+  // not_protected, so the ordinary login paths are unaffected.
   const keyHandoverRestricted = isMinorKeyHandoverRestricted(protectedMinorState);
   // #182 command-boundary re-check (mirrors the divine-mobile #5991 review
   // finding): the render gates below hide the import affordances, but pending
@@ -332,7 +332,12 @@ const LoginDialog: React.FC<LoginDialogProps> = ({ isOpen, onClose, onLogin }) =
         </DialogHeader>
 
         <div className="space-y-4 px-6 pb-6 pt-2">
-          {storedLocalNsec && !keyHandoverRestricted ? <LocalNsecBanner nsec={storedLocalNsec} /> : null}
+          {/* #182: the banner gates itself for protected minors. It must render
+              unconditionally here so a restricted flip keeps it mounted
+              (rendering null) and its command-boundary re-checks stay live; a
+              gate at this level would unmount it mid-flight (dcadenas review
+              on #476). */}
+          {storedLocalNsec ? <LocalNsecBanner nsec={storedLocalNsec} /> : null}
 
           {generalError ? (
             <Alert variant="destructive">

--- a/src/components/auth/WebAccountSignInForm.tsx
+++ b/src/components/auth/WebAccountSignInForm.tsx
@@ -5,10 +5,15 @@ interface WebAccountSignInFormProps {
   isLoading: boolean;
   onContinue: () => void;
   onToggleAdvanced: () => void;
+  /**
+   * When false, the "Use Nostr instead" disclosure is not rendered at all —
+   * #182 hides the key-import methods for protected-minor sessions.
+   */
+  showNostrOptions?: boolean;
 }
 
 export function WebAccountSignInForm(props: WebAccountSignInFormProps) {
-  const { advancedOpen, isLoading, onContinue, onToggleAdvanced } = props;
+  const { advancedOpen, isLoading, onContinue, onToggleAdvanced, showNostrOptions = true } = props;
 
   return (
     <div className="space-y-4">
@@ -16,14 +21,16 @@ export function WebAccountSignInForm(props: WebAccountSignInFormProps) {
         {isLoading ? 'Redirecting...' : 'Sign in at login.divine.video'}
       </Button>
 
-      <Button
-        className="h-auto px-0 py-0 text-sm font-medium text-muted-foreground"
-        onClick={onToggleAdvanced}
-        type="button"
-        variant="link"
-      >
-        {advancedOpen ? 'Hide Nostr options' : 'Use Nostr instead'}
-      </Button>
+      {showNostrOptions ? (
+        <Button
+          className="h-auto px-0 py-0 text-sm font-medium text-muted-foreground"
+          onClick={onToggleAdvanced}
+          type="button"
+          variant="link"
+        >
+          {advancedOpen ? 'Hide Nostr options' : 'Use Nostr instead'}
+        </Button>
+      ) : null}
     </div>
   );
 }

--- a/src/hooks/useLoginActions.test.ts
+++ b/src/hooks/useLoginActions.test.ts
@@ -1,0 +1,153 @@
+// ABOUTME: Pins the commit-time beforeCommit guard on useLoginActions'
+// ABOUTME: extension/bunker logins (#182, dcadenas review on #476).
+
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useLoginActions } from './useLoginActions';
+
+const {
+  mockAddLogin,
+  mockFromBunker,
+  mockFromExtension,
+  mockSetLoginCookie,
+} = vi.hoisted(() => ({
+  mockAddLogin: vi.fn(),
+  mockFromBunker: vi.fn(),
+  mockFromExtension: vi.fn(),
+  mockSetLoginCookie: vi.fn(),
+}));
+
+vi.mock('@nostrify/react', () => ({
+  useNostr: () => ({ nostr: { query: vi.fn() } }),
+}));
+
+vi.mock('@nostrify/react/login', () => ({
+  NLogin: {
+    fromBunker: mockFromBunker,
+    fromExtension: mockFromExtension,
+  },
+  useNostrLogin: () => ({
+    logins: [],
+    addLogin: mockAddLogin,
+    removeLogin: vi.fn(),
+  }),
+}));
+
+vi.mock('@/lib/crossSubdomainAuth', () => ({
+  clearLoginCookie: vi.fn(),
+  setLoginCookie: mockSetLoginCookie,
+}));
+
+const EXTENSION_LOGIN = {
+  type: 'extension',
+  pubkey: 'a'.repeat(64),
+};
+
+const BUNKER_LOGIN = {
+  type: 'bunker',
+  pubkey: 'b'.repeat(64),
+  data: { bunkerPubkey: 'c'.repeat(64) },
+};
+
+const BUNKER_URI = 'bunker://remote-signer.example?relay=wss%3A%2F%2Frelay.example';
+
+describe('useLoginActions commit-time guard (#182)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('extension()', () => {
+    it('runs the guard only after the extension handshake resolves, then commits', async () => {
+      let resolveHandshake!: (login: typeof EXTENSION_LOGIN) => void;
+      mockFromExtension.mockImplementation(
+        () => new Promise((resolve) => { resolveHandshake = resolve; }),
+      );
+      const beforeCommit = vi.fn(() => true);
+      const { result } = renderHook(() => useLoginActions());
+
+      const pending = result.current.extension({ beforeCommit });
+      // Commit-time, not pre-handshake: the guard must not run while the
+      // extension prompt is still open.
+      expect(beforeCommit).not.toHaveBeenCalled();
+
+      resolveHandshake(EXTENSION_LOGIN);
+      await expect(pending).resolves.toBe(true);
+
+      expect(beforeCommit).toHaveBeenCalledTimes(1);
+      expect(mockAddLogin).toHaveBeenCalledWith(EXTENSION_LOGIN);
+      expect(mockSetLoginCookie).toHaveBeenCalledWith({
+        type: 'extension',
+        pubkey: EXTENSION_LOGIN.pubkey,
+      });
+    });
+
+    it('aborts without committing anything when the guard refuses at the boundary', async () => {
+      mockFromExtension.mockResolvedValue(EXTENSION_LOGIN);
+      const { result } = renderHook(() => useLoginActions());
+
+      await expect(result.current.extension({ beforeCommit: () => false })).resolves.toBe(false);
+
+      expect(mockAddLogin).not.toHaveBeenCalled();
+      expect(mockSetLoginCookie).not.toHaveBeenCalled();
+    });
+
+    it('commits when called without options (positive control)', async () => {
+      mockFromExtension.mockResolvedValue(EXTENSION_LOGIN);
+      const { result } = renderHook(() => useLoginActions());
+
+      await expect(result.current.extension()).resolves.toBe(true);
+
+      expect(mockAddLogin).toHaveBeenCalledWith(EXTENSION_LOGIN);
+      expect(mockSetLoginCookie).toHaveBeenCalledWith({
+        type: 'extension',
+        pubkey: EXTENSION_LOGIN.pubkey,
+      });
+    });
+  });
+
+  describe('bunker()', () => {
+    it('runs the guard only after the bunker connect resolves, then commits', async () => {
+      let resolveConnect!: (login: typeof BUNKER_LOGIN) => void;
+      mockFromBunker.mockImplementation(
+        () => new Promise((resolve) => { resolveConnect = resolve; }),
+      );
+      const beforeCommit = vi.fn(() => true);
+      const { result } = renderHook(() => useLoginActions());
+
+      const pending = result.current.bunker(BUNKER_URI, { beforeCommit });
+      expect(mockFromBunker).toHaveBeenCalledWith(BUNKER_URI, expect.anything());
+      expect(beforeCommit).not.toHaveBeenCalled();
+
+      resolveConnect(BUNKER_LOGIN);
+      await expect(pending).resolves.toBe(true);
+
+      expect(beforeCommit).toHaveBeenCalledTimes(1);
+      expect(mockAddLogin).toHaveBeenCalledWith(BUNKER_LOGIN);
+      expect(mockSetLoginCookie).toHaveBeenCalledWith({
+        type: 'bunker',
+        pubkey: BUNKER_LOGIN.pubkey,
+        bunkerData: BUNKER_LOGIN.data,
+      });
+    });
+
+    it('aborts without committing anything when the guard refuses at the boundary', async () => {
+      mockFromBunker.mockResolvedValue(BUNKER_LOGIN);
+      const { result } = renderHook(() => useLoginActions());
+
+      await expect(result.current.bunker(BUNKER_URI, { beforeCommit: () => false })).resolves.toBe(false);
+
+      expect(mockAddLogin).not.toHaveBeenCalled();
+      expect(mockSetLoginCookie).not.toHaveBeenCalled();
+    });
+
+    it('commits when called without options (positive control)', async () => {
+      mockFromBunker.mockResolvedValue(BUNKER_LOGIN);
+      const { result } = renderHook(() => useLoginActions());
+
+      await expect(result.current.bunker(BUNKER_URI)).resolves.toBe(true);
+
+      expect(mockAddLogin).toHaveBeenCalledWith(BUNKER_LOGIN);
+    });
+  });
+});

--- a/src/hooks/useLoginActions.ts
+++ b/src/hooks/useLoginActions.ts
@@ -3,7 +3,6 @@ import { NLogin, useNostrLogin } from '@nostrify/react/login';
 import { followListCache } from '@/lib/followListCache';
 import { setLoginCookie, clearLoginCookie } from '@/lib/crossSubdomainAuth';
 import { debugLog } from '@/lib/debug';
-import { getActiveLocalNsecLogin } from '@/lib/localNsecAccount';
 import { nip19 } from 'nostr-tools';
 
 // NOTE: This file should not be edited except for adding new login methods.
@@ -30,9 +29,6 @@ export function useLoginActions() {
       const login = await NLogin.fromExtension();
       addLogin(login);
       setLoginCookie({ type: 'extension', pubkey: login.pubkey });
-    },
-    exportCurrentNsec(): string | null {
-      return getActiveLocalNsecLogin(logins)?.data.nsec ?? null;
     },
     // Log out the current user
     async logout(): Promise<void> {

--- a/src/hooks/useLoginActions.ts
+++ b/src/hooks/useLoginActions.ts
@@ -6,6 +6,18 @@ import { debugLog } from '@/lib/debug';
 import { nip19 } from 'nostr-tools';
 
 // NOTE: This file should not be edited except for adding new login methods.
+// Policy stays out of this file: async login methods accept an optional
+// beforeCommit guard so the caller can re-check its own policy at the moment
+// the signer is committed (#182); the policy predicate lives with the caller.
+
+interface CommitGuardOptions {
+  /** Last-chance policy re-check, run after the handshake resolves and before
+   *  the signer is committed (addLogin + login cookie). Returning false aborts
+   *  the login: nothing is committed and the method resolves false. Needed
+   *  because a pre-handshake check goes stale while the extension prompt or
+   *  bunker connect is open (dcadenas review on #476). */
+  beforeCommit?: () => boolean;
+}
 
 export function useLoginActions() {
   const { nostr } = useNostr();
@@ -18,17 +30,21 @@ export function useLoginActions() {
       addLogin(login);
       setLoginCookie({ type: 'nsec', pubkey: login.pubkey });
     },
-    // Login with a NIP-46 "bunker://" URI
-    async bunker(uri: string): Promise<void> {
+    // Login with a NIP-46 "bunker://" URI; resolves whether the signer was committed
+    async bunker(uri: string, options?: CommitGuardOptions): Promise<boolean> {
       const login = await NLogin.fromBunker(uri, nostr);
+      if (options?.beforeCommit && !options.beforeCommit()) return false;
       addLogin(login);
       setLoginCookie({ type: 'bunker', pubkey: login.pubkey, bunkerData: login.data });
+      return true;
     },
-    // Login with a NIP-07 browser extension
-    async extension(): Promise<void> {
+    // Login with a NIP-07 browser extension; resolves whether the signer was committed
+    async extension(options?: CommitGuardOptions): Promise<boolean> {
       const login = await NLogin.fromExtension();
+      if (options?.beforeCommit && !options.beforeCommit()) return false;
       addLogin(login);
       setLoginCookie({ type: 'extension', pubkey: login.pubkey });
+      return true;
     },
     // Log out the current user
     async logout(): Promise<void> {

--- a/src/lib/protectedMinor.test.ts
+++ b/src/lib/protectedMinor.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { DIVINE_LOGIN_ORIGIN } from './divineLoginOrigin';
-import { fetchProtectedMinorStatus, isMinorDmRestricted } from './protectedMinor';
+import {
+  fetchProtectedMinorStatus,
+  isMinorDmRestricted,
+  isMinorKeyHandoverRestricted,
+} from './protectedMinor';
 
 const ACCOUNT_URL = `${DIVINE_LOGIN_ORIGIN}/api/user/account`;
 
@@ -132,5 +136,19 @@ describe('isMinorDmRestricted', () => {
 
   it('lifts the restriction only on a positive not_protected verdict', () => {
     expect(isMinorDmRestricted('not_protected')).toBe(false);
+  });
+});
+
+describe('isMinorKeyHandoverRestricted', () => {
+  it('restricts a protected account', () => {
+    expect(isMinorKeyHandoverRestricted('protected')).toBe(true);
+  });
+
+  it('fails closed: restricts while the status is unknown', () => {
+    expect(isMinorKeyHandoverRestricted('unknown')).toBe(true);
+  });
+
+  it('lifts the restriction only on a positive not_protected verdict', () => {
+    expect(isMinorKeyHandoverRestricted('not_protected')).toBe(false);
   });
 });

--- a/src/lib/protectedMinor.ts
+++ b/src/lib/protectedMinor.ts
@@ -21,6 +21,17 @@ export function isMinorDmRestricted(state: ProtectedMinorState): boolean {
   return state !== 'not_protected';
 }
 
+/**
+ * Key-handover verdict for #182: whether the current account may be offered
+ * raw-key affordances (nsec backup/copy/download, key-import sign-in methods).
+ * Same fail-closed posture as {@link isMinorDmRestricted} — only a positive
+ * `not_protected` verdict lifts it — but a separate predicate so the key and
+ * DM policies can diverge without silently coupling.
+ */
+export function isMinorKeyHandoverRestricted(state: ProtectedMinorState): boolean {
+  return state !== 'not_protected';
+}
+
 // Frozen so this shared sentinel can't be mutated by a consumer and poisoned
 // for every other caller (it's returned by reference from the lib and hook).
 export const NOT_PROTECTED: ProtectedMinorStatus = Object.freeze({


### PR DESCRIPTION
Web half of divinevideo/support-trust-safety#182 (part of the divinevideo/support-trust-safety#173 epic; pairs with the Keycast-side containment in divinevideo/support-trust-safety#183).

## why

The shipped web DM restriction (#474) gates in-app sends, but a verified_minor account could sidestep it by taking the raw key to another client. This PR removes the first-class key-handover paths on web. It is friction for self-custody, not containment: for custodial accounts the real containment lever is server-side in Keycast, tracked separately.

## what's gated, and how the signal drives it

Everything rides the same tri-state protected-minor signal the DM gates use (`useProtectedMinorStatus`), through a new `isMinorKeyHandoverRestricted(state)` predicate in `src/lib/protectedMinor.ts`. It fails closed: only a positive `not_protected` verdict lifts the restriction, so `unknown` (cold start, keycast outage) restricts exactly like `protected`. It is a separate predicate rather than a reuse of `isMinorDmRestricted` so the key and DM policies can diverge later without silent coupling.

Gated affordances, confirmed user-reachable by tracing the render sites:

- **nsec backup banner** (`LocalNsecBanner`: "Back up nsec" copies the raw key to the clipboard or downloads a backup file; "Secure with divine.video login" embeds the nsec in a redirect). Hidden for restricted sessions at both render sites: `AccountSwitcher` and `LoginDialog`. This matters because the secure-account callback never removes the browser-local nsec login, so a secured minor's raw key otherwise stays one click from the clipboard for the lifetime of that browser profile.
- **key-import methods in the login dialog** (the "Use Nostr instead" disclosure: nsec paste, key-file upload, bunker URI, extension). Neither the disclosure toggle nor its content renders while the active session is restricted. The hosted sign-in and the invite/register paths stay untouched; both are custodial keycast flows.
- **`useLoginActions.exportCurrentNsec()`** removed. It returned the raw nsec and had zero callers (added in #204, never wired to any UI). Deleting it removes the API-level escape hatch outright instead of leaving it waiting to be wired up.

**Command-boundary re-checks.** The render gates decide what shows, but work already in flight (the deferred nsec-login timer, an open extension prompt or bunker connect, the clipboard and secure-redirect awaits) starts before a live status check can resolve `protected` mid-interaction. Two mechanisms close the gap (reworked per review): the nsec banner now gates itself and stays mounted through a flip (parents render it unconditionally), so its re-check reads the current verdict at the moment a backup or redirect actually happens; and `useLoginActions.extension()/bunker()` accept an optional `beforeCommit` check that runs after the handshake resolves and before the signer is saved, with the dialog passing its live verdict. Policy stays with the caller; `useLoginActions` stays policy-free. The nsec paste/file path re-checks inside its deferred timer, which is synchronous with the save. Covered by tests that flip the verdict mid-flight at both the hook and dialog level, a flip test through the real parent for the banner, and checks that unrestricted users keep every path.

## signal reach (same posture as the DM gate)

Only a session with a keycast token can resolve `protected` or `unknown`. A signed-out browser, or a manual-only login (extension, bunker, pasted nsec with no divine session), positively resolves `not_protected`, so normal accounts keep every affordance. That is the known web limitation this issue accepts: affordance removal, not containment.

## judgment calls I want eyes on

1. Decided: `exportCurrentNsec()` is removed, not gated. It was #204 swarm scaffolding whose intended consumer (the backup banner) was built against the lib helpers instead, and it is caller-free to the limit of what is checkable: no reference anywhere in the tree except two historical plan docs, exactly one consumer of `useLoginActions` (this dialog, using only nsec/bunker/extension), no call site in any commit on any ref, no hit anywhere else in the divinevideo org via GitHub code search, and the symbol is absent from this branch's build output. It does ship in the current production bundle, so this PR also removes a dormant raw-key code path from every visitor's browser. Touching `useLoginActions.ts` despite its "only add login methods" template note is deliberate; deleting an unwired raw-key export is on-mission here.
2. The hidden disclosure covers all four import methods, extension and bunker included, not just raw nsec. I read those as in scope for "change-signing-key / import-key flows" since they swap the active signer to one outside the custodial guardrails.
3. Restricted sessions get the affordances hidden, not disabled with an explanation, matching how the DM compose affordance disappears rather than announcing the restriction.

## known leave-behinds (conscious, not oversights)

- `WebAccountSignInForm` copy is hardcoded English (pre-existing for the whole component). Moving it to i18n means adding keys across all 16 locales with the parity test, which is its own change, not a rider on a safety gate. Candidate follow-up.
- FAQ copy still describes nsec import/export as account features. That is static text, not an affordance; per-viewer doc gating is not warranted. Worth a note on the epic so the docs surface is a known leave-behind.
- The sticky-store fail-safe from the DM work applies here unchanged: a transient `unknown` for an account last seen `protected` stays restricted.

## tests

TDD, red first: predicate unit tests plus component tests at both banner render sites and the login dialog disclosure, covering protected, unknown (fail closed), positively not-protected (affordances preserved), and a restriction-interlude case (a transient restriction does not leave the import disclosure popping back open unprompted). Full local gate green: tsc, eslint, vitest, vite build.

Also verified live against a local stack (real dev server, real browser, real nsec-import flow; only keycast's `GET /api/user/account` stubbed over mkcert HTTPS since the app CSP allows https connects only): baseline shows the banner; a `verified_minor: true` session hides the banner and the Nostr disclosure while hosted sign-in stays; a keycast 500 stays restricted both via the sticky fallback and for a never-seen account (pure unknown); a positive not-protected restores the affordances. One incidental extra layer confirmed live: a hosted-JWT current user gets no "Add another account" menu item at all.

