### PR TITLE
docs: sync vendored brand guidelines with canonical

### DIFF
--- a/docs/brand/AGENT_QUICK_REFERENCE.md
+++ b/docs/brand/AGENT_QUICK_REFERENCE.md
@@ -4,6 +4,12 @@ Use this as a fast lookup when writing copy, designing UI, or making product dec
 
 ---
 
+## Brand Name (read first)
+
+Always write the name as **Divine** — capital D, lowercase rest. Never "DiVine" or "diVine" in text. The stylized "V" only exists in the logotype artwork, never in written copy, UI, docs, or code.
+
+---
+
 ## One-Line Summary
 
 Divine is a decentralized short-form video app reviving Vine's 6-second format, built on Nostr, championing human creativity over AI slop.
@@ -56,7 +62,7 @@ Divine is a decentralized short-form video app reviving Vine's 6-second format, 
 - **User ownership**: Your content, your data, your feed. Built on Nostr where you own everything.
 - **Joy scrolling**: Trade doom scrolling for delight. Quick bursts of real human creativity.
 - **Community-built**: Open source, decentralized, built with and for the community.
-- **Vine nostalgia**: 100,000+ archived Vines brought back to life. The golden days of the internet, reimagined.
+- **Vine nostalgia**: 2.1 million archived Vines brought back to life. The golden days of the internet, reimagined.
 
 ---
 

--- a/docs/brand/BRAND_DNA.md
+++ b/docs/brand/BRAND_DNA.md
@@ -44,7 +44,7 @@ When people arrive, we want the feeling to be simple: Welcome Home.
 - Agency over your feed and followers
 - Your content and data stay yours
 - Space to play and experiment
-- Access to 100,000+ archived Vine videos from the original era
+- Access to 2.1 million archived Vine videos from the original era
 - A place that feels like arrival, not conversion
 
 ---

--- a/docs/brand/README.md
+++ b/docs/brand/README.md
@@ -2,6 +2,10 @@
 
 Brand guidelines for Divine, translated from the official brand PDFs (January 2026).
 
+## Brand Name
+
+Always write the brand name as **Divine** — capital D, lowercase rest. Do **not** write it as "DiVine" or "diVine" in any text (copy, headings, UI, docs, code, commit messages). The stylized capital "V" is a feature of the logotype artwork only and never carries into written text.
+
 ## Files
 
 | File | Purpose |

--- a/docs/brand/TONE_OF_VOICE.md
+++ b/docs/brand/TONE_OF_VOICE.md
@@ -57,7 +57,7 @@ We have three tone of voice principles that shape how we sound. They ensure cons
 | Instead of | Try |
 |------------|-----|
 | "Vine Revisited - A Return to the Halcyon Days of the Internet" | "Our Divine right to AI-free, human-made creativity" |
-| "Divine includes access to more than 100,000 archived Vine videos and lets people create their own six-second looping videos. We are aiming to provide an experience that is free of AI-generated content." | "We've brought back to life 100,000 Vines from the original archives. At Divine, we want everyone to show up as they are to our human-made, no-slop playground." |
+| "Divine includes access to more than 2.1 million archived Vine videos and lets people create their own six-second looping videos. We are aiming to provide an experience that is free of AI-generated content." | "We've brought back to life 2.1 million Vines from the original archives. At Divine, we want everyone to show up as they are to our human-made, no-slop playground." |
 
 ---
 

--- a/docs/brand/VISUAL_IDENTITY.md
+++ b/docs/brand/VISUAL_IDENTITY.md
@@ -7,7 +7,10 @@ The Divine logotype is the most recognizable aspect of the brand. It is built on
 ### Versions
 - **Primary**: Green and Dark Green
 - **On images**: Dark Green or White versions are permitted, provided strong contrast is maintained
-- The name is always written as "Divine" (capital D, lowercase remainder)
+
+### Brand Name
+
+**The brand name is always written "Divine."** Standard capitalization: capital D, lowercase rest. Never write it as "DiVine" or "diVine" — any stylized capitalization of the "V" belongs to the logotype artwork only and must never appear in body copy, headings, UI text, code comments, docs, or anywhere the name is set as text.
 
 ### Safe Space
 Always leave at least the x-height of the typography as free space around the logo on all sides.


### PR DESCRIPTION
The `docs/brand/` copy vendored in this repo was stale. Syncs the core files to the canonical [brand-guidelines](https://github.com/divinevideo/brand-guidelines):

- **Divine** spelling (was `diVine`) + the explicit brand-name rule
- Vine archive count **100,000+ → 2.1 million**

The web-specific report files (ALIGNMENT_REPORT, MICROCOPY_INVENTORY, codemod-lucide-report) had no stale references and are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)