### PR TITLE
feat: add Divine services directory

### DIFF
--- a/docs/superpowers/plans/2026-07-27-divine-services-directory.md
+++ b/docs/superpowers/plans/2026-07-27-divine-services-directory.md
@@ -1,0 +1,772 @@
+# Divine Services Directory Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `/services` directory page listing Divine's six public companion services, linked from the sidebar's top-level nav and footer links, prerendered for SEO.
+
+**Architecture:** A typed config module (`src/config/divineServices.ts`) is the single source for the service list. `ServicesPage` renders it with brand primitives (`SectionHeader`, `Card variant="brand"`), the sidebar links to the internal route, and `scripts/prerender-legal.mjs` emits a static HTML version from a content partial. Spec: `docs/superpowers/specs/2026-07-27-divine-services-directory-design.md`.
+
+**Tech Stack:** React 18, TypeScript, React Router 6, react-i18next, Phosphor Icons, Vitest, Testing Library.
+
+## Global Constraints
+
+- Brand hard rules (CI-enforced): no Tailwind `uppercase` class, no gradients on layout surfaces, no `lucide-react` imports (Phosphor only).
+- Copy stays casual-direct per brand voice; service names are proper nouns and are never translated.
+- All 16 locales under `src/lib/i18n/locales/` must keep identical key sets; non-English locales get the English strings as placeholders.
+- External service links use `target="_blank" rel="noopener noreferrer"`.
+- Work happens on branch `feat/divine-services-directory` (worktree `.worktrees/divine-services-directory`).
+
+---
+
+### Task 1: Add the services config module
+
+**Files:**
+
+- Create: `src/config/divineServices.ts`
+- Create: `src/config/divineServices.test.ts`
+
+**Interfaces:**
+
+- Produces: `DIVINE_SERVICES: DivineService[]` where
+  `DivineService { id: DivineServiceId; name: string; url: string; icon: Icon }`
+  and `DivineServiceId = 'space' | 'sounds' | 'badges' | 'crossposter' | 'verifier' | 'status'`.
+  Consumed by `ServicesPage` (Task 3) and the prerender guard test (Task 5).
+
+- [ ] **Step 1: Write the failing config test**
+
+Create `src/config/divineServices.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+
+import { DIVINE_SERVICES } from './divineServices';
+
+describe('DIVINE_SERVICES', () => {
+  it('lists each service with a unique id, name, https URL, and icon', () => {
+    const ids = DIVINE_SERVICES.map((service) => service.id);
+    expect(new Set(ids).size).toBe(ids.length);
+
+    for (const service of DIVINE_SERVICES) {
+      expect(service.name.length).toBeGreaterThan(0);
+      expect(service.url).toMatch(/^https:\/\//);
+      expect(service.icon).toBeTruthy();
+    }
+  });
+
+  it('includes the six launch services in display order', () => {
+    expect(DIVINE_SERVICES.map((service) => service.id)).toEqual([
+      'space',
+      'sounds',
+      'badges',
+      'crossposter',
+      'verifier',
+      'status',
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run:
+
+```bash
+npx vitest run src/config/divineServices.test.ts
+```
+
+Expected: FAIL because `./divineServices` does not exist.
+
+- [ ] **Step 3: Implement the config module**
+
+Create `src/config/divineServices.ts`:
+
+```ts
+// ABOUTME: Canonical list of public companion Divine services shown on /services
+// ABOUTME: Add future public services here; the page and prerender guard render from it
+
+import {
+  HouseLine,
+  Medal,
+  MusicNotes,
+  Pulse,
+  SealCheck,
+  ShareNetwork,
+  type Icon,
+} from '@phosphor-icons/react';
+
+export type DivineServiceId =
+  | 'space'
+  | 'sounds'
+  | 'badges'
+  | 'crossposter'
+  | 'verifier'
+  | 'status';
+
+export interface DivineService {
+  id: DivineServiceId;
+  name: string;
+  url: string;
+  icon: Icon;
+}
+
+export const DIVINE_SERVICES: DivineService[] = [
+  {
+    id: 'space',
+    name: 'Divine Space',
+    url: 'https://divine.space',
+    icon: HouseLine,
+  },
+  {
+    id: 'sounds',
+    name: 'Sounds',
+    url: 'https://sounds.divine.video',
+    icon: MusicNotes,
+  },
+  {
+    id: 'badges',
+    name: 'Badges',
+    url: 'https://badges.divine.video',
+    icon: Medal,
+  },
+  {
+    id: 'crossposter',
+    name: 'Crossposter',
+    url: 'https://crossposter.divine.video',
+    icon: ShareNetwork,
+  },
+  {
+    id: 'verifier',
+    name: 'Verifier',
+    url: 'https://inquisitor.divine.video',
+    icon: SealCheck,
+  },
+  {
+    id: 'status',
+    name: 'Status',
+    url: 'https://status.divine.video',
+    icon: Pulse,
+  },
+];
+```
+
+- [ ] **Step 4: Run the test and verify GREEN**
+
+Run:
+
+```bash
+npx vitest run src/config/divineServices.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the config module**
+
+```bash
+git add src/config/divineServices.ts src/config/divineServices.test.ts
+git commit -m "feat: add Divine services config"
+```
+
+### Task 2: Add the i18n keys in all 16 locales
+
+**Files:**
+
+- Modify: `src/lib/i18n/locales/en/common.json`
+- Modify: the other 15 locale files under `src/lib/i18n/locales/*/common.json`
+
+**Interfaces:**
+
+- Produces: `nav.services`, `servicesPage.title`, `servicesPage.intro`,
+  `servicesPage.openService` (interpolation `{{name}}`), and
+  `servicesPage.items.<id>` for every `DivineServiceId` from Task 1.
+  Consumed by `ServicesPage` (Task 3) and `AppSidebar` (Task 4).
+
+- [ ] **Step 1: Add the keys with a script**
+
+Run:
+
+```bash
+python3 - <<'EOF'
+import json, glob, collections
+
+EN = {
+    'nav_services': 'Services',
+    'title': 'Divine services',
+    'intro': 'Divine is more than loops. These services help you make the most of it.',
+    'openService': 'Open {{name}}',
+    'items': {
+        'space': 'Your profile, your rules. Themes, Top 8, profile music.',
+        'sounds': 'Trending sounds and a Creative Commons library for your loops.',
+        'badges': 'Awards for creators who show up.',
+        'crossposter': 'Post your loops to the other platforms — only when you opt in.',
+        'verifier': 'Check where a video really came from.',
+        'status': 'Is it us or is it you? Check here.',
+    },
+}
+
+for path in sorted(glob.glob('src/lib/i18n/locales/*/common.json')):
+    with open(path) as f:
+        data = json.load(f, object_pairs_hook=collections.OrderedDict)
+
+    # nav.services after nav.popular (or appended if ordering differs)
+    nav = data['nav']
+    new_nav = collections.OrderedDict()
+    inserted = False
+    for key, value in nav.items():
+        new_nav[key] = value
+        if key == 'popular':
+            new_nav['services'] = EN['nav_services']
+            inserted = True
+    if not inserted:
+        new_nav['services'] = EN['nav_services']
+    data['nav'] = new_nav
+
+    services_page = collections.OrderedDict()
+    services_page['title'] = EN['title']
+    services_page['intro'] = EN['intro']
+    services_page['openService'] = EN['openService']
+    services_page['items'] = collections.OrderedDict(EN['items'])
+
+    new_data = collections.OrderedDict()
+    placed = False
+    for key, value in data.items():
+        new_data[key] = value
+        if key == 'support':
+            new_data['servicesPage'] = services_page
+            placed = True
+    if not placed:
+        new_data['servicesPage'] = services_page
+
+    with open(path, 'w') as f:
+        json.dump(new_data, f, ensure_ascii=False, indent=2)
+        f.write('\n')
+    print('updated', path)
+EOF
+```
+
+English strings are used in every locale as placeholders; translators catch up
+later (established pattern for new keys).
+
+- [ ] **Step 2: Verify key parity and English values**
+
+Run:
+
+```bash
+python3 - <<'EOF'
+import json, glob
+
+def flat(d, prefix=''):
+    for key, value in d.items():
+        full = f'{prefix}.{key}' if prefix else key
+        if isinstance(value, dict):
+            yield from flat(value, full)
+        else:
+            yield full
+
+reference = set(flat(json.load(open('src/lib/i18n/locales/en/common.json'))))
+for path in sorted(glob.glob('src/lib/i18n/locales/*/common.json')):
+    keys = set(flat(json.load(open(path))))
+    assert keys == reference, f'{path} parity mismatch: {keys ^ reference}'
+print('all 16 locales have identical key sets')
+EOF
+```
+
+Expected: prints `all 16 locales have identical key sets`.
+
+- [ ] **Step 3: Commit the locale keys**
+
+```bash
+git add src/lib/i18n/locales/
+git commit -m "feat: add services directory locale keys"
+```
+
+### Task 3: Build the services page and register the route
+
+**Files:**
+
+- Create: `src/pages/ServicesPage.tsx`
+- Create: `src/pages/ServicesPage.test.tsx`
+- Modify: `src/AppRouter.tsx` (import list near line 52, marketing route block near line 169)
+
+**Interfaces:**
+
+- Consumes: `DIVINE_SERVICES` (Task 1); `servicesPage.*` keys (Task 2);
+  `SectionHeader` from `@/components/brand/SectionHeader` (`as="h2"`, children);
+  `Card` + `CardAccent` from `@/components/ui/card` (`variant="brand"`, `accent`);
+  `MarketingLayout` from `@/components/MarketingLayout`.
+- Produces: default + named export `ServicesPage`; route `/services`.
+
+- [ ] **Step 1: Write the failing page test**
+
+Create `src/pages/ServicesPage.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { initializeI18n } from '@/lib/i18n';
+import { DIVINE_SERVICES } from '@/config/divineServices';
+import ServicesPage from './ServicesPage';
+
+vi.mock('@/components/MarketingLayout', () => ({
+  MarketingLayout: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="marketing-layout">{children}</div>
+  ),
+}));
+
+describe('ServicesPage', () => {
+  beforeEach(async () => {
+    await initializeI18n({ force: true, languages: ['en-US'] });
+  });
+
+  it('renders the title and intro copy', () => {
+    render(
+      <MemoryRouter>
+        <ServicesPage />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByRole('heading', { name: 'Divine services' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/more than loops/i)).toBeInTheDocument();
+  });
+
+  it('links every configured service to its URL in a new tab', () => {
+    render(
+      <MemoryRouter>
+        <ServicesPage />
+      </MemoryRouter>,
+    );
+
+    for (const service of DIVINE_SERVICES) {
+      const link = screen.getByRole('link', { name: `Open ${service.name}` });
+      expect(link).toHaveAttribute('href', service.url);
+      expect(link).toHaveAttribute('target', '_blank');
+      expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'));
+      expect(link).toHaveAttribute('rel', expect.stringContaining('noreferrer'));
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run:
+
+```bash
+npx vitest run src/pages/ServicesPage.test.tsx
+```
+
+Expected: FAIL because `./ServicesPage` does not exist.
+
+- [ ] **Step 3: Implement the page**
+
+Create `src/pages/ServicesPage.tsx`:
+
+```tsx
+// ABOUTME: Directory of companion Divine services (Space, Sounds, Badges, Crossposter, Verifier, Status)
+// ABOUTME: Renders branded cards from src/config/divineServices.ts
+
+import { ArrowSquareOut } from '@phosphor-icons/react';
+import { useTranslation } from 'react-i18next';
+
+import { MarketingLayout } from '@/components/MarketingLayout';
+import { SectionHeader } from '@/components/brand/SectionHeader';
+import { Card, type CardAccent } from '@/components/ui/card';
+import { DIVINE_SERVICES } from '@/config/divineServices';
+
+const CARD_ACCENTS: CardAccent[] = [
+  'green',
+  'pink',
+  'violet',
+  'orange',
+  'yellow',
+  'blue',
+];
+
+export function ServicesPage() {
+  const { t } = useTranslation();
+
+  return (
+    <MarketingLayout>
+      <div className="container mx-auto max-w-5xl px-4 py-10">
+        <SectionHeader as="h2">{t('servicesPage.title')}</SectionHeader>
+        <p className="mt-3 max-w-2xl text-lg text-muted-foreground">
+          {t('servicesPage.intro')}
+        </p>
+
+        <div className="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {DIVINE_SERVICES.map((service, index) => {
+            const ServiceIcon = service.icon;
+            return (
+              <a
+                key={service.id}
+                href={service.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="group block"
+                aria-label={t('servicesPage.openService', { name: service.name })}
+              >
+                <Card
+                  variant="brand"
+                  accent={CARD_ACCENTS[index % CARD_ACCENTS.length]}
+                  className="flex h-full flex-col gap-3 p-5 transition-transform group-hover:-translate-y-1"
+                >
+                  <div className="flex items-center gap-3">
+                    <ServiceIcon className="h-7 w-7" />
+                    <h3 className="text-lg font-semibold text-foreground">
+                      {service.name}
+                    </h3>
+                    <ArrowSquareOut className="ml-auto h-4 w-4 text-muted-foreground" />
+                  </div>
+                  <p className="text-sm text-muted-foreground">
+                    {t(`servicesPage.items.${service.id}`)}
+                  </p>
+                </Card>
+              </a>
+            );
+          })}
+        </div>
+      </div>
+    </MarketingLayout>
+  );
+}
+
+export default ServicesPage;
+```
+
+- [ ] **Step 4: Register the route**
+
+In `src/AppRouter.tsx`, add to the page imports (near the `FAQPage` import at
+line 52):
+
+```tsx
+import { ServicesPage } from "./pages/ServicesPage";
+```
+
+Add to the marketing route block (near the `/faq` route at line 169):
+
+```tsx
+<Route path="/services" element={<ServicesPage />} />
+```
+
+- [ ] **Step 5: Run the test and verify GREEN**
+
+Run:
+
+```bash
+npx vitest run src/pages/ServicesPage.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the page and route**
+
+```bash
+git add src/pages/ServicesPage.tsx src/pages/ServicesPage.test.tsx src/AppRouter.tsx
+git commit -m "feat: add services directory page"
+```
+
+### Task 4: Link the directory from the sidebar
+
+**Files:**
+
+- Modify: `src/components/AppSidebar.tsx` (nav cluster near line 202, footer Divine links near line 458)
+- Modify: `src/components/AppSidebar.test.tsx`
+
+**Interfaces:**
+
+- Consumes: `nav.services` key (Task 2); Phosphor `SquaresFour` icon;
+  existing `NavItem` (`icon`, `label`, `onClick`, `isActive`) and `isActive(path)` helper.
+- Produces: top-level "Services" nav item after Popular; footer "Services"
+  router link in the Divine-links collapsible.
+
+- [ ] **Step 1: Write the failing sidebar tests**
+
+Add to the existing `describe('AppSidebar', ...)` block in
+`src/components/AppSidebar.test.tsx`:
+
+```tsx
+it('navigates to the services directory from the top-level nav', () => {
+  render(
+    <MemoryRouter>
+      <AppSidebar />
+    </MemoryRouter>,
+  );
+
+  fireEvent.click(screen.getByRole('button', { name: 'Services' }));
+  expect(mockNavigate).toHaveBeenCalledWith('/services');
+});
+
+it('links to the services directory from the footer Divine links', async () => {
+  render(
+    <MemoryRouter>
+      <AppSidebar />
+    </MemoryRouter>,
+  );
+
+  fireEvent.click(screen.getByRole('button', { name: /about divine/i }));
+
+  const link = await screen.findByRole('link', { name: 'Services' });
+  expect(link).toHaveAttribute('href', '/services');
+});
+```
+
+The collapsible trigger's accessible name is the English `footer.aboutDivine`
+value, "About Divine" (verified in `src/lib/i18n/locales/en/common.json`).
+
+- [ ] **Step 2: Run the tests and verify RED**
+
+Run:
+
+```bash
+npx vitest run src/components/AppSidebar.test.tsx
+```
+
+Expected: FAIL because no Services nav item or footer link exists.
+
+- [ ] **Step 3: Add the nav item and footer link**
+
+In `src/components/AppSidebar.tsx`:
+
+1. Add `SquaresFour` to the existing `@phosphor-icons/react` import list.
+2. Immediately after the Popular `NavItem` block (the one navigating to
+   `/popular`), add:
+
+```tsx
+<NavItem
+  icon={<SquaresFour className="h-[18px] w-[18px]" weight={isActive('/services') ? 'fill' : 'bold'} />}
+  label={t('nav.services')}
+  onClick={() => navigate('/services')}
+  isActive={isActive('/services')}
+/>
+```
+
+3. In the footer Divine-links collapsible, immediately before the existing
+   `/merch` router `Link`, add:
+
+```tsx
+<Link
+  to="/services"
+  className="transition-colors hover:text-primary"
+>
+  {t('nav.services')}
+</Link>
+```
+
+- [ ] **Step 4: Run the tests and verify GREEN**
+
+Run:
+
+```bash
+npx vitest run src/components/AppSidebar.test.tsx
+```
+
+Expected: PASS, including the two new tests.
+
+- [ ] **Step 5: Commit the sidebar links**
+
+```bash
+git add src/components/AppSidebar.tsx src/components/AppSidebar.test.tsx
+git commit -m "feat: link services directory from sidebar"
+```
+
+### Task 5: Prerender the directory for SEO
+
+**Files:**
+
+- Create: `scripts/prerender-content/services-content.html`
+- Modify: `scripts/prerender-legal.mjs` (`PAGES` array near line 179)
+- Create: `tests/divine-services-directory.test.ts`
+
+**Interfaces:**
+
+- Consumes: `DIVINE_SERVICES` (Task 1); the `PAGES` `contentFile` mechanism in
+  `scripts/prerender-legal.mjs` (same as `faq-content.html`).
+- Produces: prerendered `dist/services/index.html` at build time; guard test
+  keeping the static partial in sync with the config.
+
+- [ ] **Step 1: Write the failing guard test**
+
+Create `tests/divine-services-directory.test.ts`:
+
+```ts
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { DIVINE_SERVICES } from '../src/config/divineServices';
+
+const REPO_ROOT = resolve(__dirname, '..');
+
+describe('divine services prerender content', () => {
+  it('mentions every configured service name and URL', () => {
+    const html = readFileSync(
+      resolve(REPO_ROOT, 'scripts/prerender-content/services-content.html'),
+      'utf8',
+    );
+
+    for (const service of DIVINE_SERVICES) {
+      expect(html).toContain(service.url);
+      expect(html).toContain(service.name);
+    }
+  });
+
+  it('registers the /services page in the prerender script', () => {
+    const script = readFileSync(
+      resolve(REPO_ROOT, 'scripts/prerender-legal.mjs'),
+      'utf8',
+    );
+
+    expect(script).toContain("path: '/services'");
+    expect(script).toContain('services-content.html');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run:
+
+```bash
+npx vitest run tests/divine-services-directory.test.ts
+```
+
+Expected: FAIL because the content partial does not exist.
+
+- [ ] **Step 3: Add the content partial**
+
+Create `scripts/prerender-content/services-content.html`:
+
+```html
+<section>
+  <h1>Divine services</h1>
+  <p>Divine is more than loops. These services help you make the most of it.</p>
+  <ul>
+    <li>
+      <a href="https://divine.space" rel="noopener noreferrer">Divine Space</a>
+      — Your profile, your rules. Themes, Top 8, profile music.
+    </li>
+    <li>
+      <a href="https://sounds.divine.video" rel="noopener noreferrer">Sounds</a>
+      — Trending sounds and a Creative Commons library for your loops.
+    </li>
+    <li>
+      <a href="https://badges.divine.video" rel="noopener noreferrer">Badges</a>
+      — Awards for creators who show up.
+    </li>
+    <li>
+      <a href="https://crossposter.divine.video" rel="noopener noreferrer">Crossposter</a>
+      — Post your loops to the other platforms, only when you opt in.
+    </li>
+    <li>
+      <a href="https://inquisitor.divine.video" rel="noopener noreferrer">Verifier</a>
+      — Check where a video really came from.
+    </li>
+    <li>
+      <a href="https://status.divine.video" rel="noopener noreferrer">Status</a>
+      — Is it us or is it you? Check here.
+    </li>
+  </ul>
+</section>
+```
+
+- [ ] **Step 4: Register the page in the prerender script**
+
+In `scripts/prerender-legal.mjs`, add to the `PAGES` array immediately after
+the `/faq` entry:
+
+```js
+{
+  path: '/services',
+  title: 'Divine Services',
+  description: 'Companion services that help you make the most of Divine: Space, Sounds, Badges, Crossposter, Verifier, and Status.',
+  contentFile: 'services-content.html',
+},
+```
+
+- [ ] **Step 5: Run the guard test and verify GREEN**
+
+Run:
+
+```bash
+npx vitest run tests/divine-services-directory.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Verify the build emits the prerendered page**
+
+Run:
+
+```bash
+npm run build
+ls dist/services/index.html
+```
+
+Expected: build succeeds and `dist/services/index.html` exists.
+
+- [ ] **Step 7: Commit the prerender support**
+
+```bash
+git add scripts/prerender-content/services-content.html scripts/prerender-legal.mjs tests/divine-services-directory.test.ts
+git commit -m "feat: prerender services directory"
+```
+
+### Task 6: Verify the complete feature
+
+**Files:**
+
+- Verify only; do not change unrelated files.
+
+- [ ] **Step 1: Run all focused tests**
+
+```bash
+npx vitest run \
+  src/config/divineServices.test.ts \
+  src/pages/ServicesPage.test.tsx \
+  src/components/AppSidebar.test.tsx \
+  src/pages/static-pages-i18n.test.tsx \
+  tests/divine-services-directory.test.ts \
+  tests/brand/no-uppercase-class.test.ts \
+  tests/brand/no-gradients.test.ts \
+  tests/brand/no-lucide-react.test.ts
+```
+
+Expected: all PASS.
+
+- [ ] **Step 2: Run the full project gate**
+
+```bash
+npm run test
+```
+
+Expected: TypeScript, ESLint, all Vitest tests, and the production build PASS.
+
+- [ ] **Step 3: Browser verification**
+
+```bash
+npm run dev
+```
+
+At desktop and mobile widths:
+
+1. `/services` renders the title, intro, and six branded cards.
+2. Each card opens the correct service in a new tab.
+3. Sidebar top-level "Services" item navigates to `/services` and shows the
+   active state there.
+4. Footer "About Divine" expandable contains a working Services link.
+
+Stop the dev server after verification.
+
+- [ ] **Step 4: Inspect the final diff and worktree**
+
+```bash
+git diff --check origin/main
+git status --short
+git log --oneline origin/main..HEAD
+```
+
+Expected: no whitespace errors; clean worktree; seven commits (one spec doc,
+six implementation).

--- a/docs/superpowers/specs/2026-07-27-divine-services-directory-design.md
+++ b/docs/superpowers/specs/2026-07-27-divine-services-directory-design.md
@@ -37,7 +37,8 @@ and verifier were the first proof that this list will grow).
 
 ## User experience
 
-- Route `/services` renders a branded directory page:
+- Route `/services` renders a branded directory page inside the app shell
+  (sidebar stays mounted, like `/merch`):
   - `SectionHeader` title ("Divine services") and a short candid intro
     explaining Divine is more than the video app — these companion services
     help you make the most of it.

--- a/docs/superpowers/specs/2026-07-27-divine-services-directory-design.md
+++ b/docs/superpowers/specs/2026-07-27-divine-services-directory-design.md
@@ -1,0 +1,108 @@
+# Divine services directory — design
+
+**Status:** Draft, awaiting review. 2026-07-27.
+
+## Product intent
+
+Divine is more than the video app. Companion services (profile pages, sound
+library, creator awards, crossposting, provenance verification, status) help
+users take full advantage of Divine, but nothing in the app links to them or
+explains they exist. Add a "Divine services" directory page inside divine-web
+and link it from the sidebar.
+
+These are **services**, not apps: copy frames them as companion services that
+extend what you can do with Divine.
+
+## Included services (verified live 2026-07-27, all return 200)
+
+| Service | URL | What it does |
+| --- | --- | --- |
+| Divine Space | `https://divine.space` | Customizable profile home: themes, Top 8, profile music |
+| Sounds | `https://sounds.divine.video` | Trending sounds + Creative Commons audio library for loops |
+| Badges | `https://badges.divine.video` | Creator awards and recognition |
+| Crossposter | `https://crossposter.divine.video` | Opt-in crossposting of Divine videos to external short-form platforms |
+| Verifier | `https://inquisitor.divine.video` | Check a video's provenance: C2PA content credentials, live verification lab |
+| Status | `https://status.divine.video` | Live Divine service health |
+
+Explicitly excluded (confirmed with product):
+
+- **Clips** (`clips.divine.video`) and **Invite** (`invite.divine.video`) —
+  not ready.
+- **Supporters** (`supporters.divine.video`) — excluded by product.
+- **Connect** (`connect.divine.video`) — invite-only partner facade.
+- **Compiler** (`compiler.divine.video`) — internal editor.
+
+The config list is the single place future services get added (crossposter
+and verifier were the first proof that this list will grow).
+
+## User experience
+
+- Route `/services` renders a branded directory page:
+  - `SectionHeader` title ("Divine services") and a short candid intro
+    explaining Divine is more than the video app — these companion services
+    help you make the most of it.
+  - A responsive grid of `Card variant="brand"` cards with the existing
+    per-card accent rotation, one per service: Phosphor icon, service name,
+    one-line description, external-link affordance.
+  - Cards link out with `target="_blank" rel="noopener noreferrer"`.
+- Sidebar gets two entry points:
+  - A top-level nav item "Services" (Phosphor `SquaresFour` icon) in the main
+    nav cluster.
+  - A "Services" link in the footer Divine-links expandable section next to
+    the about.divine.video links.
+- The page is prerendered at build time for SEO, following the existing
+  `scripts/prerender-legal.mjs` pattern used by `/faq`, `/terms`, etc.
+- Mobile and desktop layouts both work; the grid collapses to one column on
+  small screens.
+
+## Architecture
+
+- **Config module** `src/config/divineServices.ts`: typed
+  `DivineService { id, name, url, descriptionKey, icon }` and a
+  `DIVINE_SERVICES` ordered array. Single source for the page and any future
+  consumers. Adding a service later = one array entry + one locale string.
+- **Page** `src/pages/ServicesPage.tsx`: pure presentational render of the
+  config via brand primitives. Registered as a route in `src/App.tsx`.
+- **Sidebar** `src/components/AppSidebar.tsx`: one `NavItem` plus one footer
+  link, both navigating to `/services` (internal route, not external).
+- **i18n**: new `servicesPage.*` keys (title, intro, one description per
+  service, nav label `nav.services`). English first; the other 15 locales get
+  the English strings as placeholders so translators can catch up (same
+  pattern as previous key additions). Locale key parity tests must pass.
+- **Prerender**: add `/services` to the marketing prerender list with a
+  static content partial under `scripts/prerender-content/`, matching the
+  existing FAQ/terms mechanism.
+
+## Copy (English, brand voice — candid, never corporate)
+
+- Title: "Divine services"
+- Intro: "Divine is more than loops. These services help you make the most
+  of it."
+- Divine Space: "Your profile, your rules. Themes, Top 8, profile music."
+- Sounds: "Trending sounds and a Creative Commons library for your loops."
+- Badges: "Awards for creators who show up."
+- Crossposter: "Post your loops to the other platforms — only when you opt
+  in."
+- Verifier: "Check where a video really came from."
+- Status: "Is it us or is it you? Check here."
+
+## Testing
+
+- `ServicesPage.test.tsx`: renders all six service cards, each linking to the
+  correct URL with `rel="noopener noreferrer"`; intro copy present.
+- `AppSidebar.test.tsx`: top-level Services item and footer Services link
+  both navigate to `/services`.
+- Config shape test: every entry has id, name, https URL, descriptionKey,
+  icon; ids unique.
+- Prerendered content partial covered by the same static accuracy pattern as
+  the FAQ partial (guard test asserting key copy is present).
+- Brand guardrail tests (no `uppercase`, no gradients, no lucide) run over
+  new code automatically.
+- Full gate: `npm run test` (tsc, eslint, vitest, build with prerender).
+
+## Out of scope
+
+- Listing clips, invite, supporters, connect, or compiler.
+- Live health data on the cards (Status link is enough).
+- Any backend or API work.
+- Translations beyond English placeholder strings.

--- a/scripts/prerender-content/services-content.html
+++ b/scripts/prerender-content/services-content.html
@@ -1,0 +1,30 @@
+<section>
+  <h1>Divine services</h1>
+  <p>Divine is more than loops. These services help you make the most of it.</p>
+  <ul>
+    <li>
+      <a href="https://divine.space" rel="noopener noreferrer">Divine Space</a>
+      — Your profile, your rules. Themes, Top 8, profile music.
+    </li>
+    <li>
+      <a href="https://sounds.divine.video" rel="noopener noreferrer">Sounds</a>
+      — Trending sounds and a Creative Commons library for your loops.
+    </li>
+    <li>
+      <a href="https://badges.divine.video" rel="noopener noreferrer">Badges</a>
+      — Awards for creators who show up.
+    </li>
+    <li>
+      <a href="https://crossposter.divine.video" rel="noopener noreferrer">Crossposter</a>
+      — Post your loops to the other platforms, only when you opt in.
+    </li>
+    <li>
+      <a href="https://inquisitor.divine.video" rel="noopener noreferrer">Verifier</a>
+      — Check where a video really came from.
+    </li>
+    <li>
+      <a href="https://status.divine.video" rel="noopener noreferrer">Status</a>
+      — Is it us or is it you? Check here.
+    </li>
+  </ul>
+</section>

--- a/scripts/prerender-legal.mjs
+++ b/scripts/prerender-legal.mjs
@@ -32,16 +32,26 @@ function getShellTemplate(indexHtml) {
     styleBlocks.push(m[0]);
   }
 
-  return { cssLinks, styleBlocks, fontLinks };
+  // Extract the CSP meta tag. These pages boot the full SPA, and the app's
+  // only CSP is this tag (_headers sets a policy for /embed alone), so a
+  // prerendered page without it would run the whole app unprotected for any
+  // session that entered through /terms, /faq, /services, and so on.
+  const cspMatch = indexHtml.match(
+    /<meta[^>]+http-equiv="Content-Security-Policy"[^>]*>/i
+  );
+  const cspMeta = cspMatch ? cspMatch[0] : '';
+
+  return { cssLinks, styleBlocks, fontLinks, cspMeta };
 }
 
 function buildPage({ title, description, path, content, shell }) {
-  const { cssLinks, styleBlocks, fontLinks } = shell;
+  const { cssLinks, styleBlocks, fontLinks, cspMeta } = shell;
 
   return `<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8">
+    ${cspMeta}
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, user-scalable=yes, viewport-fit=cover">
     <title>${title} - Divine Web</title>
     <meta name="description" content="${description}">

--- a/scripts/prerender-legal.mjs
+++ b/scripts/prerender-legal.mjs
@@ -182,6 +182,12 @@ const PAGES = [
     description: 'Frequently Asked Questions about Divine Web - Everything you need to know about the platform.',
     contentFile: 'faq-content.html',
   },
+  {
+    path: '/services',
+    title: 'Divine Services',
+    description: 'Companion services that help you make the most of Divine: Space, Sounds, Badges, Crossposter, Verifier, and Status.',
+    contentFile: 'services-content.html',
+  },
 ];
 
 function extractContentFromTsx(sourcePath) {

--- a/scripts/prerender-legal.mjs
+++ b/scripts/prerender-legal.mjs
@@ -256,10 +256,13 @@ function main() {
       shell,
     });
 
-    // Replace the placeholder script src with the actual bundle
+    // Replace the placeholder script src with the actual bundle. The regex
+    // only captures the opening tag, so re-add the closing </script> —
+    // without it the parser swallows the rest of the document and the app
+    // never boots on prerendered pages.
     const finalHtml = html.replace(
       '<script type="module" src="/src/main.tsx"></script>',
-      scriptMatch ? scriptMatch[0] : ''
+      scriptMatch ? scriptMatch[0] + '</script>' : ''
     );
 
     const outDir = join(DIST, page.path.slice(1));

--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -111,6 +111,7 @@ export function AppRouter() {
       <Route path="/search" element={<SearchPage />} />
       <Route path="/leaderboard" element={<LeaderboardPage />} />
       <Route path="/merch" element={<MerchPage />} />
+      <Route path="/services" element={<ServicesPage />} />
       <Route path="/u/:userId" element={<UniversalUserPage />} />
       <Route path="/list/:pubkey/:listId" element={<ListDetailPage />} />
       <Route path="/event/:eventId" element={<EventPage />} />
@@ -168,7 +169,6 @@ export function AppRouter() {
         <Route path="/kids" element={<KidsPolicyPage />} />
         <Route path="/support" element={<Support />} />
         <Route path="/faq" element={<FAQPage />} />
-        <Route path="/services" element={<ServicesPage />} />
         <Route path="/get-embed" element={<GetEmbedPage />} />
         <Route path="/app/callback" element={<AppCallbackPage />} />
         <Route path="/auth/callback" element={<AuthCallbackPage />} />

--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -50,6 +50,7 @@ import { AgeReviewPage } from "./pages/AgeReviewPage";
 import { KidsPolicyPage } from "./pages/KidsPolicyPage";
 import { Support } from "./pages/Support";
 import { FAQPage } from "./pages/FAQPage";
+import { ServicesPage } from "./pages/ServicesPage";
 import MerchPage from "./pages/MerchPage";
 import { TermsPage } from "./pages/TermsPage";
 import GetEmbedPage from "./pages/GetEmbedPage";
@@ -167,6 +168,7 @@ export function AppRouter() {
         <Route path="/kids" element={<KidsPolicyPage />} />
         <Route path="/support" element={<Support />} />
         <Route path="/faq" element={<FAQPage />} />
+        <Route path="/services" element={<ServicesPage />} />
         <Route path="/get-embed" element={<GetEmbedPage />} />
         <Route path="/app/callback" element={<AppCallbackPage />} />
         <Route path="/auth/callback" element={<AuthCallbackPage />} />

--- a/src/components/AppSidebar.test.tsx
+++ b/src/components/AppSidebar.test.tsx
@@ -194,6 +194,30 @@ describe('AppSidebar', () => {
     expect(screen.getByRole('button', { name: /musica/i })).toBeVisible();
   });
 
+  it('navigates to the services directory from the top-level nav', () => {
+    render(
+      <MemoryRouter>
+        <AppSidebar />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Services' }));
+    expect(mockNavigate).toHaveBeenCalledWith('/services');
+  });
+
+  it('links to the services directory from the footer Divine links', async () => {
+    render(
+      <MemoryRouter>
+        <AppSidebar />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /acerca de divine/i }));
+
+    const link = await screen.findByRole('link', { name: 'Services' });
+    expect(link).toHaveAttribute('href', '/services');
+  });
+
   it('keeps the language chooser collapsed until opened', () => {
     render(
       <MemoryRouter>

--- a/src/components/AppSidebar.test.tsx
+++ b/src/components/AppSidebar.test.tsx
@@ -205,6 +205,20 @@ describe('AppSidebar', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/services');
   });
 
+  it('marks the services nav item active on the prerendered /services/ URL', () => {
+    // Cloudflare Pages 308-redirects /services to /services/, so a direct hit,
+    // reload, or shared link always lands on the trailing-slash form.
+    render(
+      <MemoryRouter initialEntries={['/services/']}>
+        <AppSidebar />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('button', { name: 'Services' })).toHaveClass(
+      'bg-primary',
+    );
+  });
+
   it('links to the services directory from the footer Divine links', async () => {
     render(
       <MemoryRouter>

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -2,7 +2,7 @@
 // ABOUTME: Shows main nav, login/signup, expandable Divine links section
 
 import { Link, useLocation } from 'react-router-dom';
-import { House as Home, Compass, MagnifyingGlass as Search, Bell, User, Sun, Moon, CaretDown as ChevronDown, Headphones, ChartBar as BarChart3, SquaresFour as LayoutGrid, Rss, ChatCircle as MessageCircle, TrendUp, Handshake } from '@phosphor-icons/react';
+import { House as Home, Compass, MagnifyingGlass as Search, Bell, User, Sun, Moon, CaretDown as ChevronDown, Headphones, ChartBar as BarChart3, SquaresFour as LayoutGrid, SquaresFour, Rss, ChatCircle as MessageCircle, TrendUp, Handshake } from '@phosphor-icons/react';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useCategories } from '@/hooks/useCategories';
@@ -199,6 +199,13 @@ export function AppSidebar({ className }: { className?: string }) {
             label={t('nav.popular')}
             onClick={() => navigate('/popular')}
             isActive={isPopularActive()}
+          />
+
+          <NavItem
+            icon={<SquaresFour className="h-[18px] w-[18px]" weight={isActive('/services') ? 'fill' : 'bold'} />}
+            label={t('nav.services')}
+            onClick={() => navigate('/services')}
+            isActive={isActive('/services')}
           />
 
           {user && canUseDirectMessages && (
@@ -463,6 +470,12 @@ export function AppSidebar({ className }: { className?: string }) {
               >
                 {t('menu.mediaResources')}
               </a>
+              <Link
+                to="/services"
+                className="transition-colors hover:text-primary"
+              >
+                {t('nav.services')}
+              </Link>
               <Link
                 to="/merch"
                 className="transition-colors hover:text-primary"

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -2,7 +2,7 @@
 // ABOUTME: Shows main nav, login/signup, expandable Divine links section
 
 import { Link, useLocation } from 'react-router-dom';
-import { House as Home, Compass, MagnifyingGlass as Search, Bell, User, Sun, Moon, CaretDown as ChevronDown, Headphones, ChartBar as BarChart3, SquaresFour as LayoutGrid, SquaresFour, Rss, ChatCircle as MessageCircle, TrendUp, Handshake } from '@phosphor-icons/react';
+import { House as Home, Compass, MagnifyingGlass as Search, Bell, User, Sun, Moon, CaretDown as ChevronDown, Headphones, ChartBar as BarChart3, SquaresFour as LayoutGrid, Rss, ChatCircle as MessageCircle, TrendUp, Handshake } from '@phosphor-icons/react';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useCategories } from '@/hooks/useCategories';
@@ -202,7 +202,7 @@ export function AppSidebar({ className }: { className?: string }) {
           />
 
           <NavItem
-            icon={<SquaresFour className="h-[18px] w-[18px]" weight={isActive('/services') ? 'fill' : 'bold'} />}
+            icon={<LayoutGrid className="h-[18px] w-[18px]" weight={isActive('/services') ? 'fill' : 'bold'} />}
             label={t('nav.services')}
             onClick={() => navigate('/services')}
             isActive={isActive('/services')}

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -75,7 +75,12 @@ export function AppSidebar({ className }: { className?: string }) {
   const [appStoreUrl, setAppStoreUrl] = useState<string | null>(null);
   const { data: categories } = useCategories();
 
-  const isActive = (path: string) => location.pathname === path;
+  // Prerendered routes are served from a directory (dist/services/index.html),
+  // and Cloudflare Pages 308-redirects /services to /services/. Match the
+  // trailing-slash form too so a direct hit highlights the same nav item that
+  // an in-app navigation does.
+  const isActive = (path: string) =>
+    location.pathname === path || location.pathname === `${path}/`;
   const isDiscoveryActive = () =>
     location.pathname === '/discovery' || location.pathname.startsWith('/discovery/');
   const isPopularActive = () => location.pathname === '/popular';

--- a/src/config/divineServices.test.ts
+++ b/src/config/divineServices.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { DIVINE_SERVICES } from './divineServices';
+
+describe('DIVINE_SERVICES', () => {
+  it('lists each service with a unique id, name, https URL, and icon', () => {
+    const ids = DIVINE_SERVICES.map((service) => service.id);
+    expect(new Set(ids).size).toBe(ids.length);
+
+    for (const service of DIVINE_SERVICES) {
+      expect(service.name.length).toBeGreaterThan(0);
+      expect(service.url).toMatch(/^https:\/\//);
+      expect(service.icon).toBeTruthy();
+    }
+  });
+
+  it('includes the six launch services in display order', () => {
+    expect(DIVINE_SERVICES.map((service) => service.id)).toEqual([
+      'space',
+      'sounds',
+      'badges',
+      'crossposter',
+      'verifier',
+      'status',
+    ]);
+  });
+});

--- a/src/config/divineServices.ts
+++ b/src/config/divineServices.ts
@@ -1,0 +1,66 @@
+// ABOUTME: Canonical list of public companion Divine services shown on /services
+// ABOUTME: Add future public services here; the page and prerender guard render from it
+
+import {
+  HouseLine,
+  Medal,
+  MusicNotes,
+  Pulse,
+  SealCheck,
+  ShareNetwork,
+  type Icon,
+} from '@phosphor-icons/react';
+
+export type DivineServiceId =
+  | 'space'
+  | 'sounds'
+  | 'badges'
+  | 'crossposter'
+  | 'verifier'
+  | 'status';
+
+export interface DivineService {
+  id: DivineServiceId;
+  name: string;
+  url: string;
+  icon: Icon;
+}
+
+export const DIVINE_SERVICES: DivineService[] = [
+  {
+    id: 'space',
+    name: 'Divine Space',
+    url: 'https://divine.space',
+    icon: HouseLine,
+  },
+  {
+    id: 'sounds',
+    name: 'Sounds',
+    url: 'https://sounds.divine.video',
+    icon: MusicNotes,
+  },
+  {
+    id: 'badges',
+    name: 'Badges',
+    url: 'https://badges.divine.video',
+    icon: Medal,
+  },
+  {
+    id: 'crossposter',
+    name: 'Crossposter',
+    url: 'https://crossposter.divine.video',
+    icon: ShareNetwork,
+  },
+  {
+    id: 'verifier',
+    name: 'Verifier',
+    url: 'https://inquisitor.divine.video',
+    icon: SealCheck,
+  },
+  {
+    id: 'status',
+    name: 'Status',
+    url: 'https://status.divine.video',
+    icon: Pulse,
+  },
+];

--- a/src/lib/i18n/locales/ar/common.json
+++ b/src/lib/i18n/locales/ar/common.json
@@ -8,6 +8,7 @@
     "home": "الرئيسية",
     "discover": "اكتشف",
     "popular": "Popular",
+    "services": "Services",
     "search": "بحث",
     "messages": "الرسائل",
     "notifications": "الإشعارات",
@@ -132,6 +133,19 @@
     "communityTitle": "المجتمع",
     "communityDescription": "انضم إلى نقاشات المجتمع وتواصل مع مستخدمي Divine الآخرين على Nostr.",
     "communityBody": "تم بناء Divine على Nostr، وهو بروتوكول اجتماعي لامركزي. اعثر علينا في عميل Nostr المفضل لديك."
+  },
+  "servicesPage": {
+    "title": "Divine services",
+    "intro": "Divine is more than loops. These services help you make the most of it.",
+    "openService": "Open {{name}}",
+    "items": {
+      "space": "Your profile, your rules. Themes, Top 8, profile music.",
+      "sounds": "Trending sounds and a Creative Commons library for your loops.",
+      "badges": "Awards for creators who show up.",
+      "crossposter": "Post your loops to the other platforms — only when you opt in.",
+      "verifier": "Check where a video really came from.",
+      "status": "Is it us or is it you? Check here."
+    }
   },
   "tagPage": {
     "notFoundTitle": "لم يتم العثور على الوسم",

--- a/src/lib/i18n/locales/de/common.json
+++ b/src/lib/i18n/locales/de/common.json
@@ -8,6 +8,7 @@
     "home": "Startseite",
     "discover": "Entdecken",
     "popular": "Popular",
+    "services": "Services",
     "search": "Suchen",
     "messages": "Nachrichten",
     "notifications": "Benachrichtigungen",
@@ -133,6 +134,19 @@
     "communityDescription": "Beteilige dich an unseren Community-Diskussionen und vernetze dich mit anderen Divine-Nutzern auf Nostr.",
     "communityBody": "Divine basiert auf Nostr, einem dezentralen sozialen Protokoll. Finde uns in deinem bevorzugten Nostr-Client."
   },
+  "servicesPage": {
+    "title": "Divine services",
+    "intro": "Divine is more than loops. These services help you make the most of it.",
+    "openService": "Open {{name}}",
+    "items": {
+      "space": "Your profile, your rules. Themes, Top 8, profile music.",
+      "sounds": "Trending sounds and a Creative Commons library for your loops.",
+      "badges": "Awards for creators who show up.",
+      "crossposter": "Post your loops to the other platforms — only when you opt in.",
+      "verifier": "Check where a video really came from.",
+      "status": "Is it us or is it you? Check here."
+    }
+  },
   "tagPage": {
     "notFoundTitle": "Tag nicht gefunden",
     "notFoundDescription": "Der angeforderte Tag konnte nicht gefunden werden.",
@@ -145,7 +159,11 @@
     "emptyState": "Derzeit sind keine Kategorien verfugbar.",
     "metaTitle": "Kategorien entdecken - Divine",
     "metaDescription": "Entdecke Videokategorien auf Divine - Comedy, Musik, Tanz, Tiere, Sport, Essen und mehr.",
+    "videoCount_zero": "{{count}} videos",
     "videoCount_one": "{{count}} Video",
+    "videoCount_two": "{{count}} videos",
+    "videoCount_few": "{{count}} videos",
+    "videoCount_many": "{{count}} videos",
     "videoCount_other": "{{count}} Videos"
   },
   "vineBadge": {

--- a/src/lib/i18n/locales/en/common.json
+++ b/src/lib/i18n/locales/en/common.json
@@ -8,6 +8,7 @@
     "home": "Home",
     "discover": "Discover",
     "popular": "Popular",
+    "services": "Services",
     "search": "Search",
     "messages": "Messages",
     "notifications": "Notifications",
@@ -133,6 +134,19 @@
     "communityDescription": "Come hang with the Divine community on Nostr.",
     "communityBody": "Divine runs on Nostr, the decentralized social protocol. Find us on your favorite Nostr client."
   },
+  "servicesPage": {
+    "title": "Divine services",
+    "intro": "Divine is more than loops. These services help you make the most of it.",
+    "openService": "Open {{name}}",
+    "items": {
+      "space": "Your profile, your rules. Themes, Top 8, profile music.",
+      "sounds": "Trending sounds and a Creative Commons library for your loops.",
+      "badges": "Awards for creators who show up.",
+      "crossposter": "Post your loops to the other platforms — only when you opt in.",
+      "verifier": "Check where a video really came from.",
+      "status": "Is it us or is it you? Check here."
+    }
+  },
   "tagPage": {
     "notFoundTitle": "Tag not found.",
     "notFoundDescription": "Couldn't find that tag.",
@@ -145,7 +159,11 @@
     "emptyState": "No categories cooking right now.",
     "metaTitle": "Browse Categories - Divine",
     "metaDescription": "Explore video categories on Divine - comedy, music, dance, animals, sports, food, and more.",
+    "videoCount_zero": "{{count}} videos",
     "videoCount_one": "{{count}} video",
+    "videoCount_two": "{{count}} videos",
+    "videoCount_few": "{{count}} videos",
+    "videoCount_many": "{{count}} videos",
     "videoCount_other": "{{count}} videos"
   },
   "vineBadge": {

--- a/src/lib/i18n/locales/es/common.json
+++ b/src/lib/i18n/locales/es/common.json
@@ -8,6 +8,7 @@
     "home": "Inicio",
     "discover": "Descubrir",
     "popular": "Popular",
+    "services": "Services",
     "search": "Buscar",
     "messages": "Mensajes",
     "notifications": "Notificaciones",
@@ -133,6 +134,19 @@
     "communityDescription": "Unete a nuestras conversaciones comunitarias y conecta con otros usuarios de Divine en Nostr.",
     "communityBody": "Divine esta construido sobre Nostr, un protocolo social descentralizado. Encuentranos en tu cliente de Nostr favorito."
   },
+  "servicesPage": {
+    "title": "Divine services",
+    "intro": "Divine is more than loops. These services help you make the most of it.",
+    "openService": "Open {{name}}",
+    "items": {
+      "space": "Your profile, your rules. Themes, Top 8, profile music.",
+      "sounds": "Trending sounds and a Creative Commons library for your loops.",
+      "badges": "Awards for creators who show up.",
+      "crossposter": "Post your loops to the other platforms — only when you opt in.",
+      "verifier": "Check where a video really came from.",
+      "status": "Is it us or is it you? Check here."
+    }
+  },
   "tagPage": {
     "notFoundTitle": "Etiqueta no encontrada",
     "notFoundDescription": "No se pudo encontrar la etiqueta solicitada.",
@@ -145,7 +159,11 @@
     "emptyState": "No hay categorias disponibles en este momento.",
     "metaTitle": "Explorar categorias - Divine",
     "metaDescription": "Explora categorias de video en Divine: comedia, musica, baile, animales, deportes, comida y mas.",
+    "videoCount_zero": "{{count}} videos",
     "videoCount_one": "{{count}} video",
+    "videoCount_two": "{{count}} videos",
+    "videoCount_few": "{{count}} videos",
+    "videoCount_many": "{{count}} videos",
     "videoCount_other": "{{count}} videos"
   },
   "vineBadge": {

--- a/src/lib/i18n/locales/fil/common.json
+++ b/src/lib/i18n/locales/fil/common.json
@@ -8,6 +8,7 @@
     "home": "Tahanan",
     "discover": "Tuklasin",
     "popular": "Popular",
+    "services": "Services",
     "search": "Hanapin",
     "messages": "Mga Mensahe",
     "notifications": "Mga Abiso",
@@ -133,6 +134,19 @@
     "communityDescription": "Tara, sumama sa komunidad ng Divine sa Nostr.",
     "communityBody": "Tumatakbo ang Divine sa Nostr, ang decentralized social protocol. Hanapin kami sa paboritong Nostr client mo."
   },
+  "servicesPage": {
+    "title": "Divine services",
+    "intro": "Divine is more than loops. These services help you make the most of it.",
+    "openService": "Open {{name}}",
+    "items": {
+      "space": "Your profile, your rules. Themes, Top 8, profile music.",
+      "sounds": "Trending sounds and a Creative Commons library for your loops.",
+      "badges": "Awards for creators who show up.",
+      "crossposter": "Post your loops to the other platforms — only when you opt in.",
+      "verifier": "Check where a video really came from.",
+      "status": "Is it us or is it you? Check here."
+    }
+  },
   "tagPage": {
     "notFoundTitle": "Wala ang tag.",
     "notFoundDescription": "Wala kaming mahanap dyan.",
@@ -145,7 +159,11 @@
     "emptyState": "Walang nilulutong kategorya ngayon.",
     "metaTitle": "Galugarin ang mga Kategorya - Divine",
     "metaDescription": "Tuklasin ang mga kategorya ng video sa Divine — komedya, musika, sayaw, hayop, sports, pagkain, at marami pa.",
+    "videoCount_zero": "{{count}} videos",
     "videoCount_one": "{{count}} video",
+    "videoCount_two": "{{count}} videos",
+    "videoCount_few": "{{count}} videos",
+    "videoCount_many": "{{count}} videos",
     "videoCount_other": "{{count}} mga video"
   },
   "vineBadge": {

--- a/src/lib/i18n/locales/fr/common.json
+++ b/src/lib/i18n/locales/fr/common.json
@@ -8,6 +8,7 @@
     "home": "Accueil",
     "discover": "Decouvrir",
     "popular": "Popular",
+    "services": "Services",
     "search": "Rechercher",
     "messages": "Messages",
     "notifications": "Notifications",
@@ -133,6 +134,19 @@
     "communityDescription": "Rejoignez les discussions de la communaute et connectez-vous avec d'autres utilisateurs de Divine sur Nostr.",
     "communityBody": "Divine est construit sur Nostr, un protocole social decentralise. Retrouvez-nous sur votre client Nostr prefere."
   },
+  "servicesPage": {
+    "title": "Divine services",
+    "intro": "Divine is more than loops. These services help you make the most of it.",
+    "openService": "Open {{name}}",
+    "items": {
+      "space": "Your profile, your rules. Themes, Top 8, profile music.",
+      "sounds": "Trending sounds and a Creative Commons library for your loops.",
+      "badges": "Awards for creators who show up.",
+      "crossposter": "Post your loops to the other platforms — only when you opt in.",
+      "verifier": "Check where a video really came from.",
+      "status": "Is it us or is it you? Check here."
+    }
+  },
   "tagPage": {
     "notFoundTitle": "Tag introuvable",
     "notFoundDescription": "Le tag demande est introuvable.",
@@ -145,7 +159,11 @@
     "emptyState": "Aucune categorie disponible pour le moment.",
     "metaTitle": "Parcourir les categories - Divine",
     "metaDescription": "Explorez les categories de videos sur Divine - comedie, musique, danse, animaux, sport, cuisine et plus encore.",
+    "videoCount_zero": "{{count}} videos",
     "videoCount_one": "{{count}} video",
+    "videoCount_two": "{{count}} videos",
+    "videoCount_few": "{{count}} videos",
+    "videoCount_many": "{{count}} videos",
     "videoCount_other": "{{count}} videos"
   },
   "vineBadge": {

--- a/src/lib/i18n/locales/id/common.json
+++ b/src/lib/i18n/locales/id/common.json
@@ -8,6 +8,7 @@
     "home": "Beranda",
     "discover": "Jelajahi",
     "popular": "Popular",
+    "services": "Services",
     "search": "Cari",
     "messages": "Pesan",
     "notifications": "Notifikasi",
@@ -133,6 +134,19 @@
     "communityDescription": "Bergabunglah dalam diskusi komunitas dan terhubung dengan pengguna Divine lainnya di Nostr.",
     "communityBody": "Divine dibangun di atas Nostr, protokol sosial yang terdesentralisasi. Temukan kami di klien Nostr favorit Anda."
   },
+  "servicesPage": {
+    "title": "Divine services",
+    "intro": "Divine is more than loops. These services help you make the most of it.",
+    "openService": "Open {{name}}",
+    "items": {
+      "space": "Your profile, your rules. Themes, Top 8, profile music.",
+      "sounds": "Trending sounds and a Creative Commons library for your loops.",
+      "badges": "Awards for creators who show up.",
+      "crossposter": "Post your loops to the other platforms — only when you opt in.",
+      "verifier": "Check where a video really came from.",
+      "status": "Is it us or is it you? Check here."
+    }
+  },
   "tagPage": {
     "notFoundTitle": "Tag tidak ditemukan",
     "notFoundDescription": "Tag yang diminta tidak dapat ditemukan.",
@@ -145,7 +159,11 @@
     "emptyState": "Belum ada kategori yang tersedia saat ini.",
     "metaTitle": "Jelajahi kategori - Divine",
     "metaDescription": "Jelajahi kategori video di Divine - komedi, musik, tarian, hewan, olahraga, makanan, dan lainnya.",
+    "videoCount_zero": "{{count}} videos",
     "videoCount_one": "{{count}} video",
+    "videoCount_two": "{{count}} videos",
+    "videoCount_few": "{{count}} videos",
+    "videoCount_many": "{{count}} videos",
     "videoCount_other": "{{count}} video"
   },
   "vineBadge": {

--- a/src/lib/i18n/locales/it/common.json
+++ b/src/lib/i18n/locales/it/common.json
@@ -8,6 +8,7 @@
     "home": "Home",
     "discover": "Scopri",
     "popular": "Popular",
+    "services": "Services",
     "search": "Cerca",
     "messages": "Messaggi",
     "notifications": "Notifiche",
@@ -133,6 +134,19 @@
     "communityDescription": "Partecipa alle discussioni della comunita e connettiti con altri utenti Divine su Nostr.",
     "communityBody": "Divine e costruito su Nostr, un protocollo sociale decentralizzato. Trovaci nel tuo client Nostr preferito."
   },
+  "servicesPage": {
+    "title": "Divine services",
+    "intro": "Divine is more than loops. These services help you make the most of it.",
+    "openService": "Open {{name}}",
+    "items": {
+      "space": "Your profile, your rules. Themes, Top 8, profile music.",
+      "sounds": "Trending sounds and a Creative Commons library for your loops.",
+      "badges": "Awards for creators who show up.",
+      "crossposter": "Post your loops to the other platforms — only when you opt in.",
+      "verifier": "Check where a video really came from.",
+      "status": "Is it us or is it you? Check here."
+    }
+  },
   "tagPage": {
     "notFoundTitle": "Tag non trovata",
     "notFoundDescription": "Impossibile trovare la tag richiesta.",
@@ -145,7 +159,11 @@
     "emptyState": "Nessuna categoria disponibile in questo momento.",
     "metaTitle": "Esplora le categorie - Divine",
     "metaDescription": "Esplora le categorie video su Divine - commedia, musica, danza, animali, sport, cibo e altro.",
+    "videoCount_zero": "{{count}} videos",
     "videoCount_one": "{{count}} video",
+    "videoCount_two": "{{count}} videos",
+    "videoCount_few": "{{count}} videos",
+    "videoCount_many": "{{count}} videos",
     "videoCount_other": "{{count}} video"
   },
   "vineBadge": {

--- a/src/lib/i18n/locales/ja/common.json
+++ b/src/lib/i18n/locales/ja/common.json
@@ -8,6 +8,7 @@
     "home": "ホーム",
     "discover": "発見",
     "popular": "Popular",
+    "services": "Services",
     "search": "検索",
     "messages": "メッセージ",
     "notifications": "通知",
@@ -133,6 +134,19 @@
     "communityDescription": "コミュニティの会話に参加し、Nostr 上の他の Divine ユーザーとつながりましょう。",
     "communityBody": "Divine は分散型ソーシャルプロトコル Nostr 上に構築されています。お気に入りの Nostr クライアントで見つけてください。"
   },
+  "servicesPage": {
+    "title": "Divine services",
+    "intro": "Divine is more than loops. These services help you make the most of it.",
+    "openService": "Open {{name}}",
+    "items": {
+      "space": "Your profile, your rules. Themes, Top 8, profile music.",
+      "sounds": "Trending sounds and a Creative Commons library for your loops.",
+      "badges": "Awards for creators who show up.",
+      "crossposter": "Post your loops to the other platforms — only when you opt in.",
+      "verifier": "Check where a video really came from.",
+      "status": "Is it us or is it you? Check here."
+    }
+  },
   "tagPage": {
     "notFoundTitle": "タグが見つかりません",
     "notFoundDescription": "指定されたタグは見つかりませんでした。",
@@ -145,7 +159,11 @@
     "emptyState": "現在利用できるカテゴリはありません。",
     "metaTitle": "カテゴリを探す - Divine",
     "metaDescription": "Divine でコメディ、音楽、ダンス、動物、スポーツ、食べ物などの動画カテゴリを探そう。",
+    "videoCount_zero": "{{count}} videos",
     "videoCount_one": "{{count}}本の動画",
+    "videoCount_two": "{{count}} videos",
+    "videoCount_few": "{{count}} videos",
+    "videoCount_many": "{{count}} videos",
     "videoCount_other": "{{count}}本の動画"
   },
   "vineBadge": {

--- a/src/lib/i18n/locales/ko/common.json
+++ b/src/lib/i18n/locales/ko/common.json
@@ -8,6 +8,7 @@
     "home": "홈",
     "discover": "탐색",
     "popular": "Popular",
+    "services": "Services",
     "search": "검색",
     "messages": "메시지",
     "notifications": "알림",
@@ -133,6 +134,19 @@
     "communityDescription": "커뮤니티 대화에 참여하고 Nostr 의 다른 Divine 사용자와 연결하세요.",
     "communityBody": "Divine 은 탈중앙화 소셜 프로토콜인 Nostr 위에 구축되었습니다. 즐겨 사용하는 Nostr 클라이언트에서 저희를 찾아보세요."
   },
+  "servicesPage": {
+    "title": "Divine services",
+    "intro": "Divine is more than loops. These services help you make the most of it.",
+    "openService": "Open {{name}}",
+    "items": {
+      "space": "Your profile, your rules. Themes, Top 8, profile music.",
+      "sounds": "Trending sounds and a Creative Commons library for your loops.",
+      "badges": "Awards for creators who show up.",
+      "crossposter": "Post your loops to the other platforms — only when you opt in.",
+      "verifier": "Check where a video really came from.",
+      "status": "Is it us or is it you? Check here."
+    }
+  },
   "tagPage": {
     "notFoundTitle": "태그를 찾을 수 없습니다",
     "notFoundDescription": "요청한 태그를 찾을 수 없습니다.",
@@ -145,7 +159,11 @@
     "emptyState": "현재 사용할 수 있는 카테고리가 없습니다.",
     "metaTitle": "카테고리 둘러보기 - Divine",
     "metaDescription": "Divine 에서 코미디, 음악, 댄스, 동물, 스포츠, 음식 등 다양한 동영상 카테고리를 둘러보세요.",
+    "videoCount_zero": "{{count}} videos",
     "videoCount_one": "동영상 {{count}}개",
+    "videoCount_two": "{{count}} videos",
+    "videoCount_few": "{{count}} videos",
+    "videoCount_many": "{{count}} videos",
     "videoCount_other": "동영상 {{count}}개"
   },
   "vineBadge": {

--- a/src/lib/i18n/locales/nl/common.json
+++ b/src/lib/i18n/locales/nl/common.json
@@ -8,6 +8,7 @@
     "home": "Home",
     "discover": "Ontdekken",
     "popular": "Popular",
+    "services": "Services",
     "search": "Zoeken",
     "messages": "Berichten",
     "notifications": "Meldingen",
@@ -133,6 +134,19 @@
     "communityDescription": "Doe mee aan onze communitygesprekken en maak contact met andere Divine-gebruikers op Nostr.",
     "communityBody": "Divine is gebouwd op Nostr, een gedecentraliseerd sociaal protocol. Vind ons in je favoriete Nostr-client."
   },
+  "servicesPage": {
+    "title": "Divine services",
+    "intro": "Divine is more than loops. These services help you make the most of it.",
+    "openService": "Open {{name}}",
+    "items": {
+      "space": "Your profile, your rules. Themes, Top 8, profile music.",
+      "sounds": "Trending sounds and a Creative Commons library for your loops.",
+      "badges": "Awards for creators who show up.",
+      "crossposter": "Post your loops to the other platforms — only when you opt in.",
+      "verifier": "Check where a video really came from.",
+      "status": "Is it us or is it you? Check here."
+    }
+  },
   "tagPage": {
     "notFoundTitle": "Tag niet gevonden",
     "notFoundDescription": "De gevraagde tag kon niet worden gevonden.",
@@ -145,7 +159,11 @@
     "emptyState": "Er zijn momenteel geen categorieen beschikbaar.",
     "metaTitle": "Categorieen bekijken - Divine",
     "metaDescription": "Ontdek videocategorieen op Divine - komedie, muziek, dans, dieren, sport, eten en meer.",
+    "videoCount_zero": "{{count}} videos",
     "videoCount_one": "{{count}} video",
+    "videoCount_two": "{{count}} videos",
+    "videoCount_few": "{{count}} videos",
+    "videoCount_many": "{{count}} videos",
     "videoCount_other": "{{count}} videos"
   },
   "vineBadge": {

--- a/src/lib/i18n/locales/pl/common.json
+++ b/src/lib/i18n/locales/pl/common.json
@@ -8,6 +8,7 @@
     "home": "Strona glowna",
     "discover": "Odkrywaj",
     "popular": "Popular",
+    "services": "Services",
     "search": "Szukaj",
     "messages": "Wiadomosci",
     "notifications": "Powiadomienia",
@@ -133,6 +134,19 @@
     "communityDescription": "Dolacz do dyskusji spolecznosci i polacz sie z innymi uzytkownikami Divine na Nostr.",
     "communityBody": "Divine jest zbudowane na Nostr, zdecentralizowanym protokole spolecznosciowym. Znajdz nas w swoim ulubionym kliencie Nostr."
   },
+  "servicesPage": {
+    "title": "Divine services",
+    "intro": "Divine is more than loops. These services help you make the most of it.",
+    "openService": "Open {{name}}",
+    "items": {
+      "space": "Your profile, your rules. Themes, Top 8, profile music.",
+      "sounds": "Trending sounds and a Creative Commons library for your loops.",
+      "badges": "Awards for creators who show up.",
+      "crossposter": "Post your loops to the other platforms — only when you opt in.",
+      "verifier": "Check where a video really came from.",
+      "status": "Is it us or is it you? Check here."
+    }
+  },
   "tagPage": {
     "notFoundTitle": "Nie znaleziono tagu",
     "notFoundDescription": "Nie mozna znalezc podanego tagu.",
@@ -145,7 +159,9 @@
     "emptyState": "Obecnie brak dostepnych kategorii.",
     "metaTitle": "Przegladaj kategorie - Divine",
     "metaDescription": "Przegladaj kategorie wideo w Divine - komedia, muzyka, taniec, zwierzeta, sport, jedzenie i wiecej.",
+    "videoCount_zero": "{{count}} videos",
     "videoCount_one": "{{count}} film",
+    "videoCount_two": "{{count}} videos",
     "videoCount_few": "{{count}} filmy",
     "videoCount_many": "{{count}} filmow",
     "videoCount_other": "{{count}} filmu"

--- a/src/lib/i18n/locales/pt/common.json
+++ b/src/lib/i18n/locales/pt/common.json
@@ -8,6 +8,7 @@
     "home": "Inicio",
     "discover": "Descobrir",
     "popular": "Popular",
+    "services": "Services",
     "search": "Pesquisar",
     "messages": "Mensagens",
     "notifications": "Notificacoes",
@@ -133,6 +134,19 @@
     "communityDescription": "Participe das discussoes da comunidade e conecte-se com outros usuarios da Divine no Nostr.",
     "communityBody": "A Divine e construida sobre o Nostr, um protocolo social descentralizado. Encontre-nos no seu cliente Nostr favorito."
   },
+  "servicesPage": {
+    "title": "Divine services",
+    "intro": "Divine is more than loops. These services help you make the most of it.",
+    "openService": "Open {{name}}",
+    "items": {
+      "space": "Your profile, your rules. Themes, Top 8, profile music.",
+      "sounds": "Trending sounds and a Creative Commons library for your loops.",
+      "badges": "Awards for creators who show up.",
+      "crossposter": "Post your loops to the other platforms — only when you opt in.",
+      "verifier": "Check where a video really came from.",
+      "status": "Is it us or is it you? Check here."
+    }
+  },
   "tagPage": {
     "notFoundTitle": "Tag nao encontrada",
     "notFoundDescription": "Nao foi possivel encontrar a tag solicitada.",
@@ -145,7 +159,11 @@
     "emptyState": "Nenhuma categoria disponivel no momento.",
     "metaTitle": "Explorar categorias - Divine",
     "metaDescription": "Explore categorias de videos na Divine - comedia, musica, danca, animais, esportes, comida e mais.",
+    "videoCount_zero": "{{count}} videos",
     "videoCount_one": "{{count}} video",
+    "videoCount_two": "{{count}} videos",
+    "videoCount_few": "{{count}} videos",
+    "videoCount_many": "{{count}} videos",
     "videoCount_other": "{{count}} videos"
   },
   "vineBadge": {

--- a/src/lib/i18n/locales/ro/common.json
+++ b/src/lib/i18n/locales/ro/common.json
@@ -8,6 +8,7 @@
     "home": "Acasa",
     "discover": "Descopera",
     "popular": "Popular",
+    "services": "Services",
     "search": "Cauta",
     "messages": "Mesaje",
     "notifications": "Notificari",
@@ -133,6 +134,19 @@
     "communityDescription": "Alatura-te discutiilor comunitatii si conecteaza-te cu alti utilizatori Divine pe Nostr.",
     "communityBody": "Divine este construit pe Nostr, un protocol social descentralizat. Gaseste-ne in clientul tau Nostr preferat."
   },
+  "servicesPage": {
+    "title": "Divine services",
+    "intro": "Divine is more than loops. These services help you make the most of it.",
+    "openService": "Open {{name}}",
+    "items": {
+      "space": "Your profile, your rules. Themes, Top 8, profile music.",
+      "sounds": "Trending sounds and a Creative Commons library for your loops.",
+      "badges": "Awards for creators who show up.",
+      "crossposter": "Post your loops to the other platforms — only when you opt in.",
+      "verifier": "Check where a video really came from.",
+      "status": "Is it us or is it you? Check here."
+    }
+  },
   "tagPage": {
     "notFoundTitle": "Eticheta nu a fost gasita",
     "notFoundDescription": "Eticheta solicitata nu a putut fi gasita.",
@@ -145,8 +159,11 @@
     "emptyState": "Nu exista categorii disponibile acum.",
     "metaTitle": "Rasfoieste categoriile - Divine",
     "metaDescription": "Exploreaza categoriile video de pe Divine - comedie, muzica, dans, animale, sport, mancare si multe altele.",
+    "videoCount_zero": "{{count}} videos",
     "videoCount_one": "{{count}} videoclip",
+    "videoCount_two": "{{count}} videos",
     "videoCount_few": "{{count}} videoclipuri",
+    "videoCount_many": "{{count}} videos",
     "videoCount_other": "{{count}} de videoclipuri"
   },
   "vineBadge": {

--- a/src/lib/i18n/locales/sv/common.json
+++ b/src/lib/i18n/locales/sv/common.json
@@ -8,6 +8,7 @@
     "home": "Hem",
     "discover": "Utforska",
     "popular": "Popular",
+    "services": "Services",
     "search": "Sok",
     "messages": "Meddelanden",
     "notifications": "Aviseringar",
@@ -133,6 +134,19 @@
     "communityDescription": "Delta i våra gemenskapsdiskussioner och få kontakt med andra Divine-användare på Nostr.",
     "communityBody": "Divine är byggt på Nostr, ett decentraliserat socialt protokoll. Hitta oss i din favoritklient för Nostr."
   },
+  "servicesPage": {
+    "title": "Divine services",
+    "intro": "Divine is more than loops. These services help you make the most of it.",
+    "openService": "Open {{name}}",
+    "items": {
+      "space": "Your profile, your rules. Themes, Top 8, profile music.",
+      "sounds": "Trending sounds and a Creative Commons library for your loops.",
+      "badges": "Awards for creators who show up.",
+      "crossposter": "Post your loops to the other platforms — only when you opt in.",
+      "verifier": "Check where a video really came from.",
+      "status": "Is it us or is it you? Check here."
+    }
+  },
   "tagPage": {
     "notFoundTitle": "Tagg hittades inte",
     "notFoundDescription": "Den begarda taggen kunde inte hittas.",
@@ -145,7 +159,11 @@
     "emptyState": "Inga kategorier ar tillgangliga just nu.",
     "metaTitle": "Utforska kategorier - Divine",
     "metaDescription": "Utforska videokategorier pa Divine - komedi, musik, dans, djur, sport, mat och mer.",
+    "videoCount_zero": "{{count}} videos",
     "videoCount_one": "{{count}} video",
+    "videoCount_two": "{{count}} videos",
+    "videoCount_few": "{{count}} videos",
+    "videoCount_many": "{{count}} videos",
     "videoCount_other": "{{count}} videor"
   },
   "vineBadge": {

--- a/src/lib/i18n/locales/tr/common.json
+++ b/src/lib/i18n/locales/tr/common.json
@@ -8,6 +8,7 @@
     "home": "Ana sayfa",
     "discover": "Kesfet",
     "popular": "Popular",
+    "services": "Services",
     "search": "Ara",
     "messages": "Mesajlar",
     "notifications": "Bildirimler",
@@ -133,6 +134,19 @@
     "communityDescription": "Topluluk tartismalarimiza katil ve Nostr uzerindeki diger Divine kullanicilariyla baglan.",
     "communityBody": "Divine, merkezi olmayan bir sosyal protokol olan Nostr uzerine kuruludur. Bizi sevdigin Nostr istemcisinde bul."
   },
+  "servicesPage": {
+    "title": "Divine services",
+    "intro": "Divine is more than loops. These services help you make the most of it.",
+    "openService": "Open {{name}}",
+    "items": {
+      "space": "Your profile, your rules. Themes, Top 8, profile music.",
+      "sounds": "Trending sounds and a Creative Commons library for your loops.",
+      "badges": "Awards for creators who show up.",
+      "crossposter": "Post your loops to the other platforms — only when you opt in.",
+      "verifier": "Check where a video really came from.",
+      "status": "Is it us or is it you? Check here."
+    }
+  },
   "tagPage": {
     "notFoundTitle": "Etiket bulunamadi",
     "notFoundDescription": "Istenen etiket bulunamadi.",
@@ -145,7 +159,11 @@
     "emptyState": "Su anda hic kategori yok.",
     "metaTitle": "Kategorilere goz at - Divine",
     "metaDescription": "Divine uzerinde komedi, muzik, dans, hayvanlar, spor, yemek ve daha fazlasini kesfet.",
+    "videoCount_zero": "{{count}} videos",
     "videoCount_one": "{{count}} video",
+    "videoCount_two": "{{count}} videos",
+    "videoCount_few": "{{count}} videos",
+    "videoCount_many": "{{count}} videos",
     "videoCount_other": "{{count}} video"
   },
   "vineBadge": {

--- a/src/pages/ServicesPage.test.tsx
+++ b/src/pages/ServicesPage.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { initializeI18n } from '@/lib/i18n';
+import { DIVINE_SERVICES } from '@/config/divineServices';
+import ServicesPage from './ServicesPage';
+
+vi.mock('@/components/MarketingLayout', () => ({
+  MarketingLayout: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="marketing-layout">{children}</div>
+  ),
+}));
+
+describe('ServicesPage', () => {
+  beforeEach(async () => {
+    await initializeI18n({ force: true, languages: ['en-US'] });
+  });
+
+  it('renders the title and intro copy', () => {
+    render(
+      <MemoryRouter>
+        <ServicesPage />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByRole('heading', { name: 'Divine services' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/more than loops/i)).toBeInTheDocument();
+  });
+
+  it('links every configured service to its URL in a new tab', () => {
+    render(
+      <MemoryRouter>
+        <ServicesPage />
+      </MemoryRouter>,
+    );
+
+    for (const service of DIVINE_SERVICES) {
+      const link = screen.getByRole('link', { name: `Open ${service.name}` });
+      expect(link).toHaveAttribute('href', service.url);
+      expect(link).toHaveAttribute('target', '_blank');
+      expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'));
+      expect(link).toHaveAttribute('rel', expect.stringContaining('noreferrer'));
+    }
+  });
+});

--- a/src/pages/ServicesPage.test.tsx
+++ b/src/pages/ServicesPage.test.tsx
@@ -1,16 +1,10 @@
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { initializeI18n } from '@/lib/i18n';
 import { DIVINE_SERVICES } from '@/config/divineServices';
 import ServicesPage from './ServicesPage';
-
-vi.mock('@/components/MarketingLayout', () => ({
-  MarketingLayout: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="marketing-layout">{children}</div>
-  ),
-}));
 
 describe('ServicesPage', () => {
   beforeEach(async () => {

--- a/src/pages/ServicesPage.tsx
+++ b/src/pages/ServicesPage.tsx
@@ -1,10 +1,9 @@
 // ABOUTME: Directory of companion Divine services (Space, Sounds, Badges, Crossposter, Verifier, Status)
-// ABOUTME: Renders branded cards from src/config/divineServices.ts
+// ABOUTME: Renders branded cards from src/config/divineServices.ts inside the app shell
 
 import { ArrowSquareOut } from '@phosphor-icons/react';
 import { useTranslation } from 'react-i18next';
 
-import { MarketingLayout } from '@/components/MarketingLayout';
 import { SectionHeader } from '@/components/brand/SectionHeader';
 import { Card, type CardAccent } from '@/components/ui/card';
 import { DIVINE_SERVICES } from '@/config/divineServices';
@@ -22,47 +21,45 @@ export function ServicesPage() {
   const { t } = useTranslation();
 
   return (
-    <MarketingLayout>
-      <div className="container mx-auto max-w-5xl px-4 py-10">
-        <SectionHeader as="h2">{t('servicesPage.title')}</SectionHeader>
-        <p className="mt-3 max-w-2xl text-lg text-muted-foreground">
-          {t('servicesPage.intro')}
-        </p>
+    <div className="container mx-auto max-w-5xl px-4 py-10">
+      <SectionHeader as="h2">{t('servicesPage.title')}</SectionHeader>
+      <p className="mt-3 max-w-2xl text-lg text-muted-foreground">
+        {t('servicesPage.intro')}
+      </p>
 
-        <div className="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-          {DIVINE_SERVICES.map((service, index) => {
-            const ServiceIcon = service.icon;
-            return (
-              <a
-                key={service.id}
-                href={service.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="group block"
-                aria-label={t('servicesPage.openService', { name: service.name })}
+      <div className="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {DIVINE_SERVICES.map((service, index) => {
+          const ServiceIcon = service.icon;
+          return (
+            <a
+              key={service.id}
+              href={service.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group block"
+              aria-label={t('servicesPage.openService', { name: service.name })}
+            >
+              <Card
+                variant="brand"
+                accent={CARD_ACCENTS[index % CARD_ACCENTS.length]}
+                className="flex h-full flex-col gap-3 p-5 transition-transform group-hover:-translate-y-1"
               >
-                <Card
-                  variant="brand"
-                  accent={CARD_ACCENTS[index % CARD_ACCENTS.length]}
-                  className="flex h-full flex-col gap-3 p-5 transition-transform group-hover:-translate-y-1"
-                >
-                  <div className="flex items-center gap-3">
-                    <ServiceIcon className="h-7 w-7" />
-                    <h3 className="text-lg font-semibold text-foreground">
-                      {service.name}
-                    </h3>
-                    <ArrowSquareOut className="ml-auto h-4 w-4 text-muted-foreground" />
-                  </div>
-                  <p className="text-sm text-muted-foreground">
-                    {t(`servicesPage.items.${service.id}`)}
-                  </p>
-                </Card>
-              </a>
-            );
-          })}
-        </div>
+                <div className="flex items-center gap-3">
+                  <ServiceIcon className="h-7 w-7" />
+                  <h3 className="text-lg font-semibold text-foreground">
+                    {service.name}
+                  </h3>
+                  <ArrowSquareOut className="ml-auto h-4 w-4 text-muted-foreground" />
+                </div>
+                <p className="text-sm text-muted-foreground">
+                  {t(`servicesPage.items.${service.id}`)}
+                </p>
+              </Card>
+            </a>
+          );
+        })}
       </div>
-    </MarketingLayout>
+    </div>
   );
 }
 

--- a/src/pages/ServicesPage.tsx
+++ b/src/pages/ServicesPage.tsx
@@ -1,0 +1,69 @@
+// ABOUTME: Directory of companion Divine services (Space, Sounds, Badges, Crossposter, Verifier, Status)
+// ABOUTME: Renders branded cards from src/config/divineServices.ts
+
+import { ArrowSquareOut } from '@phosphor-icons/react';
+import { useTranslation } from 'react-i18next';
+
+import { MarketingLayout } from '@/components/MarketingLayout';
+import { SectionHeader } from '@/components/brand/SectionHeader';
+import { Card, type CardAccent } from '@/components/ui/card';
+import { DIVINE_SERVICES } from '@/config/divineServices';
+
+const CARD_ACCENTS: CardAccent[] = [
+  'green',
+  'pink',
+  'violet',
+  'orange',
+  'yellow',
+  'blue',
+];
+
+export function ServicesPage() {
+  const { t } = useTranslation();
+
+  return (
+    <MarketingLayout>
+      <div className="container mx-auto max-w-5xl px-4 py-10">
+        <SectionHeader as="h2">{t('servicesPage.title')}</SectionHeader>
+        <p className="mt-3 max-w-2xl text-lg text-muted-foreground">
+          {t('servicesPage.intro')}
+        </p>
+
+        <div className="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {DIVINE_SERVICES.map((service, index) => {
+            const ServiceIcon = service.icon;
+            return (
+              <a
+                key={service.id}
+                href={service.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="group block"
+                aria-label={t('servicesPage.openService', { name: service.name })}
+              >
+                <Card
+                  variant="brand"
+                  accent={CARD_ACCENTS[index % CARD_ACCENTS.length]}
+                  className="flex h-full flex-col gap-3 p-5 transition-transform group-hover:-translate-y-1"
+                >
+                  <div className="flex items-center gap-3">
+                    <ServiceIcon className="h-7 w-7" />
+                    <h3 className="text-lg font-semibold text-foreground">
+                      {service.name}
+                    </h3>
+                    <ArrowSquareOut className="ml-auto h-4 w-4 text-muted-foreground" />
+                  </div>
+                  <p className="text-sm text-muted-foreground">
+                    {t(`servicesPage.items.${service.id}`)}
+                  </p>
+                </Card>
+              </a>
+            );
+          })}
+        </div>
+      </div>
+    </MarketingLayout>
+  );
+}
+
+export default ServicesPage;

--- a/tests/divine-services-directory.test.ts
+++ b/tests/divine-services-directory.test.ts
@@ -1,5 +1,14 @@
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { execFileSync } from 'node:child_process';
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import { DIVINE_SERVICES } from '../src/config/divineServices';
@@ -31,12 +40,52 @@ describe('divine services prerender content', () => {
 
   it('closes the injected bundle script tag so the app boots', () => {
     // Regression guard: the script injection once dropped the closing
-    // </script>, which left every prerendered page static-only.
-    const script = readFileSync(
-      resolve(REPO_ROOT, 'scripts/prerender-legal.mjs'),
-      'utf8',
-    );
+    // </script>, which left every prerendered page static-only. Assert on the
+    // generated HTML rather than the script's source text, so the guard
+    // survives refactors of the injection expression and still catches an
+    // unclosed tag however it is reintroduced.
+    const tmp = mkdtempSync(join(tmpdir(), 'prerender-guard-'));
 
-    expect(script).toContain("scriptMatch[0] + '</script>'");
+    try {
+      mkdirSync(join(tmp, 'scripts', 'prerender-content'), { recursive: true });
+      mkdirSync(join(tmp, 'dist'), { recursive: true });
+
+      copyFileSync(
+        resolve(REPO_ROOT, 'scripts/prerender-legal.mjs'),
+        join(tmp, 'scripts', 'prerender-legal.mjs'),
+      );
+      // Pages driven by a contentFile are all this guard needs; the ones read
+      // from a .tsx sourceFile are skipped with a warning when absent.
+      for (const file of ['services-content.html', 'faq-content.html']) {
+        copyFileSync(
+          resolve(REPO_ROOT, 'scripts/prerender-content', file),
+          join(tmp, 'scripts', 'prerender-content', file),
+        );
+      }
+      writeFileSync(
+        join(tmp, 'dist', 'index.html'),
+        '<!DOCTYPE html><html><head></head><body><div id="root"></div>' +
+          '<script type="module" crossorigin src="/assets/index-TEST.js"></script>' +
+          '</body></html>',
+      );
+
+      execFileSync(process.execPath, [join(tmp, 'scripts', 'prerender-legal.mjs')], {
+        stdio: 'pipe',
+      });
+
+      const generated = readFileSync(
+        join(tmp, 'dist', 'services', 'index.html'),
+        'utf8',
+      );
+
+      expect(generated).toContain(
+        '<script type="module" crossorigin src="/assets/index-TEST.js"></script>',
+      );
+      // Nothing may follow the bundle tag unclosed: the document must still
+      // parse through to </html>.
+      expect(generated.trimEnd().endsWith('</html>')).toBe(true);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/divine-services-directory.test.ts
+++ b/tests/divine-services-directory.test.ts
@@ -28,4 +28,15 @@ describe('divine services prerender content', () => {
     expect(script).toContain("path: '/services'");
     expect(script).toContain('services-content.html');
   });
+
+  it('closes the injected bundle script tag so the app boots', () => {
+    // Regression guard: the script injection once dropped the closing
+    // </script>, which left every prerendered page static-only.
+    const script = readFileSync(
+      resolve(REPO_ROOT, 'scripts/prerender-legal.mjs'),
+      'utf8',
+    );
+
+    expect(script).toContain("scriptMatch[0] + '</script>'");
+  });
 });

--- a/tests/divine-services-directory.test.ts
+++ b/tests/divine-services-directory.test.ts
@@ -15,6 +15,52 @@ import { DIVINE_SERVICES } from '../src/config/divineServices';
 
 const REPO_ROOT = resolve(__dirname, '..');
 
+const TEST_CSP =
+  "default-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self' data:";
+
+/**
+ * Runs the real prerender script against a fixture dist/ in a temp directory
+ * and returns the generated page, so guards can assert on output rather than
+ * on the script's source text.
+ */
+function prerenderToTempDir(page: string): string {
+  const tmp = mkdtempSync(join(tmpdir(), 'prerender-guard-'));
+
+  try {
+    mkdirSync(join(tmp, 'scripts', 'prerender-content'), { recursive: true });
+    mkdirSync(join(tmp, 'dist'), { recursive: true });
+
+    copyFileSync(
+      resolve(REPO_ROOT, 'scripts/prerender-legal.mjs'),
+      join(tmp, 'scripts', 'prerender-legal.mjs'),
+    );
+    // Pages driven by a contentFile are all these guards need; the ones read
+    // from a .tsx sourceFile are skipped with a warning when absent.
+    for (const file of ['services-content.html', 'faq-content.html']) {
+      copyFileSync(
+        resolve(REPO_ROOT, 'scripts/prerender-content', file),
+        join(tmp, 'scripts', 'prerender-content', file),
+      );
+    }
+    writeFileSync(
+      join(tmp, 'dist', 'index.html'),
+      '<!DOCTYPE html><html><head>' +
+        `<meta http-equiv="Content-Security-Policy" content="${TEST_CSP}">` +
+        '</head><body><div id="root"></div>' +
+        '<script type="module" crossorigin src="/assets/index-TEST.js"></script>' +
+        '</body></html>',
+    );
+
+    execFileSync(process.execPath, [join(tmp, 'scripts', 'prerender-legal.mjs')], {
+      stdio: 'pipe',
+    });
+
+    return readFileSync(join(tmp, 'dist', page, 'index.html'), 'utf8');
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
 describe('divine services prerender content', () => {
   it('mentions every configured service name and URL', () => {
     const html = readFileSync(
@@ -44,48 +90,25 @@ describe('divine services prerender content', () => {
     // generated HTML rather than the script's source text, so the guard
     // survives refactors of the injection expression and still catches an
     // unclosed tag however it is reintroduced.
-    const tmp = mkdtempSync(join(tmpdir(), 'prerender-guard-'));
+    const generated = prerenderToTempDir('services');
 
-    try {
-      mkdirSync(join(tmp, 'scripts', 'prerender-content'), { recursive: true });
-      mkdirSync(join(tmp, 'dist'), { recursive: true });
+    expect(generated).toContain(
+      '<script type="module" crossorigin src="/assets/index-TEST.js"></script>',
+    );
+    // Nothing may follow the bundle tag unclosed: the document must still
+    // parse through to </html>.
+    expect(generated.trimEnd().endsWith('</html>')).toBe(true);
+  });
 
-      copyFileSync(
-        resolve(REPO_ROOT, 'scripts/prerender-legal.mjs'),
-        join(tmp, 'scripts', 'prerender-legal.mjs'),
+  it('carries the same CSP as index.html onto every prerendered page', () => {
+    // Prerendered pages boot the full SPA, and the app's only CSP is the meta
+    // tag in index.html (_headers sets CSP for /embed alone). Without this,
+    // any session entered through /services, /terms, /faq, ... runs the whole
+    // app unprotected, because an SPA never reloads the document.
+    for (const page of ['services', 'faq']) {
+      expect(prerenderToTempDir(page)).toContain(
+        `<meta http-equiv="Content-Security-Policy" content="${TEST_CSP}">`,
       );
-      // Pages driven by a contentFile are all this guard needs; the ones read
-      // from a .tsx sourceFile are skipped with a warning when absent.
-      for (const file of ['services-content.html', 'faq-content.html']) {
-        copyFileSync(
-          resolve(REPO_ROOT, 'scripts/prerender-content', file),
-          join(tmp, 'scripts', 'prerender-content', file),
-        );
-      }
-      writeFileSync(
-        join(tmp, 'dist', 'index.html'),
-        '<!DOCTYPE html><html><head></head><body><div id="root"></div>' +
-          '<script type="module" crossorigin src="/assets/index-TEST.js"></script>' +
-          '</body></html>',
-      );
-
-      execFileSync(process.execPath, [join(tmp, 'scripts', 'prerender-legal.mjs')], {
-        stdio: 'pipe',
-      });
-
-      const generated = readFileSync(
-        join(tmp, 'dist', 'services', 'index.html'),
-        'utf8',
-      );
-
-      expect(generated).toContain(
-        '<script type="module" crossorigin src="/assets/index-TEST.js"></script>',
-      );
-      // Nothing may follow the bundle tag unclosed: the document must still
-      // parse through to </html>.
-      expect(generated.trimEnd().endsWith('</html>')).toBe(true);
-    } finally {
-      rmSync(tmp, { recursive: true, force: true });
     }
   });
 });

--- a/tests/divine-services-directory.test.ts
+++ b/tests/divine-services-directory.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { DIVINE_SERVICES } from '../src/config/divineServices';
+
+const REPO_ROOT = resolve(__dirname, '..');
+
+describe('divine services prerender content', () => {
+  it('mentions every configured service name and URL', () => {
+    const html = readFileSync(
+      resolve(REPO_ROOT, 'scripts/prerender-content/services-content.html'),
+      'utf8',
+    );
+
+    for (const service of DIVINE_SERVICES) {
+      expect(html).toContain(service.url);
+      expect(html).toContain(service.name);
+    }
+  });
+
+  it('registers the /services page in the prerender script', () => {
+    const script = readFileSync(
+      resolve(REPO_ROOT, 'scripts/prerender-legal.mjs'),
+      'utf8',
+    );
+
+    expect(script).toContain("path: '/services'");
+    expect(script).toContain('services-content.html');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a `/services` directory page listing Divine's six public companion services — Divine Space, Sounds, Badges, Crossposter, Verifier, and Status — as branded cards linking out to each service.
- Links the page from the sidebar in two places: a top-level `Services` nav item (after Popular) and a `Services` link in the footer About-Divine expandable.
- The list is config-driven (`src/config/divineServices.ts`), so future services (clips, invite, etc.) become one array entry plus one locale string. The page is prerendered at build time for SEO.

## Motivation

- Divine has a growing set of companion services that help users take full advantage of the platform, but nothing in the app linked to them or explained they exist. Design: `docs/superpowers/specs/2026-07-27-divine-services-directory-design.md`, plan: `docs/superpowers/plans/2026-07-27-divine-services-directory.md`. Excluded per product: clips and invite (not ready), supporters, connect (invite-only), compiler (internal).

## Related Issue

- N/A

## Testing

- [x] `npm run test`
- [x] Manual verification completed

### Verification summary

- Full gate green: tsc, eslint (0 errors), vitest, production build. One 5s timeout flake (`InviteCollaboratorsDialog`, unrelated) under extreme host load (load avg 300+); passes serially — no tests or thresholds modified.
- Focused suites: config shape, `ServicesPage` (title/intro/all six cards link correctly with `rel="noopener noreferrer"`), `AppSidebar` (nav item + footer link), locale key parity (1186 keys × 16 locales identical), prerender guard, brand guardrails.
- Browser-verified (Playwright) desktop + mobile: page renders all six cards, card links open correct URLs in new tabs, sidebar Services item navigates to `/services`, footer expandable link works.
- Executed via subagent-driven development: per-task TDD, per-task reviews, final whole-branch review READY TO MERGE with no Critical/Important findings.

### Note for reviewers

- The locale task also added missing `categoriesPage.videoCount_{zero,two,few,many}` plural-form keys (English placeholders) to locales that lacked them — key parity was already broken on main (`ar`/`pl`/`ro` had extra plural forms) and the parity check required alignment. Pure additions, inert at runtime, no existing translations touched.

## Visuals

- [x] UI change with screenshots/video attached — new `/services` page (brand card grid) and new sidebar nav item; browser-verified as described above
- [ ] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved