### PR TITLE
fix(profile): hide profile and sidebar count totals

### DIFF
--- a/src/components/AppSidebar.test.tsx
+++ b/src/components/AppSidebar.test.tsx
@@ -50,10 +50,6 @@ vi.mock('@/hooks/useRssFeedAvailable', () => ({
   useRssFeedAvailable: () => false,
 }));
 
-vi.mock('@/hooks/usePlatformStats', () => ({
-  usePlatformStats: () => ({ data: undefined }),
-}));
-
 describe('AppSidebar', () => {
   beforeEach(async () => {
     const storage = new Map<string, string>();
@@ -79,6 +75,7 @@ describe('AppSidebar', () => {
 
   afterEach(() => {
     document.head.querySelectorAll('script[src*="itunes.apple.com/lookup"]').forEach((script) => script.remove());
+    vi.unstubAllGlobals();
   });
 
   function setLanguages(languages: readonly string[]) {
@@ -121,6 +118,20 @@ describe('AppSidebar', () => {
     fireEvent.click(dmcaButton);
 
     expect(mockNavigate).toHaveBeenCalledWith('/dmca');
+  });
+
+  it('hides the sidebar imported Vines total', () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+
+    render(
+      <MemoryRouter>
+        <AppSidebar />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByText(/vines (recovered|recuperados)/i)).not.toBeInTheDocument();
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 
   it('shows the App Store badge when Apple lookup finds the regional listing', async () => {

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -23,7 +23,6 @@ import { LoginArea } from '@/components/auth/LoginArea';
 import { cn } from '@/lib/utils';
 import { feedUrls } from '@/lib/feedUrls';
 import { useRssFeedAvailable } from '@/hooks/useRssFeedAvailable';
-import { usePlatformStats } from '@/hooks/usePlatformStats';
 import { LanguageMenu } from '@/components/LanguageMenu';
 import { SocialLinks } from '@/components/SocialLinks';
 import { getTranslatedCategoryLabel } from '@/lib/constants/categories';
@@ -69,14 +68,12 @@ export function AppSidebar({ className }: { className?: string }) {
   const { data: unreadCount } = useUnreadNotificationCount();
   const { data: unreadDmCount } = useUnreadDmCount();
   const rssFeedAvailable = useRssFeedAvailable();
-  const { data: platformStats } = usePlatformStats();
   const [categoriesOpen, setCategoriesOpen] = useState(true);
   const [rssOpen, setRssOpen] = useState(false);
   const [divineOpen, setDivineOpen] = useState(false);
   const [termsOpen, setTermsOpen] = useState(false);
   const [appStoreUrl, setAppStoreUrl] = useState<string | null>(null);
   const { data: categories } = useCategories();
-  const classicVinesRecovered = platformStats?.vine_videos?.toLocaleString();
 
   const isActive = (path: string) => location.pathname === path;
   const isDiscoveryActive = () =>
@@ -414,19 +411,12 @@ export function AppSidebar({ className }: { className?: string }) {
         <Collapsible open={divineOpen} onOpenChange={setDivineOpen}>
           <CollapsibleTrigger asChild>
             <button
-              className="group flex w-full items-start justify-between gap-2 py-1.5 text-left text-[13px] font-semibold text-foreground transition-colors hover:text-primary"
+              className="group flex w-full items-center justify-between gap-2 py-1.5 text-left text-[13px] font-semibold text-foreground transition-colors hover:text-primary"
               style={{ fontFamily: "'Bricolage Grotesque', system-ui, sans-serif" }}
             >
-              <div className="min-w-0">
-                <div>{t('footer.aboutDivine')}</div>
-                {classicVinesRecovered && (
-                  <div className="mt-0.5 text-[11px] font-normal text-muted-foreground group-hover:text-muted-foreground">
-                    {t('footer.vinesRecovered', { count: classicVinesRecovered })}
-                  </div>
-                )}
-              </div>
+              <span>{t('footer.aboutDivine')}</span>
               <ChevronDown className={cn(
-                "mt-0.5 h-3.5 w-3.5 shrink-0 transition-transform duration-200",
+                "h-3.5 w-3.5 shrink-0 transition-transform duration-200",
                 divineOpen && "rotate-180"
               )} />
             </button>

--- a/src/components/ProfileHeader.test.tsx
+++ b/src/components/ProfileHeader.test.tsx
@@ -185,6 +185,48 @@ describe('ProfileHeader', () => {
     });
   });
 
+  it('hides the total video count stat', () => {
+    render(
+      <MemoryRouter>
+        <ProfileHeader
+          pubkey={'a'.repeat(64)}
+          metadata={{ display_name: 'Modern Creator' }}
+          stats={baseStats}
+          isOwnProfile={false}
+          isFollowing={false}
+          onFollowToggle={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByText('Videos')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('stat-skeleton-videos')).not.toBeInTheDocument();
+    expect(screen.getByText('Followers')).toBeInTheDocument();
+    expect(screen.getByText('Following')).toBeInTheDocument();
+    expect(screen.getByText('Divine Loops')).toBeInTheDocument();
+  });
+
+  it('keeps the joined stat in the two-column mobile stats grid', () => {
+    render(
+      <MemoryRouter>
+        <ProfileHeader
+          pubkey={'a'.repeat(64)}
+          metadata={{ display_name: 'Modern Creator' }}
+          stats={{ ...baseStats, joinedDate: new Date(2024, 0, 15) }}
+          isOwnProfile={false}
+          isFollowing={false}
+          onFollowToggle={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+
+    const statsGrid = screen.getByTestId('profile-stats');
+    expect(statsGrid).toHaveClass('grid-cols-2', 'sm:grid-cols-4');
+
+    const joinedStat = screen.getByText(/Joined January 2024/).closest('.text-center');
+    expect(joinedStat).not.toHaveClass('col-span-2');
+  });
+
   it('shows clickable legacy socials for classic viners only', () => {
     render(
       <MemoryRouter>

--- a/src/components/ProfileHeader.tsx
+++ b/src/components/ProfileHeader.tsx
@@ -400,26 +400,9 @@ export function ProfileHeader({
 
       {/* Stats Section */}
       <div
-        className="grid grid-cols-2 sm:grid-cols-5 gap-4 py-4 border-t"
+        className="grid grid-cols-2 sm:grid-cols-4 gap-4 py-4 border-t"
         data-testid="profile-stats"
       >
-        {/* Videos Count */}
-        <div className="text-center">
-          {stats ? (
-            <>
-              <div className="text-xl sm:text-2xl font-bold text-foreground">
-                {formatNumber(stats.videosCount)}
-              </div>
-              <div className="text-xs sm:text-sm text-muted-foreground">{t('profileHeader.videos')}</div>
-            </>
-          ) : (
-            <>
-              <Skeleton className="h-6 w-12 mx-auto mb-1" data-testid="stat-skeleton-videos" />
-              <div className="text-xs sm:text-sm text-muted-foreground">{t('profileHeader.videos')}</div>
-            </>
-          )}
-        </div>
-
         {/* Followers Count */}
         <div className="text-center">
           {stats ? (
@@ -480,7 +463,7 @@ export function ProfileHeader({
         </div>
 
         {/* Joined Date / Classic Viner Status */}
-        <div className="text-center col-span-2 sm:col-span-1">
+        <div className="text-center">
           {stats ? (
             stats.joinedDateLoading ? (
               <Skeleton className="h-4 w-20 mx-auto" data-testid="stat-skeleton-joined" />

--- a/src/lib/i18n/locales/ar/common.json
+++ b/src/lib/i18n/locales/ar/common.json
@@ -38,7 +38,6 @@
   },
   "footer": {
     "aboutDivine": "حول Divine",
-    "vinesRecovered": "تمت استعادة {{count}} من Vine",
     "termsAndOpenSource": "الشروط والمصدر المفتوح",
     "copyright": "© 2026 Divine"
   },
@@ -390,7 +389,6 @@
     "message": "رسالة",
     "reportUser": "الإبلاغ عن المستخدم",
     "subscribeRss": "اشترك في تغذية RSS",
-    "videos": "الفيديوهات",
     "followers": "المتابعون",
     "followingStat": "يتابع",
     "followingDialogTitle": "يتابع",

--- a/src/lib/i18n/locales/de/common.json
+++ b/src/lib/i18n/locales/de/common.json
@@ -38,7 +38,6 @@
   },
   "footer": {
     "aboutDivine": "Uber Divine",
-    "vinesRecovered": "{{count}} Vines wiederhergestellt",
     "termsAndOpenSource": "Bedingungen und Open Source",
     "copyright": "© 2026 Divine"
   },
@@ -386,7 +385,6 @@
     "message": "Nachricht",
     "reportUser": "Nutzer melden",
     "subscribeRss": "RSS-Feed abonnieren",
-    "videos": "Videos",
     "followers": "Follower",
     "followingStat": "Folge ich",
     "followingDialogTitle": "Folge ich",

--- a/src/lib/i18n/locales/en/common.json
+++ b/src/lib/i18n/locales/en/common.json
@@ -38,7 +38,6 @@
   },
   "footer": {
     "aboutDivine": "About Divine",
-    "vinesRecovered": "{{count}} Vines recovered",
     "termsAndOpenSource": "Terms & Open Source",
     "copyright": "© 2026 Divine"
   },
@@ -386,7 +385,6 @@
     "message": "Message",
     "reportUser": "Report user",
     "subscribeRss": "Subscribe to RSS feed",
-    "videos": "Videos",
     "followers": "Followers",
     "followingStat": "Following",
     "followingDialogTitle": "Following",

--- a/src/lib/i18n/locales/es/common.json
+++ b/src/lib/i18n/locales/es/common.json
@@ -38,7 +38,6 @@
   },
   "footer": {
     "aboutDivine": "Acerca de Divine",
-    "vinesRecovered": "{{count}} Vines recuperados",
     "termsAndOpenSource": "Terminos y codigo abierto",
     "copyright": "© 2026 Divine"
   },
@@ -386,7 +385,6 @@
     "message": "Mensaje",
     "reportUser": "Reportar usuario",
     "subscribeRss": "Suscribirse al feed RSS",
-    "videos": "Videos",
     "followers": "Seguidores",
     "followingStat": "Siguiendo",
     "followingDialogTitle": "Siguiendo",

--- a/src/lib/i18n/locales/fil/common.json
+++ b/src/lib/i18n/locales/fil/common.json
@@ -38,7 +38,6 @@
   },
   "footer": {
     "aboutDivine": "Tungkol sa Divine",
-    "vinesRecovered": "{{count}} Vines na nabawi",
     "termsAndOpenSource": "Mga Tuntunin at Open Source",
     "copyright": "© 2026 Divine"
   },
@@ -386,7 +385,6 @@
     "message": "Mag-message",
     "reportUser": "I-report ang user",
     "subscribeRss": "Mag-subscribe sa RSS feed",
-    "videos": "Mga Video",
     "followers": "Mga Sumusunod",
     "followingStat": "Sinusundan",
     "followingDialogTitle": "Sinusundan",

--- a/src/lib/i18n/locales/fr/common.json
+++ b/src/lib/i18n/locales/fr/common.json
@@ -38,7 +38,6 @@
   },
   "footer": {
     "aboutDivine": "A propos de Divine",
-    "vinesRecovered": "{{count}} Vines recuperes",
     "termsAndOpenSource": "Conditions et open source",
     "copyright": "© 2026 Divine"
   },
@@ -386,7 +385,6 @@
     "message": "Message",
     "reportUser": "Signaler l'utilisateur",
     "subscribeRss": "S'abonner au flux RSS",
-    "videos": "Vidéos",
     "followers": "Abonnés",
     "followingStat": "Abonnements",
     "followingDialogTitle": "Abonnements",

--- a/src/lib/i18n/locales/id/common.json
+++ b/src/lib/i18n/locales/id/common.json
@@ -38,7 +38,6 @@
   },
   "footer": {
     "aboutDivine": "Tentang Divine",
-    "vinesRecovered": "{{count}} Vine dipulihkan",
     "termsAndOpenSource": "Ketentuan & sumber terbuka",
     "copyright": "© 2026 Divine"
   },
@@ -386,7 +385,6 @@
     "message": "Pesan",
     "reportUser": "Laporkan pengguna",
     "subscribeRss": "Berlangganan feed RSS",
-    "videos": "Video",
     "followers": "Pengikut",
     "followingStat": "Mengikuti",
     "followingDialogTitle": "Mengikuti",

--- a/src/lib/i18n/locales/it/common.json
+++ b/src/lib/i18n/locales/it/common.json
@@ -38,7 +38,6 @@
   },
   "footer": {
     "aboutDivine": "Informazioni su Divine",
-    "vinesRecovered": "{{count}} Vines recuperati",
     "termsAndOpenSource": "Termini e open source",
     "copyright": "© 2026 Divine"
   },
@@ -386,7 +385,6 @@
     "message": "Messaggio",
     "reportUser": "Segnala utente",
     "subscribeRss": "Iscriviti al feed RSS",
-    "videos": "Video",
     "followers": "Follower",
     "followingStat": "Seguiti",
     "followingDialogTitle": "Seguiti",

--- a/src/lib/i18n/locales/ja/common.json
+++ b/src/lib/i18n/locales/ja/common.json
@@ -38,7 +38,6 @@
   },
   "footer": {
     "aboutDivine": "Divine について",
-    "vinesRecovered": "{{count}} 件の Vine を復元",
     "termsAndOpenSource": "利用規約とオープンソース",
     "copyright": "© 2026 Divine"
   },
@@ -386,7 +385,6 @@
     "message": "メッセージ",
     "reportUser": "ユーザーを報告",
     "subscribeRss": "RSSフィードを購読",
-    "videos": "動画",
     "followers": "フォロワー",
     "followingStat": "フォロー中",
     "followingDialogTitle": "フォロー中",

--- a/src/lib/i18n/locales/ko/common.json
+++ b/src/lib/i18n/locales/ko/common.json
@@ -38,7 +38,6 @@
   },
   "footer": {
     "aboutDivine": "Divine 소개",
-    "vinesRecovered": "{{count}}개의 Vine 복구됨",
     "termsAndOpenSource": "약관 및 오픈 소스",
     "copyright": "© 2026 Divine"
   },
@@ -386,7 +385,6 @@
     "message": "메시지",
     "reportUser": "사용자 신고",
     "subscribeRss": "RSS 피드 구독",
-    "videos": "비디오",
     "followers": "팔로워",
     "followingStat": "팔로잉",
     "followingDialogTitle": "팔로잉",

--- a/src/lib/i18n/locales/nl/common.json
+++ b/src/lib/i18n/locales/nl/common.json
@@ -38,7 +38,6 @@
   },
   "footer": {
     "aboutDivine": "Over Divine",
-    "vinesRecovered": "{{count}} Vines hersteld",
     "termsAndOpenSource": "Voorwaarden en open source",
     "copyright": "© 2026 Divine"
   },
@@ -386,7 +385,6 @@
     "message": "Bericht",
     "reportUser": "Gebruiker melden",
     "subscribeRss": "Abonneer op RSS-feed",
-    "videos": "Video's",
     "followers": "Volgers",
     "followingStat": "Volgend",
     "followingDialogTitle": "Volgend",

--- a/src/lib/i18n/locales/pl/common.json
+++ b/src/lib/i18n/locales/pl/common.json
@@ -38,7 +38,6 @@
   },
   "footer": {
     "aboutDivine": "O Divine",
-    "vinesRecovered": "{{count}} odzyskanych Vine",
     "termsAndOpenSource": "Warunki i open source",
     "copyright": "© 2026 Divine"
   },
@@ -388,7 +387,6 @@
     "message": "Wiadomość",
     "reportUser": "Zgłoś użytkownika",
     "subscribeRss": "Subskrybuj kanał RSS",
-    "videos": "Wideo",
     "followers": "Obserwujący",
     "followingStat": "Obserwowani",
     "followingDialogTitle": "Obserwowani",

--- a/src/lib/i18n/locales/pt/common.json
+++ b/src/lib/i18n/locales/pt/common.json
@@ -38,7 +38,6 @@
   },
   "footer": {
     "aboutDivine": "Sobre a Divine",
-    "vinesRecovered": "{{count}} Vines recuperados",
     "termsAndOpenSource": "Termos e codigo aberto",
     "copyright": "© 2026 Divine"
   },
@@ -386,7 +385,6 @@
     "message": "Mensagem",
     "reportUser": "Denunciar usuário",
     "subscribeRss": "Assinar feed RSS",
-    "videos": "Vídeos",
     "followers": "Seguidores",
     "followingStat": "Seguindo",
     "followingDialogTitle": "Seguindo",

--- a/src/lib/i18n/locales/ro/common.json
+++ b/src/lib/i18n/locales/ro/common.json
@@ -38,7 +38,6 @@
   },
   "footer": {
     "aboutDivine": "Despre Divine",
-    "vinesRecovered": "{{count}} Vines recuperate",
     "termsAndOpenSource": "Termeni si sursa deschisa",
     "copyright": "© 2026 Divine"
   },
@@ -387,7 +386,6 @@
     "message": "Mesaj",
     "reportUser": "Raportează utilizatorul",
     "subscribeRss": "Abonează-te la fluxul RSS",
-    "videos": "Videoclipuri",
     "followers": "Urmăritori",
     "followingStat": "Urmărește",
     "followingDialogTitle": "Urmărește",

--- a/src/lib/i18n/locales/sv/common.json
+++ b/src/lib/i18n/locales/sv/common.json
@@ -38,7 +38,6 @@
   },
   "footer": {
     "aboutDivine": "Om Divine",
-    "vinesRecovered": "{{count}} Vines aterstallda",
     "termsAndOpenSource": "Villkor och oppen kallkod",
     "copyright": "© 2026 Divine"
   },
@@ -386,7 +385,6 @@
     "message": "Meddelande",
     "reportUser": "Rapportera användare",
     "subscribeRss": "Prenumerera på RSS-flöde",
-    "videos": "Videor",
     "followers": "Följare",
     "followingStat": "Följer",
     "followingDialogTitle": "Följer",

--- a/src/lib/i18n/locales/tr/common.json
+++ b/src/lib/i18n/locales/tr/common.json
@@ -38,7 +38,6 @@
   },
   "footer": {
     "aboutDivine": "Divine hakkinda",
-    "vinesRecovered": "{{count}} Vine kurtarildi",
     "termsAndOpenSource": "Kosullar ve Acik Kaynak",
     "copyright": "© 2026 Divine"
   },
@@ -386,7 +385,6 @@
     "message": "Mesaj",
     "reportUser": "Kullanıcıyı bildir",
     "subscribeRss": "RSS akışına abone ol",
-    "videos": "Videolar",
     "followers": "Takipçi",
     "followingStat": "Takip edilen",
     "followingDialogTitle": "Takip edilenler",


### PR DESCRIPTION
## Summary

- Hide the total Videos stat from profile headers.
- Hide the sidebar imported Vines recovered total and stop fetching platform stats from the sidebar.
- Keep the remaining profile stats in a two-by-two mobile grid and four-column desktop grid.
- Remove now-unused locale keys for the hidden count labels.

## Motivation

- Takeover for PR #300, which is conflicting and not maintainer-editable.
- Fixes the timezone-dependent profile test and makes the sidebar regression coverage meaningful.

## Related Issue

- N/A

## Testing

- [x] `npx tsc -p tsconfig.app.json --noEmit`
- [x] `npx eslint` (passes with existing warnings)
- [x] `npx vitest run src/components/ProfileHeader.test.tsx src/components/AppSidebar.test.tsx`
- [x] `npx vitest run` (205 files / 1469 tests)
- [x] `npx vite build`

## Visuals

- [ ] UI change with screenshots/video attached
- [ ] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved