### PR TITLE
fix(feed): hot/trending feeds render empty — worker-injected v1 array unparseable by client

### DIFF
--- a/compute-js/src/feedInjection.js
+++ b/compute-js/src/feedInjection.js
@@ -23,6 +23,22 @@ export async function resolveFeedInjectedHtml({
   }
 }
 
+// Map a Funnelcake v2 envelope ({ data, pagination }) to the client's expected
+// shape ({ videos, next_cursor, has_more }). Legacy v1 arrays and already-shaped
+// payloads pass through untouched — the client normalizes those itself.
+export function normalizeFeedResponse(feedData) {
+  if (!feedData || Array.isArray(feedData)) return feedData;
+  if (Array.isArray(feedData.data)) {
+    const pagination = feedData.pagination ?? {};
+    return {
+      videos: feedData.data,
+      next_cursor: pagination.next_cursor ?? undefined,
+      has_more: pagination.has_more ?? false,
+    };
+  }
+  return feedData;
+}
+
 export function injectFeedDataIntoHtml({ html, feedType, feedData }) {
   if (!feedData) return html;
 

--- a/compute-js/src/feedInjection.test.js
+++ b/compute-js/src/feedInjection.test.js
@@ -1,5 +1,35 @@
 import { describe, expect, it, vi } from 'vitest';
-import { injectFeedDataIntoHtml, resolveFeedInjectedHtml } from './feedInjection.js';
+import { injectFeedDataIntoHtml, normalizeFeedResponse, resolveFeedInjectedHtml } from './feedInjection.js';
+
+describe('normalizeFeedResponse', () => {
+  it('maps a v2 envelope to the client videos shape', () => {
+    const result = normalizeFeedResponse({
+      data: [{ id: 'a' }, { id: 'b' }],
+      pagination: { next_cursor: 'o:10', has_more: true },
+    });
+    expect(result).toEqual({
+      videos: [{ id: 'a' }, { id: 'b' }],
+      next_cursor: 'o:10',
+      has_more: true,
+    });
+  });
+
+  it('defaults missing pagination fields', () => {
+    const result = normalizeFeedResponse({ data: [] });
+    expect(result).toEqual({ videos: [], next_cursor: undefined, has_more: false });
+  });
+
+  it('passes legacy v1 arrays through untouched', () => {
+    const arr = [{ id: 'a' }];
+    expect(normalizeFeedResponse(arr)).toBe(arr);
+  });
+
+  it('passes null and already-shaped payloads through untouched', () => {
+    expect(normalizeFeedResponse(null)).toBeNull();
+    const shaped = { videos: [{ id: 'a' }] };
+    expect(normalizeFeedResponse(shaped)).toBe(shaped);
+  });
+});
 
 const makeHtml = (entry = '/assets/index-abc123.js') =>
   `<!doctype html><html><head>` +

--- a/compute-js/src/index.js
+++ b/compute-js/src/index.js
@@ -322,7 +322,7 @@ async function handleRequest(event) {
       // The static body is brotli/gzip-compressed for browsers, and the Fastly SDK's
       // Response.text() does NOT decompress it — reading it throws "malformed UTF-8" and
       // consumes the stream, which previously fell through to a hard 500 on the injected
-      // routes (apex + /discovery/{new,hot,classics,top}); see #435. Read the identity shell
+      // routes (apex + /discovery/{new,hot}); see #435. Read the identity shell
       // from KV instead and serve it with the compression-coupled headers stripped
       // (Content-Encoding/Content-Length/ETag). Any failure degrades to the untouched static
       // passthrough below, so injection can never 500.
@@ -377,7 +377,9 @@ function getDiscoveryFeedType(pathname) {
   const tab = match[1];
   if (tab === 'new') return 'recent';
   if (tab === 'hot') return 'trending';
-  if (tab === 'classics' || tab === 'top') return 'classics';
+  // Classics starts from a randomized offset in the client, so the first query
+  // cannot consume an injected page without changing the feed ordering.
+  if (tab === 'classics' || tab === 'top') return null;
   return null;
 }
 
@@ -390,7 +392,6 @@ function getFeedApiUrl(feedType) {
     // past the injected first page; v1 arrays cannot express one for this feed.
     case 'trending': return '/api/v2/videos?sort=watching&limit=10';
     case 'recent': return '/api/videos?sort=recent&limit=10';
-    case 'classics': return '/api/videos?sort=loops&limit=10';
     default: return '/api/videos?sort=trending&limit=10';
   }
 }

--- a/compute-js/src/index.js
+++ b/compute-js/src/index.js
@@ -24,7 +24,7 @@ import {
 } from './crawlerHandlers.js';
 import { transformVideoApiResponse } from './videoMetadata.js';
 import { renderEmbedPage } from './embedPage.js';
-import { resolveFeedInjectedHtml } from './feedInjection.js';
+import { resolveFeedInjectedHtml, normalizeFeedResponse } from './feedInjection.js';
 
 const publisherServer = PublisherServer.fromStaticPublishRc(rc);
 const DEFAULT_OG_IMAGE = 'https://divine.video/og.png';
@@ -386,7 +386,9 @@ function getDiscoveryFeedType(pathname) {
  */
 function getFeedApiUrl(feedType) {
   switch (feedType) {
-    case 'trending': return '/api/videos?sort=trending&limit=10';
+    // v2 envelope carries the opaque cursor the client needs to keep paginating
+    // past the injected first page; v1 arrays cannot express one for this feed.
+    case 'trending': return '/api/v2/videos?sort=watching&limit=10';
     case 'recent': return '/api/videos?sort=recent&limit=10';
     case 'classics': return '/api/videos?sort=loops&limit=10';
     default: return '/api/videos?sort=trending&limit=10';
@@ -442,7 +444,7 @@ async function fetchFeedData(feedType = 'trending', funnelcakeTarget = getFunnel
     const apiPath = getFeedApiUrl(feedType);
     const resp = await fetchFromFunnelcake(funnelcakeTarget, apiPath);
     if (resp.ok) {
-      feedData = await resp.json();
+      feedData = normalizeFeedResponse(await resp.json());
       // 3. Update KV cache (fire and forget)
       try {
         await contentStore.put(CACHE_KEY, JSON.stringify({

--- a/src/hooks/useInfiniteVideosFunnelcake.test.ts
+++ b/src/hooks/useInfiniteVideosFunnelcake.test.ts
@@ -3,6 +3,8 @@ import { renderHook, waitFor, act } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 
+import type { FunnelcakeVideoRaw } from '@/types/funnelcake';
+
 const mockFetchVideos = vi.fn();
 const mockFetchVideosV2 = vi.fn();
 const mockSearchVideos = vi.fn();
@@ -64,6 +66,20 @@ function createWrapper() {
 
 let useInfiniteVideosFunnelcake: typeof import('./useInfiniteVideosFunnelcake').useInfiniteVideosFunnelcake;
 
+function makeRawVideo(overrides: Partial<FunnelcakeVideoRaw> = {}): FunnelcakeVideoRaw {
+  return {
+    id: 'video-1',
+    pubkey: 'pubkey-1',
+    created_at: 1700000000,
+    kind: 34236,
+    d_tag: 'vine-id',
+    title: 'Test title',
+    content: 'Test content',
+    video_url: 'https://media.divine.video/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef.mp4',
+    ...overrides,
+  };
+}
+
 beforeEach(async () => {
   vi.clearAllMocks();
   ({ useInfiniteVideosFunnelcake } = await import('./useInfiniteVideosFunnelcake'));
@@ -76,17 +92,17 @@ describe('edge-injected feed handling', () => {
   });
 
   it('uses an injected envelope with videos and skips the network fetch', async () => {
+    const { transformToVideoPage } = await vi.importActual<typeof import('@/lib/funnelcakeTransform')>(
+      '@/lib/funnelcakeTransform'
+    );
+    mockTransformToVideoPage.mockImplementationOnce(transformToVideoPage);
+
     window.__DIVINE_FEED__ = {
-      videos: [{ id: 'raw-1' }],
+      videos: [makeRawVideo()],
       has_more: true,
       next_cursor: 'o:10',
     } as never;
     window.__DIVINE_FEED_TYPE__ = 'trending';
-    mockTransformToVideoPage.mockReturnValueOnce({
-      videos: [{ id: 'video-1', pubkey: 'p1', kind: 34236, createdAt: 101, vineId: 'd-1' }],
-      nextCursor: 'o:10',
-      hasMore: true,
-    });
 
     const { result } = renderHook(
       () => useInfiniteVideosFunnelcake({ feedType: 'trending', pageSize: 10 }),
@@ -104,6 +120,7 @@ describe('edge-injected feed handling', () => {
     );
     expect(mockFetchVideosV2).not.toHaveBeenCalled();
     expect(result.current.data?.pages[0].videos).toHaveLength(1);
+    expect(result.current.hasNextPage).toBe(true);
     expect(window.__DIVINE_FEED__).toBeUndefined();
   });
 

--- a/src/hooks/useInfiniteVideosFunnelcake.test.ts
+++ b/src/hooks/useInfiniteVideosFunnelcake.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderHook, waitFor, act } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
@@ -15,6 +15,14 @@ vi.mock('@/hooks/useCurrentUser', () => ({
   }),
 }));
 
+const mockNormalizeVideoArrayResponse = vi.fn(
+  (videos: unknown[], { limit = 20 }: { limit?: number } = {}) => ({
+    videos,
+    has_more: videos.length >= limit,
+    next_cursor: videos.length >= limit ? '1234567' : undefined,
+  })
+);
+
 vi.mock('@/lib/funnelcakeClient', () => ({
   fetchVideos: mockFetchVideos,
   fetchVideosV2: mockFetchVideosV2,
@@ -22,6 +30,7 @@ vi.mock('@/lib/funnelcakeClient', () => ({
   fetchUserVideos: vi.fn(),
   fetchUserFeed: vi.fn(),
   fetchRecommendations: mockFetchRecommendations,
+  normalizeVideoArrayResponse: mockNormalizeVideoArrayResponse,
 }));
 
 vi.mock('@/lib/funnelcakeTransform', () => ({
@@ -58,6 +67,100 @@ let useInfiniteVideosFunnelcake: typeof import('./useInfiniteVideosFunnelcake').
 beforeEach(async () => {
   vi.clearAllMocks();
   ({ useInfiniteVideosFunnelcake } = await import('./useInfiniteVideosFunnelcake'));
+});
+
+describe('edge-injected feed handling', () => {
+  afterEach(() => {
+    delete window.__DIVINE_FEED__;
+    delete window.__DIVINE_FEED_TYPE__;
+  });
+
+  it('uses an injected envelope with videos and skips the network fetch', async () => {
+    window.__DIVINE_FEED__ = {
+      videos: [{ id: 'raw-1' }],
+      has_more: true,
+      next_cursor: 'o:10',
+    } as never;
+    window.__DIVINE_FEED_TYPE__ = 'trending';
+    mockTransformToVideoPage.mockReturnValueOnce({
+      videos: [{ id: 'video-1', pubkey: 'p1', kind: 34236, createdAt: 101, vineId: 'd-1' }],
+      nextCursor: 'o:10',
+      hasMore: true,
+    });
+
+    const { result } = renderHook(
+      () => useInfiniteVideosFunnelcake({ feedType: 'trending', pageSize: 10 }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    // Opaque-cursor feed: injected envelope passed straight through with 'cursor' type
+    expect(mockTransformToVideoPage).toHaveBeenCalledWith(
+      expect.objectContaining({ next_cursor: 'o:10' }),
+      'cursor'
+    );
+    expect(mockFetchVideosV2).not.toHaveBeenCalled();
+    expect(result.current.data?.pages[0].videos).toHaveLength(1);
+    expect(window.__DIVINE_FEED__).toBeUndefined();
+  });
+
+  it('falls back to the network fetch when the injected payload parses empty', async () => {
+    window.__DIVINE_FEED__ = [] as never;
+    window.__DIVINE_FEED_TYPE__ = 'trending';
+    mockTransformToVideoPage
+      .mockReturnValueOnce({ videos: [], nextCursor: undefined, hasMore: false })
+      .mockReturnValueOnce({
+        videos: [{ id: 'video-1', pubkey: 'p1', kind: 34236, createdAt: 101, vineId: 'd-1' }],
+        nextCursor: undefined,
+        hasMore: false,
+      });
+    mockFetchVideosV2.mockResolvedValueOnce({ videos: [{}], has_more: false, next_cursor: undefined });
+
+    const { result } = renderHook(
+      () => useInfiniteVideosFunnelcake({ feedType: 'trending', pageSize: 10 }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockFetchVideosV2).toHaveBeenCalled();
+    expect(result.current.data?.pages[0].videos).toHaveLength(1);
+  });
+
+  it('wraps injected bare arrays for v1-paginated feeds so scrolling can continue', async () => {
+    const rawVideos = Array.from({ length: 10 }, (_, i) => ({ id: `raw-${i}`, created_at: 1000 - i }));
+    window.__DIVINE_FEED__ = rawVideos as never;
+    window.__DIVINE_FEED_TYPE__ = 'recent';
+    mockTransformToVideoPage.mockReturnValueOnce({
+      videos: [{ id: 'video-1', pubkey: 'p1', kind: 34236, createdAt: 101, vineId: 'd-1' }],
+      nextCursor: 1234567,
+      hasMore: true,
+    });
+
+    const { result } = renderHook(
+      () => useInfiniteVideosFunnelcake({ feedType: 'recent', pageSize: 10 }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockNormalizeVideoArrayResponse).toHaveBeenCalledWith(rawVideos, {
+      sort: 'recent',
+      limit: 10,
+    });
+    expect(mockTransformToVideoPage).toHaveBeenCalledWith(
+      expect.objectContaining({ videos: rawVideos, has_more: true }),
+      'timestamp'
+    );
+    expect(mockFetchVideos).not.toHaveBeenCalled();
+  });
 });
 
 describe('useInfiniteVideosFunnelcake', () => {

--- a/src/hooks/useInfiniteVideosFunnelcake.ts
+++ b/src/hooks/useInfiniteVideosFunnelcake.ts
@@ -7,7 +7,7 @@ import { getFunnelcakeBaseUrl } from '@/config/api';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
 import type { ParsedVideoData } from '@/types/video';
 import type { FunnelcakeFetchOptions } from '@/types/funnelcake';
-import { fetchVideos, fetchVideosV2, searchVideos, fetchUserVideos, fetchUserFeed, fetchRecommendations } from '@/lib/funnelcakeClient';
+import { fetchVideos, fetchVideosV2, searchVideos, fetchUserVideos, fetchUserFeed, fetchRecommendations, normalizeVideoArrayResponse } from '@/lib/funnelcakeClient';
 import { enrichAgeRestrictedVideos } from '@/lib/ageRestrictedVideos';
 import { transformToVideoPage } from '@/lib/funnelcakeTransform';
 import { debugLog } from '@/lib/debug';
@@ -232,22 +232,48 @@ export function useInfiniteVideosFunnelcake({
         const edgeData = window.__DIVINE_FEED__;
         delete window.__DIVINE_FEED__; // Consume once
         delete window.__DIVINE_FEED_TYPE__;
-        debugLog(`[useInfiniteVideosFunnelcake] Using edge-injected ${feedType} feed data`);
 
-        const page = transformToVideoPage(edgeData);
-        performanceMonitor.recordFeedLoad({
-          feedType: 'funnelcake-trending',
-          queryTime: 0,
-          parseTime: performance.now() - totalStart,
-          totalTime: performance.now() - totalStart,
-          videoCount: page.videos.length,
-          sortMode,
-        });
-        return {
-          videos: page.videos,
-          nextCursor: page.nextCursor,
-          offset: page.offset,
-        };
+        // Injected trending/popular pages paginate with the v2 opaque cursor,
+        // matching the cursorType used for network fetches of the same feed.
+        const edgeCursorType =
+          feedType === 'recommendations' || feedType === 'trending' || feedType === 'popular'
+            ? 'cursor'
+            : 'timestamp';
+
+        // The worker may inject a bare v1 array. For v1-paginated feeds, wrap it
+        // with a synthesized cursor (same rules as fetchVideos) so scrolling
+        // continues past the injected page. Opaque-cursor (v2) feeds can't
+        // synthesize a valid cursor from an array, so those render as a single
+        // page — the worker injects a v2 envelope for them instead.
+        const edgePayload =
+          Array.isArray(edgeData) && edgeCursorType === 'timestamp'
+            ? normalizeVideoArrayResponse(edgeData, {
+                sort: feedType === 'classics' ? 'loops' : 'recent',
+                limit: 10,
+              })
+            : edgeData;
+        const page = transformToVideoPage(edgePayload, edgeCursorType);
+
+        // An empty or unparseable injected payload must never become the first
+        // page (it would render the empty state and stop pagination) — fall
+        // through to a normal network fetch instead.
+        if (page.videos.length > 0) {
+          debugLog(`[useInfiniteVideosFunnelcake] Using edge-injected ${feedType} feed data`);
+          performanceMonitor.recordFeedLoad({
+            feedType: 'funnelcake-trending',
+            queryTime: 0,
+            parseTime: performance.now() - totalStart,
+            totalTime: performance.now() - totalStart,
+            videoCount: page.videos.length,
+            sortMode,
+          });
+          return {
+            videos: page.videos,
+            nextCursor: page.nextCursor,
+            offset: page.offset,
+          };
+        }
+        debugLog(`[useInfiniteVideosFunnelcake] Edge-injected ${feedType} feed empty or unparseable; fetching from network`);
       }
 
       // Handle pagination cursor

--- a/src/hooks/useInfiniteVideosFunnelcake.ts
+++ b/src/hooks/useInfiniteVideosFunnelcake.ts
@@ -13,6 +13,8 @@ import { transformToVideoPage } from '@/lib/funnelcakeTransform';
 import { debugLog } from '@/lib/debug';
 import { performanceMonitor } from '@/lib/performanceMonitoring';
 
+const EDGE_INJECTED_FEED_LIMIT = 10;
+
 export type FunnelcakeFeedType = 'trending' | 'recent' | 'classics' | 'hashtag' | 'profile' | 'home' | 'recommendations' | 'category' | 'popular';
 export type FunnelcakeSortMode = 'trending' | 'recent' | 'loops' | 'engagement' | 'classic' | 'watching';
 export type PopularSource = 'new' | 'classic' | 'all';
@@ -249,7 +251,7 @@ export function useInfiniteVideosFunnelcake({
           Array.isArray(edgeData) && edgeCursorType === 'timestamp'
             ? normalizeVideoArrayResponse(edgeData, {
                 sort: feedType === 'classics' ? 'loops' : 'recent',
-                limit: 10,
+                limit: EDGE_INJECTED_FEED_LIMIT,
               })
             : edgeData;
         const page = transformToVideoPage(edgePayload, edgeCursorType);
@@ -260,7 +262,7 @@ export function useInfiniteVideosFunnelcake({
         if (page.videos.length > 0) {
           debugLog(`[useInfiniteVideosFunnelcake] Using edge-injected ${feedType} feed data`);
           performanceMonitor.recordFeedLoad({
-            feedType: 'funnelcake-trending',
+            feedType: `funnelcake-${feedType}`,
             queryTime: 0,
             parseTime: performance.now() - totalStart,
             totalTime: performance.now() - totalStart,
@@ -271,6 +273,8 @@ export function useInfiniteVideosFunnelcake({
             videos: page.videos,
             nextCursor: page.nextCursor,
             offset: page.offset,
+            recommendationsCursor: feedType === 'recommendations' ? page.rawCursor : undefined,
+            v2Cursor: feedType === 'trending' || feedType === 'popular' ? page.rawCursor : undefined,
           };
         }
         debugLog(`[useInfiniteVideosFunnelcake] Edge-injected ${feedType} feed empty or unparseable; fetching from network`);

--- a/src/lib/funnelcakeClient.test.ts
+++ b/src/lib/funnelcakeClient.test.ts
@@ -676,4 +676,33 @@ describe('funnelcakeClient', () => {
       expect(result.next_cursor).toBe('36');
     });
   });
+
+  describe('normalizeVideoArrayResponse', () => {
+    it('synthesizes an offset cursor for sorted feeds at a full page', async () => {
+      const { normalizeVideoArrayResponse } = await import('./funnelcakeClient');
+      const videos = Array.from({ length: 10 }, (_, i) => ({ id: `v${i}`, created_at: 2000 - i }));
+      const result = normalizeVideoArrayResponse(videos as never, { sort: 'loops', limit: 10 });
+      expect(result.has_more).toBe(true);
+      expect(result.next_cursor).toBe('10');
+      expect(result.videos).toHaveLength(10);
+    });
+
+    it('synthesizes a timestamp cursor for chronological feeds', async () => {
+      const { normalizeVideoArrayResponse } = await import('./funnelcakeClient');
+      const videos = Array.from({ length: 10 }, (_, i) => ({ id: `v${i}`, created_at: 2000 - i }));
+      const result = normalizeVideoArrayResponse(videos as never, { sort: 'recent', limit: 10 });
+      expect(result.has_more).toBe(true);
+      expect(result.next_cursor).toBe('1991');
+    });
+
+    it('marks a short page as final', async () => {
+      const { normalizeVideoArrayResponse } = await import('./funnelcakeClient');
+      const result = normalizeVideoArrayResponse([{ id: 'v0', created_at: 1 }] as never, {
+        sort: 'recent',
+        limit: 10,
+      });
+      expect(result.has_more).toBe(false);
+      expect(result.next_cursor).toBeUndefined();
+    });
+  });
 });

--- a/src/lib/funnelcakeClient.ts
+++ b/src/lib/funnelcakeClient.ts
@@ -157,6 +157,29 @@ export async function checkFunnelcakeAvailable(
 }
 
 /**
+ * Wrap a bare v1 video array in the FunnelcakeResponse envelope, synthesizing
+ * the pagination cursor the same way fetchVideos does for direct fetches:
+ * offset-based for sorted feeds, timestamp for chronological (sort=recent).
+ * Used for edge-injected feeds, which arrive as raw v1 arrays.
+ */
+export function normalizeVideoArrayResponse(
+  videos: FunnelcakeVideoRaw[],
+  { sort = 'trending', limit = 20, offset = 0 }: { sort?: string; limit?: number; offset?: number } = {}
+): FunnelcakeResponse {
+  const videoCount = videos.length;
+  const nextOffset = offset + videoCount;
+  const next_cursor = videoCount >= limit
+    ? (sort !== 'recent' ? String(nextOffset) : String(videos[videoCount - 1].created_at))
+    : undefined;
+
+  return {
+    videos,
+    has_more: videoCount >= limit,
+    next_cursor,
+  };
+}
+
+/**
  * Fetch videos from Funnelcake API
  *
  * @param apiUrl - Base URL of the Funnelcake API

--- a/src/lib/funnelcakeClient.ts
+++ b/src/lib/funnelcakeClient.ts
@@ -221,20 +221,8 @@ export async function fetchVideos(
     signal
   );
 
-  const videoCount = videos.length;
   const currentOffset = offset ?? (params.offset as number | undefined) ?? 0;
-  const nextOffset = currentOffset + videoCount;
-
-  // For sorted feeds, return offset-based cursor; for chronological, return timestamp
-  const next_cursor = videoCount >= limit
-    ? (sort !== 'recent' ? String(nextOffset) : String(videos[videoCount - 1].created_at))
-    : undefined;
-
-  return {
-    videos,
-    has_more: videoCount >= limit,
-    next_cursor,
-  };
+  return normalizeVideoArrayResponse(videos, { sort, limit, offset: currentOffset });
 }
 
 /**

--- a/src/lib/funnelcakeTransform.test.ts
+++ b/src/lib/funnelcakeTransform.test.ts
@@ -466,6 +466,15 @@ function makeResponse(overrides: Partial<FunnelcakeResponse> = {}): FunnelcakeRe
 }
 
 describe('transformToVideoPage', () => {
+  it('normalizes bare edge-injected video arrays', () => {
+    const page = transformToVideoPage([makeRawVideo()]);
+
+    expect(page.videos).toHaveLength(1);
+    expect(page.videos[0]?.id).toBe('video-1');
+    expect(page.hasMore).toBe(false);
+    expect(page.nextCursor).toBeUndefined();
+  });
+
   describe('cursor type (recommendations)', () => {
     it('returns raw cursor string when cursorType is cursor', () => {
       const page = transformToVideoPage(makeResponse({ next_cursor: 'opaque-cursor-xyz' }), 'cursor');

--- a/src/lib/funnelcakeTransform.ts
+++ b/src/lib/funnelcakeTransform.ts
@@ -244,13 +244,15 @@ export function transformFunnelcakeVideo(raw: FunnelcakeVideoRaw): ParsedVideoDa
 /**
  * Transform a Funnelcake API response to an array of ParsedVideoData
  */
-export function transformFunnelcakeResponse(response: FunnelcakeResponse): ParsedVideoData[] {
-  if (!response.videos || !Array.isArray(response.videos)) {
+export function transformFunnelcakeResponse(response: FunnelcakeResponse | FunnelcakeVideoRaw[]): ParsedVideoData[] {
+  const rawVideos = Array.isArray(response) ? response : response.videos;
+
+  if (!Array.isArray(rawVideos)) {
     debugLog('[FunnelcakeTransform] No videos in response');
     return [];
   }
 
-  const transformed = response.videos
+  const transformed = rawVideos
     .map(raw => {
       try {
         return transformFunnelcakeVideo(raw);
@@ -274,7 +276,7 @@ export function transformFunnelcakeResponse(response: FunnelcakeResponse): Parse
   if (videos.length < transformed.length) {
     debugLog(`[FunnelcakeTransform] Deduplicated ${transformed.length} → ${videos.length} videos`);
   }
-  debugLog(`[FunnelcakeTransform] Transformed ${videos.length}/${response.videos.length} videos`);
+  debugLog(`[FunnelcakeTransform] Transformed ${videos.length}/${rawVideos.length} videos`);
 
   return videos;
 }
@@ -283,7 +285,7 @@ export function transformFunnelcakeResponse(response: FunnelcakeResponse): Parse
  * Transform Funnelcake response to video page format for infinite scroll hooks
  */
 export function transformToVideoPage(
-  response: FunnelcakeResponse,
+  response: FunnelcakeResponse | FunnelcakeVideoRaw[],
   cursorType: 'timestamp' | 'offset' | 'cursor' = 'timestamp'
 ): {
   videos: ParsedVideoData[];
@@ -300,15 +302,18 @@ export function transformToVideoPage(
   let offset: number | undefined;
   let rawCursor: string | undefined;
 
-  if (response.has_more && response.next_cursor) {
+  const hasMore = !Array.isArray(response) && response.has_more;
+  const nextCursorValue = !Array.isArray(response) ? response.next_cursor : undefined;
+
+  if (hasMore && nextCursorValue) {
     if (cursorType === 'cursor') {
       // Opaque cursor: pass through as-is (recommendations)
-      rawCursor = response.next_cursor;
+      rawCursor = nextCursorValue;
     } else if (cursorType === 'offset') {
-      offset = parseInt(response.next_cursor, 10);
+      offset = parseInt(nextCursorValue, 10);
     } else {
       // Timestamp cursor - parse as number
-      nextCursor = parseInt(response.next_cursor, 10);
+      nextCursor = parseInt(nextCursorValue, 10);
       // If parsing fails, use last video's timestamp
       if (isNaN(nextCursor) && videos.length > 0) {
         nextCursor = videos[videos.length - 1].createdAt - 1;
@@ -321,7 +326,7 @@ export function transformToVideoPage(
     nextCursor,
     offset,
     rawCursor,
-    hasMore: response.has_more,
+    hasMore,
   };
 }
 

--- a/src/types/window.d.ts
+++ b/src/types/window.d.ts
@@ -2,7 +2,7 @@
 // ABOUTME: Allows TypeScript to recognize window.nostr, window._hsp, and window.__DIVINE_FEED__ properties
 
 import type { NostrSigner } from '@nostrify/nostrify';
-import type { FunnelcakeResponse } from './funnelcake';
+import type { FunnelcakeResponse, FunnelcakeVideoRaw } from './funnelcake';
 
 declare global {
   interface Window {
@@ -10,7 +10,7 @@ declare global {
     zE?: (namespace: string, action: string, ...args: unknown[]) => void;
     _hsp?: Array<[string, ...unknown[]]>;
     /** Feed data injected by the Fastly edge worker to avoid client round-trip */
-    __DIVINE_FEED__?: FunnelcakeResponse;
+    __DIVINE_FEED__?: FunnelcakeResponse | FunnelcakeVideoRaw[];
     /** Feed type that was injected (trending, recent, classics) */
     __DIVINE_FEED_TYPE__?: string;
     /** Set by divine-brain simulations before page scripts run to suppress analytics. */


### PR DESCRIPTION
## Bug (production, user-visible)

`/discovery/hot` (and apex `/` trending) render the "Divine needs a rest" empty state even though the API has videos.

## Root cause

The Fastly worker injected `window.__DIVINE_FEED__` as the **raw v1 response — a bare JSON array** (v1 `/api/videos` returns arrays by design; the client's `fetchVideos` wraps them, but the injection path bypasses that wrapper). `transformFunnelcakeResponse` only accepts the `{videos}` envelope, so any feed whose type matches the injection (`hot` tab → `trending`) consumes the injected payload, parses it to **zero videos with `hasMore` false**, and permanently renders the empty state — no network fallback.

Verified live: `curl divine.video/discovery/hot` shows `window.__DIVINE_FEED__=[{"id":...` (bare array) + `__DIVINE_FEED_TYPE__="trending"`, while `/api/v2/videos?sort=hot` returns videos fine.

This is #483, and the failure mode predicted by #408. Also relevant: v2 rejects non-opaque cursors (`{"error":"Invalid cursor format"}`), which shaped the fix below.

## Fix (defense in depth)

1. **Transform accepts bare arrays** (cherry-picked from `feat/web-product-analytics`) — safety net for any array payload.
2. **Hook never uses an empty injected page** — if the injected payload parses to zero videos, it falls through to a normal network fetch instead of rendering the empty state.
3. **Pagination survives the injected page**:
   - v1-paginated feeds (recent/classics): bare arrays get wrapped via the new exported `normalizeVideoArrayResponse` (same cursor synthesis `fetchVideos` uses).
   - trending (v2 opaque cursor): the worker now fetches `/api/v2/videos?sort=watching&limit=10` and injects a mapped `{videos, next_cursor, has_more}` envelope; the hook passes the correct `cursor` type through, so page 2 continues from the real `o:N` cursor.
4. **Classics/top are no longer edge-injected** — the client intentionally starts classics from a randomized offset, so an injected first page would be unused or would change ordering.
5. Old cached bundles that still can't parse arrays now receive the trending envelope from the worker, so hot/trending renders too.

## Tests

- Hook tests: injected envelope used (no network call), injected trending keeps `hasNextPage`, empty injected payload falls back to network, bare arrays wrapped for v1 feeds.
- `normalizeFeedResponse` (worker) + `normalizeVideoArrayResponse` (client) unit tests.
- Full suite: 1525 passed. tsc + eslint clean.

## Deploy note

Needs **both** the worker deploy and the web publish (`npm run fastly:deploy && npm run fastly:publish`); the KV feed cache (60s TTL) self-heals after the worker rolls.

Fixes #483. Mitigates #408 (array-response handling now exists on the injection path; #408's flag concern for direct fetches remains open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
