### PR TITLE
docs(agents): forbid sensitive external identities in public artifacts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -408,3 +408,10 @@ npm run deploy:cloudflare  # Deploy to Cloudflare Pages
 Do not commit secrets. Configure deploy targets via `wrangler.toml` and
 environment variables. Verify `public/manifest.webmanifest` and required HTML
 meta tags (enforced by HTML ESLint rules) before deploy.
+
+Public issues, PRs, branch names, commit messages, screenshots, and
+descriptions must not mention corporate partners, customers, brands, campaign
+names, or other sensitive external identities unless a maintainer explicitly
+approves it. Use generic descriptors instead. The same applies to identifying
+values in code, tests, and fixtures — prefer keeping them in server-side
+configuration over committing them.


### PR DESCRIPTION
## Summary

Adds a confidentiality clause to `AGENTS.md` that already exists in
`divine-funnelcake` and `divine-moderation-service`, but was missing here.

## What changed

One paragraph under **Security**:

> Public issues, PRs, branch names, commit messages, screenshots, and
> descriptions must not mention corporate partners, customers, brands,
> campaign names, or other sensitive external identities unless a
> maintainer explicitly approves it. Use generic descriptors instead.
> The same applies to identifying values in code, tests, and fixtures —
> prefer keeping them in server-side configuration over committing them.

Two deliberate extensions over the sibling repos' wording:

- **commit messages** added to the list. The original covers issues, PRs,
  branch names, screenshots, and descriptions, but not commits.
- **a second sentence about code, tests, and fixtures.** The sibling
  version is about prose only. In a client repo the more likely leak is a
  hardcoded value in a fixture, so the rule points at server-side
  configuration as the default.

## Test plan

Docs only — no code, no tests, no CI surface affected.

Companion PR adding the same clause to `divine-mobile`:
divinevideo/divine-mobile#6636

🤖 Generated with [Claude Code](https://claude.com/claude-code)