### PR TITLE
test(worker): cover feed injection fallback flow

### DIFF
--- a/compute-js/src/feedInjection.js
+++ b/compute-js/src/feedInjection.js
@@ -1,0 +1,21 @@
+import { escapeHtml, escapeFeedJson } from './ogTags.js';
+
+export function injectFeedDataIntoHtml({ html, feedType, feedData }) {
+  if (!feedData) return html;
+
+  const feedJson = escapeFeedJson(feedData);
+  let injection = `<script>window.__DIVINE_FEED__=${feedJson};window.__DIVINE_FEED_TYPE__="${feedType}";</script>`;
+
+  const firstVideo = feedData.videos?.[0] || feedData[0];
+  const firstVideoUrl = firstVideo?.video_url;
+  const firstThumbnail = firstVideo?.thumbnail;
+
+  if (firstVideoUrl) {
+    injection += `\n<link rel="preload" href="${escapeHtml(firstVideoUrl)}" as="video" type="video/mp4">`;
+  }
+  if (firstThumbnail) {
+    injection += `\n<link rel="preload" href="${escapeHtml(firstThumbnail)}" as="image" fetchpriority="high">`;
+  }
+
+  return html.replace('</head>', injection + '</head>');
+}

--- a/compute-js/src/feedInjection.js
+++ b/compute-js/src/feedInjection.js
@@ -1,10 +1,34 @@
 import { escapeHtml, escapeFeedJson } from './ogTags.js';
+import { hasViteEntryScript } from './staticContent.js';
+
+export async function resolveFeedInjectedHtml({
+  readHtml,
+  fetchFeedData,
+  feedType,
+  pathname,
+  logger = console,
+}) {
+  try {
+    const html = await readHtml();
+    if (!html || !hasViteEntryScript(html)) {
+      logger.error('Publisher returned unusable KV HTML for', pathname, 'length:', html?.length ?? 0);
+      return null;
+    }
+
+    const feedData = await fetchFeedData(feedType);
+    return injectFeedDataIntoHtml({ html, feedType, feedData });
+  } catch (err) {
+    logger.error('Feed injection error:', err.message);
+    return null;
+  }
+}
 
 export function injectFeedDataIntoHtml({ html, feedType, feedData }) {
   if (!feedData) return html;
 
   const feedJson = escapeFeedJson(feedData);
-  let injection = `<script>window.__DIVINE_FEED__=${feedJson};window.__DIVINE_FEED_TYPE__="${feedType}";</script>`;
+  const feedTypeJson = escapeFeedJson(feedType);
+  let injection = `<script>window.__DIVINE_FEED__=${feedJson};window.__DIVINE_FEED_TYPE__=${feedTypeJson};</script>`;
 
   const firstVideo = feedData.videos?.[0] || feedData[0];
   const firstVideoUrl = firstVideo?.video_url;

--- a/compute-js/src/feedInjection.test.js
+++ b/compute-js/src/feedInjection.test.js
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+import { brotliCompressSync, brotliDecompressSync } from 'node:zlib';
+import { injectFeedDataIntoHtml } from './feedInjection.js';
+import { hasViteEntryScript } from './staticContent.js';
+
+const makeHtml = (entry = '/assets/index-abc123.js') =>
+  `<!doctype html><html><head>` +
+  `<meta charset="utf-8">` +
+  `<script type="module" crossorigin src="${entry}"></script>` +
+  `</head><body><div id="root"></div></body></html>`;
+
+const feedData = {
+  videos: [
+    {
+      video_url: 'https://cdn.example.com/video.mp4',
+      thumbnail: 'https://cdn.example.com/thumb.jpg',
+      title: 'Test Video',
+    },
+  ],
+};
+
+describe('injectFeedDataIntoHtml', () => {
+  it('injects the feed script tag before </head>', () => {
+    const result = injectFeedDataIntoHtml({
+      html: makeHtml(),
+      feedType: 'trending',
+      feedData,
+    });
+    expect(result).toContain('<script>window.__DIVINE_FEED__=');
+    expect(result).toContain('window.__DIVINE_FEED_TYPE__="trending"');
+    expect(result).toContain('</head>');
+    expect(result.indexOf('<script>')).toBeLessThan(result.indexOf('</head>'));
+  });
+
+  it('adds preload links for the first video', () => {
+    const result = injectFeedDataIntoHtml({
+      html: makeHtml(),
+      feedType: 'trending',
+      feedData,
+    });
+    expect(result).toContain('<link rel="preload" href="https://cdn.example.com/video.mp4" as="video"');
+    expect(result).toContain('<link rel="preload" href="https://cdn.example.com/thumb.jpg" as="image"');
+  });
+
+  it('returns html unchanged when feedData is null', () => {
+    const html = makeHtml();
+    expect(injectFeedDataIntoHtml({ html, feedType: 'trending', feedData: null })).toBe(html);
+  });
+
+  it('injects an empty feed script with no preloads when feedData has no videos', () => {
+    const result = injectFeedDataIntoHtml({
+      html: makeHtml(),
+      feedType: 'trending',
+      feedData: {},
+    });
+    expect(result).toContain('window.__DIVINE_FEED__={}');
+    expect(result).not.toContain('rel="preload"');
+  });
+
+  it('omits preload links when no video_url or thumbnail', () => {
+    const result = injectFeedDataIntoHtml({
+      html: makeHtml(),
+      feedType: 'trending',
+      feedData: { videos: [{ title: 'No media' }] },
+    });
+    expect(result).not.toContain('rel="preload"');
+  });
+
+  it('escapes HTML in feed data embedded in JSON', () => {
+    const malicious = {
+      videos: [{
+        video_url: 'https://example.com/video.mp4',
+        title: '</script><script>alert(1)',
+      }],
+    };
+    const result = injectFeedDataIntoHtml({
+      html: makeHtml(),
+      feedType: 'trending',
+      feedData: malicious,
+    });
+    const dataMatch = result.match(/__DIVINE_FEED__=([^<]+);/);
+    expect(dataMatch).not.toBeNull();
+    expect(dataMatch[1]).not.toContain('</script>');
+    expect(dataMatch[1]).toContain('\\u003c/script>');
+  });
+
+  it('escapes user-controlled strings in preload hrefs', () => {
+    const malicious = {
+      videos: [{
+        video_url: 'https://example.com/"onload="alert(1)',
+        thumbnail: 'https://example.com/thumb.jpg',
+      }],
+    };
+    const result = injectFeedDataIntoHtml({
+      html: makeHtml(),
+      feedType: 'trending',
+      feedData: malicious,
+    });
+    expect(result).toContain('&quot;');
+  });
+});
+
+describe('regression: compressed body injection path (#489)', () => {
+  it('injectFeedDataIntoHtml works on decompressed brotli HTML', () => {
+    const html = makeHtml();
+    const compressed = brotliCompressSync(html);
+    const decompressed = brotliDecompressSync(compressed).toString();
+
+    expect(hasViteEntryScript(decompressed)).toBe(true);
+
+    const result = injectFeedDataIntoHtml({
+      html: decompressed,
+      feedType: 'trending',
+      feedData,
+    });
+    expect(result).toContain('window.__DIVINE_FEED__=');
+    expect(result).toContain('rel="preload"');
+  });
+
+  it('returns valid HTML structure after injection', () => {
+    const html = makeHtml();
+    const result = injectFeedDataIntoHtml({
+      html,
+      feedType: 'classics',
+      feedData,
+    });
+
+    expect(result).toMatch(/^<!doctype html>/i);
+    expect(result).toContain('</html>');
+    expect(result.split('</head>').length - 1).toBe(1);
+  });
+});

--- a/compute-js/src/feedInjection.test.js
+++ b/compute-js/src/feedInjection.test.js
@@ -1,7 +1,5 @@
-import { describe, expect, it } from 'vitest';
-import { brotliCompressSync, brotliDecompressSync } from 'node:zlib';
-import { injectFeedDataIntoHtml } from './feedInjection.js';
-import { hasViteEntryScript } from './staticContent.js';
+import { describe, expect, it, vi } from 'vitest';
+import { injectFeedDataIntoHtml, resolveFeedInjectedHtml } from './feedInjection.js';
 
 const makeHtml = (entry = '/assets/index-abc123.js') =>
   `<!doctype html><html><head>` +
@@ -78,7 +76,7 @@ describe('injectFeedDataIntoHtml', () => {
       feedType: 'trending',
       feedData: malicious,
     });
-    const dataMatch = result.match(/__DIVINE_FEED__=([^<]+);/);
+    const dataMatch = result.match(/window\.__DIVINE_FEED__=(.*?);window\.__DIVINE_FEED_TYPE__/);
     expect(dataMatch).not.toBeNull();
     expect(dataMatch[1]).not.toContain('</script>');
     expect(dataMatch[1]).toContain('\\u003c/script>');
@@ -96,37 +94,95 @@ describe('injectFeedDataIntoHtml', () => {
       feedType: 'trending',
       feedData: malicious,
     });
-    expect(result).toContain('&quot;');
+    expect(result).toContain('href="https://example.com/&quot;onload=&quot;alert(1)"');
+  });
+
+  it('escapes feedType as JavaScript data', () => {
+    const result = injectFeedDataIntoHtml({
+      html: makeHtml(),
+      feedType: 'x";alert(1);//',
+      feedData,
+    });
+
+    expect(result).toContain('window.__DIVINE_FEED_TYPE__="x\\";alert(1);//"');
+    expect(result).not.toContain('window.__DIVINE_FEED_TYPE__="x";alert(1);//"');
   });
 });
 
-describe('regression: compressed body injection path (#489)', () => {
-  it('injectFeedDataIntoHtml works on decompressed brotli HTML', () => {
-    const html = makeHtml();
-    const compressed = brotliCompressSync(html);
-    const decompressed = brotliDecompressSync(compressed).toString();
-
-    expect(hasViteEntryScript(decompressed)).toBe(true);
-
-    const result = injectFeedDataIntoHtml({
-      html: decompressed,
+describe('resolveFeedInjectedHtml', () => {
+  it('reads identity HTML, fetches feed data, and injects it', async () => {
+    const result = await resolveFeedInjectedHtml({
+      readHtml: () => Promise.resolve(makeHtml()),
+      fetchFeedData: vi.fn(() => Promise.resolve(feedData)),
       feedType: 'trending',
-      feedData,
+      pathname: '/',
     });
+
     expect(result).toContain('window.__DIVINE_FEED__=');
     expect(result).toContain('rel="preload"');
   });
 
-  it('returns valid HTML structure after injection', () => {
+  it('returns valid HTML structure after injection', async () => {
     const html = makeHtml();
-    const result = injectFeedDataIntoHtml({
-      html,
+    const result = await resolveFeedInjectedHtml({
+      readHtml: () => Promise.resolve(html),
+      fetchFeedData: () => Promise.resolve(feedData),
       feedType: 'classics',
-      feedData,
+      pathname: '/discovery/classics',
     });
 
     expect(result).toMatch(/^<!doctype html>/i);
     expect(result).toContain('</html>');
     expect(result.split('</head>').length - 1).toBe(1);
+  });
+
+  it('returns null when reading HTML fails so the worker can serve static passthrough', async () => {
+    const logger = { error: vi.fn() };
+
+    const result = await resolveFeedInjectedHtml({
+      readHtml: () => Promise.reject(new Error('malformed UTF-8')),
+      fetchFeedData: () => Promise.resolve(feedData),
+      feedType: 'trending',
+      pathname: '/',
+      logger,
+    });
+
+    expect(result).toBeNull();
+    expect(logger.error).toHaveBeenCalledWith('Feed injection error:', 'malformed UTF-8');
+  });
+
+  it('returns null when KV HTML is missing the Vite entry script', async () => {
+    const logger = { error: vi.fn() };
+
+    const result = await resolveFeedInjectedHtml({
+      readHtml: () => Promise.resolve('<!doctype html><html><head></head><body></body></html>'),
+      fetchFeedData: () => Promise.resolve(feedData),
+      feedType: 'trending',
+      pathname: '/',
+      logger,
+    });
+
+    expect(result).toBeNull();
+    expect(logger.error).toHaveBeenCalledWith(
+      'Publisher returned unusable KV HTML for',
+      '/',
+      'length:',
+      54,
+    );
+  });
+
+  it('returns null when fetching feed data throws', async () => {
+    const logger = { error: vi.fn() };
+
+    const result = await resolveFeedInjectedHtml({
+      readHtml: () => Promise.resolve(makeHtml()),
+      fetchFeedData: () => Promise.reject(new Error('feed unavailable')),
+      feedType: 'trending',
+      pathname: '/',
+      logger,
+    });
+
+    expect(result).toBeNull();
+    expect(logger.error).toHaveBeenCalledWith('Feed injection error:', 'feed unavailable');
   });
 });

--- a/compute-js/src/index.js
+++ b/compute-js/src/index.js
@@ -10,7 +10,7 @@ import rc from '../static-publish.rc.js';
 import { buildFunnelcakeUrl, getFunnelcakeOriginForApiHost } from './funnelcakeOrigin.js';
 import { handleAuthPersistCookie } from './authPersistCookie.js';
 import { isJsonWellKnownPath, shouldServeWellKnownBeforeWwwRedirect } from './wellKnownPaths.js';
-import { buildCrawlerHtml, buildUserScript, escapeHtml, escapeFeedJson, cleanText, truncateText } from './ogTags.js';
+import { buildCrawlerHtml, buildUserScript, escapeHtml, cleanText, truncateText } from './ogTags.js';
 import { hexToNpub, decodeNpubToHex } from './bech32.js';
 import { buildWwwRedirectResponse } from './hostRedirect.js';
 import { applyStaticResponseHeaders } from './staticResponseHeaders.js';
@@ -24,6 +24,7 @@ import {
 } from './crawlerHandlers.js';
 import { transformVideoApiResponse } from './videoMetadata.js';
 import { renderEmbedPage } from './embedPage.js';
+import { injectFeedDataIntoHtml } from './feedInjection.js';
 
 const publisherServer = PublisherServer.fromStaticPublishRc(rc);
 const DEFAULT_OG_IMAGE = 'https://divine.video/og.png';
@@ -333,21 +334,7 @@ async function handleRequest(event) {
           const feedData = await fetchFeedData(feedType, funnelcakeTarget);
           let finalHtml = html;
           if (feedData) {
-            // feedData carries user-controlled strings (video titles etc), so escape it for
-            // safe <script> embedding. feedType is a fixed allowlist value
-            // (getDiscoveryFeedType), so it needs no escaping.
-            const feedJson = escapeFeedJson(feedData);
-            let injection = `<script>window.__DIVINE_FEED__=${feedJson};window.__DIVINE_FEED_TYPE__="${feedType}";</script>`;
-            const firstVideo = feedData.videos?.[0] || feedData[0];
-            const firstVideoUrl = firstVideo?.video_url;
-            const firstThumbnail = firstVideo?.thumbnail;
-            if (firstVideoUrl) {
-              injection += `\n<link rel="preload" href="${escapeHtml(firstVideoUrl)}" as="video" type="video/mp4">`;
-            }
-            if (firstThumbnail) {
-              injection += `\n<link rel="preload" href="${escapeHtml(firstThumbnail)}" as="image" fetchpriority="high">`;
-            }
-            finalHtml = html.replace('</head>', injection + '</head>');
+            finalHtml = injectFeedDataIntoHtml({ html, feedType, feedData });
           }
           return new Response(finalHtml, { status: response.status, headers: decodedHeaders });
         }

--- a/compute-js/src/index.js
+++ b/compute-js/src/index.js
@@ -14,7 +14,7 @@ import { buildCrawlerHtml, buildUserScript, escapeHtml, cleanText, truncateText 
 import { hexToNpub, decodeNpubToHex } from './bech32.js';
 import { buildWwwRedirectResponse } from './hostRedirect.js';
 import { applyStaticResponseHeaders } from './staticResponseHeaders.js';
-import { hasViteEntryScript, readPublishedStaticFile } from './staticContent.js';
+import { readPublishedStaticFile } from './staticContent.js';
 import {
   handleAtUsernameOg,
   handleHashtagOgTags,
@@ -24,7 +24,7 @@ import {
 } from './crawlerHandlers.js';
 import { transformVideoApiResponse } from './videoMetadata.js';
 import { renderEmbedPage } from './embedPage.js';
-import { injectFeedDataIntoHtml } from './feedInjection.js';
+import { resolveFeedInjectedHtml } from './feedInjection.js';
 
 const publisherServer = PublisherServer.fromStaticPublishRc(rc);
 const DEFAULT_OG_IMAGE = 'https://divine.video/og.png';
@@ -327,20 +327,15 @@ async function handleRequest(event) {
       // (Content-Encoding/Content-Length/ETag). Any failure degrades to the untouched static
       // passthrough below, so injection can never 500.
       const decodedHeaders = applyStaticResponseHeaders(response.headers, { isHtml: true, decoded: true });
-      try {
-        const html = await readIndexHtmlFromKv();
-        if (html && hasViteEntryScript(html)) {
-          const feedType = discoveryFeedType || 'trending';
-          const feedData = await fetchFeedData(feedType, funnelcakeTarget);
-          let finalHtml = html;
-          if (feedData) {
-            finalHtml = injectFeedDataIntoHtml({ html, feedType, feedData });
-          }
-          return new Response(finalHtml, { status: response.status, headers: decodedHeaders });
-        }
-        console.error('Publisher returned unusable KV HTML for', url.pathname, 'length:', html?.length ?? 0);
-      } catch (err) {
-        console.error('Feed injection error:', err.message);
+      const feedType = discoveryFeedType || 'trending';
+      const finalHtml = await resolveFeedInjectedHtml({
+        readHtml: readIndexHtmlFromKv,
+        fetchFeedData: (type) => fetchFeedData(type, funnelcakeTarget),
+        feedType,
+        pathname: url.pathname,
+      });
+      if (finalHtml) {
+        return new Response(finalHtml, { status: response.status, headers: decodedHeaders });
       }
       // fall through to the untouched static passthrough below
     }


### PR DESCRIPTION
## Summary

Extracts the feed-data injection logic (building the `__DIVINE_FEED__` script tag, preload links, and `</head>` replacement) from the Fastly Compute worker into a testable helper. Also adds a guarded read -> inject -> fallback seam so worker tests can assert injection failures degrade to static passthrough.

## Motivation

PR #489 fixed a bug where `response.text()` on a compressed static body produced a 500 on injected routes. The worker needs regression coverage for the failure class: if reading the HTML shell fails, if the shell is unusable, or if feed fetching throws, the request should fall through to the untouched static response instead of propagating the failure.

## Related Issue

- Refs #490 (Guard 3)

## Testing

- [x] `npx vitest run compute-js/src/feedInjection.test.js`
- [x] `npm run test`
- 13 feed injection tests pass
- 1484 total tests pass

## Visuals

- [x] No visual change