### PR TITLE
feat: add /list/* playlist deep links to apple-app-site-association

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- **FEATURE**: iOS Universal Links for playlists — added `/list/*` to `apple-app-site-association` (and to the build's `verify-well-known` check) so playlist links open the Divine app when installed; app-side handling in divinevideo/divine-mobile#6094
 - **PERFORMANCE**: Migrate to Funnelcake REST API for faster data loading
   - `useProfileStats` now uses REST API first (10s → <500ms), falls back to WebSocket
   - `useBatchedAuthors` now uses bulk REST endpoint instead of individual WebSocket queries

--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -26,6 +26,10 @@
             "comment": "Invite redemption deep links"
           },
           {
+            "/": "/list/*",
+            "comment": "Playlist (curated list) deep links"
+          },
+          {
             "/": "/app/callback",
             "comment": "OAuth callback for Divine app"
           }

--- a/scripts/verify-well-known.mjs
+++ b/scripts/verify-well-known.mjs
@@ -23,7 +23,7 @@ if (!Array.isArray(appIds) || appIds.length === 0) {
   throw new Error('apple-app-site-association is missing applinks.details[].appIDs');
 }
 
-const requiredPaths = new Set(['/video/*', '/profile/*', '/invite/*']);
+const requiredPaths = new Set(['/video/*', '/profile/*', '/invite/*', '/list/*']);
 const declaredPaths = new Set(
   aasa?.applinks?.details?.flatMap((detail) =>
     (detail.components ?? []).map((component) => component?.['/']).filter(Boolean),


### PR DESCRIPTION
## Description

Adds the `/list/*` component to the Apple App Site Association file so iOS opens `divine.video/list/<pubkey>/<listId>` playlist links in the Divine app when it's installed. Mirrors the existing `/video/*` / `/profile/*` / `/hashtag/*` / `/search/*` / `/invite/*` entries. Also adds `/list/*` to `scripts/verify-well-known.mjs`'s required-paths check so the build verification pins the new component.

The web playlist page at `/list/:pubkey/:listId` (`ListDetailPage`) is untouched and remains the fallback when the app isn't installed.

**Cross-repo dependency:** the app-side handling (deep-link parser branch, `/list/:pubkey/:listId` route, and the Android `/list` intent-filter prefix) is divinevideo/divine-mobile#6094. Playlist links only open the app end-to-end once **both** are live. Note Apple caches AASA per device/CDN, so iOS devices can pick this up with a delay after deploy. Android needs no web change — `assetlinks.json` is domain-wide.

**Related Issue:** Relates to divinevideo/divine-mobile#6093

## Verification

- `node scripts/copy-well-known.mjs && node scripts/verify-well-known.mjs` — passes with the new required path
- JSON validated (`python3 -m json.tool`)
