### PR TITLE
fix(ci): audit Cloudflare production deployment in og-audit, handle wrangler 4.x output

### DIFF
--- a/.github/workflows/og-audit.yml
+++ b/.github/workflows/og-audit.yml
@@ -1,5 +1,5 @@
 # ABOUTME: GitHub Actions workflow that audits OG/Twitter Card parity on production and
-# ABOUTME: the latest main-branch Cloudflare Pages preview deployment.
+# ABOUTME: the latest main-branch Cloudflare Pages production deployment.
 
 name: OG/Twitter Card parity audit
 
@@ -40,8 +40,8 @@ jobs:
         if: github.event_name == 'schedule' && steps.audit-prod.outcome == 'failure'
         run: echo "::warning::Scheduled production OG audit failed. This monitors live production state and is warning-only on schedule."
 
-  audit-cloudflare-preview:
-    name: Audit Cloudflare preview (latest main-branch deployment)
+  audit-cloudflare-production:
+    name: Audit Cloudflare production (latest main-branch deployment)
     runs-on: ubuntu-24.04
     timeout-minutes: 8
     steps:
@@ -51,8 +51,8 @@ jobs:
       - name: Install wrangler
         run: npm install -g wrangler@4.31.0
 
-      - name: Find latest Cloudflare Pages main-branch preview deployment URL
-        id: find-preview
+      - name: Find latest Cloudflare Pages main-branch production deployment URL
+        id: find-production
         continue-on-error: ${{ github.event_name == 'schedule' }}
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -60,41 +60,45 @@ jobs:
         run: |
           set -euo pipefail
           if [[ -z "${CLOUDFLARE_API_TOKEN:-}" ]]; then
-            echo "::error::CLOUDFLARE_API_TOKEN not set; cannot audit Cloudflare preview."
+            echo "::error::CLOUDFLARE_API_TOKEN not set; cannot audit Cloudflare production."
             exit 1
           fi
           if [[ -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]]; then
-            echo "::error::CLOUDFLARE_ACCOUNT_ID not set; cannot audit Cloudflare preview."
+            echo "::error::CLOUDFLARE_ACCOUNT_ID not set; cannot audit Cloudflare production."
             exit 1
           fi
           # Project name matches deploy.yml and preview.yml (divine-web-direct-deploy).
-          # Filter to branch=main so we audit the post-merge preview, not PR previews.
+          # Main has no preview deployments (previews are per-PR); audit the latest
+          # main-branch production deployment instead.
+          # wrangler 4.x prints a version banner before the JSON payload — strip it.
+          # Field names are PascalCase: Environment/Branch/Deployment.
           if ! URL=$(wrangler pages deployment list \
             --project-name divine-web-direct-deploy \
-            --environment preview \
+            --environment production \
             --json \
-            | jq -er '(first(.[] | select(.environment == "preview" and .deployment_trigger.metadata.branch == "main" and (.url // "") != "")) // empty) | .url'); then
-            echo "::error::No main-branch Cloudflare preview deployment found, or Wrangler could not list deployments."
+            | sed -n '/^\[/,$p' \
+            | jq -er '(first(.[] | select(.Environment == "Production" and .Branch == "main" and (.Deployment // "") != "")) // empty) | .Deployment'); then
+            echo "::error::No main-branch Cloudflare production deployment found, or Wrangler could not list deployments."
             exit 1
           fi
           if [[ -z "$URL" ]]; then
-            echo "::error::No main-branch Cloudflare preview deployment found."
+            echo "::error::No main-branch Cloudflare production deployment found."
             exit 1
           fi
-          echo "preview_url=$URL" >> "$GITHUB_OUTPUT"
+          echo "production_url=$URL" >> "$GITHUB_OUTPUT"
 
-      - name: Annotate scheduled Cloudflare preview discovery result
-        if: github.event_name == 'schedule' && steps.find-preview.outcome == 'failure'
-        run: echo "::warning::Scheduled Cloudflare preview discovery failed. This monitors live deployment state and is warning-only on schedule."
+      - name: Annotate scheduled Cloudflare production discovery result
+        if: github.event_name == 'schedule' && steps.find-production.outcome == 'failure'
+        run: echo "::warning::Scheduled Cloudflare production discovery failed. This monitors live deployment state and is warning-only on schedule."
 
-      - name: Run OG parity audit against Cloudflare preview
-        id: audit-preview
-        if: steps.find-preview.outputs.preview_url != ''
+      - name: Run OG parity audit against Cloudflare production
+        id: audit-production-cf
+        if: steps.find-production.outputs.production_url != ''
         continue-on-error: ${{ github.event_name == 'schedule' }}
         env:
-          BASE_URL: ${{ steps.find-preview.outputs.preview_url }}
+          BASE_URL: ${{ steps.find-production.outputs.production_url }}
         run: bash scripts/verify-og-tags.sh
 
-      - name: Annotate scheduled Cloudflare preview audit result
-        if: github.event_name == 'schedule' && steps.audit-preview.outcome == 'failure'
-        run: echo "::warning::Scheduled Cloudflare preview OG audit failed. This monitors live deployment state and is warning-only on schedule."
+      - name: Annotate scheduled Cloudflare production audit result
+        if: github.event_name == 'schedule' && steps.audit-production-cf.outcome == 'failure'
+        run: echo "::warning::Scheduled Cloudflare production OG audit failed. This monitors live deployment state and is warning-only on schedule."


### PR DESCRIPTION
## Summary

Fixes the OG/Twitter Card parity audit workflow (added in #411), which has failed on every main push since merge.

Root causes found by reproducing the wrangler call locally:

1. **wrangler 4.x prints a version banner** (`⛅️ wrangler 4.31.0 …`) before the JSON payload → `jq: parse error: Invalid numeric literal at line 2, column 8`.
2. **Wrong jq field paths** — the filter assumed `.environment` / `.deployment_trigger.metadata.branch` / `.url`, but wrangler emits PascalCase: `Environment` / `Branch` / `Deployment`.
3. **No main-branch preview deployments exist** — Cloudflare Pages previews are per-PR; main deploys to production via deploy.yml. The preview filter could never match.

Fix: strip the banner (`sed -n '/^\[/,$p'`), filter on the real PascalCase fields, and audit the latest main-branch **production** deployment instead of a nonexistent preview. Verified end-to-end locally — the exact CI pipeline now returns a live deployment URL (`https://793265ac.divine-web-fm8.pages.dev`).

## Motivation

Red workflow on every main push masks real failures and trains everyone to ignore CI.

## Related issue

Follow-up to #411.

## Testing

- [x] Reproduced the failure locally with wrangler 4.31.0
- [x] Ran the exact patched pipeline locally against the real project — returns the latest main production deployment URL
- [x] YAML parses cleanly
- [ ] GitHub Actions run on this PR (workflow only triggers on main push/schedule/dispatch, so full validation lands post-merge)

## Visuals

No visual change.