### PR TITLE
fix(profile-links): validate nip05 before friendly routing

### DIFF
--- a/src/components/NoteContent.test.tsx
+++ b/src/components/NoteContent.test.tsx
@@ -1,15 +1,24 @@
-import { describe, it, expect, vi } from 'vitest';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { nip19 } from 'nostr-tools';
 import { NoteContent } from './NoteContent';
 import type { NostrEvent } from '@nostrify/nostrify';
 
+const noteMocks = vi.hoisted(() => ({
+  metadata: { display_name: 'rabble' } as Record<string, unknown>,
+  useNip05Validation: vi.fn(),
+}));
+
 vi.mock('@/hooks/useAuthor', () => ({
   useAuthor: () => ({
-    data: { metadata: { display_name: 'rabble' } },
+    data: { metadata: noteMocks.metadata },
     isLoading: false,
   }),
+}));
+
+vi.mock('@/hooks/useNip05Validation', () => ({
+  useNip05Validation: noteMocks.useNip05Validation,
 }));
 
 const PUBKEY_HEX = 'a'.repeat(64);
@@ -38,6 +47,17 @@ function renderContent(content: string) {
     </MemoryRouter>,
   );
 }
+
+beforeEach(() => {
+  noteMocks.metadata = { display_name: 'rabble' };
+  noteMocks.useNip05Validation.mockReturnValue({
+    isValid: false,
+    isLoading: false,
+    isInvalid: true,
+    state: 'invalid',
+    nip05: undefined,
+  });
+});
 
 describe('NoteContent — bare nostr identifiers', () => {
   it('linkifies a bare npub1... as @mention', () => {
@@ -70,6 +90,35 @@ describe('NoteContent — bare nostr identifiers', () => {
     renderContent(`hi ${NPROFILE}`);
     const link = screen.getByRole('link');
     expect(link).toHaveAttribute('href', `/${NPROFILE}`);
+  });
+
+  it('uses a friendly mention profile link when the NIP-05 is valid', () => {
+    noteMocks.metadata = {
+      display_name: 'rabble',
+      nip05: '_@rabble.divine.video',
+    };
+    noteMocks.useNip05Validation.mockReturnValue({
+      isValid: true,
+      isLoading: false,
+      isInvalid: false,
+      state: 'valid',
+      nip05: '_@rabble.divine.video',
+    });
+
+    renderContent(`hello ${NPUB}`);
+
+    expect(screen.getByRole('link', { name: '@rabble' })).toHaveAttribute('href', '/u/rabble');
+  });
+
+  it('uses the npub mention profile link when the NIP-05 is invalid', () => {
+    noteMocks.metadata = {
+      display_name: 'rabble',
+      nip05: 'rabble@spoofed.example',
+    };
+
+    renderContent(`hello ${NPUB}`);
+
+    expect(screen.getByRole('link', { name: '@rabble' })).toHaveAttribute('href', `/${NPUB}`);
   });
 });
 

--- a/src/components/NoteContent.tsx
+++ b/src/components/NoteContent.tsx
@@ -3,6 +3,7 @@ import { type NostrEvent } from '@nostrify/nostrify';
 import { SmartLink } from '@/components/SmartLink';
 import { nip19 } from 'nostr-tools';
 import { useAuthor } from '@/hooks/useAuthor';
+import { useNip05Validation } from '@/hooks/useNip05Validation';
 import { genUserName } from '@/lib/genUserName';
 import { buildProfileLinkPath } from '@/lib/profileLinks';
 import { cn } from '@/lib/utils';
@@ -120,9 +121,11 @@ function NostrMention({ pubkey }: { pubkey: string }) {
   const author = useAuthor(pubkey);
   const hasRealName = !!(author.data?.metadata?.name || author.data?.metadata?.display_name);
   const displayName = author.data?.metadata?.name || author.data?.metadata?.display_name || genUserName(pubkey);
+  const nip05 = author.data?.metadata?.nip05;
+  const { state: nip05State } = useNip05Validation(nip05, pubkey);
   const profilePath = buildProfileLinkPath({
     pubkey,
-    nip05: author.data?.metadata?.nip05,
+    nip05: nip05State === 'valid' ? nip05 : undefined,
   });
 
   return (

--- a/src/components/VideoCard.test.tsx
+++ b/src/components/VideoCard.test.tsx
@@ -6,6 +6,7 @@ import type {
   ReactNode,
 } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { nip19 } from 'nostr-tools';
 import type { ParsedVideoData } from '@/types/video';
 import { initializeI18n } from '@/lib/i18n';
 import { VideoCard } from './VideoCard';
@@ -28,6 +29,14 @@ const authMocks = vi.hoisted(() => ({
   confirmAdult: vi.fn(),
   useCurrentUser: vi.fn(),
   useAdultVerification: vi.fn(),
+}));
+
+const authorMocks = vi.hoisted(() => ({
+  metadata: {
+    name: 'Video Author',
+    picture: 'https://example.com/avatar.jpg',
+  } as Record<string, unknown>,
+  useNip05Validation: vi.fn(),
 }));
 
 vi.mock('@/components/ui/card', () => ({
@@ -172,22 +181,24 @@ vi.mock('@/components/SmartLink', () => ({
   SmartLink: ({
     children,
     ownerPubkey: _ownerPubkey,
+    to,
     ...props
-  }: HTMLAttributes<HTMLAnchorElement> & { ownerPubkey?: string }) => (
-    <a {...props}>{children}</a>
+  }: HTMLAttributes<HTMLAnchorElement> & { ownerPubkey?: string; to: string }) => (
+    <a href={to} {...props}>{children}</a>
   ),
 }));
 
 vi.mock('@/hooks/useAuthor', () => ({
   useAuthor: () => ({
     data: {
-      metadata: {
-        name: 'Video Author',
-        picture: 'https://example.com/avatar.jpg',
-      },
+      metadata: authorMocks.metadata,
     },
     isLoading: false,
   }),
+}));
+
+vi.mock('@/hooks/useNip05Validation', () => ({
+  useNip05Validation: authorMocks.useNip05Validation,
 }));
 
 vi.mock('@/hooks/useIsMobile', () => ({
@@ -407,6 +418,17 @@ describe('VideoCard', () => {
       isLoading: false,
       hasSigner: false,
     });
+    authorMocks.metadata = {
+      name: 'Video Author',
+      picture: 'https://example.com/avatar.jpg',
+    };
+    authorMocks.useNip05Validation.mockReturnValue({
+      isValid: false,
+      isLoading: false,
+      isInvalid: true,
+      state: 'invalid',
+      nip05: undefined,
+    });
   });
 
   it('renders the thumbnail as a real link to the video page in thumbnail mode', () => {
@@ -415,6 +437,40 @@ describe('VideoCard', () => {
     const link = screen.getByTestId('thumbnail-link');
     expect(link).toHaveAttribute('href', `/video/${baseVideo.id}`);
     expect(playbackMocks.navigate).not.toHaveBeenCalled();
+  });
+
+  it('links the author through a friendly profile path when NIP-05 is valid', () => {
+    authorMocks.metadata = {
+      name: 'Video Author',
+      picture: 'https://example.com/avatar.jpg',
+      nip05: '_@author.divine.video',
+    };
+    authorMocks.useNip05Validation.mockReturnValue({
+      isValid: true,
+      isLoading: false,
+      isInvalid: false,
+      state: 'valid',
+      nip05: '_@author.divine.video',
+    });
+
+    render(<VideoCard video={baseVideo} mode="thumbnail" />);
+
+    expect(screen.getByRole('link', { name: 'Video Author' })).toHaveAttribute('href', '/u/author');
+  });
+
+  it('links the author through npub when NIP-05 is invalid', () => {
+    authorMocks.metadata = {
+      name: 'Video Author',
+      picture: 'https://example.com/avatar.jpg',
+      nip05: 'author@spoofed.example',
+    };
+
+    render(<VideoCard video={baseVideo} mode="thumbnail" />);
+
+    expect(screen.getByRole('link', { name: 'Video Author' })).toHaveAttribute(
+      'href',
+      `/${nip19.npubEncode(baseVideo.pubkey)}`,
+    );
   });
 
   it('builds the thumbnail link from the navigation context when provided', () => {

--- a/src/components/VideoCard.tsx
+++ b/src/components/VideoCard.tsx
@@ -55,6 +55,7 @@ import { debugLog } from '@/lib/debug';
 import { useLoginDialog } from '@/contexts/LoginDialogContext';
 import { AgeRestrictedMediaPlaceholder } from '@/components/AgeRestrictedMediaPlaceholder';
 import { buildProfileLinkPath } from '@/lib/profileLinks';
+import { useNip05Validation } from '@/hooks/useNip05Validation';
 
 interface VideoCardProps {
   video: ParsedVideoData;
@@ -297,9 +298,11 @@ export function VideoCard({
   const profileImage = getSafeProfileImage(
     rawMetadata?.picture || video.authorAvatar || metadata.picture
   );
+  const authorNip05 = rawMetadata?.nip05;
+  const { state: authorNip05State } = useNip05Validation(authorNip05, video.pubkey);
   const profileUrl = buildProfileLinkPath({
     pubkey: video.pubkey,
-    nip05: rawMetadata?.nip05,
+    nip05: authorNip05State === 'valid' ? authorNip05 : undefined,
   });
 
   const reposterName = reposterData.isLoading

--- a/src/pages/SearchPage.test.tsx
+++ b/src/pages/SearchPage.test.tsx
@@ -838,6 +838,13 @@ describe('SearchPage', () => {
   });
 
   it('uses the friendly-path profile link for users with a NIP-05', () => {
+    mockUseNip05Validation.mockReturnValue({
+      isValid: true,
+      isLoading: false,
+      isInvalid: false,
+      state: 'valid',
+      nip05: '_@sam.dvine.video',
+    });
     mockUseSearchUsers.mockReturnValue({
       data: [
         {
@@ -856,5 +863,34 @@ describe('SearchPage', () => {
 
     fireEvent.click(screen.getAllByRole('button', { name: /view profile of sam/i })[0]!);
     expect(mockNavigate).toHaveBeenCalledWith('/u/sam.dvine.video');
+  });
+
+  it('uses the npub profile link for users with an unvalidated NIP-05', () => {
+    const pubkey = '5'.repeat(64);
+    mockUseNip05Validation.mockReturnValue({
+      isValid: false,
+      isLoading: false,
+      isInvalid: true,
+      state: 'invalid',
+      nip05: 'sam@spoofed.example',
+    });
+    mockUseSearchUsers.mockReturnValue({
+      data: [
+        {
+          pubkey,
+          metadata: {
+            display_name: 'Sam',
+            nip05: 'sam@spoofed.example',
+          },
+        },
+      ],
+      isLoading: false,
+      error: null,
+    });
+
+    renderPage(['/search?q=sam&filter=users']);
+
+    fireEvent.click(screen.getAllByRole('button', { name: /view profile of sam/i })[0]!);
+    expect(mockNavigate).toHaveBeenCalledWith(`/${nip19.npubEncode(pubkey)}`);
   });
 });

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -764,7 +764,7 @@ function UserCard({ user }: { user: { pubkey: string; metadata?: UserCardMetadat
   const picture = getSafeProfileImage(user.metadata?.picture);
   const profilePath = buildProfileLinkPath({
     pubkey: user.pubkey,
-    nip05,
+    nip05: nip05State === 'valid' ? nip05 : undefined,
   });
 
   const handleClick = () => {


### PR DESCRIPTION
## Summary

- Gate profile-link friendly `/u/...` routing on successful NIP-05 validation in search user cards, video cards, and note mentions.
- Preserve friendly profile URLs for validated identifiers while falling back to direct npub links for unvalidated or invalid metadata.
- Add regression coverage for valid and invalid NIP-05 routing behavior in the touched surfaces.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- Raw NIP-05 metadata could route users through a friendly profile path even when the identifier had not been verified for that pubkey.
- The app already treats NIP-05 as user-visible trust signal only after validation; profile routing should follow the same rule.
- This replaces the stale direct-npub sweep direction with validate-then-friendly behavior.

## Related Issue

- Supersedes #405

## Testing

- [x] `npm run test`
- [x] Manual verification completed: targeted `npx vitest run src/pages/SearchPage.test.tsx src/components/VideoCard.test.tsx src/components/NoteContent.test.tsx`

## Visuals

- [ ] UI change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved
