### PR TITLE
fix: disable unmoderated new video discovery

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -60,6 +60,8 @@ routing resolves user profiles (e.g., `alice.divine.video/`) by reading the
 subdomain and loading the corresponding Nostr profile. Static hosts use
 `404.html` (copied from [`index.html`](./index.html) during build) as a
 catch-all fallback.
+The retired `/discovery/new` chronological feed redirects to
+`/discovery/hot`; Discovery does not expose or mount an all-new-video feed.
 
 ## Styling
 

--- a/docs/superpowers/plans/2026-07-26-disable-new-videos-discovery.md
+++ b/docs/superpowers/plans/2026-07-26-disable-new-videos-discovery.md
@@ -1,0 +1,259 @@
+# Disable New Videos Discovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the chronological New feed from Discovery and redirect old `/discovery/new` links to the Hot feed.
+
+**Architecture:** `DiscoveryPage` will stop declaring, rendering, or accepting the `new` tab, so it cannot mount `VideoFeed` with `feedType="recent"`. `AppRouter` will own backward compatibility through a specific React Router redirect from `/discovery/new` to `/discovery/hot`, ahead of the existing parameterized Discovery route.
+
+**Tech Stack:** React 18, TypeScript, React Router 6, Radix Tabs, Vitest, Testing Library.
+
+**Design:** `docs/superpowers/specs/2026-07-26-disable-new-videos-discovery-design.md`
+
+---
+
+## File Structure
+
+- Modify `src/pages/DiscoveryPage.test.tsx`: prove the New tab and recent feed are unavailable.
+- Modify `src/pages/DiscoveryPage.tsx`: remove the New tab type, trigger, feed content, clock icon, and obsolete file description.
+- Modify `src/AppRouter.test.tsx`: prove direct visits to `/discovery/new` resolve to `/discovery/hot`.
+- Modify `src/AppRouter.tsx`: register the specific replace redirect.
+- Modify `ARCHITECTURE.md`: record the route-level safety behavior because this document references `AppRouter`.
+
+### Task 1: Remove New From Discovery
+
+**Files:**
+- Modify: `src/pages/DiscoveryPage.test.tsx`
+- Modify: `src/pages/DiscoveryPage.tsx`
+
+- [ ] **Step 1: Write the failing component test**
+
+Change the `VideoFeed` mock in `src/pages/DiscoveryPage.test.tsx` so its feed
+type is visible to user-facing test queries:
+
+```tsx
+vi.mock('@/components/VideoFeed', () => ({
+  VideoFeed: ({ feedType }: { feedType: string }) => (
+    <div data-testid={`video-feed-${feedType}`} />
+  ),
+}));
+```
+
+Add this test inside `describe('DiscoveryPage', ...)`:
+
+```tsx
+it('does not expose or render the all-new video feed', () => {
+  render(
+    <MemoryRouter initialEntries={['/discovery/new']}>
+      <Routes>
+        <Route path="/discovery/:tab" element={<DiscoveryPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+
+  expect(screen.queryByRole('tab', { name: 'Nuevo' })).not.toBeInTheDocument();
+  expect(screen.queryByTestId('video-feed-recent')).not.toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run:
+
+```bash
+npx vitest run src/pages/DiscoveryPage.test.tsx -t "does not expose or render"
+```
+
+Expected: FAIL because the current page renders the localized New tab and
+mounts `video-feed-recent` for `/discovery/new`.
+
+- [ ] **Step 3: Remove the New tab and recent feed**
+
+In `src/pages/DiscoveryPage.tsx`, change the file description and icon import:
+
+```tsx
+// ABOUTME: Discovery feed page showing public videos with tabs for Classics, Hot, and Hashtags
+// ABOUTME: Each video tab uses a moderated or curated feed source
+// ABOUTME: For You tab shows personalized recommendations when user is logged in
+```
+
+```tsx
+import { Star, Hash, Flame, Sparkle as Sparkles } from '@phosphor-icons/react';
+```
+
+Change the allowed tab declarations to:
+
+```tsx
+type AllowedTab = 'foryou' | 'classics' | 'hot' | 'hashtags';
+const ALL_TABS: AllowedTab[] = ['foryou', 'classics', 'hot', 'hashtags'];
+const BASE_TABS: AllowedTab[] = ['classics', 'hot', 'hashtags'];
+```
+
+Change the tab grid count to match the remaining controls:
+
+```tsx
+<TabsList className={`w-full grid gap-1 ${isLoggedIn ? 'grid-cols-4' : 'grid-cols-3'}`}>
+```
+
+Delete the New trigger:
+
+```tsx
+<TabsTrigger value="new" className="gap-1.5 sm:gap-2">
+  <Clock className="h-4 w-4" />
+  <span className="hidden sm:inline">{t('discovery.new')}</span>
+</TabsTrigger>
+```
+
+Delete the New content:
+
+```tsx
+<TabsContent value="new" className="mt-0 space-y-6">
+  <VideoFeed
+    feedType="recent"
+    verifiedOnly={verifiedOnly}
+    data-testid="video-feed-new"
+    className="space-y-6"
+    key="recent"
+  />
+</TabsContent>
+```
+
+- [ ] **Step 4: Run the focused component suite and verify GREEN**
+
+Run:
+
+```bash
+npx vitest run src/pages/DiscoveryPage.test.tsx
+```
+
+Expected: PASS for the existing localization/category test and the new
+all-new-feed regression test.
+
+### Task 2: Redirect The Retired URL
+
+**Files:**
+- Modify: `src/AppRouter.test.tsx`
+- Modify: `src/AppRouter.tsx`
+- Modify: `ARCHITECTURE.md`
+
+- [ ] **Step 1: Write the failing router test**
+
+In `src/AppRouter.test.tsx`, add `waitFor` to the Testing Library import:
+
+```tsx
+import { render, screen, waitFor } from '@testing-library/react';
+```
+
+Mock the Discovery page to keep the router test focused:
+
+```tsx
+vi.mock('./pages/DiscoveryPage', () => ({
+  default: () => <div data-testid="discovery-page" />,
+}));
+```
+
+Add this test inside `describe('AppRouter', ...)`:
+
+```tsx
+it('redirects the retired new-video feed to hot', async () => {
+  window.history.pushState({}, '', '/discovery/new');
+
+  render(<AppRouter />);
+
+  await waitFor(() => {
+    expect(window.location.pathname).toBe('/discovery/hot');
+  });
+  expect(screen.getByTestId('discovery-page')).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run:
+
+```bash
+npx vitest run src/AppRouter.test.tsx -t "redirects the retired"
+```
+
+Expected: FAIL because the parameterized `/discovery/:tab` route currently
+keeps the browser at `/discovery/new`.
+
+- [ ] **Step 3: Add the specific replace redirect**
+
+In `src/AppRouter.tsx`, add `Navigate` to the React Router import:
+
+```tsx
+import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
+```
+
+Register the specific redirect immediately before the existing Discovery
+routes:
+
+```tsx
+<Route path="/discovery/new" element={<Navigate to="/discovery/hot" replace />} />
+<Route path="/discovery" element={<DiscoveryPage />} />
+<Route path="/discovery/:tab" element={<DiscoveryPage />} />
+```
+
+- [ ] **Step 4: Document the route behavior**
+
+Append this sentence to the Routing section of `ARCHITECTURE.md`:
+
+```markdown
+The retired `/discovery/new` chronological feed redirects to
+`/discovery/hot`; Discovery does not expose or mount an all-new-video feed.
+```
+
+- [ ] **Step 5: Run both focused suites and verify GREEN**
+
+Run:
+
+```bash
+npx vitest run src/AppRouter.test.tsx src/pages/DiscoveryPage.test.tsx
+```
+
+Expected: PASS for both files, including the new redirect and feed-removal
+regressions.
+
+### Task 3: Verify And Commit
+
+**Files:**
+- Modify: `src/pages/DiscoveryPage.test.tsx`
+- Modify: `src/pages/DiscoveryPage.tsx`
+- Modify: `src/AppRouter.test.tsx`
+- Modify: `src/AppRouter.tsx`
+- Modify: `ARCHITECTURE.md`
+
+- [ ] **Step 1: Check the focused diff and stale feed references**
+
+Run:
+
+```bash
+git diff --check
+rg -n 'video-feed-new|feedType="recent"|discovery\\.new|value="new"|Clock' src/pages/DiscoveryPage.tsx
+rg -n '/discovery/new' src/AppRouter.tsx ARCHITECTURE.md
+```
+
+Expected: `git diff --check` succeeds; the Discovery search returns no
+matches; the route/documentation search returns only the explicit redirect
+and its architecture note.
+
+- [ ] **Step 2: Run the full repository gate**
+
+Run:
+
+```bash
+npm test
+```
+
+Expected: TypeScript, ESLint, all Vitest suites, and the Vite production build
+pass.
+
+- [ ] **Step 3: Commit the focused implementation**
+
+Stage only the task files, leaving unrelated untracked PNGs untouched:
+
+```bash
+git add src/pages/DiscoveryPage.test.tsx src/pages/DiscoveryPage.tsx src/AppRouter.test.tsx src/AppRouter.tsx ARCHITECTURE.md
+git commit -m "fix: disable unmoderated new video discovery"
+```

--- a/docs/superpowers/specs/2026-07-26-disable-new-videos-discovery-design.md
+++ b/docs/superpowers/specs/2026-07-26-disable-new-videos-discovery-design.md
@@ -1,0 +1,31 @@
+# Disable New Videos Discovery
+
+## Goal
+
+Prevent viewers from browsing an unmoderated chronological feed of newly
+published videos.
+
+## Behavior
+
+- Discovery no longer offers a **New** tab.
+- Discovery no longer mounts a `recent` video feed.
+- Requests for `/discovery/new` redirect to `/discovery/hot` and replace the
+  stale URL in browser history.
+- Other Discovery tabs and their existing behavior remain unchanged.
+
+## Implementation
+
+Remove `new` from the Discovery tab type and allowed-tab collections, remove
+its tab trigger and content, and remove imports that become unused. Register
+an explicit `/discovery/new` redirect in `AppRouter` before the parameterized
+Discovery route so old links and bookmarks resolve to the Hot feed.
+
+No feature flag or dormant recent-feed branch will remain in the Discovery
+page.
+
+## Verification
+
+Component tests will prove that Discovery renders no **New** tab and does not
+mount a recent video feed. Router coverage will prove that
+`/discovery/new` resolves to `/discovery/hot`. The focused tests will be run
+first, followed by the repository's full test command.

--- a/src/AppRouter.test.tsx
+++ b/src/AppRouter.test.tsx
@@ -1,5 +1,5 @@
 import { Outlet } from 'react-router-dom';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import AppRouter from './AppRouter';
 
@@ -42,6 +42,10 @@ vi.mock('./pages/NIP19Page', () => ({
   NIP19Page: () => <div data-testid="nip19-page" />,
 }));
 
+vi.mock('./pages/DiscoveryPage', () => ({
+  default: () => <div data-testid="discovery-page" />,
+}));
+
 describe('AppRouter', () => {
   beforeEach(() => {
     mockUseCurrentUser.mockReset();
@@ -59,5 +63,16 @@ describe('AppRouter', () => {
 
     expect(screen.getByTestId('analytics-page')).toBeInTheDocument();
     expect(screen.queryByTestId('nip19-page')).not.toBeInTheDocument();
+  });
+
+  it('redirects the retired new-video feed to hot', async () => {
+    window.history.pushState({}, '', '/discovery/new');
+
+    render(<AppRouter />);
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe('/discovery/hot');
+    });
+    expect(screen.getByTestId('discovery-page')).toBeInTheDocument();
   });
 });

--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -3,7 +3,7 @@
  */
 
 import { lazy, Suspense } from "react";
-import { BrowserRouter, Route, Routes } from "react-router-dom";
+import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 import { ScrollToTop } from "./components/ScrollToTop";
 import { AnalyticsPageTracker } from "./components/AnalyticsPageTracker";
 import { AnalyticsUserTracker } from "./components/AnalyticsUserTracker";
@@ -94,6 +94,7 @@ export function AppRouter() {
   const appShellRoutes = (
     <>
       {/* Public browsing routes - accessible without login */}
+      <Route path="/discovery/new" element={<Navigate to="/discovery/hot" replace />} />
       <Route path="/discovery" element={<DiscoveryPage />} />
       <Route path="/discovery/:tab" element={<DiscoveryPage />} />
       <Route path="/trending" element={<TrendingPage />} />

--- a/src/pages/DiscoveryPage.test.tsx
+++ b/src/pages/DiscoveryPage.test.tsx
@@ -28,7 +28,9 @@ vi.mock('@/hooks/useCategories', () => ({
 }));
 
 vi.mock('@/components/VideoFeed', () => ({
-  VideoFeed: () => <div data-testid="video-feed" />,
+  VideoFeed: ({ feedType }: { feedType: string }) => (
+    <div data-testid={`video-feed-${feedType}`} />
+  ),
 }));
 
 vi.mock('@/components/HashtagExplorer', () => ({
@@ -83,5 +85,18 @@ describe('DiscoveryPage', () => {
     expect(screen.getByText('Explora videos de la red')).toBeInTheDocument();
     expect(screen.getByText('Clasico')).toBeInTheDocument();
     expect(screen.getByText('Musica')).toBeInTheDocument();
+  });
+
+  it('does not expose or render the all-new video feed', () => {
+    render(
+      <MemoryRouter initialEntries={['/discovery/new']}>
+        <Routes>
+          <Route path="/discovery/:tab" element={<DiscoveryPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByRole('tab', { name: 'Nuevo' })).not.toBeInTheDocument();
+    expect(screen.queryByTestId('video-feed-recent')).not.toBeInTheDocument();
   });
 });

--- a/src/pages/DiscoveryPage.tsx
+++ b/src/pages/DiscoveryPage.tsx
@@ -1,5 +1,5 @@
-// ABOUTME: Discovery feed page showing all public videos with tabs for Classics, Hot, Rising, New, and Hashtags
-// ABOUTME: Each tab uses different sort modes; Classics uses Funnelcake REST API for pre-computed metrics
+// ABOUTME: Discovery feed page showing public videos with tabs for Classics, Hot, and Hashtags
+// ABOUTME: Each video tab uses a moderated or curated feed source
 // ABOUTME: For You tab shows personalized recommendations when user is logged in
 
 import { useEffect, useMemo, useState } from 'react';
@@ -11,16 +11,16 @@ import { VerifiedOnlyToggle } from '@/components/VerifiedOnlyToggle';
 import { HashtagExplorer } from '@/components/HashtagExplorer';
 import { ClassicVinersRow } from '@/components/ClassicVinersRow';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Star, Clock, Hash, Flame, Sparkle as Sparkles } from '@phosphor-icons/react';
+import { Star, Hash, Flame, Sparkle as Sparkles } from '@phosphor-icons/react';
 // Zap temporarily unused - will be needed when Rising tab is re-enabled
 import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { useCategories } from '@/hooks/useCategories';
 import { getTranslatedCategoryLabel } from '@/lib/constants/categories';
 
 // All possible tab values (foryou only shown when logged in)
-type AllowedTab = 'foryou' | 'classics' | 'hot' | 'new' | 'hashtags';
-const ALL_TABS: AllowedTab[] = ['foryou', 'classics', 'hot', 'new', 'hashtags'];
-const BASE_TABS: AllowedTab[] = ['classics', 'hot', 'new', 'hashtags'];
+type AllowedTab = 'foryou' | 'classics' | 'hot' | 'hashtags';
+const ALL_TABS: AllowedTab[] = ['foryou', 'classics', 'hot', 'hashtags'];
+const BASE_TABS: AllowedTab[] = ['classics', 'hot', 'hashtags'];
 
 export function DiscoveryPage() {
   const navigate = useSubdomainNavigate();
@@ -122,7 +122,7 @@ export function DiscoveryPage() {
           }}
           className="space-y-6"
         >
-          <TabsList className={`w-full grid gap-1 ${isLoggedIn ? 'grid-cols-5' : 'grid-cols-4'}`}>
+          <TabsList className={`w-full grid gap-1 ${isLoggedIn ? 'grid-cols-4' : 'grid-cols-3'}`}>
             {isLoggedIn && (
               <TabsTrigger value="foryou" className="gap-1.5 sm:gap-2">
                 <Sparkles className="h-4 w-4" />
@@ -143,10 +143,6 @@ export function DiscoveryPage() {
               <span className="hidden sm:inline">Rising</span>
             </TabsTrigger>
             */}
-            <TabsTrigger value="new" className="gap-1.5 sm:gap-2">
-              <Clock className="h-4 w-4" />
-              <span className="hidden sm:inline">{t('discovery.new')}</span>
-            </TabsTrigger>
             <TabsTrigger value="hashtags" className="gap-1.5 sm:gap-2">
               <Hash className="h-4 w-4" />
               <span className="hidden sm:inline">{t('discovery.tags')}</span>
@@ -204,16 +200,6 @@ export function DiscoveryPage() {
             />
           </TabsContent>
           */}
-
-          <TabsContent value="new" className="mt-0 space-y-6">
-            <VideoFeed
-              feedType="recent"
-              verifiedOnly={verifiedOnly}
-              data-testid="video-feed-new"
-              className="space-y-6"
-              key="recent"
-            />
-          </TabsContent>
 
           <TabsContent value="hashtags" className="mt-0 space-y-6">
             <HashtagExplorer />


### PR DESCRIPTION
## Summary

- Remove the all-new videos tab and its recent-feed mount from Discovery.
- Redirect `/discovery/new` to `/discovery/hot` with history replacement.
- Add regression coverage and document the retired route.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- New videos do not yet have sufficient moderation coverage for an unfiltered discovery surface. Hot remains the supported destination.

## Related Issue

- N/A

## Testing

- [ ] `npm run test` — GitHub CI is the authoritative run; local execution was invalidated by host-wide CPU contention and unrelated fixed-timeout failures.
- [ ] Manual verification completed

## Visuals

- [ ] UI change with screenshots/video attached — no screenshot attached; the visible change is removal of the New tab.
- [ ] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved
