### PR TITLE
fix: add deleted kind tag for video lists

### DIFF
--- a/src/hooks/useVideoLists.test.ts
+++ b/src/hooks/useVideoLists.test.ts
@@ -465,7 +465,7 @@ describe('useVideoLists hooks', () => {
   });
 
   describe('useDeleteVideoList', () => {
-    it('publishes kind 5 deletion with addressable a tag', async () => {
+    it('publishes kind 5 deletion with addressable a tag and deleted kind tag', async () => {
       const { useDeleteVideoList } = await import('./useVideoLists');
       const { result } = renderHook(() => useDeleteVideoList(), { wrapper: createWrapper() });
 
@@ -474,7 +474,10 @@ describe('useVideoLists hooks', () => {
       expect(mockPublishAsync).toHaveBeenCalledWith({
         kind: 5,
         content: 'List deleted by owner',
-        tags: [['a', `30005:${TEST_PUBKEY}:to-delete`]],
+        tags: [
+          ['a', `30005:${TEST_PUBKEY}:to-delete`],
+          ['k', '30005'],
+        ],
       });
     });
 

--- a/src/hooks/useVideoLists.ts
+++ b/src/hooks/useVideoLists.ts
@@ -468,13 +468,14 @@ export function useDeleteVideoList() {
         throw new Error('Only the list owner can delete this list');
       }
 
-      // Publish a kind 5 deletion event targeting the list
-      // The 'a' tag references the addressable event to delete
+      // Publish a kind 5 deletion event targeting the list.
+      // The 'a' tag references the addressable event, and 'k' names its kind.
       await publishEvent({
         kind: 5, // NIP-09 deletion event
         content: 'List deleted by owner',
         tags: [
           ['a', `30005:${ownerPubkey}:${listId}`],
+          ['k', '30005'],
         ]
       });
 


### PR DESCRIPTION
## Summary

- Add the NIP-09 deleted-kind `k` tag when deleting kind 30005 video lists.
- Update the video-list deletion regression test to assert both the addressable `a` tag and `k` tag.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- This isolates the correct protocol fix from the closed people-lists umbrella PR and keeps the existing video-list delete behavior intact.

## Related Issue

- Closes #495

## Testing

- [x] `npx vitest run src/hooks/useVideoLists.test.ts`
- [x] `npm run test`
- [ ] Manual verification completed

## Visuals

- [ ] UI change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved