### PR TITLE
feat(profile): add public list discovery

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -62,6 +62,11 @@ subdomain and loading the corresponding Nostr profile. Static hosts use
 catch-all fallback.
 The retired `/discovery/new` chronological feed redirects to
 `/discovery/hot`; Discovery does not expose or mount an all-new-video feed.
+Public profiles expose a compact mixed NIP-51 list shelf and a filterable
+`/profile/:npub/lists` gallery. Kind `30005` video sets retain their
+owner-aware `/list/:pubkey/:listId` route; kind `30000` people sets use
+`/people-lists/:pubkey/:listId`, where member context appears above a primary
+video grid assembled from the listed pubkeys.
 
 ## Styling
 

--- a/docs/superpowers/plans/2026-07-26-profile-list-discovery.md
+++ b/docs/superpowers/plans/2026-07-26-profile-list-discovery.md
@@ -1,0 +1,440 @@
+# Profile List Discovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let anyone discover a profile's public people and video lists, open either list type, and browse people-list videos as the primary content.
+
+**Architecture:** Preserve NIP-51's separate addressable event kinds—kind `30000` follow sets and kind `30005` video sets—then merge them through a small discriminated presentation model. Public React Query hooks own relay access, pure parsers own event validation and addressable-event deduplication, and pages/components consume those hooks without requiring login.
+
+**Tech Stack:** React 18, TypeScript, React Router, TanStack Query, Nostrify, Vitest, React Testing Library, TailwindCSS, Phosphor Icons
+
+---
+
+### Task 1: Parse and query public people lists
+
+**Files:**
+- Create: `src/lib/parsePeopleListFromEvent.ts`
+- Create: `src/lib/parsePeopleListFromEvent.test.ts`
+- Create: `src/hooks/usePeopleLists.ts`
+- Create: `src/hooks/usePeopleLists.test.ts`
+
+- [ ] **Step 1: Write failing parser tests**
+
+Cover a valid kind `30000` event, title fallback to `d`, ordered/deduplicated full `p` tags, rejection of the reserved `d=block` set, rejection of the wrong kind, and newest-event-wins deduplication by the full `${pubkey}:30000:${d}` address.
+
+```ts
+expect(parsePeopleListFromEvent(event)).toMatchObject({
+  id: 'friends',
+  name: 'Friends',
+  pubkey: OWNER,
+  memberPubkeys: [ALICE, BOB],
+})
+expect(parsePeopleListFromEvent({ ...event, tags: [['d', 'block']] })).toBeNull()
+expect(deduplicatePeopleLists([older, newer])).toEqual([parsePeopleListFromEvent(newer)])
+```
+
+- [ ] **Step 2: Run the parser tests and verify RED**
+
+Run: `npx vitest run src/lib/parsePeopleListFromEvent.test.ts`
+
+Expected: FAIL because `parsePeopleListFromEvent.ts` does not exist.
+
+- [ ] **Step 3: Implement the pure parser and addressable dedupe**
+
+```ts
+export interface PeopleList {
+  id: string
+  name: string
+  description?: string
+  image?: string
+  pubkey: string
+  createdAt: number
+  memberPubkeys: string[]
+}
+
+export function peopleListAddress(list: PeopleList): string {
+  return `${list.pubkey}:30000:${list.id}`
+}
+
+export function parsePeopleListFromEvent(event: NostrEvent): PeopleList | null {
+  if (event.kind !== 30000) return null
+  const id = event.tags.find((tag) => tag[0] === 'd')?.[1]
+  if (!id || id === 'block') return null
+  const memberPubkeys = [...new Set(
+    event.tags.filter((tag) => tag[0] === 'p' && tag[1]).map((tag) => tag[1]),
+  )]
+  return {
+    id,
+    name: event.tags.find((tag) => tag[0] === 'title')?.[1] || id,
+    description: event.tags.find((tag) => tag[0] === 'description')?.[1],
+    image: event.tags.find((tag) => tag[0] === 'image')?.[1],
+    pubkey: event.pubkey,
+    createdAt: event.created_at,
+    memberPubkeys,
+  }
+}
+```
+
+Implement `deduplicatePeopleLists(events)` by parsing, sorting newest-first, and keeping the first full address. Never shorten a pubkey in storage or key construction.
+
+- [ ] **Step 4: Run the parser tests and verify GREEN**
+
+Run: `npx vitest run src/lib/parsePeopleListFromEvent.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Write failing hook tests**
+
+Mock `useNostr()` and assert `usePeopleLists(OWNER)` queries `{ kinds: [30000], authors: [OWNER], limit: 100 }`, removes `block`, and collapses relay duplicates. Assert `usePeopleList(OWNER, 'friends')` adds `'#d': ['friends']` and returns the newest exact event.
+
+- [ ] **Step 6: Run the hook tests and verify RED**
+
+Run: `npx vitest run src/hooks/usePeopleLists.test.ts`
+
+Expected: FAIL because the hooks do not exist.
+
+- [ ] **Step 7: Implement the public React Query hooks**
+
+```ts
+export function usePeopleLists(pubkey: string | undefined) {
+  const { nostr } = useNostr()
+  return useQuery({
+    queryKey: ['people-lists', pubkey],
+    queryFn: async ({ signal }) => deduplicatePeopleLists(await nostr.query([{
+      kinds: [30000],
+      authors: [pubkey!],
+      limit: 100,
+    }], { signal: AbortSignal.any([signal, AbortSignal.timeout(5000)]) })),
+    enabled: Boolean(pubkey),
+    staleTime: 60_000,
+    gcTime: 300_000,
+  })
+}
+```
+
+Add `usePeopleList(pubkey, listId)` with the same timeout, exact `#d` query, a limit of `10` so duplicate relay versions can be resolved, and newest-valid selection.
+
+- [ ] **Step 8: Run both focused test files and commit**
+
+Run: `npx vitest run src/lib/parsePeopleListFromEvent.test.ts src/hooks/usePeopleLists.test.ts`
+
+Expected: PASS.
+
+```bash
+git add src/lib/parsePeopleListFromEvent.ts src/lib/parsePeopleListFromEvent.test.ts src/hooks/usePeopleLists.ts src/hooks/usePeopleLists.test.ts
+git commit -m "feat: read public people lists"
+```
+
+### Task 2: Build the mixed list presentation model and cards
+
+**Files:**
+- Create: `src/lib/profileLists.ts`
+- Create: `src/lib/profileLists.test.ts`
+- Create: `src/components/ProfileListCard.tsx`
+- Create: `src/components/ProfileListCard.test.tsx`
+
+- [ ] **Step 1: Write failing adapter tests**
+
+Assert video lists map to `type: 'videos'`, people lists map to `type: 'people'`, the mixed result sorts newest-first, the stable key contains kind + complete owner pubkey + d-tag, and routes are owner-aware.
+
+```ts
+expect(toDiscoverablePeopleList(peopleList)).toMatchObject({
+  type: 'people',
+  itemCount: 2,
+  href: `/people-lists/${OWNER}/friends`,
+})
+expect(toDiscoverableVideoList(videoList).href).toBe(`/list/${OWNER}/favorites`)
+```
+
+- [ ] **Step 2: Run adapter tests and verify RED**
+
+Run: `npx vitest run src/lib/profileLists.test.ts`
+
+Expected: FAIL because `profileLists.ts` does not exist.
+
+- [ ] **Step 3: Implement a discriminated presentation model**
+
+```ts
+export interface DiscoverableList {
+  key: string
+  type: 'people' | 'videos'
+  id: string
+  name: string
+  description?: string
+  image?: string
+  ownerPubkey: string
+  createdAt: number
+  itemCount: number
+  href: string
+}
+
+export function mergeProfileLists(
+  peopleLists: PeopleList[],
+  videoLists: VideoList[],
+): DiscoverableList[] {
+  return [
+    ...peopleLists.map(toDiscoverablePeopleList),
+    ...videoLists.map(toDiscoverableVideoList),
+  ].sort((a, b) => b.createdAt - a.createdAt)
+}
+```
+
+- [ ] **Step 4: Run adapter tests and verify GREEN**
+
+Run: `npx vitest run src/lib/profileLists.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Write failing accessible card tests**
+
+Render one card of each type in `MemoryRouter`. Assert the whole card is a link, visible labels say `People list` or `Video list`, counts say `2 people` or `3 videos`, an absent image uses the type icon, and the href is the adapter's public route.
+
+- [ ] **Step 6: Implement the card**
+
+Use `Card variant="brand"` with Phosphor `UsersThree` and `VideoCamera`, visible type text, a square image/fallback, title, optional two-line description, and item count. Use no gradients, no all-caps class, and no truncated identifier.
+
+- [ ] **Step 7: Run focused tests and commit**
+
+Run: `npx vitest run src/lib/profileLists.test.ts src/components/ProfileListCard.test.tsx`
+
+Expected: PASS.
+
+```bash
+git add src/lib/profileLists.ts src/lib/profileLists.test.ts src/components/ProfileListCard.tsx src/components/ProfileListCard.test.tsx
+git commit -m "feat: present mixed profile lists"
+```
+
+### Task 3: Add the profile shelf and public all-lists gallery
+
+**Files:**
+- Create: `src/components/ProfileListsSection.tsx`
+- Create: `src/components/ProfileListsSection.test.tsx`
+- Create: `src/pages/ProfileListsPage.tsx`
+- Create: `src/pages/ProfileListsPage.test.tsx`
+- Modify: `src/pages/ProfilePage.tsx`
+
+- [ ] **Step 1: Write failing shelf tests**
+
+Mock both list hooks. Assert the shelf renders a skeleton during initial load, hides only after both sources finish empty, preserves one successful source when the other errors, shows the three newest mixed cards, and links `See all` to `/profile/${npub}/lists`.
+
+- [ ] **Step 2: Run the shelf tests and verify RED**
+
+Run: `npx vitest run src/components/ProfileListsSection.test.tsx`
+
+Expected: FAIL because the section does not exist.
+
+- [ ] **Step 3: Implement and place the shelf**
+
+```tsx
+const lists = mergeProfileLists(peopleLists ?? [], videoLists ?? [])
+if (!isLoading && lists.length === 0) return null
+return (
+  <section aria-labelledby="profile-lists-heading" className="space-y-4">
+    <div className="flex items-center justify-between">
+      <SectionHeader id="profile-lists-heading">Lists</SectionHeader>
+      <Link to={`/profile/${nip19.npubEncode(pubkey)}/lists`}>See all</Link>
+    </div>
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {lists.slice(0, 3).map((list) => <ProfileListCard key={list.key} list={list} />)}
+    </div>
+  </section>
+)
+```
+
+Insert `<ProfileListsSection pubkey={pubkey} />` after `PinnedVideosSection` and before the videos heading so videos remain the main profile body below the compact shelf.
+
+- [ ] **Step 4: Run the shelf tests and verify GREEN**
+
+Run: `npx vitest run src/components/ProfileListsSection.test.tsx`
+
+Expected: PASS.
+
+- [ ] **Step 5: Write failing public gallery tests**
+
+Mock the two hooks and render `/profile/:npub/lists`. Assert `All` is selected by default, `People` and `Videos` filters change the visible cards, loading and empty states are readable, and no auth state is required.
+
+- [ ] **Step 6: Implement the gallery page**
+
+Decode `npub` or accept a 64-character hex key, call both hooks, render the owner heading and mixed grid, and use `Tabs` with `All`, `People`, and `Videos`. Invalid identifiers show a factual not-found state without querying.
+
+- [ ] **Step 7: Run focused tests and commit**
+
+Run: `npx vitest run src/components/ProfileListsSection.test.tsx src/pages/ProfileListsPage.test.tsx`
+
+Expected: PASS.
+
+```bash
+git add src/components/ProfileListsSection.tsx src/components/ProfileListsSection.test.tsx src/pages/ProfileListsPage.tsx src/pages/ProfileListsPage.test.tsx src/pages/ProfilePage.tsx
+git commit -m "feat: surface lists on public profiles"
+```
+
+### Task 4: Query videos for people-list members
+
+**Files:**
+- Create: `src/lib/peopleListVideos.ts`
+- Create: `src/lib/peopleListVideos.test.ts`
+- Create: `src/hooks/usePeopleListVideos.ts`
+- Create: `src/hooks/usePeopleListVideos.test.ts`
+
+- [ ] **Step 1: Write failing query-helper tests**
+
+Assert `buildPeopleListVideoFilters` deduplicates member pubkeys, chunks authors into groups of at most `100`, uses `VIDEO_KINDS`, applies `limit: 60` and optional `until`, and returns no filters for an empty member list. Assert `mergePeopleListVideoEvents` deduplicates addressable videos by `${pubkey}:${kind}:${d}`, keeps the newest version, sorts newest-first, and caps at `60`.
+
+- [ ] **Step 2: Run helper tests and verify RED**
+
+Run: `npx vitest run src/lib/peopleListVideos.test.ts`
+
+Expected: FAIL because the helper does not exist.
+
+- [ ] **Step 3: Implement bounded filter construction and event merging**
+
+```ts
+export function buildPeopleListVideoFilters(pubkeys: string[], until?: number): NostrFilter[] {
+  return chunk([...new Set(pubkeys)], 100).map((authors) => ({
+    kinds: VIDEO_KINDS,
+    authors,
+    limit: 60,
+    ...(until ? { until } : {}),
+  }))
+}
+```
+
+Merge raw events before calling the existing pure `parseVideoEvents()` from `src/lib/videoParser.ts`; use the complete addressable coordinate and never an event-id prefix.
+
+- [ ] **Step 4: Run helper tests and verify GREEN**
+
+Run: `npx vitest run src/lib/peopleListVideos.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Write failing hook tests**
+
+Assert the hook sends the bounded filters, returns parsed recent videos, disables for an empty list, and exposes a next page whose `until` is one second older than the oldest raw event.
+
+- [ ] **Step 6: Implement the infinite hook**
+
+Use `useInfiniteQuery` keyed by the full sorted member set. Query all batch filters together with a ten-second combined abort signal, merge/dedupe/cap events, parse with `parseVideoEvents`, and return `{ videos, nextUntil }`. Set `getNextPageParam` to `nextUntil` only when the page has 60 raw merged events.
+
+- [ ] **Step 7: Run focused tests and commit**
+
+Run: `npx vitest run src/lib/peopleListVideos.test.ts src/hooks/usePeopleListVideos.test.ts`
+
+Expected: PASS.
+
+```bash
+git add src/lib/peopleListVideos.ts src/lib/peopleListVideos.test.ts src/hooks/usePeopleListVideos.ts src/hooks/usePeopleListVideos.test.ts
+git commit -m "feat: load people list videos"
+```
+
+### Task 5: Add the people-list detail page and public routes
+
+**Files:**
+- Create: `src/components/PeopleListMember.tsx`
+- Create: `src/components/PeopleListMembers.tsx`
+- Create: `src/pages/PeopleListDetailPage.tsx`
+- Create: `src/pages/PeopleListDetailPage.test.tsx`
+- Modify: `src/AppRouter.tsx`
+- Modify: `ARCHITECTURE.md`
+
+- [ ] **Step 1: Write failing detail-page tests**
+
+Mock `usePeopleList`, `usePeopleListVideos`, and author lookups. Assert the page renders the list title and description, a horizontal `People` region before the `Videos` heading, full profile links for members, a primary `VideoGrid`, a load-more action when another page exists, public loading/empty/not-found states, and no subscribe control.
+
+- [ ] **Step 2: Run the page tests and verify RED**
+
+Run: `npx vitest run src/pages/PeopleListDetailPage.test.tsx`
+
+Expected: FAIL because the detail page does not exist.
+
+- [ ] **Step 3: Implement member cells and carousel**
+
+Each `PeopleListMember` calls `useAuthor(pubkey)` and links to `/profile/${nip19.npubEncode(pubkey)}` with an avatar and display name. `PeopleListMembers` renders a labeled horizontal `overflow-x-auto` row and keeps source order.
+
+- [ ] **Step 4: Implement the video-primary detail page**
+
+Read owner and d-tag from `/people-lists/:pubkey/:listId`, fetch the exact kind `30000` list, render its owner/list metadata, then the people carousel, then a larger Videos section using flattened pages in `VideoGrid`. Empty member lists and member lists with no videos get distinct casual-direct copy.
+
+- [ ] **Step 5: Register both public discovery routes and document them**
+
+```tsx
+<Route path="/profile/:npub/lists" element={<ProfileListsPage />} />
+<Route path="/people-lists/:pubkey/:listId" element={<PeopleListDetailPage />} />
+```
+
+Keep both routes outside the `isLoggedIn` block. Update `ARCHITECTURE.md` to list the mixed profile shelf/gallery and the owner-aware people-list route beside existing list pages.
+
+- [ ] **Step 6: Run focused tests and commit**
+
+Run: `npx vitest run src/pages/PeopleListDetailPage.test.tsx src/pages/ProfileListsPage.test.tsx src/components/ProfileListsSection.test.tsx`
+
+Expected: PASS.
+
+```bash
+git add src/components/PeopleListMember.tsx src/components/PeopleListMembers.tsx src/pages/PeopleListDetailPage.tsx src/pages/PeopleListDetailPage.test.tsx src/AppRouter.tsx ARCHITECTURE.md
+git commit -m "feat: browse people lists and their videos"
+```
+
+### Task 6: Verify the discovery slice
+
+**Files:**
+- Modify only if verification exposes a feature regression.
+
+- [ ] **Step 1: Run all feature tests**
+
+Run:
+
+```bash
+npx vitest run \
+  src/lib/parsePeopleListFromEvent.test.ts \
+  src/hooks/usePeopleLists.test.ts \
+  src/lib/profileLists.test.ts \
+  src/components/ProfileListCard.test.tsx \
+  src/components/ProfileListsSection.test.tsx \
+  src/pages/ProfileListsPage.test.tsx \
+  src/lib/peopleListVideos.test.ts \
+  src/hooks/usePeopleListVideos.test.ts \
+  src/pages/PeopleListDetailPage.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run brand guardrails**
+
+Run:
+
+```bash
+npx vitest run \
+  tests/brand/no-uppercase-class.test.ts \
+  tests/brand/no-gradients.test.ts \
+  tests/brand/no-lucide-react.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run full project verification**
+
+Run: `npm run test`
+
+Expected: type-check, ESLint, all Vitest tests, and production build pass. If an unrelated baseline timeout recurs, rerun its file alone and record both results rather than hiding the failure.
+
+- [ ] **Step 4: Review identifiers, scope, and worktree**
+
+Run:
+
+```bash
+rg -n "slice\\(|substring\\(" src/lib/parsePeopleListFromEvent.ts src/lib/profileLists.ts src/lib/peopleListVideos.ts src/components/ProfileListCard.tsx src/components/PeopleListMember.tsx
+rg -n "Subscribe|subscribe|localStorage|SharedPreferences" src/components/ProfileListsSection.tsx src/pages/ProfileListsPage.tsx src/pages/PeopleListDetailPage.tsx
+git status --short
+git diff --check
+```
+
+Expected: no identifier truncation in storage/routes, no subscription persistence in this discovery-only slice, only intended files changed, and no whitespace errors.
+
+- [ ] **Step 5: Commit verification fixes, if any**
+
+```bash
+git add <only-the-files-corrected-during-verification>
+git commit -m "fix: polish profile list discovery"
+```
+
+Skip this commit when verification required no fixes.

--- a/docs/superpowers/specs/2026-07-26-profile-list-discovery-design.md
+++ b/docs/superpowers/specs/2026-07-26-profile-list-discovery-design.md
@@ -1,0 +1,346 @@
+# Profile List Discovery
+
+**Date:** 2026-07-26
+**Status:** Design approved; pending written-spec review
+**Initial client:** Divine Web
+**Scope:** Public discovery and navigation for a profile's NIP-51 people and
+video lists
+
+## Summary
+
+Profiles will show a compact, mixed shelf of their public lists immediately
+above the Videos section. Each card will state whether it is a People list or
+a Video list and show the corresponding member or video count. The shelf will
+show the three most recently updated lists and link to a public mixed gallery
+containing all lists for that profile.
+
+Video lists continue to use the existing kind `30005` implementation and
+canonical `/list/:pubkey/:listId` URLs. People lists use NIP-51 kind `30000`,
+with a separate parser and query layer matching Divine Mobile's existing
+domain boundary. A public people-list detail page will show member profiles in
+a horizontal carousel above a primary grid of recent videos from those
+members.
+
+Subscription and Home-feed integration are follow-up work. This slice does not
+show an inert Subscribe control or introduce temporary persistence.
+
+## Goals
+
+- Make a user's public curation visible from their profile.
+- Make list type obvious before navigation using text, not only color or icon.
+- Let anyone, including logged-out visitors, browse the profile's lists.
+- Preserve existing video-list links and behavior.
+- Match the proven Divine Mobile people-list experience: member videos are
+  primary, with the people themselves visible above them.
+- Establish discovery boundaries that can support live subscriptions later
+  without coupling this slice to unfinished persistence semantics.
+
+## Existing Behavior
+
+### Divine Web
+
+- `useVideoLists` queries kind `30005` video lists.
+- `/list/:pubkey/:listId` is the public video-list detail route.
+- `/lists` shows the signed-in user's lists, recent public video lists, and
+  video lists from followed users, but the route itself requires login.
+- Profile pages do not query or display lists.
+- Kind `30000` is currently used only for block-list filtering; there is no
+  general people-list parser or public people-list page.
+
+### Divine Mobile
+
+- Kind `30000` people lists and kind `30005` video lists have separate
+  repositories and models.
+- A combined provider composes both types only for presentation.
+- The people-list detail screen renders a member carousel over a primary video
+  grid.
+- Mobile recognizes Web's `/list/:pubkey/:listId` URL as the canonical public
+  video-list deep link.
+- Mobile excludes the reserved kind-`30000` `d=block` event from user-facing
+  people lists.
+
+The Web implementation will follow those established boundaries rather than
+replace both list domains with one persistence model.
+
+## Product Behavior
+
+### Profile shelf
+
+Profiles with at least one public list show a `Lists` section above `Videos`.
+The section contains:
+
+- the heading `Lists`;
+- a `See all N` link;
+- up to three list cards, ordered by newest list event first.
+
+The shelf mixes both list types. Every card includes:
+
+- list title;
+- the visible label `People` or `Videos`;
+- `N people` or `N videos`;
+- optional list artwork when present;
+- a type-appropriate Phosphor icon as a secondary cue.
+
+The shelf does not appear when both successful queries return no lists. While
+the queries are unresolved, the section uses a compact skeleton that reserves
+only the shelf's eventual height. It must not delay the profile header, pinned
+videos, or profile video feed.
+
+If only one list query succeeds, its results render normally. Failure of one
+list type does not hide or invalidate the other.
+
+### All-lists gallery
+
+`See all N` opens a public route scoped to the profile owner. The page:
+
+- keeps people and video lists in one collection;
+- labels every card by type;
+- defaults to newest first;
+- offers `All`, `People`, and `Videos` filters;
+- uses the same card vocabulary as the profile shelf;
+- supports loading, empty, partial-error, and retry states without requiring
+  login.
+
+The page shows the profile owner and provides a clear route back to the
+profile. Creating or editing lists remains outside this public gallery.
+
+### Video-list detail
+
+Video list cards continue to open the existing
+`/list/:pubkey/:listId` route and `ListDetailPage`. Existing public links,
+sharing behavior, ownership controls, collaboration controls, and video
+ordering remain unchanged.
+
+### People-list detail
+
+People list cards open a new public, owner-aware route:
+
+```text
+/people-lists/:pubkey/:listId
+```
+
+The page resolves the exact kind-`30000` address using the owner pubkey and
+`d` tag. Its primary content is a newest-first grid of recent videos authored
+by current list members. A horizontal member carousel sits above the video
+grid and shows avatars and names. Selecting a member opens that profile.
+
+The member carousel remains visible while browsing the grid and may collapse
+or scroll away using the same responsive principle as Divine Mobile. It is not
+a second tab that hides the videos. On narrow screens it scrolls horizontally;
+on desktop it fits as many members as space allows.
+
+List owners may receive editing controls in later work. Public discovery in
+this slice is read-only.
+
+## Protocol and Data Model
+
+### People lists
+
+Public people lists are NIP-51 kind `30000` addressable events:
+
+```json
+{
+  "kind": 30000,
+  "tags": [
+    ["d", "nostr-builders"],
+    ["title", "Nostr builders"],
+    ["description", "People making strange useful things"],
+    ["image", "https://example.com/list.webp"],
+    ["p", "<full-64-character-pubkey>"]
+  ],
+  "content": ""
+}
+```
+
+The parser requires a non-empty `d` tag. It:
+
+- prefers `title` and falls back to the `d` value;
+- reads optional `description` and `image`;
+- preserves the ordered, full-length values of valid public `p` tags;
+- ignores private encrypted content in this discovery slice;
+- rejects `d=block`;
+- rejects events of any other kind.
+
+### Video lists
+
+Existing kind-`30005` parsing remains the source of truth for video lists.
+Divine's existing addressable NIP-71 `a` tags continue to work. This feature
+must not rewrite list events or narrow existing support.
+
+### Address identity and deduplication
+
+Neither a `d` tag nor an event ID is sufficient list identity. The stable
+address is:
+
+```text
+kind:owner-pubkey:d-tag
+```
+
+Each query deduplicates relay results by that full address and keeps the event
+with the greatest `created_at`. The presentation adapter uses the same address
+as the React key and link identity. A person may therefore use the same `d`
+value for one people list and one video list without collision.
+
+## Client Architecture
+
+The implementation keeps protocol ownership separate:
+
+```text
+kind 30000 events -> parsePeopleListFromEvent -> usePeopleLists
+kind 30005 events -> parseVideoListFromEvent  -> useVideoLists
+                                      \        /
+                                       profile list presentation
+```
+
+The presentation layer maps both models into a small discriminated view model
+containing:
+
+- `type: 'people' | 'videos'`;
+- full address identity;
+- owner pubkey and `d` tag;
+- title, description, image, update timestamp, and item count;
+- type-specific destination.
+
+This view model is for rendering and navigation only. It does not become a new
+write model or replace either protocol parser.
+
+### Query flow
+
+On a profile:
+
+1. Resolve the profile pubkey using the existing route, NIP-05, override, or
+   subdomain path.
+2. Start kind-`30000` and kind-`30005` author queries in parallel.
+3. Parse and deduplicate each result independently.
+4. Merge the presentation records and sort by update time.
+5. Render the first three on the profile and make the full set available to
+   the all-lists gallery through React Query caches.
+
+On people-list detail:
+
+1. Query kind `30000` by owner and `#d`.
+2. Parse the newest valid event.
+3. Resolve member profiles in batches through existing profile-loading
+   infrastructure.
+4. Query recent supported video kinds in filters containing at most 100 member
+   pubkeys, with a maximum of 60 events returned per filter.
+5. Deduplicate addressable videos by `pubkey:kind:d-tag`, apply existing
+   block/moderation filtering, merge the batches, sort newest first, and retain
+   the newest 60 videos for the initial page.
+
+Pagination uses the oldest retained `created_at` as the next `until` boundary
+and repeats the same bounded batch process. It stops when every member batch
+returns fewer than 60 usable events.
+
+## Loading, Empty, and Error States
+
+- No public lists: omit the profile shelf.
+- One list type fails: show the successful type and a small retry affordance
+  only on the all-lists page.
+- Both list queries fail: omit an error card from the profile and show a
+  retryable factual error on the all-lists page.
+- Malformed or reserved events: exclude them without breaking sibling lists.
+- Empty people list: show its metadata and `Nobody here yet.`
+- People list with no available videos: show its member carousel and
+  `Nothing looping from this crew yet.`
+- Missing member metadata: use existing generated-name and avatar fallbacks.
+- Deleted, blocked, or unavailable videos: exclude them from the grid.
+- Logged-out viewer: all discovery and detail views remain readable; actions
+  that require login are not part of this slice.
+
+## Accessibility, Brand, and Responsive Behavior
+
+- Type is always written as `People` or `Videos`; icons and accent colors are
+  supplemental.
+- Cards are semantic links with descriptive accessible names.
+- Loading uses `aria-busy` and non-jarring skeletons.
+- Retry controls are keyboard reachable and announce the affected list type.
+- Member carousel controls support keyboard navigation and visible focus.
+- Cards and carousel entries preserve full Nostr identifiers internally and
+  use normal UI overflow handling rather than truncating source data.
+- User-facing copy follows Divine's casual-direct voice.
+- Icons come from `@phosphor-icons/react`.
+- The feature introduces no gradients, all-caps Tailwind classes, or
+  non-brand fonts.
+- The desktop shelf shows three cards. Narrow screens use a horizontally
+  scrollable shelf without shrinking tap targets below accessible sizes.
+
+## Testing
+
+### Pure parser and mapping tests
+
+- Decode valid kind-`30000` metadata and ordered full pubkeys.
+- Fall back from missing title to `d`.
+- Reject wrong kinds, missing `d`, and `d=block`.
+- Deduplicate by full address and retain the newest event.
+- Keep identical `d` values distinct across list kinds.
+- Merge and order presentation records correctly.
+
+### Hook tests
+
+- Query kind `30000` with the profile author.
+- Query kind `30005` through the existing hook without changing its filter.
+- Preserve successful results when the sibling query fails.
+- Resolve people-list detail by owner plus `d`.
+- Batch member-video queries and deduplicate addressable videos.
+- Apply existing blocked-content filtering.
+
+### Component and route tests
+
+- Render no shelf for a profile with no lists.
+- Render a mixed, visibly labeled shelf above Videos.
+- Limit the profile shelf to three cards and show the correct total.
+- Navigate Video cards through the unchanged video-list route.
+- Navigate People cards through the owner-aware people-list route.
+- Render the all-lists gallery and its type filters.
+- Render member carousel plus primary video grid on people-list detail.
+- Keep public browsing available when logged out.
+- Preserve the existing video-list deep-link regression coverage.
+- Exercise keyboard, accessible-name, loading, empty, partial-error, and retry
+  behavior.
+
+### Visual verification
+
+Playwright coverage will verify the profile shelf at desktop and mobile
+breakpoints and check that the new surfaces introduce no axe WCAG 2 A/AA
+violations.
+
+## Out of Scope
+
+- Creating, editing, or deleting people lists on Web.
+- Private NIP-44 list decryption.
+- Subscribing or unsubscribing.
+- Persisting subscribed list addresses.
+- Merging subscribed list content into Home.
+- Ranking public lists globally.
+- Changing Divine Mobile.
+- Replacing or migrating existing kind-`30005` events.
+
+## Subscription Follow-Up
+
+The intended later behavior is live subscription:
+
+- a subscribed people list supplies videos from its current members;
+- a subscribed video list supplies videos currently referenced by that list;
+- curator updates automatically affect the subscriber's available feed
+  sources.
+
+That work requires a separate design for portable persistence, full-address
+identity, refresh semantics, attribution, and Home-feed composition. Mobile's
+current local list-ID subscription cache demonstrates the product behavior but
+is not a cross-device protocol contract to copy unchanged.
+
+## Acceptance Criteria
+
+The discovery slice is complete when:
+
+1. A public profile with lists shows a mixed, clearly labeled shelf above
+   Videos.
+2. `See all` shows every successfully loaded public people and video list for
+   that profile.
+3. Existing video-list links behave exactly as before.
+4. A public people-list link resolves by full owner address and displays
+   member videos as primary content with the people carousel above.
+5. Partial failures do not break the profile or hide the successful list type.
+6. Logged-out visitors can browse every new discovery surface.
+7. Focused unit, component, route, visual, and accessibility checks pass.

--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -28,6 +28,8 @@ import { LegacyVineVideoPage } from "./pages/LegacyVineVideoPage";
 import { TagPage } from "./pages/TagPage";
 import ListsPage from "./pages/ListsPage";
 import ListDetailPage from "./pages/ListDetailPage";
+import ProfileListsPage from "./pages/ProfileListsPage";
+import PeopleListDetailPage from "./pages/PeopleListDetailPage";
 import ModerationSettingsPage from "./pages/ModerationSettingsPage";
 import LinkedAccountsSettingsPage from "./pages/LinkedAccountsSettingsPage";
 // import { NIP05ProfilePage } from "./pages/NIP05ProfilePage";
@@ -105,6 +107,7 @@ export function AppRouter() {
       <Route path="/category/:name" element={<CategoryPage />} />
       <Route path="/t/:tag" element={<TagPage />} />
       <Route path="/profile/:npub" element={<ProfilePage />} />
+      <Route path="/profile/:npub/lists" element={<ProfileListsPage />} />
       <Route path="/video/:id" element={<VideoPage />} />
       <Route path="/v/:legacyVineId" element={<LegacyVineVideoPage />} />
       <Route path="/search" element={<SearchPage />} />
@@ -112,6 +115,7 @@ export function AppRouter() {
       <Route path="/merch" element={<MerchPage />} />
       <Route path="/u/:userId" element={<UniversalUserPage />} />
       <Route path="/list/:pubkey/:listId" element={<ListDetailPage />} />
+      <Route path="/people-lists/:pubkey/:listId" element={<PeopleListDetailPage />} />
       <Route path="/event/:eventId" element={<EventPage />} />
       <Route path="/event/a/:kind/:pubkey/:identifier" element={<EventPage />} />
       <Route path="/:nip19" element={<NIP19Page />} />

--- a/src/components/PeopleListMember.tsx
+++ b/src/components/PeopleListMember.tsx
@@ -1,0 +1,27 @@
+// ABOUTME: Avatar link for one member of a public people list
+
+import { nip19 } from 'nostr-tools';
+import { Link } from 'react-router-dom';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { useAuthor } from '@/hooks/useAuthor';
+import { genUserName } from '@/lib/genUserName';
+import { getSafeProfileImage } from '@/lib/imageUtils';
+
+export function PeopleListMember({ pubkey }: { pubkey: string }) {
+  const author = useAuthor(pubkey);
+  const metadata = author.data?.metadata;
+  const name = metadata?.display_name || metadata?.name || genUserName(pubkey);
+
+  return (
+    <Link
+      to={`/profile/${nip19.npubEncode(pubkey)}`}
+      className="flex w-24 shrink-0 flex-col items-center gap-2 rounded-xl p-2 text-center hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    >
+      <Avatar size="lg">
+        <AvatarImage src={getSafeProfileImage(metadata?.picture)} alt="" />
+        <AvatarFallback>{name[0]?.toUpperCase()}</AvatarFallback>
+      </Avatar>
+      <span className="w-full truncate text-sm font-semibold">{name}</span>
+    </Link>
+  );
+}

--- a/src/components/PeopleListMember.tsx
+++ b/src/components/PeopleListMember.tsx
@@ -1,20 +1,23 @@
 // ABOUTME: Avatar link for one member of a public people list
 
-import { nip19 } from 'nostr-tools';
+import type { NostrMetadata } from '@nostrify/nostrify';
 import { Link } from 'react-router-dom';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
-import { useAuthor } from '@/hooks/useAuthor';
 import { genUserName } from '@/lib/genUserName';
 import { getSafeProfileImage } from '@/lib/imageUtils';
+import { buildProfileLinkPath } from '@/lib/profileLinks';
 
-export function PeopleListMember({ pubkey }: { pubkey: string }) {
-  const author = useAuthor(pubkey);
-  const metadata = author.data?.metadata;
+interface PeopleListMemberProps {
+  pubkey: string;
+  metadata?: NostrMetadata;
+}
+
+export function PeopleListMember({ pubkey, metadata }: PeopleListMemberProps) {
   const name = metadata?.display_name || metadata?.name || genUserName(pubkey);
 
   return (
     <Link
-      to={`/profile/${nip19.npubEncode(pubkey)}`}
+      to={buildProfileLinkPath({ pubkey })}
       className="flex w-24 shrink-0 flex-col items-center gap-2 rounded-xl p-2 text-center hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
     >
       <Avatar size="lg">

--- a/src/components/PeopleListMembers.tsx
+++ b/src/components/PeopleListMembers.tsx
@@ -2,8 +2,11 @@
 
 import { PeopleListMember } from '@/components/PeopleListMember';
 import { SectionHeader } from '@/components/brand/SectionHeader';
+import { useBatchedAuthors } from '@/hooks/useBatchedAuthors';
 
 export function PeopleListMembers({ pubkeys }: { pubkeys: string[] }) {
+  const { data: authors = {} } = useBatchedAuthors(pubkeys);
+
   return (
     <section aria-labelledby="people-list-members-heading" className="space-y-3">
       <div className="flex items-baseline justify-between gap-3">
@@ -14,7 +17,13 @@ export function PeopleListMembers({ pubkeys }: { pubkeys: string[] }) {
       </div>
       {pubkeys.length > 0 ? (
         <div className="-mx-2 flex gap-2 overflow-x-auto px-2 pb-3 scrollbar-hide">
-          {pubkeys.map((pubkey) => <PeopleListMember key={pubkey} pubkey={pubkey} />)}
+          {pubkeys.map((pubkey) => (
+            <PeopleListMember
+              key={pubkey}
+              pubkey={pubkey}
+              metadata={authors[pubkey]?.metadata}
+            />
+          ))}
         </div>
       ) : (
         <p className="rounded-2xl border border-dashed p-6 text-muted-foreground">

--- a/src/components/PeopleListMembers.tsx
+++ b/src/components/PeopleListMembers.tsx
@@ -1,0 +1,26 @@
+// ABOUTME: Horizontally scrollable member context for a public people list
+
+import { PeopleListMember } from '@/components/PeopleListMember';
+import { SectionHeader } from '@/components/brand/SectionHeader';
+
+export function PeopleListMembers({ pubkeys }: { pubkeys: string[] }) {
+  return (
+    <section aria-labelledby="people-list-members-heading" className="space-y-3">
+      <div className="flex items-baseline justify-between gap-3">
+        <SectionHeader id="people-list-members-heading" className="text-xl">People</SectionHeader>
+        <span className="text-sm text-muted-foreground">
+          {pubkeys.length} {pubkeys.length === 1 ? 'person' : 'people'}
+        </span>
+      </div>
+      {pubkeys.length > 0 ? (
+        <div className="-mx-2 flex gap-2 overflow-x-auto px-2 pb-3 scrollbar-hide">
+          {pubkeys.map((pubkey) => <PeopleListMember key={pubkey} pubkey={pubkey} />)}
+        </div>
+      ) : (
+        <p className="rounded-2xl border border-dashed p-6 text-muted-foreground">
+          Nobody&apos;s in this list yet.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/src/components/ProfileHeader.tsx
+++ b/src/components/ProfileHeader.tsx
@@ -324,7 +324,7 @@ export function ProfileHeader({
             </Link>
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <Button variant="outline" size="sm" data-testid="own-profile-menu-button">
+                <Button variant="outline" size="sm" aria-label="More profile actions" data-testid="own-profile-menu-button">
                   <MoreVertical className="h-4 w-4" />
                 </Button>
               </DropdownMenuTrigger>
@@ -368,7 +368,7 @@ export function ProfileHeader({
             )}
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <Button variant="outline" size="sm" data-testid="profile-menu-button">
+                <Button variant="outline" size="sm" aria-label="More profile actions" data-testid="profile-menu-button">
                   <MoreVertical className="h-4 w-4" />
                 </Button>
               </DropdownMenuTrigger>

--- a/src/components/ProfileListCard.test.tsx
+++ b/src/components/ProfileListCard.test.tsx
@@ -1,0 +1,49 @@
+// ABOUTME: Tests the labeled mixed-list card used on profiles
+
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+import type { DiscoverableList } from '@/lib/profileLists';
+import { ProfileListCard } from './ProfileListCard';
+
+const OWNER = 'a'.repeat(64);
+
+function renderCard(type: DiscoverableList['type']) {
+  const list: DiscoverableList = {
+    key: `${type}:${OWNER}:friends`,
+    type,
+    id: 'friends',
+    name: type === 'people' ? 'Friends' : 'Favorites',
+    description: 'A very good list',
+    ownerPubkey: OWNER,
+    createdAt: 10,
+    itemCount: type === 'people' ? 2 : 3,
+    href: type === 'people'
+      ? `/people-lists/${OWNER}/friends`
+      : `/list/${OWNER}/friends`,
+  };
+
+  render(<ProfileListCard list={list} />, { wrapper: MemoryRouter });
+}
+
+describe('ProfileListCard', () => {
+  it('labels and links a people list', () => {
+    renderCard('people');
+    expect(screen.getByText('People list')).toBeInTheDocument();
+    expect(screen.getByText('2 people')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Friends/ })).toHaveAttribute(
+      'href',
+      `/people-lists/${OWNER}/friends`,
+    );
+  });
+
+  it('labels and links a video list', () => {
+    renderCard('videos');
+    expect(screen.getByText('Video list')).toBeInTheDocument();
+    expect(screen.getByText('3 videos')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Favorites/ })).toHaveAttribute(
+      'href',
+      `/list/${OWNER}/friends`,
+    );
+  });
+});

--- a/src/components/ProfileListCard.tsx
+++ b/src/components/ProfileListCard.tsx
@@ -1,0 +1,49 @@
+// ABOUTME: Compact labeled card shared by profile people-list and video-list discovery
+
+import { UsersThree, VideoCamera } from '@phosphor-icons/react';
+import { Link } from 'react-router-dom';
+import type { DiscoverableList } from '@/lib/profileLists';
+import { Card } from '@/components/ui/card';
+
+interface ProfileListCardProps {
+  list: DiscoverableList;
+}
+
+export function ProfileListCard({ list }: ProfileListCardProps) {
+  const isPeopleList = list.type === 'people';
+  const TypeIcon = isPeopleList ? UsersThree : VideoCamera;
+  const typeLabel = isPeopleList ? 'People list' : 'Video list';
+  const itemLabel = isPeopleList
+    ? `${list.itemCount} ${list.itemCount === 1 ? 'person' : 'people'}`
+    : `${list.itemCount} ${list.itemCount === 1 ? 'video' : 'videos'}`;
+
+  return (
+    <Link to={list.href} className="block h-full rounded-[22px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+      <Card
+        variant="brand"
+        accent={isPeopleList ? 'green' : 'violet'}
+        className="h-full overflow-hidden transition-transform hover:-translate-y-0.5"
+      >
+        <div className="flex min-h-32">
+          <div className="flex w-28 shrink-0 items-center justify-center bg-brand-light-green/60 dark:bg-brand-dark-green/70">
+            {list.image ? (
+              <img src={list.image} alt="" className="h-full w-full object-cover" />
+            ) : (
+              <TypeIcon className="h-10 w-10 text-brand-dark-green dark:text-brand-green" aria-hidden="true" />
+            )}
+          </div>
+          <div className="min-w-0 p-4">
+            <p className="mb-1 text-xs font-semibold text-primary">{typeLabel}</p>
+            <h3 className="line-clamp-1 font-display text-lg font-extrabold text-brand-dark-green dark:text-brand-off-white">
+              {list.name}
+            </h3>
+            {list.description && (
+              <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">{list.description}</p>
+            )}
+            <p className="mt-3 text-sm font-medium text-foreground">{itemLabel}</p>
+          </div>
+        </div>
+      </Card>
+    </Link>
+  );
+}

--- a/src/components/ProfileListCard.tsx
+++ b/src/components/ProfileListCard.tsx
@@ -3,6 +3,7 @@
 import { UsersThree, VideoCamera } from '@phosphor-icons/react';
 import { Link } from 'react-router-dom';
 import type { DiscoverableList } from '@/lib/profileLists';
+import { getSafeProfileImage } from '@/lib/imageUtils';
 import { Card } from '@/components/ui/card';
 
 interface ProfileListCardProps {
@@ -16,6 +17,7 @@ export function ProfileListCard({ list }: ProfileListCardProps) {
   const itemLabel = isPeopleList
     ? `${list.itemCount} ${list.itemCount === 1 ? 'person' : 'people'}`
     : `${list.itemCount} ${list.itemCount === 1 ? 'video' : 'videos'}`;
+  const imageUrl = getSafeProfileImage(list.image);
 
   return (
     <Link to={list.href} className="block h-full rounded-[22px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
@@ -26,8 +28,8 @@ export function ProfileListCard({ list }: ProfileListCardProps) {
       >
         <div className="flex min-h-32">
           <div className="flex w-28 shrink-0 items-center justify-center bg-brand-light-green/60 dark:bg-brand-dark-green/70">
-            {list.image ? (
-              <img src={list.image} alt="" className="h-full w-full object-cover" />
+            {imageUrl ? (
+              <img src={imageUrl} alt="" className="h-full w-full object-cover" />
             ) : (
               <TypeIcon className="h-10 w-10 text-brand-dark-green dark:text-brand-green" aria-hidden="true" />
             )}

--- a/src/components/ProfileListsSection.test.tsx
+++ b/src/components/ProfileListsSection.test.tsx
@@ -1,0 +1,65 @@
+// ABOUTME: Tests the mixed list shelf displayed above profile videos
+
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { nip19 } from 'nostr-tools';
+import { ProfileListsSection } from './ProfileListsSection';
+
+const OWNER = 'a'.repeat(64);
+const mockUsePeopleLists = vi.fn();
+const mockUseVideoLists = vi.fn();
+
+vi.mock('@/hooks/usePeopleLists', () => ({
+  usePeopleLists: (...args: unknown[]) => mockUsePeopleLists(...args),
+}));
+vi.mock('@/hooks/useVideoLists', () => ({
+  useVideoLists: (...args: unknown[]) => mockUseVideoLists(...args),
+}));
+
+function listResult(data: unknown[] = [], isLoading = false, isError = false) {
+  return { data, isLoading, isError };
+}
+
+describe('ProfileListsSection', () => {
+  beforeEach(() => {
+    mockUsePeopleLists.mockReturnValue(listResult());
+    mockUseVideoLists.mockReturnValue(listResult());
+  });
+
+  it('shows a loading shelf while either initial query is pending', () => {
+    mockUsePeopleLists.mockReturnValue(listResult([], true));
+    const { container } = render(<ProfileListsSection pubkey={OWNER} />, { wrapper: MemoryRouter });
+    expect(container.querySelectorAll('[data-list-skeleton]')).toHaveLength(3);
+  });
+
+  it('hides after both sources finish empty', () => {
+    const { container } = render(<ProfileListsSection pubkey={OWNER} />, { wrapper: MemoryRouter });
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows the three newest mixed lists and preserves a successful partial result', () => {
+    mockUsePeopleLists.mockReturnValue(listResult([
+      { id: 'people-new', name: 'People new', pubkey: OWNER, createdAt: 40, memberPubkeys: [] },
+      { id: 'people-old', name: 'People old', pubkey: OWNER, createdAt: 10, memberPubkeys: [] },
+    ]));
+    mockUseVideoLists.mockReturnValue({
+      ...listResult([
+        { id: 'video-new', name: 'Video new', pubkey: OWNER, createdAt: 30, videoCoordinates: [], public: true },
+        { id: 'video-mid', name: 'Video mid', pubkey: OWNER, createdAt: 20, videoCoordinates: [], public: true },
+      ]),
+      isError: true,
+    });
+
+    render(<ProfileListsSection pubkey={OWNER} />, { wrapper: MemoryRouter });
+
+    expect(screen.getByText('People new')).toBeInTheDocument();
+    expect(screen.getByText('Video new')).toBeInTheDocument();
+    expect(screen.getByText('Video mid')).toBeInTheDocument();
+    expect(screen.queryByText('People old')).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'See all' })).toHaveAttribute(
+      'href',
+      `/profile/${nip19.npubEncode(OWNER)}/lists`,
+    );
+  });
+});

--- a/src/components/ProfileListsSection.test.tsx
+++ b/src/components/ProfileListsSection.test.tsx
@@ -31,6 +31,8 @@ describe('ProfileListsSection', () => {
     mockUsePeopleLists.mockReturnValue(listResult([], true));
     const { container } = render(<ProfileListsSection pubkey={OWNER} />, { wrapper: MemoryRouter });
     expect(container.querySelectorAll('[data-list-skeleton]')).toHaveLength(3);
+    expect(screen.queryByRole('heading', { name: 'Lists' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'See all' })).not.toBeInTheDocument();
   });
 
   it('hides after both sources finish empty', () => {

--- a/src/components/ProfileListsSection.tsx
+++ b/src/components/ProfileListsSection.tsx
@@ -15,6 +15,22 @@ export function ProfileListsSection({ pubkey }: { pubkey: string }) {
   const lists = mergeProfileLists(peopleQuery.data ?? [], videoQuery.data ?? []);
   const isLoading = peopleQuery.isLoading || videoQuery.isLoading;
 
+  if (isLoading && lists.length === 0) {
+    return (
+      <section aria-label="Loading lists">
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 3 }, (_, index) => (
+            <Skeleton
+              key={index}
+              data-list-skeleton
+              className="h-32 rounded-[22px]"
+            />
+          ))}
+        </div>
+      </section>
+    );
+  }
+
   if (!isLoading && lists.length === 0) return null;
 
   return (
@@ -29,17 +45,9 @@ export function ProfileListsSection({ pubkey }: { pubkey: string }) {
         </Link>
       </div>
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {isLoading && lists.length === 0
-          ? Array.from({ length: 3 }, (_, index) => (
-              <Skeleton
-                key={index}
-                data-list-skeleton
-                className="h-32 rounded-[22px]"
-              />
-            ))
-          : lists.slice(0, 3).map((list) => (
-              <ProfileListCard key={list.key} list={list} />
-            ))}
+        {lists.slice(0, 3).map((list) => (
+          <ProfileListCard key={list.key} list={list} />
+        ))}
       </div>
     </section>
   );

--- a/src/components/ProfileListsSection.tsx
+++ b/src/components/ProfileListsSection.tsx
@@ -1,0 +1,46 @@
+// ABOUTME: Mixed people-list and video-list discovery shelf for public profiles
+
+import { nip19 } from 'nostr-tools';
+import { Link } from 'react-router-dom';
+import { ProfileListCard } from '@/components/ProfileListCard';
+import { SectionHeader } from '@/components/brand/SectionHeader';
+import { Skeleton } from '@/components/ui/skeleton';
+import { usePeopleLists } from '@/hooks/usePeopleLists';
+import { useVideoLists } from '@/hooks/useVideoLists';
+import { mergeProfileLists } from '@/lib/profileLists';
+
+export function ProfileListsSection({ pubkey }: { pubkey: string }) {
+  const peopleQuery = usePeopleLists(pubkey);
+  const videoQuery = useVideoLists(pubkey);
+  const lists = mergeProfileLists(peopleQuery.data ?? [], videoQuery.data ?? []);
+  const isLoading = peopleQuery.isLoading || videoQuery.isLoading;
+
+  if (!isLoading && lists.length === 0) return null;
+
+  return (
+    <section aria-labelledby="profile-lists-heading" className="space-y-4">
+      <div className="flex items-center justify-between">
+        <SectionHeader id="profile-lists-heading" className="text-xl">Lists</SectionHeader>
+        <Link
+          to={`/profile/${nip19.npubEncode(pubkey)}/lists`}
+          className="text-sm font-semibold text-primary hover:underline"
+        >
+          See all
+        </Link>
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {isLoading && lists.length === 0
+          ? Array.from({ length: 3 }, (_, index) => (
+              <Skeleton
+                key={index}
+                data-list-skeleton
+                className="h-32 rounded-[22px]"
+              />
+            ))
+          : lists.slice(0, 3).map((list) => (
+              <ProfileListCard key={list.key} list={list} />
+            ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/VideoGrid.test.tsx
+++ b/src/components/VideoGrid.test.tsx
@@ -229,6 +229,23 @@ describe('VideoGrid native link navigation', () => {
     expect(href).toContain('index=0');
   });
 
+  it('preserves people-list navigation context in tile links', () => {
+    const owner = 'a'.repeat(64);
+    renderGrid(
+      <VideoGrid
+        videos={[makeVideo({ id: 'ctx-video' })]}
+        navigationContext={{ source: 'people-list', pubkey: owner, listId: 'friends' }}
+      />
+    );
+
+    const href = screen.getByRole('link').getAttribute('href') ?? '';
+    expect(href).toContain('/video/ctx-video');
+    expect(href).toContain('source=people-list');
+    expect(href).toContain(`pubkey=${owner}`);
+    expect(href).toContain('listId=friends');
+    expect(href).toContain('index=0');
+  });
+
   it('does not render a link for age-gated tiles', () => {
     renderGrid(
       <VideoGrid

--- a/src/hooks/usePeopleListVideos.test.ts
+++ b/src/hooks/usePeopleListVideos.test.ts
@@ -112,6 +112,26 @@ describe('usePeopleListVideos', () => {
     expect(secondFilters[0].until).toBe(999);
   });
 
+  it('continues from the oldest retained video when raw results exceed the page cap', async () => {
+    const rawPage = Array.from({ length: 120 }, (_, index) => (
+      videoEvent(ALICE, `video-${index}`, 1000 - index)
+    ));
+    mockNostrQuery.mockResolvedValueOnce(rawPage).mockResolvedValue([]);
+    const { usePeopleListVideos } = await import('./usePeopleListVideos');
+
+    const { result } = renderHook(() => usePeopleListVideos([ALICE]), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.pages[0].videos).toHaveLength(60);
+    expect(result.current.hasNextPage).toBe(true);
+
+    await result.current.fetchNextPage();
+    await waitFor(() => expect(mockNostrQuery).toHaveBeenCalledTimes(2));
+
+    const secondFilters = mockNostrQuery.mock.calls[1][0];
+    expect(secondFilters[0].until).toBe(940);
+  });
+
   it('stops paginating when the raw page comes back below the limit', async () => {
     mockNostrQuery.mockResolvedValue([
       videoEvent(ALICE, 'one', 200),

--- a/src/hooks/usePeopleListVideos.test.ts
+++ b/src/hooks/usePeopleListVideos.test.ts
@@ -4,11 +4,37 @@ import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { NostrEvent } from '@nostrify/nostrify';
 
 const mockNostrQuery = vi.fn();
 vi.mock('@nostrify/react', () => ({
   useNostr: () => ({ nostr: { query: mockNostrQuery } }),
 }));
+
+let mockBlocklist = new Set<string>();
+vi.mock('@/hooks/useFeedBlocklist', () => ({
+  useFeedBlocklist: () => mockBlocklist,
+}));
+
+const ALICE = 'b'.repeat(64);
+const BOB = 'c'.repeat(64);
+
+let fixtureCounter = 0;
+function videoEvent(pubkey: string, dTag: string, createdAt: number): NostrEvent {
+  fixtureCounter += 1;
+  return {
+    id: fixtureCounter.toString(16).padStart(64, '0'),
+    pubkey,
+    kind: 34236,
+    created_at: createdAt,
+    tags: [
+      ['d', dTag],
+      ['imeta', `url https://cdn.example.com/${dTag}.mp4`, 'm video/mp4'],
+    ],
+    content: '',
+    sig: 'f'.repeat(128),
+  };
+}
 
 function createWrapper() {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -20,6 +46,7 @@ function createWrapper() {
 describe('usePeopleListVideos', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockBlocklist = new Set();
     mockNostrQuery.mockResolvedValue([]);
   });
 
@@ -43,5 +70,58 @@ describe('usePeopleListVideos', () => {
 
     expect(result.current.fetchStatus).toBe('idle');
     expect(mockNostrQuery).not.toHaveBeenCalled();
+  });
+
+  it('hides videos from blocked or muted authors', async () => {
+    mockBlocklist = new Set([BOB]);
+    mockNostrQuery.mockResolvedValue([
+      videoEvent(ALICE, 'alice-loop', 200),
+      videoEvent(BOB, 'bob-loop', 100),
+    ]);
+    const { usePeopleListVideos } = await import('./usePeopleListVideos');
+
+    const { result } = renderHook(() => usePeopleListVideos([ALICE, BOB]), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const videos = result.current.data?.pages.flatMap((page) => page.videos) ?? [];
+    expect(videos).toHaveLength(1);
+    expect(videos[0].pubkey).toBe(ALICE);
+  });
+
+  it('keeps paginating when a full raw page dedupes below the page cap', async () => {
+    // 60 raw events that collapse to 2 addressable videos: dedupe must not
+    // be mistaken for the relay having no older events left.
+    const rawPage = [
+      ...Array.from({ length: 59 }, (_, index) => videoEvent(ALICE, 'dupe', 1000 + index)),
+      videoEvent(ALICE, 'unique', 1059),
+    ];
+    mockNostrQuery.mockResolvedValueOnce(rawPage).mockResolvedValue([]);
+    const { usePeopleListVideos } = await import('./usePeopleListVideos');
+
+    const { result } = renderHook(() => usePeopleListVideos([ALICE]), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.pages[0].videos).toHaveLength(2);
+    expect(result.current.hasNextPage).toBe(true);
+
+    await result.current.fetchNextPage();
+    await waitFor(() => expect(mockNostrQuery).toHaveBeenCalledTimes(2));
+
+    // Cursor derives from the oldest raw event, not the deduped page size.
+    const secondFilters = mockNostrQuery.mock.calls[1][0];
+    expect(secondFilters[0].until).toBe(999);
+  });
+
+  it('stops paginating when the raw page comes back below the limit', async () => {
+    mockNostrQuery.mockResolvedValue([
+      videoEvent(ALICE, 'one', 200),
+      videoEvent(ALICE, 'two', 100),
+    ]);
+    const { usePeopleListVideos } = await import('./usePeopleListVideos');
+
+    const { result } = renderHook(() => usePeopleListVideos([ALICE]), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.hasNextPage).toBe(false);
   });
 });

--- a/src/hooks/usePeopleListVideos.test.ts
+++ b/src/hooks/usePeopleListVideos.test.ts
@@ -1,0 +1,47 @@
+// ABOUTME: Tests paginated relay video queries for people-list members
+
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockNostrQuery = vi.fn();
+vi.mock('@nostrify/react', () => ({
+  useNostr: () => ({ nostr: { query: mockNostrQuery } }),
+}));
+
+function createWrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client }, children);
+  };
+}
+
+describe('usePeopleListVideos', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockNostrQuery.mockResolvedValue([]);
+  });
+
+  it('queries member authors in bounded batches', async () => {
+    const members = Array.from({ length: 101 }, (_, index) => index.toString(16).padStart(64, '0'));
+    const { usePeopleListVideos } = await import('./usePeopleListVideos');
+
+    const { result } = renderHook(() => usePeopleListVideos(members), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const filters = mockNostrQuery.mock.calls[0][0];
+    expect(filters).toHaveLength(2);
+    expect(filters[0].authors).toHaveLength(100);
+    expect(filters[1].authors).toHaveLength(1);
+    expect(filters.every((filter: { limit: number }) => filter.limit === 60)).toBe(true);
+  });
+
+  it('stays idle for an empty people list', async () => {
+    const { usePeopleListVideos } = await import('./usePeopleListVideos');
+    const { result } = renderHook(() => usePeopleListVideos([]), { wrapper: createWrapper() });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockNostrQuery).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/usePeopleListVideos.ts
+++ b/src/hooks/usePeopleListVideos.ts
@@ -1,0 +1,46 @@
+// ABOUTME: Paginated public video feed assembled from all members of a people list
+
+import { useNostr } from '@nostrify/react';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { parseVideoEvents } from '@/lib/videoParser';
+import {
+  buildPeopleListVideoFilters,
+  mergePeopleListVideoEvents,
+  PEOPLE_LIST_VIDEO_PAGE_SIZE,
+} from '@/lib/peopleListVideos';
+import type { ParsedVideoData } from '@/types/video';
+
+export interface PeopleListVideoPage {
+  videos: ParsedVideoData[];
+  nextUntil?: number;
+}
+
+export function usePeopleListVideos(memberPubkeys: string[]) {
+  const { nostr } = useNostr();
+  const stableMembers = Array.from(new Set(memberPubkeys)).sort();
+
+  return useInfiniteQuery({
+    queryKey: ['people-list-videos', stableMembers],
+    queryFn: async ({ pageParam, signal }): Promise<PeopleListVideoPage> => {
+      const until = pageParam as number | undefined;
+      const filters = buildPeopleListVideoFilters(stableMembers, until);
+      const events = await nostr.query(filters, {
+        signal: AbortSignal.any([signal, AbortSignal.timeout(10000)]),
+      });
+      const mergedEvents = mergePeopleListVideoEvents(events);
+      const nextUntil = mergedEvents.length === PEOPLE_LIST_VIDEO_PAGE_SIZE
+        ? mergedEvents[mergedEvents.length - 1].created_at - 1
+        : undefined;
+
+      return {
+        videos: parseVideoEvents(mergedEvents),
+        nextUntil,
+      };
+    },
+    initialPageParam: undefined as number | undefined,
+    getNextPageParam: (lastPage) => lastPage.nextUntil,
+    enabled: stableMembers.length > 0,
+    staleTime: 60_000,
+    gcTime: 300_000,
+  });
+}

--- a/src/hooks/usePeopleListVideos.ts
+++ b/src/hooks/usePeopleListVideos.ts
@@ -18,8 +18,25 @@ export interface PeopleListVideoPage {
   nextUntil?: number;
 }
 
-export function usePeopleListVideos(memberPubkeys: string[]) {
+interface UsePeopleListVideosOptions {
+  enabled?: boolean;
+}
+
+function getNextUntil(events: { created_at: number }[], mergedEvents: { created_at: number }[]): number | undefined {
+  if (mergedEvents.length >= PEOPLE_LIST_VIDEO_PAGE_SIZE) {
+    return mergedEvents[mergedEvents.length - 1].created_at - 1;
+  }
+
+  if (events.length >= PEOPLE_LIST_VIDEO_PAGE_SIZE && events.length > 0) {
+    return Math.min(...events.map((event) => event.created_at)) - 1;
+  }
+
+  return undefined;
+}
+
+export function usePeopleListVideos(memberPubkeys: string[], options: UsePeopleListVideosOptions = {}) {
   const { nostr } = useNostr();
+  const { enabled = true } = options;
   const stableMembers = Array.from(new Set(memberPubkeys)).sort();
 
   const query = useInfiniteQuery({
@@ -31,13 +48,7 @@ export function usePeopleListVideos(memberPubkeys: string[]) {
         signal: AbortSignal.any([signal, AbortSignal.timeout(10000)]),
       });
       const mergedEvents = mergePeopleListVideoEvents(events);
-      // Paginate whenever the raw result could have hit a per-filter limit,
-      // even if dedupe/trimming shrank the merged page below the cap. The
-      // cursor derives from the oldest raw event so discarded duplicates
-      // never make older videos unreachable.
-      const nextUntil = events.length >= PEOPLE_LIST_VIDEO_PAGE_SIZE
-        ? Math.min(...events.map((event) => event.created_at)) - 1
-        : undefined;
+      const nextUntil = getNextUntil(events, mergedEvents);
 
       return {
         videos: parseVideoEvents(mergedEvents),
@@ -46,7 +57,7 @@ export function usePeopleListVideos(memberPubkeys: string[]) {
     },
     initialPageParam: undefined as number | undefined,
     getNextPageParam: (lastPage) => lastPage.nextUntil,
-    enabled: stableMembers.length > 0,
+    enabled: enabled && stableMembers.length > 0,
     staleTime: 60_000,
     gcTime: 300_000,
   });

--- a/src/hooks/usePeopleListVideos.ts
+++ b/src/hooks/usePeopleListVideos.ts
@@ -1,5 +1,6 @@
 // ABOUTME: Paginated public video feed assembled from all members of a people list
 
+import { useMemo } from 'react';
 import { useNostr } from '@nostrify/react';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { parseVideoEvents } from '@/lib/videoParser';
@@ -8,6 +9,8 @@ import {
   mergePeopleListVideoEvents,
   PEOPLE_LIST_VIDEO_PAGE_SIZE,
 } from '@/lib/peopleListVideos';
+import { useFeedBlocklist } from '@/hooks/useFeedBlocklist';
+import { filterBlockedVideoPages } from '@/lib/blocklistFilter';
 import type { ParsedVideoData } from '@/types/video';
 
 export interface PeopleListVideoPage {
@@ -19,7 +22,7 @@ export function usePeopleListVideos(memberPubkeys: string[]) {
   const { nostr } = useNostr();
   const stableMembers = Array.from(new Set(memberPubkeys)).sort();
 
-  return useInfiniteQuery({
+  const query = useInfiniteQuery({
     queryKey: ['people-list-videos', stableMembers],
     queryFn: async ({ pageParam, signal }): Promise<PeopleListVideoPage> => {
       const until = pageParam as number | undefined;
@@ -28,8 +31,12 @@ export function usePeopleListVideos(memberPubkeys: string[]) {
         signal: AbortSignal.any([signal, AbortSignal.timeout(10000)]),
       });
       const mergedEvents = mergePeopleListVideoEvents(events);
-      const nextUntil = mergedEvents.length === PEOPLE_LIST_VIDEO_PAGE_SIZE
-        ? mergedEvents[mergedEvents.length - 1].created_at - 1
+      // Paginate whenever the raw result could have hit a per-filter limit,
+      // even if dedupe/trimming shrank the merged page below the cap. The
+      // cursor derives from the oldest raw event so discarded duplicates
+      // never make older videos unreachable.
+      const nextUntil = events.length >= PEOPLE_LIST_VIDEO_PAGE_SIZE
+        ? Math.min(...events.map((event) => event.created_at)) - 1
         : undefined;
 
       return {
@@ -43,4 +50,15 @@ export function usePeopleListVideos(memberPubkeys: string[]) {
     staleTime: 60_000,
     gcTime: 300_000,
   });
+
+  // Per-viewer block/mute filtering, matching useVideoProvider (divine-web#399).
+  // Deleted videos are excluded relay-side: relays honoring NIP-09 drop them
+  // from query results, same as the other WebSocket feeds.
+  const blockedPubkeys = useFeedBlocklist();
+  const data = useMemo(
+    () => filterBlockedVideoPages(query.data, blockedPubkeys),
+    [query.data, blockedPubkeys],
+  );
+
+  return { ...query, data };
 }

--- a/src/hooks/usePeopleLists.test.ts
+++ b/src/hooks/usePeopleLists.test.ts
@@ -1,0 +1,90 @@
+// ABOUTME: Tests for public people-list relay queries
+
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { NostrEvent } from '@nostrify/nostrify';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockNostrQuery = vi.fn();
+
+vi.mock('@nostrify/react', () => ({
+  useNostr: () => ({ nostr: { query: mockNostrQuery } }),
+}));
+
+const OWNER = 'a'.repeat(64);
+const MEMBER = 'b'.repeat(64);
+
+function peopleListEvent(overrides: Partial<NostrEvent> = {}): NostrEvent {
+  return {
+    id: 'c'.repeat(64),
+    pubkey: OWNER,
+    kind: 30000,
+    created_at: 100,
+    tags: [['d', 'friends'], ['title', 'Friends'], ['p', MEMBER]],
+    content: '',
+    sig: 'd'.repeat(128),
+    ...overrides,
+  };
+}
+
+function createWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client }, children);
+  };
+}
+
+describe('people list hooks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockNostrQuery.mockResolvedValue([]);
+  });
+
+  it('queries and deduplicates a profile’s public kind 30000 lists', async () => {
+    mockNostrQuery.mockResolvedValue([
+      peopleListEvent({ created_at: 10, tags: [['d', 'friends'], ['title', 'Old']] }),
+      peopleListEvent({ created_at: 20, tags: [['d', 'friends'], ['title', 'New']] }),
+      peopleListEvent({ created_at: 30, tags: [['d', 'block'], ['p', MEMBER]] }),
+    ]);
+    const { usePeopleLists } = await import('./usePeopleLists');
+
+    const { result } = renderHook(() => usePeopleLists(OWNER), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockNostrQuery).toHaveBeenCalledWith(
+      [{ kinds: [30000], authors: [OWNER], limit: 100 }],
+      { signal: expect.any(AbortSignal) },
+    );
+    expect(result.current.data?.map((list) => list.name)).toEqual(['New']);
+  });
+
+  it('does not query without an owner pubkey', async () => {
+    const { usePeopleLists } = await import('./usePeopleLists');
+    const { result } = renderHook(() => usePeopleLists(undefined), { wrapper: createWrapper() });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockNostrQuery).not.toHaveBeenCalled();
+  });
+
+  it('queries an exact owner-aware people list and keeps the newest version', async () => {
+    mockNostrQuery.mockResolvedValue([
+      peopleListEvent({ created_at: 10, tags: [['d', 'friends'], ['title', 'Old']] }),
+      peopleListEvent({ created_at: 20, tags: [['d', 'friends'], ['title', 'New']] }),
+    ]);
+    const { usePeopleList } = await import('./usePeopleLists');
+
+    const { result } = renderHook(() => usePeopleList(OWNER, 'friends'), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockNostrQuery).toHaveBeenCalledWith(
+      [{ kinds: [30000], authors: [OWNER], '#d': ['friends'], limit: 10 }],
+      { signal: expect.any(AbortSignal) },
+    );
+    expect(result.current.data?.name).toBe('New');
+  });
+});

--- a/src/hooks/usePeopleLists.ts
+++ b/src/hooks/usePeopleLists.ts
@@ -1,0 +1,52 @@
+// ABOUTME: Public relay queries for NIP-51 kind 30000 people lists
+
+import { useNostr } from '@nostrify/react';
+import { useQuery } from '@tanstack/react-query';
+import { deduplicatePeopleLists } from '@/lib/parsePeopleListFromEvent';
+
+const PEOPLE_LIST_KIND = 30000;
+
+export function usePeopleLists(pubkey: string | undefined) {
+  const { nostr } = useNostr();
+
+  return useQuery({
+    queryKey: ['people-lists', pubkey],
+    queryFn: async ({ signal }) => {
+      const events = await nostr.query([{
+        kinds: [PEOPLE_LIST_KIND],
+        authors: [pubkey!],
+        limit: 100,
+      }], {
+        signal: AbortSignal.any([signal, AbortSignal.timeout(5000)]),
+      });
+
+      return deduplicatePeopleLists(events);
+    },
+    enabled: Boolean(pubkey),
+    staleTime: 60_000,
+    gcTime: 300_000,
+  });
+}
+
+export function usePeopleList(pubkey: string | undefined, listId: string | undefined) {
+  const { nostr } = useNostr();
+
+  return useQuery({
+    queryKey: ['people-list', pubkey, listId],
+    queryFn: async ({ signal }) => {
+      const events = await nostr.query([{
+        kinds: [PEOPLE_LIST_KIND],
+        authors: [pubkey!],
+        '#d': [listId!],
+        limit: 10,
+      }], {
+        signal: AbortSignal.any([signal, AbortSignal.timeout(5000)]),
+      });
+
+      return deduplicatePeopleLists(events)[0] ?? null;
+    },
+    enabled: Boolean(pubkey && listId),
+    staleTime: 60_000,
+    gcTime: 300_000,
+  });
+}

--- a/src/hooks/useVideoLists.test.ts
+++ b/src/hooks/useVideoLists.test.ts
@@ -124,6 +124,19 @@ describe('useVideoLists hooks', () => {
       expect(lists.map((l) => l.id)).toEqual(['l2', 'my-list']);
     });
 
+    it('collapses duplicate relay versions of the same addressable list', async () => {
+      const { useVideoLists } = await import('./useVideoLists');
+      mockNostrQuery.mockResolvedValue([
+        listEvent({ created_at: 100, tags: [['d', 'same'], ['title', 'Old']] }),
+        listEvent({ created_at: 300, tags: [['d', 'same'], ['title', 'New']] }),
+      ]);
+
+      const { result } = renderHook(() => useVideoLists(TEST_PUBKEY), { wrapper: createWrapper() });
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(result.current.data?.map((list) => list.name)).toEqual(['New']);
+    });
+
     it('uses current user pubkey in filter when hook arg is omitted', async () => {
       const { useVideoLists } = await import('./useVideoLists');
       mockNostrQuery.mockResolvedValue([listEvent()]);

--- a/src/hooks/useVideoLists.test.ts
+++ b/src/hooks/useVideoLists.test.ts
@@ -170,7 +170,7 @@ describe('useVideoLists hooks', () => {
   });
 
   describe('useVideosInLists', () => {
-    it('uses #a filter and is disabled without videoId', async () => {
+    it('queries public video lists without unsupported wildcards and filters locally', async () => {
       const { useVideosInLists } = await import('./useVideoLists');
 
       const { result: disabled } = renderHook(() => useVideosInLists(undefined), {
@@ -178,7 +178,22 @@ describe('useVideoLists hooks', () => {
       });
       expect(disabled.current.fetchStatus).toBe('idle');
 
-      mockNostrQuery.mockResolvedValue([]);
+      mockNostrQuery.mockResolvedValue([
+        listEvent({
+          tags: [
+            ['d', 'matching'],
+            ['title', 'Matching'],
+            ['a', `34236:${'b'.repeat(64)}:my-dtag`],
+          ],
+        }),
+        listEvent({
+          tags: [
+            ['d', 'other'],
+            ['title', 'Other'],
+            ['a', `34236:${'b'.repeat(64)}:other-dtag`],
+          ],
+        }),
+      ]);
       const { result } = renderHook(() => useVideosInLists('my-dtag'), { wrapper: createWrapper() });
 
       await waitFor(() => expect(result.current.isFetched).toBe(true));
@@ -187,12 +202,13 @@ describe('useVideoLists hooks', () => {
         [
           expect.objectContaining({
             kinds: [30005],
-            '#a': [`${SHORT_VIDEO_KIND}:*:my-dtag`],
             limit: 100,
           }),
         ],
         expect.any(Object)
       );
+      expect(mockNostrQuery.mock.calls[0][0][0]).not.toHaveProperty('#a');
+      expect(result.current.data?.map((list) => list.id)).toEqual(['matching']);
     });
   });
 

--- a/src/hooks/useVideoLists.ts
+++ b/src/hooks/useVideoLists.ts
@@ -7,7 +7,7 @@ import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { useNostrPublish } from '@/hooks/useNostrPublish';
 import type { NostrEvent, NostrFilter } from '@nostrify/nostrify';
 import { SHORT_VIDEO_KIND } from '@/types/video';
-import { parseVideoListFromEvent, type PlayOrder, type VideoList } from '@/lib/parseVideoListFromEvent';
+import { deduplicateVideoLists, parseVideoListFromEvent, type PlayOrder, type VideoList } from '@/lib/parseVideoListFromEvent';
 import { resolveListPermissions } from '@/lib/listPermissions';
 
 export type { PlayOrder, VideoList };
@@ -133,10 +133,7 @@ export function useVideoLists(pubkey?: string) {
 
       console.log('[useVideoLists] Found', events.length, 'list events');
 
-      const lists = events
-        .map(parseVideoListFromEvent)
-        .filter((list): list is VideoList => list !== null)
-        .sort((a, b) => b.createdAt - a.createdAt);
+      const lists = deduplicateVideoLists(events);
 
       console.log('[useVideoLists] Parsed', lists.length, 'valid lists');
 
@@ -171,10 +168,7 @@ export function useVideosInLists(videoId?: string) {
         limit: 100
       }], { signal });
 
-      const lists = events
-        .map(parseVideoListFromEvent)
-        .filter((list): list is VideoList => list !== null)
-        .sort((a, b) => b.createdAt - a.createdAt);
+      const lists = deduplicateVideoLists(events);
 
       return lists;
     },
@@ -435,9 +429,8 @@ export function useTrendingVideoLists() {
         limit: 50
       }], { signal });
 
-      const lists = events
-        .map(parseVideoListFromEvent)
-        .filter((list): list is VideoList => list !== null && list.videoCoordinates.length > 0)
+      const lists = deduplicateVideoLists(events)
+        .filter((list) => list.videoCoordinates.length > 0)
         .sort((a, b) => {
           // Sort by number of videos and recency
           const scoreA = a.videoCoordinates.length * 10 + (a.createdAt / 1000);
@@ -521,9 +514,8 @@ export function useFollowedUsersLists(followedPubkeys: string[] | undefined) {
         limit: 100
       }], { signal });
 
-      const lists = events
-        .map(parseVideoListFromEvent)
-        .filter((list): list is VideoList => list !== null && list.videoCoordinates.length > 0)
+      const lists = deduplicateVideoLists(events)
+        .filter((list) => list.videoCoordinates.length > 0)
         .sort((a, b) => b.createdAt - a.createdAt);
 
       return lists;

--- a/src/hooks/useVideoLists.ts
+++ b/src/hooks/useVideoLists.ts
@@ -6,11 +6,23 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { useNostrPublish } from '@/hooks/useNostrPublish';
 import type { NostrEvent, NostrFilter } from '@nostrify/nostrify';
-import { SHORT_VIDEO_KIND } from '@/types/video';
+import { VIDEO_KINDS } from '@/types/video';
 import { deduplicateVideoLists, parseVideoListFromEvent, type PlayOrder, type VideoList } from '@/lib/parseVideoListFromEvent';
 import { resolveListPermissions } from '@/lib/listPermissions';
+import { debugLog } from '@/lib/debug';
 
 export type { PlayOrder, VideoList };
+
+function videoCoordinateMatchesId(coordinate: string, videoId: string): boolean {
+  const firstSeparator = coordinate.indexOf(':');
+  const secondSeparator = coordinate.indexOf(':', firstSeparator + 1);
+  if (firstSeparator < 0 || secondSeparator < 0) return false;
+
+  const kind = Number(coordinate.slice(0, firstSeparator));
+  const identifier = coordinate.slice(secondSeparator + 1);
+
+  return VIDEO_KINDS.includes(kind) && identifier === videoId;
+}
 
 function buildListTags(
   list: Pick<VideoList, 'id' | 'name' | 'description' | 'image' | 'tags' | 'isCollaborative' | 'allowedCollaborators' | 'thumbnailEventId' | 'playOrder'>,
@@ -127,15 +139,15 @@ export function useVideoLists(pubkey?: string) {
         filter.authors = [targetPubkey];
       }
 
-      console.log('[useVideoLists] Querying for lists with filter:', filter);
+      debugLog('[useVideoLists] Querying for lists with filter:', filter);
 
       const events = await nostr.query([filter], { signal });
 
-      console.log('[useVideoLists] Found', events.length, 'list events');
+      debugLog('[useVideoLists] Found', events.length, 'list events');
 
       const lists = deduplicateVideoLists(events);
 
-      console.log('[useVideoLists] Parsed', lists.length, 'valid lists');
+      debugLog('[useVideoLists] Parsed', lists.length, 'valid lists');
 
       return lists;
     },
@@ -161,14 +173,17 @@ export function useVideosInLists(videoId?: string) {
         AbortSignal.timeout(5000)
       ]);
 
-      // Query for lists that contain this video
+      // Relay tag filters require exact addressable coordinates, but this call
+      // only has the video's d tag. Query recent public lists and match locally.
       const events = await nostr.query([{
         kinds: [30005], // Video sets
-        '#a': [`${SHORT_VIDEO_KIND}:*:${videoId}`], // Search for any author with this d-tag
         limit: 100
       }], { signal });
 
-      const lists = deduplicateVideoLists(events);
+      const lists = deduplicateVideoLists(events)
+        .filter((list) => list.videoCoordinates.some((coordinate) => (
+          videoCoordinateMatchesId(coordinate, videoId)
+        )));
 
       return lists;
     },

--- a/src/hooks/useVideoNavigation.ts
+++ b/src/hooks/useVideoNavigation.ts
@@ -4,13 +4,18 @@
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import { useCallback, useMemo } from 'react';
 import { useVideoEvents } from './useVideoEvents';
+import { usePeopleList } from '@/hooks/usePeopleLists';
+import { usePeopleListVideos } from '@/hooks/usePeopleListVideos';
 import type { ParsedVideoData } from '@/types/video';
 import type { SortMode } from '@/types/nostr';
 
+type WebSocketFeedType = 'discovery' | 'home' | 'trending' | 'hashtag' | 'profile' | 'recent' | 'classics' | 'category';
+
 export interface VideoNavigationContext {
-  source: 'hashtag' | 'profile' | 'discovery' | 'home' | 'trending' | 'popular' | 'recent' | 'classics' | 'foryou' | 'category' | 'search';
+  source: 'hashtag' | 'profile' | 'discovery' | 'home' | 'trending' | 'popular' | 'recent' | 'classics' | 'foryou' | 'category' | 'search' | 'people-list';
   hashtag?: string;
   pubkey?: string;
+  listId?: string;
   query?: string;
   sortMode?: SortMode | 'relevance';
   currentIndex?: number;
@@ -45,21 +50,50 @@ export function useVideoNavigation(videoId: string, options: UseVideoNavigationO
       source,
       hashtag: searchParams.get('hashtag') || undefined,
       pubkey: searchParams.get('pubkey') || undefined,
+      listId: searchParams.get('listId') || undefined,
       query: searchParams.get('q') || undefined,
       sortMode: searchParams.get('sort') as VideoNavigationContext['sortMode'],
       currentIndex: searchParams.get('index') ? parseInt(searchParams.get('index')!) : undefined,
     };
   }, [searchParams]);
 
+  const isPeopleListContext = context?.source === 'people-list';
+  const peopleListQuery = usePeopleList(
+    isPeopleListContext ? context.pubkey : undefined,
+    isPeopleListContext ? context.listId : undefined,
+  );
+  const peopleListVideosQuery = usePeopleListVideos(
+    isPeopleListContext ? peopleListQuery.data?.memberPubkeys ?? [] : [],
+    { enabled: enabled && isPeopleListContext && Boolean(peopleListQuery.data) },
+  );
+  const peopleListVideos = useMemo(
+    () => peopleListVideosQuery.data?.pages.flatMap((page) => page.videos),
+    [peopleListVideosQuery.data],
+  );
+
   // Fetch videos based on context
   // Map 'foryou' to 'trending' for WebSocket fallback (foryou only works via Funnelcake API)
-  const feedTypeForWebSocket = context?.source === 'foryou' || context?.source === 'popular'
-    ? 'trending'
-    : context?.source === 'search'
-      ? 'discovery'
-      : context?.source;
-  const { data: videos, isLoading } = useVideoEvents(
-    context ? {
+  const feedTypeForWebSocket: WebSocketFeedType | undefined = (() => {
+    if (!context) return undefined;
+    if (isPeopleListContext) return 'discovery';
+    if (context.source === 'foryou' || context.source === 'popular') return 'trending';
+    if (context.source === 'search') return 'discovery';
+    if (
+      context.source === 'hashtag' ||
+      context.source === 'profile' ||
+      context.source === 'discovery' ||
+      context.source === 'home' ||
+      context.source === 'trending' ||
+      context.source === 'recent' ||
+      context.source === 'classics' ||
+      context.source === 'category'
+    ) {
+      return context.source;
+    }
+    return 'discovery';
+  })();
+  const { data: feedVideos, isLoading: feedVideosLoading } = useVideoEvents(
+    context && !isPeopleListContext ? {
       feedType: feedTypeForWebSocket,
       hashtag: context.hashtag,
       pubkey: context.pubkey,
@@ -69,9 +103,13 @@ export function useVideoNavigation(videoId: string, options: UseVideoNavigationO
       filter: { ids: [videoId] },
       limit: 1,
       feedType: 'discovery',
-      enabled,
+      enabled: enabled && !isPeopleListContext,
     }
   );
+  const videos = isPeopleListContext ? peopleListVideos : feedVideos;
+  const isLoading = isPeopleListContext
+    ? peopleListQuery.isLoading || peopleListVideosQuery.isLoading
+    : feedVideosLoading;
 
   // Find current video and its index
   const { currentVideo, currentIndex } = useMemo(() => {
@@ -98,6 +136,7 @@ export function useVideoNavigation(videoId: string, options: UseVideoNavigationO
 
     if (context.hashtag) params.set('hashtag', context.hashtag);
     if (context.pubkey) params.set('pubkey', context.pubkey);
+    if (context.listId) params.set('listId', context.listId);
     if (context.query) params.set('q', context.query);
     if (context.sortMode) params.set('sort', context.sortMode);
 
@@ -140,6 +179,7 @@ export function buildVideoNavigationUrl(
 
   if (context.hashtag) params.set('hashtag', context.hashtag);
   if (context.pubkey) params.set('pubkey', context.pubkey);
+  if (context.listId) params.set('listId', context.listId);
   if (context.query) params.set('q', context.query);
   if (context.sortMode) params.set('sort', context.sortMode);
   if (index !== undefined) params.set('index', index.toString());

--- a/src/lib/parsePeopleListFromEvent.test.ts
+++ b/src/lib/parsePeopleListFromEvent.test.ts
@@ -1,0 +1,77 @@
+// ABOUTME: Unit tests for parsing public NIP-51 kind 30000 people lists
+
+import { describe, expect, it } from 'vitest';
+import type { NostrEvent } from '@nostrify/nostrify';
+import {
+  deduplicatePeopleLists,
+  parsePeopleListFromEvent,
+  peopleListAddress,
+} from './parsePeopleListFromEvent';
+
+const OWNER = 'a'.repeat(64);
+const ALICE = 'b'.repeat(64);
+const BOB = 'c'.repeat(64);
+
+function peopleListEvent(overrides: Partial<NostrEvent> = {}): NostrEvent {
+  return {
+    id: 'd'.repeat(64),
+    pubkey: OWNER,
+    kind: 30000,
+    created_at: 100,
+    tags: [
+      ['d', 'friends'],
+      ['title', 'Friends'],
+      ['description', 'Good people'],
+      ['image', 'https://example.com/friends.jpg'],
+      ['p', ALICE],
+      ['p', BOB],
+      ['p', ALICE],
+    ],
+    content: '',
+    sig: 'e'.repeat(128),
+    ...overrides,
+  };
+}
+
+describe('parsePeopleListFromEvent', () => {
+  it('parses a public people list and preserves member order', () => {
+    expect(parsePeopleListFromEvent(peopleListEvent())).toEqual({
+      id: 'friends',
+      name: 'Friends',
+      description: 'Good people',
+      image: 'https://example.com/friends.jpg',
+      pubkey: OWNER,
+      createdAt: 100,
+      memberPubkeys: [ALICE, BOB],
+    });
+  });
+
+  it('falls back to the d tag for an unnamed list', () => {
+    const event = peopleListEvent({ tags: [['d', 'makers']] });
+    expect(parsePeopleListFromEvent(event)?.name).toBe('makers');
+  });
+
+  it('rejects missing d tags, the reserved block list, and other event kinds', () => {
+    expect(parsePeopleListFromEvent(peopleListEvent({ tags: [] }))).toBeNull();
+    expect(parsePeopleListFromEvent(peopleListEvent({ tags: [['d', 'block']] }))).toBeNull();
+    expect(parsePeopleListFromEvent(peopleListEvent({ kind: 30005 }))).toBeNull();
+  });
+
+  it('uses the complete addressable coordinate as its key', () => {
+    const list = parsePeopleListFromEvent(peopleListEvent());
+    expect(list && peopleListAddress(list)).toBe(`${OWNER}:30000:friends`);
+  });
+});
+
+describe('deduplicatePeopleLists', () => {
+  it('keeps the newest event for each owner and d tag', () => {
+    const older = peopleListEvent({ created_at: 10, tags: [['d', 'friends'], ['title', 'Old']] });
+    const newer = peopleListEvent({ created_at: 20, tags: [['d', 'friends'], ['title', 'New']] });
+    const other = peopleListEvent({ created_at: 15, tags: [['d', 'makers']] });
+
+    expect(deduplicatePeopleLists([older, other, newer]).map((list) => list.name)).toEqual([
+      'New',
+      'makers',
+    ]);
+  });
+});

--- a/src/lib/parsePeopleListFromEvent.ts
+++ b/src/lib/parsePeopleListFromEvent.ts
@@ -1,0 +1,57 @@
+// ABOUTME: Parses public NIP-51 kind 30000 follow sets into discoverable people lists
+
+import type { NostrEvent } from '@nostrify/nostrify';
+
+export interface PeopleList {
+  id: string;
+  name: string;
+  description?: string;
+  image?: string;
+  pubkey: string;
+  createdAt: number;
+  memberPubkeys: string[];
+}
+
+export function peopleListAddress(list: PeopleList): string {
+  return `${list.pubkey}:30000:${list.id}`;
+}
+
+export function parsePeopleListFromEvent(event: NostrEvent): PeopleList | null {
+  if (event.kind !== 30000) return null;
+
+  const id = event.tags.find((tag) => tag[0] === 'd')?.[1];
+  if (!id || id === 'block') return null;
+
+  const memberPubkeys = Array.from(new Set(
+    event.tags
+      .filter((tag) => tag[0] === 'p' && Boolean(tag[1]))
+      .map((tag) => tag[1]),
+  ));
+
+  return {
+    id,
+    name: event.tags.find((tag) => tag[0] === 'title')?.[1] || id,
+    description: event.tags.find((tag) => tag[0] === 'description')?.[1],
+    image: event.tags.find((tag) => tag[0] === 'image')?.[1],
+    pubkey: event.pubkey,
+    createdAt: event.created_at,
+    memberPubkeys,
+  };
+}
+
+export function deduplicatePeopleLists(events: NostrEvent[]): PeopleList[] {
+  const newestByAddress = new Map<string, PeopleList>();
+
+  events
+    .map(parsePeopleListFromEvent)
+    .filter((list): list is PeopleList => list !== null)
+    .sort((a, b) => b.createdAt - a.createdAt)
+    .forEach((list) => {
+      const address = peopleListAddress(list);
+      if (!newestByAddress.has(address)) {
+        newestByAddress.set(address, list);
+      }
+    });
+
+  return Array.from(newestByAddress.values());
+}

--- a/src/lib/parseVideoListFromEvent.test.ts
+++ b/src/lib/parseVideoListFromEvent.test.ts
@@ -3,7 +3,7 @@
 import { describe, it, expect } from 'vitest';
 import type { NostrEvent } from '@nostrify/nostrify';
 import { SHORT_VIDEO_KIND } from '@/types/video';
-import { parseVideoListFromEvent } from './parseVideoListFromEvent';
+import { deduplicateVideoLists, parseVideoListFromEvent } from './parseVideoListFromEvent';
 
 const OWNER = 'b'.repeat(64);
 const COORD = `${SHORT_VIDEO_KIND}:${OWNER}:my-video`;
@@ -141,5 +141,18 @@ describe('parseVideoListFromEvent', () => {
     const list = parseVideoListFromEvent(ev);
     expect(list?.description).toBe('About');
     expect(list?.image).toBe('https://example.com/cover.jpg');
+  });
+});
+
+describe('deduplicateVideoLists', () => {
+  it('keeps the newest version of a full owner and d-tag address', () => {
+    const older = baseEvent({ created_at: 10, tags: [['d', 'same'], ['title', 'Old']] });
+    const newer = baseEvent({ created_at: 30, tags: [['d', 'same'], ['title', 'New']] });
+    const other = baseEvent({ created_at: 20, tags: [['d', 'other']] });
+
+    expect(deduplicateVideoLists([older, other, newer]).map((list) => list.name)).toEqual([
+      'New',
+      'other',
+    ]);
   });
 });

--- a/src/lib/parseVideoListFromEvent.ts
+++ b/src/lib/parseVideoListFromEvent.ts
@@ -21,6 +21,10 @@ export interface VideoList {
   playOrder?: PlayOrder;
 }
 
+export function videoListAddress(list: VideoList): string {
+  return `${list.pubkey}:30005:${list.id}`;
+}
+
 /**
  * Parse a video list event (kind 30005) into a VideoList, or null if invalid.
  * Uses {@link VIDEO_KINDS} for `a` tag coordinates so supported kinds stay in one place.
@@ -81,4 +85,21 @@ export function parseVideoListFromEvent(event: NostrEvent): VideoList | null {
     thumbnailEventId,
     playOrder,
   };
+}
+
+export function deduplicateVideoLists(events: NostrEvent[]): VideoList[] {
+  const newestByAddress = new Map<string, VideoList>();
+
+  events
+    .map(parseVideoListFromEvent)
+    .filter((list): list is VideoList => list !== null)
+    .sort((a, b) => b.createdAt - a.createdAt)
+    .forEach((list) => {
+      const address = videoListAddress(list);
+      if (!newestByAddress.has(address)) {
+        newestByAddress.set(address, list);
+      }
+    });
+
+  return Array.from(newestByAddress.values());
 }

--- a/src/lib/peopleListVideos.test.ts
+++ b/src/lib/peopleListVideos.test.ts
@@ -1,0 +1,63 @@
+// ABOUTME: Tests bounded relay filters and addressable dedupe for people-list videos
+
+import { describe, expect, it } from 'vitest';
+import type { NostrEvent } from '@nostrify/nostrify';
+import { VIDEO_KINDS } from '@/types/video';
+import {
+  buildPeopleListVideoFilters,
+  mergePeopleListVideoEvents,
+} from './peopleListVideos';
+
+const OWNER = 'a'.repeat(64);
+
+function videoEvent(dTag: string, createdAt: number): NostrEvent {
+  return {
+    id: `${createdAt}`.padStart(64, '0'),
+    pubkey: OWNER,
+    kind: VIDEO_KINDS[0],
+    created_at: createdAt,
+    tags: [['d', dTag]],
+    content: '',
+    sig: 'f'.repeat(128),
+  };
+}
+
+describe('buildPeopleListVideoFilters', () => {
+  it('deduplicates and chunks authors at the relay-safe maximum', () => {
+    const pubkeys = Array.from({ length: 101 }, (_, index) => index.toString(16).padStart(64, '0'));
+    const filters = buildPeopleListVideoFilters([...pubkeys, pubkeys[0]], 999);
+
+    expect(filters).toHaveLength(2);
+    expect(filters[0]).toEqual({
+      kinds: VIDEO_KINDS,
+      authors: pubkeys.slice(0, 100),
+      limit: 60,
+      until: 999,
+    });
+    expect(filters[1].authors).toEqual([pubkeys[100]]);
+  });
+
+  it('returns no filters when the list has no people', () => {
+    expect(buildPeopleListVideoFilters([])).toEqual([]);
+  });
+});
+
+describe('mergePeopleListVideoEvents', () => {
+  it('keeps the newest addressable version and sorts recent videos first', () => {
+    const merged = mergePeopleListVideoEvents([
+      videoEvent('same', 10),
+      videoEvent('other', 20),
+      videoEvent('same', 30),
+    ]);
+
+    expect(merged.map((event) => [event.tags[0][1], event.created_at])).toEqual([
+      ['same', 30],
+      ['other', 20],
+    ]);
+  });
+
+  it('caps a merged page at 60 videos', () => {
+    const events = Array.from({ length: 70 }, (_, index) => videoEvent(`video-${index}`, index));
+    expect(mergePeopleListVideoEvents(events)).toHaveLength(60);
+  });
+});

--- a/src/lib/peopleListVideos.ts
+++ b/src/lib/peopleListVideos.ts
@@ -1,0 +1,45 @@
+// ABOUTME: Builds bounded Nostr filters and merges videos for people-list feeds
+
+import type { NostrEvent, NostrFilter } from '@nostrify/nostrify';
+import { VIDEO_KINDS } from '@/types/video';
+
+const AUTHORS_PER_FILTER = 100;
+export const PEOPLE_LIST_VIDEO_PAGE_SIZE = 60;
+
+export function buildPeopleListVideoFilters(
+  pubkeys: string[],
+  until?: number,
+): NostrFilter[] {
+  const uniquePubkeys = Array.from(new Set(pubkeys));
+  const filters: NostrFilter[] = [];
+
+  for (let index = 0; index < uniquePubkeys.length; index += AUTHORS_PER_FILTER) {
+    filters.push({
+      kinds: VIDEO_KINDS,
+      authors: uniquePubkeys.slice(index, index + AUTHORS_PER_FILTER),
+      limit: PEOPLE_LIST_VIDEO_PAGE_SIZE,
+      ...(until !== undefined ? { until } : {}),
+    });
+  }
+
+  return filters;
+}
+
+export function mergePeopleListVideoEvents(events: NostrEvent[]): NostrEvent[] {
+  const newestByAddress = new Map<string, NostrEvent>();
+
+  events
+    .filter((event) => VIDEO_KINDS.includes(event.kind))
+    .sort((a, b) => b.created_at - a.created_at)
+    .forEach((event) => {
+      const dTag = event.tags.find((tag) => tag[0] === 'd')?.[1];
+      if (!dTag) return;
+
+      const address = `${event.pubkey}:${event.kind}:${dTag}`;
+      if (!newestByAddress.has(address)) {
+        newestByAddress.set(address, event);
+      }
+    });
+
+  return Array.from(newestByAddress.values()).slice(0, PEOPLE_LIST_VIDEO_PAGE_SIZE);
+}

--- a/src/lib/profileLists.test.ts
+++ b/src/lib/profileLists.test.ts
@@ -1,0 +1,56 @@
+// ABOUTME: Tests for merging people and video lists into one profile presentation model
+
+import { describe, expect, it } from 'vitest';
+import type { PeopleList } from './parsePeopleListFromEvent';
+import type { VideoList } from './parseVideoListFromEvent';
+import {
+  mergeProfileLists,
+  toDiscoverablePeopleList,
+  toDiscoverableVideoList,
+} from './profileLists';
+
+const OWNER = 'a'.repeat(64);
+
+const peopleList: PeopleList = {
+  id: 'friends',
+  name: 'Friends',
+  pubkey: OWNER,
+  createdAt: 20,
+  memberPubkeys: ['b'.repeat(64), 'c'.repeat(64)],
+};
+
+const videoList: VideoList = {
+  id: 'favorites',
+  name: 'Favorites',
+  pubkey: OWNER,
+  createdAt: 10,
+  videoCoordinates: ['34236:owner:one'],
+  public: true,
+};
+
+describe('profile list presentation', () => {
+  it('maps people lists to an owner-aware public route', () => {
+    expect(toDiscoverablePeopleList(peopleList)).toMatchObject({
+      key: `30000:${OWNER}:friends`,
+      type: 'people',
+      itemCount: 2,
+      href: `/people-lists/${OWNER}/friends`,
+    });
+  });
+
+  it('maps video lists to the existing public route', () => {
+    expect(toDiscoverableVideoList(videoList)).toMatchObject({
+      key: `30005:${OWNER}:favorites`,
+      type: 'videos',
+      itemCount: 1,
+      href: `/list/${OWNER}/favorites`,
+    });
+  });
+
+  it('merges both kinds newest-first', () => {
+    expect(mergeProfileLists([peopleList], [videoList]).map((list) => list.type)).toEqual([
+      'people',
+      'videos',
+    ]);
+  });
+});

--- a/src/lib/profileLists.ts
+++ b/src/lib/profileLists.ts
@@ -1,0 +1,57 @@
+// ABOUTME: Merges NIP-51 people and video lists into one labeled profile model
+
+import type { PeopleList } from '@/lib/parsePeopleListFromEvent';
+import type { VideoList } from '@/lib/parseVideoListFromEvent';
+
+export interface DiscoverableList {
+  key: string;
+  type: 'people' | 'videos';
+  id: string;
+  name: string;
+  description?: string;
+  image?: string;
+  ownerPubkey: string;
+  createdAt: number;
+  itemCount: number;
+  href: string;
+}
+
+export function toDiscoverablePeopleList(list: PeopleList): DiscoverableList {
+  return {
+    key: `30000:${list.pubkey}:${list.id}`,
+    type: 'people',
+    id: list.id,
+    name: list.name,
+    description: list.description,
+    image: list.image,
+    ownerPubkey: list.pubkey,
+    createdAt: list.createdAt,
+    itemCount: list.memberPubkeys.length,
+    href: `/people-lists/${list.pubkey}/${encodeURIComponent(list.id)}`,
+  };
+}
+
+export function toDiscoverableVideoList(list: VideoList): DiscoverableList {
+  return {
+    key: `30005:${list.pubkey}:${list.id}`,
+    type: 'videos',
+    id: list.id,
+    name: list.name,
+    description: list.description,
+    image: list.image,
+    ownerPubkey: list.pubkey,
+    createdAt: list.createdAt,
+    itemCount: list.videoCoordinates.length,
+    href: `/list/${list.pubkey}/${encodeURIComponent(list.id)}`,
+  };
+}
+
+export function mergeProfileLists(
+  peopleLists: PeopleList[],
+  videoLists: VideoList[],
+): DiscoverableList[] {
+  return [
+    ...peopleLists.map(toDiscoverablePeopleList),
+    ...videoLists.map(toDiscoverableVideoList),
+  ].sort((a, b) => b.createdAt - a.createdAt);
+}

--- a/src/pages/PeopleListDetailPage.test.tsx
+++ b/src/pages/PeopleListDetailPage.test.tsx
@@ -1,0 +1,95 @@
+// ABOUTME: Tests public people-list detail with people context and a video-primary feed
+
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { nip19 } from 'nostr-tools';
+import PeopleListDetailPage from './PeopleListDetailPage';
+
+const OWNER = 'a'.repeat(64);
+const ALICE = 'b'.repeat(64);
+const BOB = 'c'.repeat(64);
+const mockUsePeopleList = vi.fn();
+const mockUsePeopleListVideos = vi.fn();
+
+vi.mock('@/hooks/usePeopleLists', () => ({
+  usePeopleList: (...args: unknown[]) => mockUsePeopleList(...args),
+}));
+vi.mock('@/hooks/usePeopleListVideos', () => ({
+  usePeopleListVideos: (...args: unknown[]) => mockUsePeopleListVideos(...args),
+}));
+vi.mock('@/hooks/useAuthor', () => ({
+  useAuthor: (pubkey: string) => ({
+    data: { metadata: { name: pubkey === ALICE ? 'Alice' : 'Bob' } },
+  }),
+}));
+vi.mock('@/components/VideoGrid', () => ({
+  VideoGrid: ({ videos }: { videos: unknown[] }) => <div data-testid="video-grid">{videos.length} videos</div>,
+}));
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={[`/people-lists/${OWNER}/friends`]}>
+      <Routes>
+        <Route path="/people-lists/:pubkey/:listId" element={<PeopleListDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('PeopleListDetailPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUsePeopleList.mockReturnValue({
+      data: {
+        id: 'friends',
+        name: 'Friends',
+        description: 'Good people making good loops.',
+        pubkey: OWNER,
+        createdAt: 10,
+        memberPubkeys: [ALICE, BOB],
+      },
+      isLoading: false,
+      isError: false,
+      isFetched: true,
+    });
+    mockUsePeopleListVideos.mockReturnValue({
+      data: { pages: [{ videos: [{ id: 'video-1' }] }] },
+      isLoading: false,
+      hasNextPage: false,
+      fetchNextPage: vi.fn(),
+      isFetchingNextPage: false,
+    });
+  });
+
+  it('shows people before the primary videos section with full member links', () => {
+    renderPage();
+
+    expect(screen.getByRole('heading', { name: 'Friends' })).toBeInTheDocument();
+    expect(screen.getByText('Good people making good loops.')).toBeInTheDocument();
+    const peopleHeading = screen.getByRole('heading', { name: 'People' });
+    const videosHeading = screen.getByRole('heading', { name: 'Videos' });
+    expect(peopleHeading.compareDocumentPosition(videosHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(screen.getByRole('link', { name: /Alice/ })).toHaveAttribute(
+      'href',
+      `/profile/${nip19.npubEncode(ALICE)}`,
+    );
+    expect(screen.getByRole('link', { name: /Bob/ })).toHaveAttribute(
+      'href',
+      `/profile/${nip19.npubEncode(BOB)}`,
+    );
+    expect(screen.getByTestId('video-grid')).toHaveTextContent('1 videos');
+    expect(screen.queryByRole('button', { name: /subscribe/i })).not.toBeInTheDocument();
+  });
+
+  it('shows a not-found state when the exact list is absent', () => {
+    mockUsePeopleList.mockReturnValue({
+      data: null,
+      isLoading: false,
+      isError: false,
+      isFetched: true,
+    });
+    renderPage();
+    expect(screen.getByText('That people list could not be found.')).toBeInTheDocument();
+  });
+});

--- a/src/pages/PeopleListDetailPage.test.tsx
+++ b/src/pages/PeopleListDetailPage.test.tsx
@@ -1,6 +1,6 @@
 // ABOUTME: Tests public people-list detail with people context and a video-primary feed
 
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { nip19 } from 'nostr-tools';
@@ -18,13 +18,20 @@ vi.mock('@/hooks/usePeopleLists', () => ({
 vi.mock('@/hooks/usePeopleListVideos', () => ({
   usePeopleListVideos: (...args: unknown[]) => mockUsePeopleListVideos(...args),
 }));
-vi.mock('@/hooks/useAuthor', () => ({
-  useAuthor: (pubkey: string) => ({
-    data: { metadata: { name: pubkey === ALICE ? 'Alice' : 'Bob' } },
+vi.mock('@/hooks/useBatchedAuthors', () => ({
+  useBatchedAuthors: () => ({
+    data: {
+      [ALICE]: { metadata: { name: 'Alice' } },
+      [BOB]: { metadata: { name: 'Bob' } },
+    },
   }),
 }));
 vi.mock('@/components/VideoGrid', () => ({
-  VideoGrid: ({ videos }: { videos: unknown[] }) => <div data-testid="video-grid">{videos.length} videos</div>,
+  VideoGrid: ({ videos, navigationContext }: { videos: unknown[]; navigationContext?: unknown }) => (
+    <div data-testid="video-grid" data-navigation-context={JSON.stringify(navigationContext)}>
+      {videos.length} videos
+    </div>
+  ),
 }));
 
 function renderPage() {
@@ -56,8 +63,10 @@ describe('PeopleListDetailPage', () => {
     mockUsePeopleListVideos.mockReturnValue({
       data: { pages: [{ videos: [{ id: 'video-1' }] }] },
       isLoading: false,
+      isError: false,
       hasNextPage: false,
       fetchNextPage: vi.fn(),
+      refetch: vi.fn(),
       isFetchingNextPage: false,
     });
   });
@@ -72,13 +81,17 @@ describe('PeopleListDetailPage', () => {
     expect(peopleHeading.compareDocumentPosition(videosHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(screen.getByRole('link', { name: /Alice/ })).toHaveAttribute(
       'href',
-      `/profile/${nip19.npubEncode(ALICE)}`,
+      `/${nip19.npubEncode(ALICE)}`,
     );
     expect(screen.getByRole('link', { name: /Bob/ })).toHaveAttribute(
       'href',
-      `/profile/${nip19.npubEncode(BOB)}`,
+      `/${nip19.npubEncode(BOB)}`,
     );
     expect(screen.getByTestId('video-grid')).toHaveTextContent('1 videos');
+    expect(screen.getByTestId('video-grid')).toHaveAttribute(
+      'data-navigation-context',
+      JSON.stringify({ source: 'people-list', pubkey: OWNER, listId: 'friends' }),
+    );
     expect(screen.queryByRole('button', { name: /subscribe/i })).not.toBeInTheDocument();
   }, 10_000);
 
@@ -91,5 +104,24 @@ describe('PeopleListDetailPage', () => {
     });
     renderPage();
     expect(screen.getByText('That people list could not be found.')).toBeInTheDocument();
+  });
+
+  it('keeps load more reachable when the loaded videos are filtered out', () => {
+    const fetchNextPage = vi.fn();
+    mockUsePeopleListVideos.mockReturnValue({
+      data: { pages: [{ videos: [] }] },
+      isLoading: false,
+      isError: false,
+      hasNextPage: true,
+      fetchNextPage,
+      refetch: vi.fn(),
+      isFetchingNextPage: false,
+    });
+
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }));
+    expect(fetchNextPage).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText('No loops from these people yet.')).not.toBeInTheDocument();
   });
 });

--- a/src/pages/PeopleListDetailPage.test.tsx
+++ b/src/pages/PeopleListDetailPage.test.tsx
@@ -80,7 +80,7 @@ describe('PeopleListDetailPage', () => {
     );
     expect(screen.getByTestId('video-grid')).toHaveTextContent('1 videos');
     expect(screen.queryByRole('button', { name: /subscribe/i })).not.toBeInTheDocument();
-  });
+  }, 10_000);
 
   it('shows a not-found state when the exact list is absent', () => {
     mockUsePeopleList.mockReturnValue({

--- a/src/pages/PeopleListDetailPage.tsx
+++ b/src/pages/PeopleListDetailPage.tsx
@@ -72,9 +72,19 @@ function PeopleListContent({ pubkey, listId }: { pubkey: string; listId: string 
           </p>
         ) : videosQuery.isLoading ? (
           <VideoGrid videos={[]} loading />
+        ) : videosQuery.isError ? (
+          <div className="rounded-2xl border border-dashed p-8 text-center text-muted-foreground">
+            <p>These loops did not load.</p>
+            <Button className="mt-4" variant="outline" onClick={() => videosQuery.refetch()}>
+              Try again
+            </Button>
+          </div>
         ) : videos.length > 0 ? (
           <>
-            <VideoGrid videos={videos} />
+            <VideoGrid
+              videos={videos}
+              navigationContext={{ source: 'people-list', pubkey, listId }}
+            />
             {videosQuery.hasNextPage && (
               <div className="flex justify-center">
                 <Button
@@ -87,6 +97,18 @@ function PeopleListContent({ pubkey, listId }: { pubkey: string; listId: string 
               </div>
             )}
           </>
+        ) : videosQuery.hasNextPage ? (
+          <div className="rounded-2xl border border-dashed p-8 text-center text-muted-foreground">
+            <p>More loops may be hiding on the next page.</p>
+            <Button
+              className="mt-4"
+              variant="outline"
+              onClick={() => videosQuery.fetchNextPage()}
+              disabled={videosQuery.isFetchingNextPage}
+            >
+              {videosQuery.isFetchingNextPage ? 'Loading...' : 'Load more'}
+            </Button>
+          </div>
         ) : (
           <p className="rounded-2xl border border-dashed p-8 text-center text-muted-foreground">
             No loops from these people yet.

--- a/src/pages/PeopleListDetailPage.tsx
+++ b/src/pages/PeopleListDetailPage.tsx
@@ -1,0 +1,113 @@
+// ABOUTME: Public detail page for a NIP-51 people list with member videos as primary content
+
+import { ArrowLeft, UsersThree } from '@phosphor-icons/react';
+import { nip19 } from 'nostr-tools';
+import { Link, useParams } from 'react-router-dom';
+import { PeopleListMembers } from '@/components/PeopleListMembers';
+import { VideoGrid } from '@/components/VideoGrid';
+import { SectionHeader } from '@/components/brand/SectionHeader';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { usePeopleList } from '@/hooks/usePeopleLists';
+import { usePeopleListVideos } from '@/hooks/usePeopleListVideos';
+
+function PeopleListContent({ pubkey, listId }: { pubkey: string; listId: string }) {
+  const listQuery = usePeopleList(pubkey, listId);
+  const memberPubkeys = listQuery.data?.memberPubkeys ?? [];
+  const videosQuery = usePeopleListVideos(memberPubkeys);
+  const videos = videosQuery.data?.pages.flatMap((page) => page.videos) ?? [];
+
+  if (listQuery.isLoading) {
+    return (
+      <div className="container mx-auto max-w-5xl space-y-6 px-4 py-8">
+        <Skeleton className="h-9 w-64" />
+        <Skeleton className="h-28 w-full rounded-2xl" />
+        <Skeleton className="h-96 w-full rounded-2xl" />
+      </div>
+    );
+  }
+
+  if (listQuery.isError || (listQuery.isFetched && !listQuery.data)) {
+    return (
+      <div className="container mx-auto max-w-3xl px-4 py-16 text-center">
+        <SectionHeader className="text-2xl">That people list could not be found.</SectionHeader>
+      </div>
+    );
+  }
+
+  const list = listQuery.data;
+  if (!list) return null;
+
+  return (
+    <div className="container mx-auto max-w-5xl space-y-8 px-4 py-8">
+      <Link
+        to={`/profile/${nip19.npubEncode(pubkey)}/lists`}
+        className="inline-flex items-center gap-2 text-sm font-semibold text-primary hover:underline"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Back to lists
+      </Link>
+
+      <header className="flex items-start gap-4">
+        <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl bg-brand-light-green dark:bg-brand-dark-green">
+          <UsersThree className="h-7 w-7 text-brand-dark-green dark:text-brand-green" aria-hidden="true" />
+        </div>
+        <div className="min-w-0">
+          <p className="text-sm font-semibold text-primary">People list</p>
+          <SectionHeader as="h2" className="text-3xl">{list.name}</SectionHeader>
+          {list.description && <p className="mt-2 text-muted-foreground">{list.description}</p>}
+        </div>
+      </header>
+
+      <PeopleListMembers pubkeys={list.memberPubkeys} />
+
+      <section aria-labelledby="people-list-videos-heading" className="space-y-4">
+        <div>
+          <SectionHeader id="people-list-videos-heading" className="text-2xl">Videos</SectionHeader>
+          <p className="text-sm text-muted-foreground">Recent loops from everyone in this list.</p>
+        </div>
+        {list.memberPubkeys.length === 0 ? (
+          <p className="rounded-2xl border border-dashed p-8 text-center text-muted-foreground">
+            Add people to this list and their loops will land here.
+          </p>
+        ) : videosQuery.isLoading ? (
+          <VideoGrid videos={[]} loading />
+        ) : videos.length > 0 ? (
+          <>
+            <VideoGrid videos={videos} />
+            {videosQuery.hasNextPage && (
+              <div className="flex justify-center">
+                <Button
+                  variant="outline"
+                  onClick={() => videosQuery.fetchNextPage()}
+                  disabled={videosQuery.isFetchingNextPage}
+                >
+                  {videosQuery.isFetchingNextPage ? 'Loading…' : 'Load more'}
+                </Button>
+              </div>
+            )}
+          </>
+        ) : (
+          <p className="rounded-2xl border border-dashed p-8 text-center text-muted-foreground">
+            No loops from these people yet.
+          </p>
+        )}
+      </section>
+    </div>
+  );
+}
+
+export default function PeopleListDetailPage() {
+  const { pubkey, listId } = useParams<{ pubkey: string; listId: string }>();
+  const isValidPubkey = Boolean(pubkey && /^[0-9a-fA-F]{64}$/.test(pubkey));
+
+  if (!isValidPubkey || !pubkey || !listId) {
+    return (
+      <div className="container mx-auto max-w-3xl px-4 py-16 text-center">
+        <SectionHeader className="text-2xl">That people list link is not valid.</SectionHeader>
+      </div>
+    );
+  }
+
+  return <PeopleListContent pubkey={pubkey} listId={listId} />;
+}

--- a/src/pages/ProfileListsPage.test.tsx
+++ b/src/pages/ProfileListsPage.test.tsx
@@ -17,7 +17,7 @@ vi.mock('@/hooks/useVideoLists', () => ({
   useVideoLists: (...args: unknown[]) => mockUseVideoLists(...args),
 }));
 
-function renderPage(identifier = nip19.npubEncode(OWNER)) {
+function renderPage(identifier: string = nip19.npubEncode(OWNER)) {
   return render(
     <MemoryRouter initialEntries={[`/profile/${identifier}/lists`]}>
       <Routes>

--- a/src/pages/ProfileListsPage.test.tsx
+++ b/src/pages/ProfileListsPage.test.tsx
@@ -9,6 +9,8 @@ import ProfileListsPage from './ProfileListsPage';
 const OWNER = 'a'.repeat(64);
 const mockUsePeopleLists = vi.fn();
 const mockUseVideoLists = vi.fn();
+const mockRefetchPeople = vi.fn();
+const mockRefetchVideos = vi.fn();
 
 vi.mock('@/hooks/usePeopleLists', () => ({
   usePeopleLists: (...args: unknown[]) => mockUsePeopleLists(...args),
@@ -33,10 +35,14 @@ describe('ProfileListsPage', () => {
     mockUsePeopleLists.mockReturnValue({
       data: [{ id: 'people', name: 'My people', pubkey: OWNER, createdAt: 20, memberPubkeys: [] }],
       isLoading: false,
+      isError: false,
+      refetch: mockRefetchPeople,
     });
     mockUseVideoLists.mockReturnValue({
       data: [{ id: 'videos', name: 'My videos', pubkey: OWNER, createdAt: 10, videoCoordinates: [], public: true }],
       isLoading: false,
+      isError: false,
+      refetch: mockRefetchVideos,
     });
   });
 
@@ -61,5 +67,50 @@ describe('ProfileListsPage', () => {
     expect(screen.getByText('That profile link is not valid.')).toBeInTheDocument();
     expect(mockUsePeopleLists).not.toHaveBeenCalled();
     expect(mockUseVideoLists).not.toHaveBeenCalled();
+  });
+
+  it('shows a retryable error when both list queries fail', () => {
+    mockUsePeopleLists.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      refetch: mockRefetchPeople,
+    });
+    mockUseVideoLists.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      refetch: mockRefetchVideos,
+    });
+
+    renderPage();
+
+    expect(screen.getByText('Lists did not load.')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }));
+    expect(mockRefetchPeople).toHaveBeenCalledTimes(1);
+    expect(mockRefetchVideos).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves successful lists and offers retry when one query fails', () => {
+    mockUsePeopleLists.mockReturnValue({
+      data: [{ id: 'people', name: 'My people', pubkey: OWNER, createdAt: 20, memberPubkeys: [] }],
+      isLoading: false,
+      isError: false,
+      refetch: mockRefetchPeople,
+    });
+    mockUseVideoLists.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      refetch: mockRefetchVideos,
+    });
+
+    renderPage();
+
+    expect(screen.getByText('My people')).toBeInTheDocument();
+    expect(screen.getByText('Some lists did not load.')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }));
+    expect(mockRefetchPeople).not.toHaveBeenCalled();
+    expect(mockRefetchVideos).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/pages/ProfileListsPage.test.tsx
+++ b/src/pages/ProfileListsPage.test.tsx
@@ -1,0 +1,65 @@
+// ABOUTME: Tests the public filterable gallery of a profile's lists
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { nip19 } from 'nostr-tools';
+import ProfileListsPage from './ProfileListsPage';
+
+const OWNER = 'a'.repeat(64);
+const mockUsePeopleLists = vi.fn();
+const mockUseVideoLists = vi.fn();
+
+vi.mock('@/hooks/usePeopleLists', () => ({
+  usePeopleLists: (...args: unknown[]) => mockUsePeopleLists(...args),
+}));
+vi.mock('@/hooks/useVideoLists', () => ({
+  useVideoLists: (...args: unknown[]) => mockUseVideoLists(...args),
+}));
+
+function renderPage(identifier = nip19.npubEncode(OWNER)) {
+  return render(
+    <MemoryRouter initialEntries={[`/profile/${identifier}/lists`]}>
+      <Routes>
+        <Route path="/profile/:npub/lists" element={<ProfileListsPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('ProfileListsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUsePeopleLists.mockReturnValue({
+      data: [{ id: 'people', name: 'My people', pubkey: OWNER, createdAt: 20, memberPubkeys: [] }],
+      isLoading: false,
+    });
+    mockUseVideoLists.mockReturnValue({
+      data: [{ id: 'videos', name: 'My videos', pubkey: OWNER, createdAt: 10, videoCoordinates: [], public: true }],
+      isLoading: false,
+    });
+  });
+
+  it('shows mixed lists by default and filters by type', () => {
+    renderPage();
+    expect(screen.getByText('My people')).toBeInTheDocument();
+    expect(screen.getByText('My videos')).toBeInTheDocument();
+
+    fireEvent.mouseDown(screen.getByRole('tab', { name: 'People' }));
+    fireEvent.click(screen.getByRole('tab', { name: 'People' }));
+    expect(screen.getByText('My people')).toBeInTheDocument();
+    expect(screen.queryByText('My videos')).not.toBeInTheDocument();
+
+    fireEvent.mouseDown(screen.getByRole('tab', { name: 'Videos' }));
+    fireEvent.click(screen.getByRole('tab', { name: 'Videos' }));
+    expect(screen.queryByText('My people')).not.toBeInTheDocument();
+    expect(screen.getByText('My videos')).toBeInTheDocument();
+  });
+
+  it('rejects invalid identifiers without querying another user or global lists', () => {
+    renderPage('not-a-pubkey');
+    expect(screen.getByText('That profile link is not valid.')).toBeInTheDocument();
+    expect(mockUsePeopleLists).not.toHaveBeenCalled();
+    expect(mockUseVideoLists).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/ProfileListsPage.tsx
+++ b/src/pages/ProfileListsPage.tsx
@@ -5,6 +5,7 @@ import { nip19 } from 'nostr-tools';
 import { Link, useParams } from 'react-router-dom';
 import { ProfileListCard } from '@/components/ProfileListCard';
 import { SectionHeader } from '@/components/brand/SectionHeader';
+import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { usePeopleLists } from '@/hooks/usePeopleLists';
@@ -30,14 +31,29 @@ function ListsGallery({ pubkey, profileIdentifier }: { pubkey: string; profileId
   const peopleLists = lists.filter((list) => list.type === 'people');
   const videoLists = lists.filter((list) => list.type === 'videos');
   const isLoading = peopleQuery.isLoading || videoQuery.isLoading;
+  const peopleFailed = peopleQuery.isError;
+  const videoFailed = videoQuery.isError;
+  const hasFailedQuery = peopleFailed || videoFailed;
 
-  const grid = (items: typeof lists) => {
+  const retryFailedQueries = () => {
+    if (peopleFailed) void peopleQuery.refetch();
+    if (videoFailed) void videoQuery.refetch();
+  };
+
+  const grid = (items: typeof lists, unavailable = false) => {
     if (isLoading && items.length === 0) {
       return (
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {Array.from({ length: 6 }, (_, index) => (
             <Skeleton key={index} className="h-32 rounded-[22px]" />
           ))}
+        </div>
+      );
+    }
+    if (unavailable && items.length === 0) {
+      return (
+        <div className="rounded-2xl border border-dashed p-10 text-center text-muted-foreground">
+          These lists did not load.
         </div>
       );
     }
@@ -55,11 +71,25 @@ function ListsGallery({ pubkey, profileIdentifier }: { pubkey: string; profileId
     );
   };
 
+  if (!isLoading && peopleFailed && videoFailed && lists.length === 0) {
+    return (
+      <div className="container mx-auto max-w-3xl px-4 py-16 text-center">
+        <SectionHeader className="text-2xl">Lists did not load.</SectionHeader>
+        <p className="mt-3 text-muted-foreground">
+          Relay trouble got in the way. Try again?
+        </p>
+        <Button className="mt-6" variant="outline" onClick={retryFailedQueries}>
+          Try again
+        </Button>
+      </div>
+    );
+  }
+
   return (
     <div className="container mx-auto max-w-5xl px-4 py-8">
       <Link
         to={`/profile/${profileIdentifier}`}
-        className="mb-5 inline-flex items-center gap-2 text-sm font-semibold text-primary hover:underline"
+        className="mb-5 inline-flex items-center gap-2 text-sm font-semibold text-foreground hover:underline"
       >
         <ArrowLeft className="h-4 w-4" />
         Back to profile
@@ -71,6 +101,14 @@ function ListsGallery({ pubkey, profileIdentifier }: { pubkey: string; profileId
           <p className="text-muted-foreground">People to meet and videos worth looping.</p>
         </div>
       </div>
+      {hasFailedQuery && (
+        <div className="mb-6 flex flex-wrap items-center gap-3 rounded-2xl border border-dashed p-4 text-sm text-muted-foreground">
+          <span>Some lists did not load.</span>
+          <Button variant="outline" size="sm" onClick={retryFailedQueries}>
+            Try again
+          </Button>
+        </div>
+      )}
       <Tabs defaultValue="all" className="space-y-6">
         <TabsList aria-label="List type">
           <TabsTrigger value="all">All</TabsTrigger>
@@ -78,8 +116,8 @@ function ListsGallery({ pubkey, profileIdentifier }: { pubkey: string; profileId
           <TabsTrigger value="videos">Videos</TabsTrigger>
         </TabsList>
         <TabsContent value="all">{grid(lists)}</TabsContent>
-        <TabsContent value="people">{grid(peopleLists)}</TabsContent>
-        <TabsContent value="videos">{grid(videoLists)}</TabsContent>
+        <TabsContent value="people">{grid(peopleLists, peopleFailed)}</TabsContent>
+        <TabsContent value="videos">{grid(videoLists, videoFailed)}</TabsContent>
       </Tabs>
     </div>
   );

--- a/src/pages/ProfileListsPage.tsx
+++ b/src/pages/ProfileListsPage.tsx
@@ -1,0 +1,101 @@
+// ABOUTME: Public gallery for all people and video lists published by one profile
+
+import { ArrowLeft, ListBullets } from '@phosphor-icons/react';
+import { nip19 } from 'nostr-tools';
+import { Link, useParams } from 'react-router-dom';
+import { ProfileListCard } from '@/components/ProfileListCard';
+import { SectionHeader } from '@/components/brand/SectionHeader';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { usePeopleLists } from '@/hooks/usePeopleLists';
+import { useVideoLists } from '@/hooks/useVideoLists';
+import { mergeProfileLists } from '@/lib/profileLists';
+
+function decodeProfilePubkey(identifier: string | undefined): string | null {
+  if (!identifier) return null;
+  if (/^[0-9a-fA-F]{64}$/.test(identifier)) return identifier;
+
+  try {
+    const decoded = nip19.decode(identifier);
+    return decoded.type === 'npub' ? decoded.data : null;
+  } catch {
+    return null;
+  }
+}
+
+function ListsGallery({ pubkey, profileIdentifier }: { pubkey: string; profileIdentifier: string }) {
+  const peopleQuery = usePeopleLists(pubkey);
+  const videoQuery = useVideoLists(pubkey);
+  const lists = mergeProfileLists(peopleQuery.data ?? [], videoQuery.data ?? []);
+  const peopleLists = lists.filter((list) => list.type === 'people');
+  const videoLists = lists.filter((list) => list.type === 'videos');
+  const isLoading = peopleQuery.isLoading || videoQuery.isLoading;
+
+  const grid = (items: typeof lists) => {
+    if (isLoading && items.length === 0) {
+      return (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 6 }, (_, index) => (
+            <Skeleton key={index} className="h-32 rounded-[22px]" />
+          ))}
+        </div>
+      );
+    }
+    if (items.length === 0) {
+      return (
+        <div className="rounded-2xl border border-dashed p-10 text-center text-muted-foreground">
+          Nothing listed here yet.
+        </div>
+      );
+    }
+    return (
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {items.map((list) => <ProfileListCard key={list.key} list={list} />)}
+      </div>
+    );
+  };
+
+  return (
+    <div className="container mx-auto max-w-5xl px-4 py-8">
+      <Link
+        to={`/profile/${profileIdentifier}`}
+        className="mb-5 inline-flex items-center gap-2 text-sm font-semibold text-primary hover:underline"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Back to profile
+      </Link>
+      <div className="mb-7 flex items-center gap-3">
+        <ListBullets className="h-8 w-8 text-primary" aria-hidden="true" />
+        <div>
+          <SectionHeader className="text-3xl">Lists</SectionHeader>
+          <p className="text-muted-foreground">People to meet and videos worth looping.</p>
+        </div>
+      </div>
+      <Tabs defaultValue="all" className="space-y-6">
+        <TabsList aria-label="List type">
+          <TabsTrigger value="all">All</TabsTrigger>
+          <TabsTrigger value="people">People</TabsTrigger>
+          <TabsTrigger value="videos">Videos</TabsTrigger>
+        </TabsList>
+        <TabsContent value="all">{grid(lists)}</TabsContent>
+        <TabsContent value="people">{grid(peopleLists)}</TabsContent>
+        <TabsContent value="videos">{grid(videoLists)}</TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+
+export default function ProfileListsPage() {
+  const { npub } = useParams<{ npub: string }>();
+  const pubkey = decodeProfilePubkey(npub);
+
+  if (!pubkey || !npub) {
+    return (
+      <div className="container mx-auto max-w-3xl px-4 py-16 text-center">
+        <SectionHeader className="text-2xl">That profile link is not valid.</SectionHeader>
+      </div>
+    );
+  }
+
+  return <ListsGallery pubkey={pubkey} profileIdentifier={npub} />;
+}

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -30,6 +30,7 @@ import { useClassicVineArchiveStats } from '@/hooks/useClassicVineArchiveStats';
 import { useFollowRelationship, useFollowUser, useUnfollowUser, FollowRaceError } from '@/hooks/useFollowRelationship';
 import { useFollowListSafetyCheck } from '@/hooks/useFollowListSafetyCheck';
 import { PinnedVideosSection } from '@/components/PinnedVideosSection';
+import { ProfileListsSection } from '@/components/ProfileListsSection';
 import { useLoginDialog } from '@/contexts/LoginDialogContext';
 import { toast } from '@/hooks/useToast';
 import { debugLog } from '@/lib/debug';
@@ -419,6 +420,9 @@ export function ProfilePage({ pubkeyOverride }: { pubkeyOverride?: string } = {}
 
         {/* Pinned Videos */}
         <PinnedVideosSection pubkey={pubkey} isOwnProfile={isOwnProfile} />
+
+        {/* Public Lists */}
+        <ProfileListsSection pubkey={pubkey} />
 
         {/* Content Section */}
         <div className="space-y-4">

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -469,6 +469,7 @@ export function ProfilePage({ pubkeyOverride }: { pubkeyOverride?: string } = {}
                   variant={viewMode === 'grid' ? 'default' : 'outline'}
                   size="sm"
                   onClick={() => setViewMode('grid')}
+                  aria-label="Grid view"
                   data-testid="grid-view-button"
                 >
                   <Grid className="w-4 h-4" />
@@ -477,6 +478,7 @@ export function ProfilePage({ pubkeyOverride }: { pubkeyOverride?: string } = {}
                   variant={viewMode === 'list' ? 'default' : 'outline'}
                   size="sm"
                   onClick={() => setViewMode('list')}
+                  aria-label="List view"
                   data-testid="list-view-button"
                 >
                   <List className="w-4 h-4" />

--- a/src/pages/VideoPage.tsx
+++ b/src/pages/VideoPage.tsx
@@ -42,11 +42,13 @@ export function VideoPage() {
       source,
       hashtag: searchParams.get('hashtag') || undefined,
       pubkey: searchParams.get('pubkey') || undefined,
+      listId: searchParams.get('listId') || undefined,
       query: searchParams.get('q') || undefined,
       sortMode: searchParams.get('sort') as VideoNavigationContext['sortMode'],
       currentIndex: searchParams.get('index') ? parseInt(searchParams.get('index')!) : undefined,
     };
   }, [searchParams]);
+  const profileContextPubkey = context?.source === 'profile' ? context.pubkey : undefined;
 
   // Fast video loading via Funnelcake REST API
   const {
@@ -57,9 +59,9 @@ export function VideoPage() {
     error: funnelcakeError,
   } = useVideoByIdFunnelcake({
     videoId: id || '',
-    pubkey: context?.pubkey,
-    hashtag: context?.hashtag,
-    query: context?.query,
+    pubkey: profileContextPubkey,
+    hashtag: context?.source === 'hashtag' ? context.hashtag : undefined,
+    query: context?.source === 'search' ? context.query : undefined,
     sortMode: context?.sortMode,
     currentIndex: context?.currentIndex,
     enabled: !!id,
@@ -107,6 +109,7 @@ export function VideoPage() {
 
     if (context.hashtag) params.set('hashtag', context.hashtag);
     if (context.pubkey) params.set('pubkey', context.pubkey);
+    if (context.listId) params.set('listId', context.listId);
     if (context.query) params.set('q', context.query);
     if (context.sortMode) params.set('sort', context.sortMode);
 
@@ -127,12 +130,12 @@ export function VideoPage() {
 
   // Get author data for profile context
   // Prefer cached author name from video/Funnelcake, then fetched profile, then generated fallback
-  const authorData = useAuthor(context?.pubkey || '', {
+  const authorData = useAuthor(profileContextPubkey || '', {
     initialName: currentVideo?.authorName,
     initialAvatar: currentVideo?.authorAvatar,
   });
-  const authorName = context?.pubkey
-    ? (authorData.data?.metadata?.display_name || authorData.data?.metadata?.name || currentVideo?.authorName || genUserName(context.pubkey))
+  const authorName = profileContextPubkey
+    ? (authorData.data?.metadata?.display_name || authorData.data?.metadata?.name || currentVideo?.authorName || genUserName(profileContextPubkey))
     : null;
 
   // Progressive rendering: only render a window of videos, expand on scroll
@@ -167,7 +170,7 @@ export function VideoPage() {
     if (!usingWebsocketFallback) return;
 
     const reason = funnelcakeError?.message || 'REST returned no matching video';
-    const fallbackKey = `VideoPage|${id}|${context?.pubkey ?? ''}|${context?.hashtag ?? ''}|${reason}`;
+    const fallbackKey = `VideoPage|${id}|${profileContextPubkey ?? ''}|${context?.hashtag ?? ''}|${reason}`;
 
     if (fallbackReportKeyRef.current === fallbackKey) {
       return;
@@ -180,13 +183,13 @@ export function VideoPage() {
       dedupeKey: fallbackKey,
       context: {
         videoId: id,
-        pubkey: context?.pubkey,
+        pubkey: profileContextPubkey,
         hashtag: context?.hashtag,
       },
     });
   }, [
     context?.hashtag,
-    context?.pubkey,
+    profileContextPubkey,
     funnelcakeError?.message,
     funnelcakeLoading,
     funnelcakeVideo,
@@ -286,6 +289,8 @@ export function VideoPage() {
       if (context.sortMode) params.set('sort', context.sortMode);
       const target = params.toString() ? `/search?${params.toString()}` : '/search';
       navigate(target);
+    } else if (context?.source === 'people-list' && context.pubkey && context.listId) {
+      navigate(`/people-lists/${context.pubkey}/${encodeURIComponent(context.listId)}`);
     } else {
       navigate(-1); // Browser back
     }
@@ -607,6 +612,9 @@ export function VideoPage() {
               {context.source === 'search' && (
                 <span>{context.query ? t('videoPage.searchPrefix', { query: context.query }) : t('videoPage.searchResults')}</span>
               )}
+              {context.source === 'people-list' && (
+                <span>People list</span>
+              )}
               {(context.source === 'discovery' || context.source === 'trending' || context.source === 'home') && (
                 <span className="capitalize">{context.source}</span>
               )}
@@ -667,6 +675,9 @@ export function VideoPage() {
               )}
               {context.source === 'search' && (
                 <span>{context.query ? t('videoPage.searchPrefix', { query: context.query }) : t('videoPage.searchResults')}</span>
+              )}
+              {context.source === 'people-list' && (
+                <span>People list</span>
               )}
               {(context.source === 'discovery' || context.source === 'trending' || context.source === 'home') && (
                 <span className="capitalize">{context.source}</span>
@@ -766,6 +777,14 @@ export function VideoPage() {
                 className="text-muted-foreground hover:text-primary transition-colors text-xs"
               >
                 {context.query ? t('videoPage.searchPrefix', { query: context.query }) : t('videoPage.searchResults')}
+              </button>
+            )}
+            {context.source === 'people-list' && (
+              <button
+                onClick={handleGoBack}
+                className="text-muted-foreground hover:text-primary transition-colors text-xs"
+              >
+                People list
               </button>
             )}
             {(context.source === 'discovery' || context.source === 'trending' || context.source === 'home') && (

--- a/tests/visual/a11y.spec.ts
+++ b/tests/visual/a11y.spec.ts
@@ -1,7 +1,20 @@
 import { test, expect } from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';
 
-const ROUTES = ['/', '/discovery', '/search', '/merch', '/family', '/age-review', '/kids', '/__brand-preview'];
+const PUBKEY = 'a'.repeat(64);
+const ROUTES = [
+  '/',
+  '/discovery',
+  '/search',
+  '/merch',
+  '/family',
+  '/age-review',
+  '/kids',
+  `/profile/${PUBKEY}`,
+  `/profile/${PUBKEY}/lists`,
+  `/people-lists/${PUBKEY}/friends`,
+  '/__brand-preview',
+];
 
 for (const route of ROUTES) {
   test(`a11y: ${route} has no WCAG 2 A/AA violations`, async ({ page }) => {


### PR DESCRIPTION
## Summary

- Add a mixed, labeled people-list and video-list shelf above profile videos.
- Add public profile list galleries and owner-aware people-list detail pages with member videos as the primary content.
- Parse and deduplicate NIP-51 kind 30000 people sets, bound member-video relay queries, and deduplicate kind 30005 relay versions.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- Profiles currently expose videos but not the public lists their owners curate. This makes those lists discoverable without adding subscription or feed persistence yet.

## Related Issue

- Closes #518

## Testing

- [x] npm run test
- [x] npm run test:visual
- [ ] Manual verification completed

## Visuals

- [ ] UI change with screenshots/video attached
- [ ] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved

Screenshots are not attached; the responsive states are covered by focused component tests, route-level axe coverage, and the existing Playwright visual suite.
